### PR TITLE
`InstructorDocumentEmbedder`: Enrich documents with embeddings instead of recreating documents

### DIFF
--- a/components/instructor-embedders/instructor_embedders/instructor_document_embedder.py
+++ b/components/instructor-embedders/instructor_embedders/instructor_document_embedder.py
@@ -126,11 +126,7 @@ class InstructorDocumentEmbedder:
             normalize_embeddings=self.normalize_embeddings,
         )
 
-        documents_with_embeddings = []
         for doc, emb in zip(documents, embeddings):
-            doc_as_dict = doc.to_dict()
-            doc_as_dict["embedding"] = emb
-            del doc_as_dict["id"]
-            documents_with_embeddings.append(Document.from_dict(doc_as_dict))
+            doc.embedding = emb
 
-        return {"documents": documents_with_embeddings}
+        return {"documents": documents}


### PR DESCRIPTION
Part of https://github.com/deepset-ai/haystack/issues/6107

### Proposed Changes:

Enrich documents with embeddings instead of recreating documents for `InstructorDocumentEmbedder`.
The Document class is not frozen anymore, so we can add the embedding to the document without recreating it.

### Requesting Review:

@anakin87 