### PR TITLE
[instructor] Fix osx install

### DIFF
--- a/components/instructor-embedders/instructor_embedders/__init__.py
+++ b/components/instructor-embedders/instructor_embedders/__init__.py
@@ -1,3 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from instructor_embedders.instructor_document_embedder import InstructorDocumentEmbedder
+from instructor_embedders.instructor_text_embedder import InstructorTextEmbedder
+
+__all__ = ["InstructorDocumentEmbedder", "InstructorTextEmbedder"]

--- a/components/instructor-embedders/pyproject.toml
+++ b/components/instructor-embedders/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   # Commenting some of them to not interfere with the dependencies of Haystack.
   #"transformers==4.20.0",
   "datasets>=2.2.0",
-  "pyarrow==8.0.0",
+  "pyarrow",
   "jsonlines",
   "numpy",
   "requests>=2.26.0",
@@ -137,4 +137,3 @@ log_cli = true
 
 [tool.black]
 line-length = 120
-

--- a/components/instructor-embedders/pyproject.toml
+++ b/components/instructor-embedders/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   # Commenting some of them to not interfere with the dependencies of Haystack.
   #"transformers==4.20.0",
   "datasets>=2.2.0",
-  "pyarrow",
+  #"pyarrow==8.0.0",
   "jsonlines",
   "numpy",
   "requests>=2.26.0",


### PR DESCRIPTION
The pinned version of `pyarrow` can't install on OSX. Removing the pin still works, not sure if we want to test the package in other environments to confirm.

Also exported the embedders in the root package for convenience.