### PR TITLE
feat: Add PineconeDocumentStore (v2)

### DIFF
--- a/.github/workflows/document_stores_pinecone.yml
+++ b/.github/workflows/document_stores_pinecone.yml
@@ -1,0 +1,49 @@
+# This workflow comes from https://github.com/ofek/hatch-mypyc
+# https://github.com/ofek/hatch-mypyc/blob/5a198c0ba8660494d02716cfc9d79ce4adfb1442/.github/workflows/test.yml
+name: Test / Document Stores / pinecone
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - "document_stores/pinecone/**"
+      - ".github/workflows/pinecone.yml"
+
+concurrency:
+  group: document_stores_pinecone-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUNBUFFERED: "1"
+  FORCE_COLOR: "1"
+
+jobs:
+  run:
+    name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Hatch
+        run: pip install --upgrade hatch
+
+      - name: Lint
+        working-directory: document_stores/pinecone
+        if: matrix.python-version == '3.9'
+        run: hatch run lint:all
+
+      - name: Run tests
+        working-directory: document_stores/pinecone
+        run: hatch run cov

--- a/document_stores/pinecone/README.md
+++ b/document_stores/pinecone/README.md
@@ -1,0 +1,18 @@
+[![test](https://github.com/deepset-ai/document-store/actions/workflows/test.yml/badge.svg)](https://github.com/deepset-ai/document-store/actions/workflows/test.yml)
+
+# Pinecone Document Store
+
+This Github repository is a template that can be used to create custom document stores to extend
+the new [Haystack](https://github.com/deepset-ai/haystack/) API available under the `preview`
+package starting from version 1.15.
+
+While the new API is still under active development, the new "Store" architecture is quite stable
+and we are encouraging early adopters to contribute their custom document stores.
+
+## Installation
+
+## Examples
+
+## License
+
+`pinecone-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/document_stores/pinecone/pyproject.toml
+++ b/document_stores/pinecone/pyproject.toml
@@ -1,0 +1,181 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pinecone_haystack"
+dynamic = ["version"]
+description = ''
+readme = "README.md"
+requires-python = ">=3.7"
+license = "Apache-2.0"
+keywords = []
+authors = [
+  { name = "John Doe", email = "jd@example.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+  # we distribute the preview version of Haystack 2.0 under the package "haystack-ai"
+  "haystack-ai",
+  "pinecone-client",
+]
+
+[project.urls]
+Documentation = "https://github.com/unknown/example-store#readme"
+Issues = "https://github.com/unknown/example-store/issues"
+Source = "https://github.com/unknown/example-store"
+
+[tool.hatch.version]
+path = "src/pinecone_haystack/__about__.py"
+
+[tool.hatch.envs.default]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+]
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black>=23.1.0",
+  "mypy>=1.0.0",
+  "ruff>=0.0.243",
+  "numpy",
+]
+[tool.hatch.envs.lint.scripts]
+typing = "mypy --install-types --non-interactive {args:src/pinecone_haystack tests}"
+style = [
+  "ruff {args:.}",
+  "black --check --diff {args:.}",
+]
+fmt = [
+  "black {args:.}",
+  "ruff --fix {args:.}",
+  "style",
+]
+all = [
+  "style",
+  "typing",
+]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.black]
+target-version = ["py37"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py37"
+line-length = 120
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "DTZ",
+  "E",
+  "EM",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
+ignore = [
+  # Allow non-abstract empty methods in abstract base classes
+  "B027",
+  # Allow boolean positional values in function calls, like `dict.get(... True)`
+  "FBT003",
+  # Ignore checks for possible passwords
+  "S105", "S106", "S107",
+  # Ignore complexity
+  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+]
+unfixable = [
+  # Don't touch unused imports
+  "F401",
+]
+
+[tool.ruff.isort]
+known-first-party = ["pinecone_haystack"]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+source_pkgs = ["pinecone_haystack", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/pinecone_haystack/__about__.py",
+  "example"
+]
+
+[tool.coverage.paths]
+pinecone_haystack = ["src/pinecone_haystack", "*/pinecone_haystack/src/pinecone_haystack"]
+tests = ["tests", "*/pinecone_haystack/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+markers = [
+  "unit: unit tests",
+  "integration: integration tests"
+]
+
+[[tool.mypy.overrides]]
+module = [
+  "pinecone.*",
+  "haystack.*",
+  "pytest.*"
+]
+ignore_missing_imports = true

--- a/document_stores/pinecone/src/pinecone_haystack/__about__.py
+++ b/document_stores/pinecone/src/pinecone_haystack/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2023-present John Doe <jd@example.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+__version__ = "0.0.1"

--- a/document_stores/pinecone/src/pinecone_haystack/__init__.py
+++ b/document_stores/pinecone/src/pinecone_haystack/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023-present John Doe <jd@example.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from pinecone_haystack.document_store import PineconeDocumentStore
+
+__all__ = ["PineconeDocumentStore"]

--- a/document_stores/pinecone/src/pinecone_haystack/document_store.py
+++ b/document_stores/pinecone/src/pinecone_haystack/document_store.py
@@ -1,0 +1,990 @@
+# SPDX-FileCopyrightText: 2023-present John Doe <jd@example.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import json
+import logging
+import operator
+from functools import reduce
+from itertools import islice
+from typing import Any, Dict, Generator, List, Literal, Optional, Set, Union
+
+import numpy as np
+from tqdm import tqdm
+import pinecone
+
+from haystack.preview.dataclasses import Document
+from haystack.preview.document_stores.decorator import document_store
+from haystack.preview.document_stores.errors import (
+    DuplicateDocumentError,
+    MissingDocumentError,
+)
+from haystack.preview.document_stores.protocols import DuplicatePolicy
+
+from pinecone_haystack.errors import (
+    PineconeDocumentStoreError,
+    PineconeDocumentStoreFilterError,
+)
+from pinecone_haystack.filter_utils import LogicalFilterClause
+
+
+logger = logging.getLogger(__name__)
+
+
+TYPE_METADATA_FIELD = "doc_type"
+DOCUMENT_WITH_EMBEDDING = "vector"
+DOCUMENT_WITHOUT_EMBEDDING = "no-vector"
+LABEL = "label"
+
+AND_OPERATOR = "$and"
+IN_OPERATOR = "$in"
+EQ_OPERATOR = "$eq"
+
+DocTypeMetadata = Literal["vector", "no-vector", "label"]
+
+
+def _sanitize_index(index: Optional[str]) -> Optional[str]:
+    if index:
+        return index.replace("_", "-").lower()
+    return None
+
+
+def _get_by_path(root, items):
+    """Access a nested object in root by item sequence."""
+    return reduce(operator.getitem, items, root)
+
+
+def _set_by_path(root, items, value):
+    """Set a value in a nested object in root by item sequence."""
+    _get_by_path(root, items[:-1])[items[-1]] = value
+
+
+@document_store
+class PineconeDocumentStore:
+    """
+    It implements the Pinecone vector database ([https://www.pinecone.io](https://www.pinecone.io))
+    to perform similarity search on vectors. In order to use this document store, you need an API key that you can
+    obtain by creating an account on the [Pinecone website](https://www.pinecone.io).
+
+    This is a hosted document store,
+    this means that your vectors will not be stored locally but in the cloud. This means that the similarity
+    search will be run on the cloud as well.
+    """
+
+    top_k_limit = 10_000
+    top_k_limit_vectors = 1_000
+
+    def __init__(
+        self,
+        api_key: str,
+        environment: str = "us-west1-gcp",
+        pinecone_index: Optional["pinecone.Index"] = None,
+        embedding_dim: int = 768,
+        batch_size: int = 100,
+        return_embedding: bool = False,
+        index: str = "document",
+        similarity: str = "cosine",
+        replicas: int = 1,
+        shards: int = 1,
+        namespace: Optional[str] = None,
+        embedding_field: str = "embedding",
+        progress_bar: bool = True,
+        duplicate_documents: str = "overwrite",
+        recreate_index: bool = False,
+        metadata_config: Optional[Dict] = None,
+        validate_index_sync: bool = True,
+    ):
+        """
+        :param api_key: Pinecone vector database API key ([https://app.pinecone.io](https://app.pinecone.io)).
+        :param environment: Pinecone cloud environment uses `"us-west1-gcp"` by default. Other GCP and AWS
+            regions are supported, contact Pinecone [here](https://www.pinecone.io/contact/) if required.
+        :param pinecone_index: pinecone-client Index object, an index will be initialized or loaded if not specified.
+        :param embedding_dim: The embedding vector size.
+        :param batch_size: The batch size to be used when writing documents to the document store.
+        :param return_embedding: Whether to return document embeddings.
+        :param index: Name of index in document store to use.
+        :param similarity: The similarity function used to compare document vectors. `"cosine"` is the default
+            and is recommended if you are using a Sentence-Transformer model. `"dot_product"` is more performant
+            with DPR embeddings.
+            In both cases, the returned values in Document.score are normalized to be in range [0,1]:
+                - For `"dot_product"`: `expit(np.asarray(raw_score / 100))`
+                - For `"cosine"`: `(raw_score + 1) / 2`
+        :param replicas: The number of replicas. Replicas duplicate the index. They provide higher availability and
+            throughput.
+        :param shards: The number of shards to be used in the index. We recommend to use 1 shard per 1GB of data.
+        :param namespace: Optional namespace. If not specified, None is default.
+        :param embedding_field: Name of field containing an embedding vector.
+        :param progress_bar: Whether to show a tqdm progress bar or not.
+            Can be helpful to disable in production deployments to keep the logs clean.
+        :param duplicate_documents: Handle duplicate documents based on parameter options.\
+            Parameter options:
+                - `"skip"`: Ignore the duplicate documents.
+                - `"overwrite"`: Update any existing documents with the same ID when adding documents.
+                - `"fail"`: An error is raised if the document ID of the document being added already exists.
+        :param recreate_index: If set to True, an existing Pinecone index will be deleted and a new one will be
+            created using the config you are using for initialization. Be aware that all data in the old index will be
+            lost if you choose to recreate the index. Be aware that both the document_index and the label_index will
+            be recreated.
+        :param metadata_config: Which metadata fields should be indexed, part of the
+            [selective metadata filtering](https://www.pinecone.io/docs/manage-indexes/#selective-metadata-indexing) feature.
+            Should be in the format `{"indexed": ["metadata-field-1", "metadata-field-2", "metadata-field-n"]}`. By default,
+            no fields are indexed.
+        """
+
+        if metadata_config is None:
+            metadata_config = {"indexed": []}
+        # Connect to Pinecone server using python client binding
+        if not api_key:
+            raise PineconeDocumentStoreError(
+                "Pinecone requires an API key, please provide one. https://app.pinecone.io"
+            )
+
+        pinecone.init(api_key=api_key, environment=environment)
+        self._api_key = api_key
+
+        # Format similarity string
+        self._set_similarity_metric(similarity)
+
+        self.similarity = similarity
+        self.index: str = self._index(index)
+        self.embedding_dim = embedding_dim
+        self.batch_size = batch_size
+        self.return_embedding = return_embedding
+        self.embedding_field = embedding_field
+        self.progress_bar = progress_bar
+        self.duplicate_documents = duplicate_documents
+
+        # Pinecone index params
+        self.replicas = replicas
+        self.shards = shards
+        self.namespace = namespace
+
+        # Add necessary metadata fields to metadata_config
+        fields = ["label-id", "query", TYPE_METADATA_FIELD]
+        metadata_config["indexed"] += fields
+        self.metadata_config = metadata_config
+
+        # Initialize dictionary of index connections
+        self.pinecone_indexes: Dict[str, pinecone.Index] = {}
+        self.return_embedding = return_embedding
+        self.embedding_field = embedding_field
+
+        # Initialize dictionary to store temporary set of document IDs
+        self.all_ids: dict = {}
+
+        # Dummy query to be used during searches
+        self.dummy_query = [0.0] * self.embedding_dim
+
+        if pinecone_index:
+            if not isinstance(pinecone_index, pinecone.Index):
+                raise PineconeDocumentStoreError(
+                    f"The parameter `pinecone_index` needs to be a "
+                    f"`pinecone.Index` object. You provided an object of "
+                    f"type `{type(pinecone_index)}`."
+                )
+            self.pinecone_indexes[self.index] = pinecone_index
+        else:
+            self.pinecone_indexes[self.index] = self._create_index(
+                embedding_dim=self.embedding_dim,
+                index=self.index,
+                metric_type=self.metric_type,
+                replicas=self.replicas,
+                shards=self.shards,
+                recreate_index=recreate_index,
+                metadata_config=self.metadata_config,
+            )
+
+        super().__init__()
+
+    def _index(self, index) -> str:
+        index = _sanitize_index(index) or self.index
+        return index
+
+    def _create_index(
+        self,
+        embedding_dim: int,
+        index: Optional[str] = None,
+        metric_type: Optional[str] = "cosine",
+        replicas: Optional[int] = 1,
+        shards: Optional[int] = 1,
+        recreate_index: bool = False,
+        metadata_config: Optional[Dict] = None,
+    ) -> "pinecone.Index":
+        """
+        Create a new index for storing documents in case an index with the name
+        doesn't exist already.
+        """
+        if metadata_config is None:
+            metadata_config = {"indexed": []}
+
+        if recreate_index:
+            self.delete_index(index)
+
+        # Skip if already exists
+        if index in self.pinecone_indexes:
+            index_connection = self.pinecone_indexes[index]
+        else:
+            # Search pinecone hosted indexes and create an index if it does not exist
+            if index not in pinecone.list_indexes():
+                pinecone.create_index(
+                    name=index,
+                    dimension=embedding_dim,
+                    metric=metric_type,
+                    replicas=replicas,
+                    shards=shards,
+                    metadata_config=metadata_config,
+                )
+            index_connection = pinecone.Index(index)
+
+        # return index connection
+        return index_connection
+
+    def get_index_stats(self):
+        stats = self.pinecone_indexes[self.index]
+        self.index_stats = stats
+        # Get index statistics
+        dims = stats["dimension"]
+        count = stats["namespaces"][""]["vector_count"] if stats["namespaces"].get("") else 0
+        logger.info(
+            "Index statistics: name: %s embedding dimensions: %s, record count: %s",
+            self.index,
+            dims,
+            count,
+        )
+
+        return stats, dims, count
+
+    def _index_connection_exists(self, index: str, create: bool = False) -> Optional["pinecone.Index"]:
+        """
+        Check if the index connection exists. If specified, create an index if it does not exist yet.
+
+        :param index: Index name.
+        :param create: Indicates if an index needs to be created or not. If set to `True`, create an index
+            and return connection to it, otherwise raise `PineconeDocumentStoreError` error.
+        :raises PineconeDocumentStoreError: Exception trigger when index connection not found.
+        """
+        if index not in self.pinecone_indexes:
+            if create:
+                return self._create_index(
+                    embedding_dim=self.embedding_dim,
+                    index=index,
+                    metric_type=self.metric_type,
+                    replicas=self.replicas,
+                    shards=self.shards,
+                    recreate_index=False,
+                    metadata_config=self.metadata_config,
+                )
+            raise PineconeDocumentStoreError(
+                f"Index named '{index}' does not exist. Try reinitializing PineconeDocumentStore() and running "
+                f"'update_embeddings()' to create and populate an index."
+            )
+        return None
+
+    def _set_similarity_metric(self, similarity: str):
+        """
+        Set vector similarity metric.
+        """
+        if similarity == "cosine":
+            self.metric_type = similarity
+        elif similarity == "dot_product":
+            self.metric_type = "dotproduct"
+        elif similarity in ["l2", "euclidean"]:
+            self.metric_type = "euclidean"
+        else:
+            raise ValueError(
+                "The Pinecone document store can currently only support dot_product, cosine and euclidean metrics. "
+                "Please set similarity to one of the above."
+            )
+
+    def _add_local_ids(self, index: str, ids: List[str]):
+        """
+        Add all document IDs to the set of all IDs.
+        """
+        if index not in self.all_ids:
+            self.all_ids[index] = set()
+        self.all_ids[index] = self.all_ids[index].union(set(ids))
+
+    def _add_type_metadata_filter(
+        self, filters: Dict[str, Any], type_value: Optional[DocTypeMetadata]
+    ) -> Dict[str, Any]:
+        """
+        Add new filter for `doc_type` metadata field.
+        """
+        if type_value:
+            new_type_filter = {TYPE_METADATA_FIELD: {EQ_OPERATOR: type_value}}
+            if AND_OPERATOR not in filters and TYPE_METADATA_FIELD not in filters:
+                # extend filters with new `doc_type` filter and add $and operator
+                filters.update(new_type_filter)
+                all_filters = filters
+                return {AND_OPERATOR: all_filters}
+
+            filters_content = filters[AND_OPERATOR] if AND_OPERATOR in filters else filters
+            if TYPE_METADATA_FIELD in filters_content:  # type: ignore
+                current_type_filter = filters_content[TYPE_METADATA_FIELD]  # type: ignore
+                type_values = {type_value}
+                if isinstance(current_type_filter, str):
+                    type_values.add(current_type_filter)  # type: ignore
+                elif isinstance(current_type_filter, dict):
+                    if EQ_OPERATOR in current_type_filter:
+                        # current `doc_type` filter has single value
+                        type_values.add(current_type_filter[EQ_OPERATOR])
+                    else:
+                        # current `doc_type` filter has multiple values
+                        type_values.update(set(current_type_filter[IN_OPERATOR]))
+                new_type_filter = {TYPE_METADATA_FIELD: {IN_OPERATOR: list(type_values)}}  # type: ignore
+            filters_content.update(new_type_filter)  # type: ignore
+
+        return filters
+
+    def _get_default_type_metadata(self, index: Optional[str], namespace: Optional[str] = None) -> str:
+        """
+        Get default value for `doc_type` metadata filed. If there is at least one embedding, default value
+        will be `vector`, otherwise it will be `no-vector`.
+        """
+        if self.get_embedding_count(index=index, namespace=namespace) > 0:
+            return DOCUMENT_WITH_EMBEDDING
+        return DOCUMENT_WITHOUT_EMBEDDING
+
+    def _get_vector_count(
+        self,
+        index: str,
+        filters: Optional[Dict[str, Any]],
+        namespace: Optional[str],
+    ) -> int:
+        res = self.pinecone_indexes[index].query(
+            self.dummy_query,
+            top_k=self.top_k_limit,
+            include_values=False,
+            include_metadata=False,
+            filter=filters,
+            namespace=namespace,
+        )
+        return len(res["matches"])
+
+    def get_document_count(
+        self,
+        filters: Dict[str, Any] = None,
+        index: Optional[str] = None,
+        only_documents_without_embedding: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        namespace: Optional[str] = None,
+        type_metadata: Optional[DocTypeMetadata] = None,
+    ) -> int:
+        """
+        Return the count of documents in the document store.
+
+        :param filters: Optional filters to narrow down the documents which will be counted.
+            Filters are defined as nested dictionaries. The keys of the dictionaries can be a logical
+            operator (`"$and"`, `"$or"`, `"$not"`), a comparison operator (`"$eq"`, `"$in"`, `"$gt"`,
+            `"$gte"`, `"$lt"`, `"$lte"`), or a metadata field name.
+            Logical operator keys take a dictionary of metadata field names or logical operators as
+            value. Metadata field names take a dictionary of comparison operators as value. Comparison
+            operator keys take a single value or (in case of `"$in"`) a list of values as value.
+            If no logical operator is provided, `"$and"` is used as default operation. If no comparison
+            operator is provided, `"$eq"` (or `"$in"` if the comparison value is a list) is used as default
+            operation.
+                __Example__:
+
+                ```python
+                filters = {
+                    "$and": {
+                        "type": {"$eq": "article"},
+                        "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"},
+                        "rating": {"$gte": 3},
+                        "$or": {
+                            "genre": {"$in": ["economy", "politics"]},
+                            "publisher": {"$eq": "nytimes"}
+                        }
+                    }
+                }
+                ```
+        :param index: Optional index name to use for the query. If not provided, the default index name is used.
+        :param only_documents_without_embedding: If set to `True`, only documents without embeddings are counted.
+        :param headers: PineconeDocumentStore does not support headers.
+        :param namespace: Optional namespace to count documents from. If not specified, None is default.
+        :param type_metadata: Optional value for `doc_type` metadata to reference documents that need to be counted.
+            Parameter options:
+                - `"vector"`: Documents with embedding.
+                - `"no-vector"`: Documents without embedding (dummy embedding only).
+                - `"label"`: Labels.
+        """
+        if headers:
+            raise NotImplementedError("PineconeDocumentStore does not support headers.")
+
+        index = self._index(index)
+        self._index_connection_exists(index)
+
+        filters = filters or {}
+        if not type_metadata:
+            # add filter for `doc_type` metadata related to documents without embeddings
+            filters = self._add_type_metadata_filter(filters, type_value=DOCUMENT_WITHOUT_EMBEDDING)  # type: ignore
+            if not only_documents_without_embedding:
+                # add filter for `doc_type` metadata related to documents with embeddings
+                filters = self._add_type_metadata_filter(filters, type_value=DOCUMENT_WITH_EMBEDDING)  # type: ignore
+        else:
+            # if value for `doc_type` metadata is specified, add filter with given value
+            filters = self._add_type_metadata_filter(filters, type_value=type_metadata)
+
+        pinecone_syntax_filter = LogicalFilterClause.parse(filters).convert_to_pinecone() if filters else None
+        return self._get_vector_count(index, filters=pinecone_syntax_filter, namespace=namespace)
+
+    def get_embedding_count(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        index: Optional[str] = None,
+        namespace: Optional[str] = None,
+    ) -> int:
+        """
+        Return the count of embeddings in the document store.
+
+        :param index: Optional index name to retrieve all documents from.
+        :param filters: Filters are not supported for `get_embedding_count` in Pinecone.
+        :param namespace: Optional namespace to count embeddings from. If not specified, None is default.
+        """
+        if filters:
+            raise NotImplementedError("Filters are not supported for get_embedding_count in PineconeDocumentStore")
+
+        index = self._index(index)
+        self._index_connection_exists(index)
+
+        pinecone_filters = self._meta_for_pinecone({TYPE_METADATA_FIELD: DOCUMENT_WITH_EMBEDDING})
+        return self._get_vector_count(index, filters=pinecone_filters, namespace=namespace)
+
+    def _meta_for_pinecone(self, meta: Dict[str, Any], parent_key: str = "", labels: bool = False) -> Dict[str, Any]:
+        """
+        Converts the meta dictionary to a format that can be stored in Pinecone.
+        :param meta: Metadata dictionary to be converted.
+        :param parent_key: Optional, used for recursive calls to keep track of parent keys, for example:
+            ```
+            {"parent1": {"parent2": {"child": "value"}}}
+            ```
+            On the second recursive call, parent_key would be "parent1", and the final key would be "parent1.parent2.child".
+        :param labels: Optional, used to indicate whether the metadata is being stored as a label or not. If True the
+            the flattening of dictionaries is not required.
+        """
+        items: list = []
+        if labels:
+            # Replace any None values with empty strings
+            for key, value in meta.items():
+                if value is None:
+                    meta[key] = ""
+        else:
+            # Explode dict of dicts into single flattened dict
+            for key, value in meta.items():
+                # Replace any None values with empty strings
+                if value is None:
+                    value = ""
+                if key == "_split_overlap":
+                    value = json.dumps(value)
+                # format key
+                new_key = f"{parent_key}.{key}" if parent_key else key
+                # if value is dict, expand
+                if isinstance(value, dict):
+                    items.extend(self._meta_for_pinecone(value, parent_key=new_key).items())
+                else:
+                    items.append((new_key, value))
+            # Create new flattened dictionary
+            meta = dict(items)
+        return meta
+
+    def _pinecone_meta_format(self, meta: Dict[str, Any], labels: bool = False) -> Dict[str, Any]:
+        """
+        Converts the meta extracted from Pinecone into a better format for Python.
+        :param meta: Metadata dictionary to be converted.
+        :param labels: Optional, used to indicate whether the metadata is being stored as a label or not. If True the
+            the flattening of dictionaries is not required.
+        """
+        new_meta: Dict[str, Any] = {}
+
+        if labels:
+            # Replace any empty strings with None values
+            for key, value in meta.items():
+                if value == "":
+                    meta[key] = None
+            return meta
+        else:
+            for key, value in meta.items():
+                # Replace any empty strings with None values
+                if value == "":
+                    value = None
+                if "." in key:
+                    # We must split into nested dictionary
+                    keys = key.split(".")
+                    # Iterate through each dictionary level
+                    for i in range(len(keys)):
+                        path = keys[: i + 1]
+                        # Check if path exists
+                        try:
+                            _get_by_path(new_meta, path)
+                        except KeyError:
+                            # Create path
+                            if i == len(keys) - 1:
+                                _set_by_path(new_meta, path, value)
+                            else:
+                                _set_by_path(new_meta, path, {})
+                else:
+                    new_meta[key] = value
+            return new_meta
+
+    def _validate_index_sync(self, index: Optional[str] = None):
+        """
+        This check ensures the correct number of documents with embeddings and embeddings are found in the
+        Pinecone database.
+        """
+        if self.get_document_count(
+            index=index, type_metadata=DOCUMENT_WITH_EMBEDDING  # type: ignore
+        ) != self.get_embedding_count(index=index):
+            raise PineconeDocumentStoreError(
+                f"The number of documents present in Pinecone ({self.get_document_count(index=index)}) "
+                "does not match the number of embeddings in Pinecone "
+                f" ({self.get_embedding_count(index=index)}). This can happen if a document store "
+                "instance is deleted during write operations. Call "
+                "the `update_documents` method to fix it."
+            )
+
+    def count_documents(self) -> int:
+        """
+        Returns how many documents are present in the document store.
+        """
+        count = self.index_stats["namespaces"][""]["vector_count"] if self.index_stats["namespaces"].get("") else 0
+        return count
+
+    def write_documents(
+        self,
+        documents: List[Document],
+        policy: DuplicatePolicy = "fail",
+    ) -> None:
+        """
+        Writes (or overwrites) documents into the store.
+
+        :param documents: a list of documents.
+        :param policy: documents with the same ID count as duplicates. When duplicates are met,
+            the store can:
+             - skip: keep the existing document and ignore the new one.
+             - overwrite: remove the old document and write the new one.
+             - fail: an error is raised
+        :raises DuplicateDocumentError: Exception trigger on duplicate document if `policy=DuplicatePolicy.FAIL`
+        :return: None
+        """
+        if not isinstance(documents, list):
+            msg = "Documents must be a list"
+            raise ValueError(msg)
+
+        index = self._index(self.index)
+        index_connection = self._index_connection_exists(index, create=True)
+        if index_connection:
+            self.pinecone_indexes[index] = index_connection
+
+        duplicate_documents = policy or self.duplicate_documents
+        policy_options = ["skip", "overwrite", "fail"]
+        assert (
+            duplicate_documents in policy_options
+        ), f"duplicate_documents parameter must be {', '.join(policy_options)}"
+
+        add_vectors = documents[0].embedding is not None
+        type_metadata = DOCUMENT_WITH_EMBEDDING if add_vectors else DOCUMENT_WITHOUT_EMBEDDING
+
+        if not add_vectors:
+            # To store documents in Pinecone, we use dummy embeddings (to be replaced with real embeddings later)
+            embeddings_to_index = np.zeros((self.batch_size, self.embedding_dim), dtype="float32")
+            # Convert embeddings to list objects
+            embeddings = [embed.tolist() if embed is not None else None for embed in embeddings_to_index]
+
+        with tqdm(
+            total=len(documents),
+            disable=not self.progress_bar,
+            position=0,
+            desc="Writing Documents",
+        ) as progress_bar:
+            for i in range(0, len(documents), self.batch_size):
+                document_batch = documents[i : i + self.batch_size]
+                ids = [doc.id for doc in document_batch]
+                # If duplicate_documents set to `skip` or `fail`, we need to check for existing documents
+                if duplicate_documents in ["skip", "fail"]:
+                    existing_documents = self.get_documents_by_id(
+                        ids=ids,
+                        index=index,
+                        namespace=self.namespace,
+                        include_type_metadata=True,
+                    )
+                    # First check for documents in current batch that exist in the index
+                    if existing_documents:
+                        if duplicate_documents == "skip":
+                            # If we should skip existing documents, we drop the ids that already exist
+                            skip_ids = [doc.id for doc in existing_documents]
+                            # We need to drop the affected document objects from the batch
+                            document_batch = [doc for doc in document_batch if doc.id not in skip_ids]
+                            # Now rebuild the ID list
+                            ids = [doc.id for doc in document_batch]
+                            progress_bar.update(len(skip_ids))
+                        elif duplicate_documents == "fail":
+                            # Otherwise, we raise an error
+                            raise DuplicateDocumentError(
+                                f"Document ID {existing_documents[0].id} already exists in index {index}"
+                            )
+                    # Now check for duplicate documents within the batch itself
+                    if len(ids) != len(set(ids)):
+                        if duplicate_documents == "skip":
+                            # We just keep the first instance of each duplicate document
+                            ids = []
+                            temp_document_batch = []
+                            for doc in document_batch:
+                                if doc.id not in ids:
+                                    ids.append(doc.id)
+                                    temp_document_batch.append(doc)
+                            document_batch = temp_document_batch
+                        elif duplicate_documents == "fail":
+                            # Otherwise, we raise an error
+                            raise DuplicateDocumentError(f"Duplicate document IDs found in batch: {ids}")
+                metadata = [
+                    self._meta_for_pinecone(
+                        {
+                            TYPE_METADATA_FIELD: type_metadata,  # add `doc_type` in metadata
+                            "text": doc.text,
+                            "content_type": doc.metadata,
+                        }
+                    )
+                    for doc in documents[i : i + self.batch_size]
+                ]
+                if add_vectors:
+                    embeddings = [doc.embedding for doc in documents[i : i + self.batch_size]]
+                    embeddings_to_index = np.array(embeddings, dtype="float32")
+
+                    # Convert embeddings to list objects
+                    embeddings = [embed.tolist() if embed is not None else None for embed in embeddings_to_index]
+                data_to_write_to_pinecone = zip(ids, embeddings, metadata)
+                # Metadata fields and embeddings are stored in Pinecone
+                self.pinecone_indexes[index].upsert(vectors=data_to_write_to_pinecone, namespace=self.namespace)
+                # Add IDs to ID list
+                self._add_local_ids(index, ids)
+                progress_bar.update(self.batch_size)
+        progress_bar.close()
+
+    def _limit_check(self, top_k: int, include_values: Optional[bool] = None):
+        """
+        Confirms the top_k value does not exceed Pinecone vector database limits.
+        """
+        if include_values:
+            if top_k > self.top_k_limit_vectors:
+                raise PineconeDocumentStoreError(
+                    f"PineconeDocumentStore allows requests of no more than {self.top_k_limit_vectors} records "
+                    f"when returning embedding values. This request is attempting to return {top_k} records."
+                )
+        else:
+            if top_k > self.top_k_limit:
+                raise PineconeDocumentStoreError(
+                    f"PineconeDocumentStore allows requests of no more than {self.top_k_limit} records. "
+                    f"This request is attempting to return {top_k} records."
+                )
+
+    def query_by_embedding(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        scale_score: bool = True,
+        return_embedding: Optional[bool] = None,
+    ) -> List[Document]:
+        """
+        Find the document that is most similar to the provided `query_embedding` by using a vector similarity metric.
+
+        :param query_embedding: Embedding of the query.
+        :param filters: A dictionary with filters to narrow down the search space.
+        :param top_k: The maximum number of documents to return.
+        :param scale_score: Whether to scale the scores of the retrieved documents or not.
+        :param return_embedding: Whether to return the embedding of the retrieved Documents.
+        :return: The retrieved documents.
+        """
+        if return_embedding is None:
+            return_embedding = self.return_embedding
+
+        self._limit_check(top_k, include_values=return_embedding)
+
+        index = self._index(self.index)
+        self._index_connection_exists(index)
+
+        type_metadata = DOCUMENT_WITH_EMBEDDING  # type: ignore
+
+        filters = filters or {}
+        filters = self._add_type_metadata_filter(filters, type_metadata)
+
+        pinecone_syntax_filter = LogicalFilterClause.parse(filters).convert_to_pinecone() if filters else None
+
+        res = self.pinecone_indexes[index].query(
+            query_embedding,
+            namespace=self.namespace,
+            top_k=top_k,
+            include_values=return_embedding,
+            include_metadata=True,
+            filter=pinecone_syntax_filter,
+        )
+
+        score_matrix = []
+        vector_id_matrix = []
+        meta_matrix = []
+        embedding_matrix = []
+        for match in res["matches"]:
+            score_matrix.append(match["score"])
+            vector_id_matrix.append(match["id"])
+            meta_matrix.append(match["metadata"])
+            if return_embedding:
+                embedding_matrix.append(match["values"])
+        if return_embedding:
+            values = embedding_matrix
+        else:
+            values = None
+        documents = self._get_documents_by_meta(
+            vector_id_matrix,
+            meta_matrix,
+            values=values,
+            index=index,
+            return_embedding=return_embedding,
+        )
+
+        # assign query score to each document
+        scores_for_vector_ids: Dict[str, float] = {str(v_id): s for v_id, s in zip(vector_id_matrix, score_matrix)}
+        return_documents = []
+        for doc in documents:
+            score = scores_for_vector_ids[doc.id]
+            if scale_score:
+                if self.similarity == "cosine":
+                    score = (score + 1) / 2
+                else:
+                    score = float(1 / (1 + np.exp(-score / 100)))
+            doc.score = score
+            return_document = copy.copy(doc)
+            return_documents.append(return_document)
+
+        return return_documents
+
+    def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
+        """
+        Returns the documents that match the filters provided.
+
+        Filters are defined as nested dictionaries. The keys of the dictionaries can be a logical operator (`"$and"`,
+        `"$or"`, `"$not"`), a comparison operator (`"$eq"`, `$ne`, `"$in"`, `$nin`, `"$gt"`, `"$gte"`, `"$lt"`,
+        `"$lte"`) or a metadata field name.
+
+        Logical operator keys take a dictionary of metadata field names and/or logical operators as value. Metadata
+        field names take a dictionary of comparison operators as value. Comparison operator keys take a single value or
+        (in case of `"$in"`) a list of values as value. If no logical operator is provided, `"$and"` is used as default
+        operation. If no comparison operator is provided, `"$eq"` (or `"$in"` if the comparison value is a list) is used
+        as default operation.
+
+        Example:
+
+        ```python
+        filters = {
+            "$and": {
+                "type": {"$eq": "article"},
+                "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"},
+                "rating": {"$gte": 3},
+                "$or": {
+                    "genre": {"$in": ["economy", "politics"]},
+                    "publisher": {"$eq": "nytimes"}
+                }
+            }
+        }
+        # or simpler using default operators
+        filters = {
+            "type": "article",
+            "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"},
+            "rating": {"$gte": 3},
+            "$or": {
+                "genre": ["economy", "politics"],
+                "publisher": "nytimes"
+            }
+        }
+        ```
+
+        To use the same logical operator multiple times on the same level, logical operators can take a list of
+        dictionaries as value.
+
+        Example:
+
+        ```python
+        filters = {
+            "$or": [
+                {
+                    "$and": {
+                        "Type": "News Paper",
+                        "Date": {
+                            "$lt": "2019-01-01"
+                        }
+                    }
+                },
+                {
+                    "$and": {
+                        "Type": "Blog Post",
+                        "Date": {
+                            "$gte": "2019-01-01"
+                        }
+                    }
+                }
+            ]
+        }
+        ```
+
+        :param filters: the filters to apply to the document list.
+        :return: a list of Documents that match the given filters.
+        """
+        docs = self.query_by_embedding(
+            query_embedding=self.dummy_query,
+            filters=filters,
+            top_k=10,
+            scale_score=True,
+            return_embedding=True,
+        )
+
+        return docs
+
+    def _attach_embedding_to_document(self, document: Document, index: str):
+        """
+        Fetches the Document's embedding from the specified Pinecone index and attaches it to the Document's
+        embedding field.
+        """
+        result = self.pinecone_indexes[index].fetch(ids=[document.id])
+        if result["vectors"].get(document.id, False):
+            embedding = result["vectors"][document.id].get("values", None)
+            document.embedding = np.asarray(embedding, dtype=np.float32)
+
+    def _get_documents_by_meta(
+        self,
+        ids: List[str],
+        metadata: List[dict],
+        values: Optional[List[List[float]]] = None,
+        index: Optional[str] = None,
+        return_embedding: Optional[bool] = None,
+    ) -> List[Document]:
+        if return_embedding is None:
+            return_embedding = self.return_embedding
+
+        index = self._index(index)
+
+        # extract ID, content, and metadata to create Documents
+        documents = []
+        for _id, meta in zip(ids, metadata):
+            content = meta.pop("content")
+            content_type = meta.pop("content_type")
+            if "_split_overlap" in meta:
+                meta["_split_overlap"] = json.loads(meta["_split_overlap"])
+            doc = Document(id=_id, content=content, content_type=content_type, meta=meta)
+            documents.append(doc)
+        if return_embedding:
+            if values is None:
+                # If no embedding values are provided, we must request the embeddings from Pinecone
+                for doc in documents:
+                    self._attach_embedding_to_document(document=doc, index=index)
+            else:
+                # If embedding values are given, we just add
+                for doc, embedding in zip(documents, values):
+                    doc.embedding = np.asarray(embedding, dtype=np.float32)
+
+        return documents
+
+    def get_documents_by_id(
+        self,
+        ids: List[str],
+        index: Optional[str] = None,
+        batch_size: int = 100,
+        return_embedding: Optional[bool] = None,
+        namespace: Optional[str] = None,
+        include_type_metadata: Optional[bool] = False,
+    ) -> List[Document]:
+        """
+        Retrieves all documents in the index using their IDs.
+
+        :param ids: List of IDs to retrieve.
+        :param index: Optional index name to retrieve all documents from.
+        :param batch_size: Number of documents to retrieve at a time. When working with large number of documents,
+            batching can help reduce memory footprint.
+        :param headers: Pinecone does not support headers.
+        :param return_embedding: Optional flag to return the embedding of the document.
+        :param namespace: Optional namespace to retrieve document from. If not specified, None is default.
+        :param include_type_metadata: Indicates if `doc_type` value will be included in document metadata or not.
+            If not specified, `doc_type` field will be dropped from document metadata.
+        """
+
+        if return_embedding is None:
+            return_embedding = self.return_embedding
+
+        index = self._index(index)
+        self._index_connection_exists(index)
+
+        documents = []
+        for i in range(0, len(ids), batch_size):
+            i_end = min(len(ids), i + batch_size)
+            id_batch = ids[i:i_end]
+            result = self.pinecone_indexes[index].fetch(ids=id_batch, namespace=namespace)
+
+            vector_id_matrix = []
+            meta_matrix = []
+            embedding_matrix = []
+            for _id in result["vectors"]:
+                vector_id_matrix.append(_id)
+                metadata = result["vectors"][_id]["metadata"]
+                if not include_type_metadata and TYPE_METADATA_FIELD in metadata:
+                    metadata.pop(TYPE_METADATA_FIELD)
+                meta_matrix.append(self._pinecone_meta_format(metadata))
+                if return_embedding:
+                    embedding_matrix.append(result["vectors"][_id]["values"])
+            if return_embedding:
+                values = embedding_matrix
+            else:
+                values = None
+            document_batch = self._get_documents_by_meta(
+                vector_id_matrix,
+                meta_matrix,
+                values=values,
+                index=index,
+                return_embedding=return_embedding,
+            )
+            documents.extend(document_batch)
+
+        return documents
+
+    def delete_documents(self, document_ids: List[str]) -> None:
+        """
+        Deletes all documents with a matching document_ids from the document store.
+        Fails with `MissingDocumentError` if no document with this id is present in the store.
+
+        :param document_ids: the document_ids to delete
+        """
+        for doc_id in document_ids:
+            msg = f"ID '{doc_id}' not found, cannot delete it."
+            document_ids.remove(doc_id)
+            raise MissingDocumentError(msg)
+
+        index = self._index(self.index)
+        self._index_connection_exists(index)
+
+        if index not in self.all_ids:
+            self.all_ids[index] = set()
+        if document_ids is None:
+            # If no IDs we delete everything
+            self.pinecone_indexes[index].delete(delete_all=True, namespace=self.namespace)
+            id_values = list(self.all_ids[index])
+        else:
+            id_values = document_ids
+            self.pinecone_indexes[index].delete(ids=document_ids, namespace=self.namespace)
+
+        # Remove deleted ids from all_ids
+        self.all_ids[index] = self.all_ids[index].difference(set(id_values))
+
+    def delete_index(self, index: Optional[str]):
+        """
+        Delete an existing index. The index including all data will be removed.
+
+        :param index: The name of the index to delete.
+        :return: None
+        """
+        index = self._index(index)
+
+        if index in pinecone.list_indexes():
+            pinecone.delete_index(index)
+            logger.info("Index '%s' deleted.", index)
+        if index in self.pinecone_indexes:
+            del self.pinecone_indexes[index]
+        if index in self.all_ids:
+            self.all_ids[index] = set()

--- a/document_stores/pinecone/src/pinecone_haystack/document_store.py
+++ b/document_stores/pinecone/src/pinecone_haystack/document_store.py
@@ -11,9 +11,7 @@ from itertools import islice
 from typing import Any, Dict, Generator, List, Literal, Optional, Set, Union
 
 import numpy as np
-from tqdm import tqdm
 import pinecone
-
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores.decorator import document_store
 from haystack.preview.document_stores.errors import (
@@ -21,13 +19,13 @@ from haystack.preview.document_stores.errors import (
     MissingDocumentError,
 )
 from haystack.preview.document_stores.protocols import DuplicatePolicy
+from tqdm import tqdm
 
 from pinecone_haystack.errors import (
     PineconeDocumentStoreError,
     PineconeDocumentStoreFilterError,
 )
 from pinecone_haystack.filter_utils import LogicalFilterClause
-
 
 logger = logging.getLogger(__name__)
 

--- a/document_stores/pinecone/src/pinecone_haystack/document_store.py
+++ b/document_stores/pinecone/src/pinecone_haystack/document_store.py
@@ -641,8 +641,8 @@ class PineconeDocumentStore:
                     self._meta_for_pinecone(
                         {
                             TYPE_METADATA_FIELD: type_metadata,  # add `doc_type` in metadata
-                            "text": doc.text,
-                            "content_type": doc.metadata,
+                            "text": doc.content,
+                            "content_type": doc.meta,
                         }
                     )
                     for doc in documents[i : i + self.batch_size]

--- a/document_stores/pinecone/src/pinecone_haystack/errors.py
+++ b/document_stores/pinecone/src/pinecone_haystack/errors.py
@@ -1,0 +1,10 @@
+from haystack.preview.document_stores.errors import DocumentStoreError
+from haystack.preview.errors import FilterError
+
+
+class PineconeDocumentStoreError(DocumentStoreError):
+    pass
+
+
+class PineconeDocumentStoreFilterError(FilterError):
+    pass

--- a/document_stores/pinecone/src/pinecone_haystack/filter_utils.py
+++ b/document_stores/pinecone/src/pinecone_haystack/filter_utils.py
@@ -1,8 +1,10 @@
 import logging
-from typing import Union, List, Dict
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import Dict, List, Union
+
 from haystack.preview.errors import FilterError
+
 from pinecone_haystack.errors import PineconeDocumentStoreFilterError
 
 logger = logging.getLogger(__file__)
@@ -168,7 +170,7 @@ class ComparisonOperation(ABC):
         elif isinstance(comparison_clause, list):
             comparison_operations.append(InOperation(field_name, comparison_clause))
         else:
-            comparison_operations.append((EqOperation(field_name, comparison_clause)))
+            comparison_operations.append(EqOperation(field_name, comparison_clause))
 
         return comparison_operations
 

--- a/document_stores/pinecone/src/pinecone_haystack/filter_utils.py
+++ b/document_stores/pinecone/src/pinecone_haystack/filter_utils.py
@@ -1,0 +1,435 @@
+import logging
+from typing import Union, List, Dict
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from haystack.errors import FilterError
+from pinecone_haystack.errors import PineconeDocumentStoreFilterError
+
+logger = logging.getLogger(__file__)
+
+
+
+def nested_defaultdict() -> defaultdict:
+    """
+    Data structure that recursively adds a dictionary as value if a key does not exist. Advantage: In nested dictionary
+    structures, we don't need to check if a key already exists (which can become hard to maintain in nested dictionaries
+    with many levels) but access the existing value if a key exists and create an empty dictionary if a key does not
+    exist.
+    """
+    return defaultdict(nested_defaultdict)
+
+
+class LogicalFilterClause(ABC):
+    """
+    Class that is able to parse a filter and convert it to the format that the underlying databases of our
+    DocumentStores require.
+
+    Filters are defined as nested dictionaries. The keys of the dictionaries can be a logical
+    operator (`"$and"`, `"$or"`, `"$not"`), a comparison operator (`"$eq"`, `"$in"`, `"$gt"`, `"$gte"`, `"$lt"`,
+    `"$lte"`) or a metadata field name.
+    Logical operator keys take a dictionary of metadata field names and/or logical operators as
+    value. Metadata field names take a dictionary of comparison operators as value. Comparison
+    operator keys take a single value or (in case of `"$in"`) a list of values as value.
+    If no logical operator is provided, `"$and"` is used as default operation. If no comparison
+    operator is provided, `"$eq"` (or `"$in"` if the comparison value is a list) is used as default
+    operation.
+    Example:
+        ```python
+        filters = {
+            "$and": {
+                "type": {"$eq": "article"},
+                "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"},
+                "rating": {"$gte": 3},
+                "$or": {
+                    "genre": {"$in": ["economy", "politics"]},
+                    "publisher": {"$eq": "nytimes"}
+                }
+            }
+        }
+        # or simpler using default operators
+        filters = {
+            "type": "article",
+            "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"},
+            "rating": {"$gte": 3},
+            "$or": {
+                "genre": ["economy", "politics"],
+                "publisher": "nytimes"
+            }
+        }
+        ```
+
+    To use the same logical operator multiple times on the same level, logical operators take optionally a list of
+    dictionaries as value.
+
+    Example:
+        ```python
+        filters = {
+            "$or": [
+                {
+                    "$and": {
+                        "Type": "News Paper",
+                        "Date": {
+                            "$lt": "2019-01-01"
+                        }
+                    }
+                },
+                {
+                    "$and": {
+                        "Type": "Blog Post",
+                        "Date": {
+                            "$gte": "2019-01-01"
+                        }
+                    }
+                }
+            ]
+        }
+        ```
+
+    """
+
+    def __init__(self, conditions: List[Union["LogicalFilterClause", "ComparisonOperation"]]):
+        self.conditions = conditions
+
+    @abstractmethod
+    def evaluate(self, fields) -> bool:
+        pass
+
+    @classmethod
+    def parse(cls, filter_term: Union[dict, List[dict]]) -> Union["LogicalFilterClause", "ComparisonOperation"]:
+        """
+        Parses a filter dictionary/list and returns a LogicalFilterClause instance.
+
+        :param filter_term: Dictionary or list that contains the filter definition.
+        """
+        conditions: List[Union[LogicalFilterClause, ComparisonOperation]] = []
+
+        if isinstance(filter_term, dict):
+            filter_term = [filter_term]
+        for item in filter_term:
+            for key, value in item.items():
+                if key == "$not":
+                    conditions.append(NotOperation.parse(value))
+                elif key == "$and":
+                    conditions.append(AndOperation.parse(value))
+                elif key == "$or":
+                    conditions.append(OrOperation.parse(value))
+                # Key needs to be a metadata field
+                else:
+                    conditions.extend(ComparisonOperation.parse(key, value))
+
+        if cls == LogicalFilterClause:
+            if len(conditions) == 1:
+                return conditions[0]
+            else:
+                return AndOperation(conditions)
+        else:
+            return cls(conditions)
+
+    def convert_to_pinecone(self):
+        """
+        Converts the LogicalFilterClause instance to a Pinecone filter.
+        """
+        pass
+
+
+
+class ComparisonOperation(ABC):
+    def __init__(self, field_name: str, comparison_value: Union[str, int, float, bool, List]):
+        self.field_name = field_name
+        self.comparison_value = comparison_value
+
+    @abstractmethod
+    def evaluate(self, fields) -> bool:
+        pass
+
+    @classmethod
+    def parse(cls, field_name, comparison_clause: Union[Dict, List, str, float]) -> List["ComparisonOperation"]:
+        comparison_operations: List[ComparisonOperation] = []
+
+        if isinstance(comparison_clause, dict):
+            for comparison_operation, comparison_value in comparison_clause.items():
+                if comparison_operation == "$eq":
+                    comparison_operations.append(EqOperation(field_name, comparison_value))
+                elif comparison_operation == "$in":
+                    comparison_operations.append(InOperation(field_name, comparison_value))
+                elif comparison_operation == "$ne":
+                    comparison_operations.append(NeOperation(field_name, comparison_value))
+                elif comparison_operation == "$nin":
+                    comparison_operations.append(NinOperation(field_name, comparison_value))
+                elif comparison_operation == "$gt":
+                    comparison_operations.append(GtOperation(field_name, comparison_value))
+                elif comparison_operation == "$gte":
+                    comparison_operations.append(GteOperation(field_name, comparison_value))
+                elif comparison_operation == "$lt":
+                    comparison_operations.append(LtOperation(field_name, comparison_value))
+                elif comparison_operation == "$lte":
+                    comparison_operations.append(LteOperation(field_name, comparison_value))
+
+        # No comparison operator is given, so we use the default operators "$in" if the comparison value is a list and
+        # "$eq" in every other case
+        elif isinstance(comparison_clause, list):
+            comparison_operations.append(InOperation(field_name, comparison_clause))
+        else:
+            comparison_operations.append((EqOperation(field_name, comparison_clause)))
+
+        return comparison_operations
+
+    def convert_to_pinecone(self):
+        """
+        Converts the ComparisonOperation instance to a Pinecone comparison operator.
+        """
+        pass
+
+    def invert(self) -> "ComparisonOperation":
+        """
+        Inverts the ComparisonOperation.
+        Necessary for Weaviate as Weaviate doesn't seem to support the 'Not' operator anymore.
+        (https://github.com/semi-technologies/weaviate/issues/1717)
+        """
+        pass
+
+
+
+
+class NotOperation(LogicalFilterClause):
+    """
+    Handles conversion of logical 'NOT' operations.
+    """
+
+    def evaluate(self, fields) -> bool:
+        return not any(condition.evaluate(fields) for condition in self.conditions)
+
+    def convert_to_pinecone(self) -> Dict[str, Union[str, int, float, bool, List[Dict]]]:
+        conditions = [condition.invert().convert_to_pinecone() for condition in self.conditions]
+        if len(conditions) > 1:
+            # Conditions in self.conditions are by default combined with AND which becomes OR according to DeMorgan
+            return {"$or": conditions}
+        else:
+            return conditions[0]
+
+    def invert(self) -> Union[LogicalFilterClause, ComparisonOperation]:
+        # This method is called when a "$not" operation is embedded in another "$not" operation. Therefore, we don't
+        # invert the operations here, as two "$not" operation annihilate each other.
+        # (If we have more than one condition, we return an AndOperation, the default logical operation for combining
+        # multiple conditions.)
+        if len(self.conditions) > 1:
+            return AndOperation(self.conditions)
+        else:
+            return self.conditions[0]
+
+
+class AndOperation(LogicalFilterClause):
+    """
+    Handles conversion of logical 'AND' operations.
+    """
+
+    def evaluate(self, fields) -> bool:
+        return all(condition.evaluate(fields) for condition in self.conditions)
+
+    def convert_to_pinecone(self) -> Dict[str, Union[str, List[Dict]]]:
+        conditions = [condition.convert_to_pinecone() for condition in self.conditions]
+        return {"$and": conditions}
+
+    def invert(self) -> "OrOperation":
+        return OrOperation([condition.invert() for condition in self.conditions])
+
+
+class OrOperation(LogicalFilterClause):
+    """
+    Handles conversion of logical 'OR' operations.
+    """
+
+    def evaluate(self, fields) -> bool:
+        return any(condition.evaluate(fields) for condition in self.conditions)
+
+    def convert_to_pinecone(self) -> Dict[str, Union[str, List[Dict]]]:
+        conditions = [condition.convert_to_pinecone() for condition in self.conditions]
+        return {"$or": conditions}
+
+    def invert(self) -> AndOperation:
+        return AndOperation([condition.invert() for condition in self.conditions])
+
+
+class EqOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$eq' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return False
+        return fields[self.field_name] == self.comparison_value
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, Union[List[str], str, int, float, bool]]]:
+        return {self.field_name: {"$eq": self.comparison_value}}
+
+    def invert(self) -> "NeOperation":
+        return NeOperation(self.field_name, self.comparison_value)
+
+
+class InOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$in' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return False
+
+        if not isinstance(self.comparison_value, list):
+            raise PineconeDocumentStoreFilterError("'$in' operation requires comparison value to be a list.")
+
+        # If the document field is a list, check if any of its values are in the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field in self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] in self.comparison_value
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, List]]:
+        if not isinstance(self.comparison_value, list):
+            raise PineconeDocumentStoreFilterError("'$in' operation requires comparison value to be a list.")
+        return {self.field_name: {"$in": self.comparison_value}}
+
+    def invert(self) -> "NinOperation":
+        return NinOperation(self.field_name, self.comparison_value)
+
+
+class NeOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$ne' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return False
+        return fields[self.field_name] != self.comparison_value
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, Union[List[str], str, int, float, bool]]]:
+        return {self.field_name: {"$ne": self.comparison_value}}
+
+    def invert(self) -> "EqOperation":
+        return EqOperation(self.field_name, self.comparison_value)
+
+
+class NinOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$nin' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return True
+
+        if not isinstance(self.comparison_value, list):
+            raise PineconeDocumentStoreFilterError("'$nin' operation requires comparison value to be a list.")
+
+        # If the document field is a list, check if any of its values are in the comparison value
+        if isinstance(fields[self.field_name], list):
+            return not any(field in self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] not in self.comparison_value
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, List]]:
+        if not isinstance(self.comparison_value, list):
+            raise PineconeDocumentStoreFilterError("'$in' operation requires comparison value to be a list.")
+        return {self.field_name: {"$nin": self.comparison_value}}
+
+    def invert(self) -> "InOperation":
+        return InOperation(self.field_name, self.comparison_value)
+
+
+class GtOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$gt' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return False
+
+        # If the document field is a list, check if any of its values are greater than the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field > self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] > self.comparison_value
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, Union[float, int]]]:
+        if not isinstance(self.comparison_value, (float, int)):
+            raise PineconeDocumentStoreFilterError("Comparison value for '$gt' operation must be a float or int.")
+        return {self.field_name: {"$gt": self.comparison_value}}
+
+    def invert(self) -> "LteOperation":
+        return LteOperation(self.field_name, self.comparison_value)
+
+
+class GteOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$gte' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return False
+
+        # If the document field is a list, check if any of its values are greater than or equal to the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field >= self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] >= self.comparison_value
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, Union[float, int]]]:
+        if not isinstance(self.comparison_value, (float, int)):
+            raise PineconeDocumentStoreFilterError("Comparison value for '$gte' operation must be a float or int.")
+        return {self.field_name: {"$gte": self.comparison_value}}
+
+    def invert(self) -> "LtOperation":
+        return LtOperation(self.field_name, self.comparison_value)
+
+
+class LtOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$lt' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return False
+
+        # If the document field is a list, check if any of its values are less than the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field < self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] < self.comparison_value
+
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, Union[float, int]]]:
+        if not isinstance(self.comparison_value, (float, int)):
+            raise PineconeDocumentStoreFilterError("Comparison value for '$lt' operation must be a float or int.")
+        return {self.field_name: {"$lt": self.comparison_value}}
+
+    def invert(self) -> "GteOperation":
+        return GteOperation(self.field_name, self.comparison_value)
+
+
+class LteOperation(ComparisonOperation):
+    """
+    Handles conversion of the '$lte' comparison operation.
+    """
+
+    def evaluate(self, fields) -> bool:
+        if self.field_name not in fields:
+            return False
+
+        # If the document field is a list, check if any of its values are less than or equal to the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field <= self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] <= self.comparison_value
+
+    def convert_to_pinecone(self) -> Dict[str, Dict[str, Union[float, int]]]:
+        if not isinstance(self.comparison_value, (float, int)):
+            raise PineconeDocumentStoreFilterError("Comparison value for '$lte' operation must be a float or int.")
+        return {self.field_name: {"$lte": self.comparison_value}}
+
+    def invert(self) -> "GtOperation":
+        return GtOperation(self.field_name, self.comparison_value)

--- a/document_stores/pinecone/src/pinecone_haystack/filter_utils.py
+++ b/document_stores/pinecone/src/pinecone_haystack/filter_utils.py
@@ -2,11 +2,10 @@ import logging
 from typing import Union, List, Dict
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from haystack.errors import FilterError
+from haystack.preview.errors import FilterError
 from pinecone_haystack.errors import PineconeDocumentStoreFilterError
 
 logger = logging.getLogger(__file__)
-
 
 
 def nested_defaultdict() -> defaultdict:
@@ -132,7 +131,6 @@ class LogicalFilterClause(ABC):
         pass
 
 
-
 class ComparisonOperation(ABC):
     def __init__(self, field_name: str, comparison_value: Union[str, int, float, bool, List]):
         self.field_name = field_name
@@ -187,8 +185,6 @@ class ComparisonOperation(ABC):
         (https://github.com/semi-technologies/weaviate/issues/1717)
         """
         pass
-
-
 
 
 class NotOperation(LogicalFilterClause):
@@ -400,7 +396,6 @@ class LtOperation(ComparisonOperation):
             return any(field < self.comparison_value for field in fields[self.field_name])
 
         return fields[self.field_name] < self.comparison_value
-
 
     def convert_to_pinecone(self) -> Dict[str, Dict[str, Union[float, int]]]:
         if not isinstance(self.comparison_value, (float, int)):

--- a/document_stores/pinecone/src/pinecone_haystack/retriever.py
+++ b/document_stores/pinecone/src/pinecone_haystack/retriever.py
@@ -1,16 +1,17 @@
 # SPDX-FileCopyrightText: 2023-present John Doe <jd@example.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional
 
 from haystack.preview import (
-    component,
-    Document,
-    default_to_dict,
-    default_from_dict,
     DeserializationError,
+    Document,
+    component,
+    default_from_dict,
+    default_to_dict,
 )
 from haystack.preview.dataclasses import Document
+
 from pinecone_haystack.document_store import PineconeDocumentStore
 
 

--- a/document_stores/pinecone/src/pinecone_haystack/retriever.py
+++ b/document_stores/pinecone/src/pinecone_haystack/retriever.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2023-present John Doe <jd@example.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict, List, Any, Optional
+
+from haystack.preview import (
+    component,
+    Document,
+    default_to_dict,
+    default_from_dict,
+    DeserializationError,
+)
+from haystack.preview.dataclasses import Document
+from pinecone_haystack.document_store import PineconeDocumentStore
+
+
+@component
+class PineconeRetriever:
+    """
+    A component for retrieving documents from an PineconeDocumentStore using a vector similarity metric.
+
+    Needs to be connected to a PineconeDocumentStore to run.
+    """
+
+    def __init__(
+        self,
+        document_store: PineconeDocumentStore,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        scale_score: bool = True,
+        return_embedding: bool = False,
+    ):
+        """
+        Create a PineconeRetriever component.
+
+        :param document_store: An instance of PineconeDocumentStore.
+        :param filters: A dictionary with filters to narrow down the search space. Default is None.
+        :param top_k: The maximum number of documents to retrieve. Default is 10.
+        :param scale_score: Whether to scale the scores of the retrieved documents or not. Default is True.
+        :param return_embedding: Whether to return the embedding of the retrieved Documents. Default is False.
+
+        :raises ValueError: If the specified top_k is not > 0.
+        """
+        if not isinstance(document_store, PineconeDocumentStore):
+            raise ValueError("document_store must be an instance of PineconeDocumentStore")
+
+        self.document_store = document_store
+
+        if top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
+        self.filters = filters
+        self.top_k = top_k
+        self.scale_score = scale_score
+        self.return_embedding = return_embedding
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        docstore = self.document_store.to_dict()
+        return default_to_dict(
+            self,
+            document_store=docstore,
+            filters=self.filters,
+            top_k=self.top_k,
+            scale_score=self.scale_score,
+            return_embedding=self.return_embedding,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PineconeRetriever":
+        """
+        Deserialize this component from a dictionary.
+        """
+        init_params = data.get("init_parameters", {})
+        if "document_store" not in init_params:
+            raise DeserializationError("Missing 'document_store' in serialization data")
+        if "type" not in init_params["document_store"]:
+            raise DeserializationError("Missing 'type' in document store's serialization data")
+        if init_params["document_store"]["type"] not in document_store.registry:
+            raise DeserializationError(f"DocumentStore type '{init_params['document_store']['type']}' not found")
+
+        docstore_class = document_store.registry[init_params["document_store"]["type"]]
+        docstore = docstore_class.from_dict(init_params["document_store"])
+        data["init_parameters"]["document_store"] = docstore
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        scale_score: Optional[bool] = None,
+        return_embedding: Optional[bool] = None,
+    ):
+        """
+        Run the Embedding Retriever on the given input data.
+
+        :param query_embedding: Embedding of the query.
+        :param filters: A dictionary with filters to narrow down the search space.
+        :param top_k: The maximum number of documents to return.
+        :param scale_score: Whether to scale the scores of the retrieved documents or not.
+        :param return_embedding: Whether to return the embedding of the retrieved Documents.
+        :return: The retrieved documents.
+
+        :raises ValueError: If the specified DocumentStore is not found or is not a MemoryDocumentStore instance.
+        """
+        if filters is None:
+            filters = self.filters
+        if top_k is None:
+            top_k = self.top_k
+        if scale_score is None:
+            scale_score = self.scale_score
+        if return_embedding is None:
+            return_embedding = self.return_embedding
+
+        docs = self.document_store.query_by_embedding(
+            query_embedding=query_embedding,
+            filters=filters,
+            top_k=top_k,
+            scale_score=scale_score,
+            return_embedding=return_embedding,
+        )
+
+        return {"documents": docs}

--- a/document_stores/pinecone/tests/__init__.py
+++ b/document_stores/pinecone/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present John Doe <jd@example.com>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/document_stores/pinecone/tests/pinecone_mock.py
+++ b/document_stores/pinecone/tests/pinecone_mock.py
@@ -1,7 +1,5 @@
-from typing import Optional, List, Union, Dict, Any
-
 import logging
-
+from typing import Any, Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +144,7 @@ class Index:
                 }
         return response
 
-    def _filter(  # noqa: C901,PLR0912
+    def _filter(
         self,
         metadata: dict,
         filters: Dict[str, Any] = None,

--- a/document_stores/pinecone/tests/pinecone_mock.py
+++ b/document_stores/pinecone/tests/pinecone_mock.py
@@ -1,0 +1,331 @@
+from typing import Optional, List, Union, Dict, Any
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+# Mock Pinecone instance
+CONFIG: dict = {"api_key": None, "environment": None, "indexes": {}}
+
+
+# Mock Pinecone Index instance
+class IndexObject:
+    def __init__(
+        self,
+        index: str,
+        api_key: Optional[str] = None,
+        environment: Optional[str] = None,
+        dimension: Optional[int] = None,
+        metric: Optional[str] = None,
+        replicas: Optional[int] = None,
+        shards: Optional[int] = None,
+        metadata_config: Optional[dict] = None,
+    ):
+        self.index = index
+        self.api_key = api_key
+        self.environment = environment
+        self.dimension = dimension
+        self.metric = metric
+        self.replicas = replicas
+        self.shards = shards
+        self.metadata_config = metadata_config
+        self.namespaces: dict = {}
+
+
+# Mock the Pinecone Index class
+class Index:
+    def __init__(self, index: str):
+        self.index = index
+        self.index_config = CONFIG["indexes"][index]
+
+    def upsert(self, vectors: List[tuple], namespace: str = ""):
+        if namespace not in self.index_config.namespaces:
+            self.index_config.namespaces[namespace] = {}
+        upsert_count = 0
+        for record in vectors:
+            # Extract info from tuple
+            _id = record[0]
+            vector = record[1]
+            metadata = record[2]
+            # Checks
+            assert type(_id) is str
+            assert type(vector) is list
+            assert len(vector) == self.index_config.dimension
+            assert type(metadata) is dict
+            # Create record (eg document)
+            new_record: dict = {"id": _id, "values": vector, "metadata": metadata}
+            self.index_config.namespaces[namespace][_id] = new_record
+            upsert_count += 1
+        return {"upserted_count": upsert_count}
+
+    def update(self, namespace: str, id: str, set_metadata: dict):
+        # Get existing item metadata
+        meta = self.index_config.namespaces[namespace][id]["metadata"]
+        # Add new metadata to existing item metadata
+        self.index_config.namespaces[namespace][id]["metadata"] = {**meta, **set_metadata}
+
+    def describe_index_stats(self, filter=None):
+        namespaces = {}
+        for namespace in self.index_config.namespaces.items():
+            records = self.index_config.namespaces[namespace[0]]
+            if filter:
+                filtered_records = []
+                for record in records.values():
+                    if self._filter(metadata=record["metadata"], filters=filter, top_level=True):
+                        filtered_records.append(record)
+                records = filtered_records
+            namespaces[namespace[0]] = {"vector_count": len(records)}
+        return {"dimension": self.index_config.dimension, "index_fullness": 0.0, "namespaces": namespaces}
+
+    def query(
+        self,
+        vector: List[float],
+        top_k: int,
+        namespace: str = "",
+        include_values: bool = False,
+        include_metadata: bool = False,
+        filter: Optional[dict] = None,
+    ):
+        return self.query_filter(
+            vector=vector,
+            top_k=top_k,
+            namespace=namespace,
+            include_values=include_values,
+            include_metadata=include_metadata,
+            filter=filter,
+        )
+
+    def query_filter(
+        self,
+        vector: List[float],
+        top_k: int,
+        namespace: str = "",
+        include_values: bool = False,
+        include_metadata: bool = False,
+        filter: Optional[dict] = None,
+    ):
+        assert len(vector) == self.index_config.dimension
+        response: dict = {"matches": []}
+        if namespace not in self.index_config.namespaces:
+            return response
+        else:
+            records = self.index_config.namespaces[namespace]
+            namespace_ids = list(records.keys())[:top_k]
+
+            for _id in namespace_ids:
+                match = {"id": _id}
+                if include_values:
+                    match["values"] = records[_id]["values"].copy()
+                if include_metadata:
+                    match["metadata"] = records[_id]["metadata"].copy()
+                match["score"] = 0.0
+
+                if filter is None or (
+                    filter is not None and self._filter(records[_id]["metadata"], filter, top_level=True)
+                ):
+                    # filter if needed
+                    response["matches"].append(match)
+            return response
+
+    def fetch(self, ids: List[str], namespace: str = ""):
+        response: dict = {"namespace": namespace, "vectors": {}}
+        if namespace not in self.index_config.namespaces:
+            # If we query an empty/non-existent namespace, Pinecone will just return an empty response
+            logger.warning("No namespace called '%s'", namespace)
+            return response
+        records = self.index_config.namespaces[namespace]
+        namespace_ids = records.keys()
+        for _id in namespace_ids:
+            if _id in ids.copy():
+                response["vectors"][_id] = {
+                    "id": _id,
+                    "metadata": records[_id]["metadata"].copy(),
+                    "values": records[_id]["values"].copy(),
+                }
+        return response
+
+    def _filter(  # noqa: C901,PLR0912
+        self,
+        metadata: dict,
+        filters: Dict[str, Any] = None,
+        mode: Optional[str] = "$and",
+        top_level=False,
+    ) -> dict:
+        """
+        Mock filtering function
+        """
+        # This function has a very high McCabe cyclomatic complexity score of 38
+        # (recommended is 10) and contains 55 branches (recommended is 12).
+        bools = []
+        if type(filters) is list:
+            list_bools = []
+            for _filter in filters:
+                res = self._filter(metadata, _filter, mode=mode)
+                for key, value in res.items():
+                    if key == "$and":
+                        list_bools.append(all(value))
+                    else:
+                        list_bools.append(any(value))
+            if mode == "$and":
+                bools.append(all(list_bools))
+            elif mode == "$or":
+                bools.append(any(list_bools))
+        else:
+            for field, potential_value in filters.items():
+                if field in ["$and", "$or"]:
+                    bools.append(self._filter(metadata, potential_value, mode=field))
+                    mode = field
+                    cond = field
+                else:
+                    if type(potential_value) is dict:
+                        sub_bool = []
+                        for cond, value in potential_value.items():
+                            if len(potential_value.keys()) > 1:
+                                sub_filter = {field: {cond: value}}
+                                bools.append(self._filter(metadata, sub_filter))
+                        if len(sub_bool) > 1:
+                            if field == "$or":
+                                bools.append(any(sub_bool))
+                            else:
+                                bools.append(all(sub_bool))
+                    elif type(potential_value) is list:
+                        cond = "$in"
+                        value = potential_value
+                    else:
+                        cond = "$eq"
+                        value = potential_value
+                    # main chunk of condition checks
+                    if cond == "$eq":
+                        if field in metadata and metadata[field] == value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+                    elif cond == "$ne":
+                        if field in metadata and metadata[field] != value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+                    elif cond == "$in":
+                        if field in metadata and metadata[field] in value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+                    elif cond == "$nin":
+                        if field in metadata and metadata[field] not in value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+                    elif cond == "$gt":
+                        if field in metadata and metadata[field] > value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+                    elif cond == "$lt":
+                        if field in metadata and metadata[field] < value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+                    elif cond == "$gte":
+                        if field in metadata and metadata[field] >= value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+                    elif cond == "$lte":
+                        if field in metadata and metadata[field] <= value:
+                            bools.append(True)
+                        else:
+                            bools.append(False)
+        if top_level:
+            final = []
+            for item in bools:
+                if type(item) is dict:
+                    for key, value in item.items():
+                        if key == "$and":
+                            final.append(all(value))
+                        else:
+                            final.append(any(value))
+                else:
+                    final.append(item)
+            if mode == "$and":
+                bools = all(final)
+            else:
+                bools = any(final)
+        else:
+            if mode == "$and":
+                return {"$and": bools}
+            else:
+                return {"$or": bools}
+        return bools
+
+    def delete(
+        self,
+        ids: Optional[List[str]] = None,
+        namespace: str = "",
+        filters: Dict[str, Any] = None,
+        delete_all: bool = False,
+    ):
+        if filters:
+            # Get a filtered list of IDs
+            matches = self.query(filters=filters, namespace=namespace, include_values=False, include_metadata=False)[
+                "vectors"
+            ]
+            filter_ids: List[str] = matches.keys()  # .keys() returns an object that supports set operators already
+        elif delete_all:
+            self.index_config.namespaces[namespace] = {}
+
+        if namespace not in self.index_config.namespaces:
+            pass
+        elif ids is not None:
+            id_list: List[str] = ids
+            if filters:
+                # We find the intersect between the IDs and filtered IDs
+                id_list = set(id_list).intersection(filter_ids)
+            records = self.index_config.namespaces[namespace]
+            for _id in list(records.keys()):  # list() is needed to be able to del below
+                if _id in id_list:
+                    del records[_id]
+        else:
+            # Delete all
+            self.index_config.namespaces[namespace] = {}
+        return {}
+
+    def _get_config(self):
+        return self.index_config
+
+
+# Mock core Pinecone client functions
+def init(api_key: Optional[str] = None, environment: Optional[str] = None):
+    CONFIG["api_key"] = api_key
+    CONFIG["environment"] = environment
+    CONFIG["indexes"] = {}
+
+
+def list_indexes():
+    return list(CONFIG["indexes"].keys())
+
+
+def create_index(
+    name: str,
+    dimension: int,
+    metric: str = "cosine",
+    replicas: int = 1,
+    shards: int = 1,
+    metadata_config: Optional[dict] = None,
+):
+    index_object = IndexObject(
+        api_key=CONFIG["api_key"],
+        environment=CONFIG["environment"],
+        index=name,
+        dimension=dimension,
+        metric=metric,
+        replicas=replicas,
+        shards=shards,
+        metadata_config=metadata_config,
+    )
+    CONFIG["indexes"][name] = index_object
+
+
+def delete_index(index: str):
+    del CONFIG["indexes"][index]

--- a/document_stores/pinecone/tests/test_pinecone_document_store.py
+++ b/document_stores/pinecone/tests/test_pinecone_document_store.py
@@ -16,7 +16,7 @@ from tests import pinecone_mock
 import pinecone
 
 
-class TestPineconeDocumentStore:
+class TestPineconeDocumentStore(DocumentStoreBaseTests):
     @pytest.fixture
     def ds(self, monkeypatch, request) -> PineconeDocumentStore:
         """

--- a/document_stores/pinecone/tests/test_pinecone_document_store.py
+++ b/document_stores/pinecone/tests/test_pinecone_document_store.py
@@ -15,13 +15,14 @@ from haystack.preview.testing.document_store import DocumentStoreBaseTests
 from tests import pinecone_mock
 import pinecone
 
+
 class TestPineconeDocumentStore:
     @pytest.fixture
     def ds(self, monkeypatch, request) -> PineconeDocumentStore:
         """
         This fixture provides an empty document store and takes care of cleaning up after each test
         """
-    
+
         for fname, function in getmembers(pinecone_mock, isfunction):
             monkeypatch.setattr(f"pinecone.{fname}", function, raising=False)
         for cname, class_ in getmembers(pinecone_mock, isclass):
@@ -41,41 +42,42 @@ class TestPineconeDocumentStore:
         """
         This fixture provides a pre-populated document store and takes care of cleaning up after each test
         """
-        documents = [Document(
-                text="Lloyds to cut 945 jobs as part of 3-year restructuring plan, Last month we added to our $GILD position and started a new one in $BWLD We see slow, steady, unspectacular growth going forward near term. Lloyds Banking Group's share price lifts amid reports bank is poised to axe hundreds of UK jobs",
-                metadata={
+        documents = [
+            Document(
+                content="Lloyds to cut 945 jobs as part of 3-year restructuring plan, Last month we added to our $GILD position and started a new one in $BWLD We see slow, steady, unspectacular growth going forward near term. Lloyds Banking Group's share price lifts amid reports bank is poised to axe hundreds of UK jobs",
+                meta={
                     "target": "Lloyds",
                     "sentiment_score": -0.532,
                     "format": "headline",
                 },
             ),
             Document(
-                text="FTSE 100 drops 2.5 pct on Glencore, metals price fears. Glencore sees Tripoli-based NOC as sole legal seller of Libyan oil. Glencore Studies Possible IPO for Agricultural Trading Business. Glencore chief blames rivals' overproduction for share price fall.",
-                metadata={
+                content="FTSE 100 drops 2.5 pct on Glencore, metals price fears. Glencore sees Tripoli-based NOC as sole legal seller of Libyan oil. Glencore Studies Possible IPO for Agricultural Trading Business. Glencore chief blames rivals' overproduction for share price fall.",
+                meta={
                     "target": "Glencore",
                     "sentiment_score": 0.037,
                     "format": "headline",
                 },
             ),
             Document(
-                text="Shell's $70 Billion BG Deal Meets Shareholder Skepticism. Shell and BG Shareholders to Vote on Deal at End of January. EU drops Shell, BP, Statoil from ethanol benchmark investigation. Shell challenges Exxon dominance with 47 billion-pound bid for BG",
-                metadata={
+                content="Shell's $70 Billion BG Deal Meets Shareholder Skepticism. Shell and BG Shareholders to Vote on Deal at End of January. EU drops Shell, BP, Statoil from ethanol benchmark investigation. Shell challenges Exxon dominance with 47 billion-pound bid for BG",
+                meta={
                     "target": "Shell",
                     "sentiment_score": -0.345,
                     "format": "headline",
                 },
             ),
             Document(
-                text="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
-                metadata={
+                content="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
+                meta={
                     "target": "TSLA",
                     "sentiment_score": 0.318,
                     "format": "post",
                 },
             ),
             Document(
-                text="HSBC appoints business leaders to board. HSBC Says Unit to Book $585 Million Charge on Settlement. HSBC Hit by Fresh Details of Tax Evasion Claims. HSBC Hit by Fresh Details of Tax Evasion Claims. Goldman Sachs, Barclays, HSBC downplay Brexit threat.",
-                metadata={
+                content="HSBC appoints business leaders to board. HSBC Says Unit to Book $585 Million Charge on Settlement. HSBC Hit by Fresh Details of Tax Evasion Claims. HSBC Hit by Fresh Details of Tax Evasion Claims. Goldman Sachs, Barclays, HSBC downplay Brexit threat.",
+                meta={
                     "target": "HSBC",
                     "sentiment_score": 0.154,
                     "format": "post",
@@ -83,13 +85,13 @@ class TestPineconeDocumentStore:
             ),
             # Without meta
             Document(
-                text="Aspen to Buy Anaesthetics From AstraZeneca for $520 Million. AstraZeneca wins FDA approval for key new lung cancer pill. AstraZeneca boosts respiratory unit with $575 mln Takeda deal. AstraZeneca Acquires ZS Pharma in $2.7 Billion Deal."
+                content="Aspen to Buy Anaesthetics From AstraZeneca for $520 Million. AstraZeneca wins FDA approval for key new lung cancer pill. AstraZeneca boosts respiratory unit with $575 mln Takeda deal. AstraZeneca Acquires ZS Pharma in $2.7 Billion Deal."
             ),
             Document(
-                text="Anheuser-Busch InBev Increases Offer for Rival SABMiller. Australia clears AB Inbev's $100 billion SABMiller buyout plan.Australia clears AB Inbev's $100 billion SABMiller buyout plan."
+                content="Anheuser-Busch InBev Increases Offer for Rival SABMiller. Australia clears AB Inbev's $100 billion SABMiller buyout plan.Australia clears AB Inbev's $100 billion SABMiller buyout plan."
             ),
             Document(
-                text="The Coca-Cola Company and Coca-Cola FEMSA to Acquire AdeS Soy-Based Beverage Business From Unilever."
+                content="The Coca-Cola Company and Coca-Cola FEMSA to Acquire AdeS Soy-Based Beverage Business From Unilever."
             ),
         ]
         ds.write_documents(documents)
@@ -110,40 +112,40 @@ class TestPineconeDocumentStore:
         return [
             # Document object
             Document(
-                text="Lloyds to cut 945 jobs as part of 3-year restructuring plan, Last month we added to our $GILD position and started a new one in $BWLD We see slow, steady, unspectacular growth going forward near term. Lloyds Banking Group's share price lifts amid reports bank is poised to axe hundreds of UK jobs",
-                metadata={
+                content="Lloyds to cut 945 jobs as part of 3-year restructuring plan, Last month we added to our $GILD position and started a new one in $BWLD We see slow, steady, unspectacular growth going forward near term. Lloyds Banking Group's share price lifts amid reports bank is poised to axe hundreds of UK jobs",
+                meta={
                     "target": "Lloyds",
                     "sentiment_score": -0.532,
                     "format": "headline",
                 },
             ),
             Document(
-                text="FTSE 100 drops 2.5 pct on Glencore, metals price fears. Glencore sees Tripoli-based NOC as sole legal seller of Libyan oil. Glencore Studies Possible IPO for Agricultural Trading Business. Glencore chief blames rivals' overproduction for share price fall.",
-                metadata={
+                content="FTSE 100 drops 2.5 pct on Glencore, metals price fears. Glencore sees Tripoli-based NOC as sole legal seller of Libyan oil. Glencore Studies Possible IPO for Agricultural Trading Business. Glencore chief blames rivals' overproduction for share price fall.",
+                meta={
                     "target": "Glencore",
                     "sentiment_score": 0.037,
                     "format": "headline",
                 },
             ),
             Document(
-                text="Shell's $70 Billion BG Deal Meets Shareholder Skepticism. Shell and BG Shareholders to Vote on Deal at End of January. EU drops Shell, BP, Statoil from ethanol benchmark investigation. Shell challenges Exxon dominance with 47 billion-pound bid for BG",
-                metadata={
+                content="Shell's $70 Billion BG Deal Meets Shareholder Skepticism. Shell and BG Shareholders to Vote on Deal at End of January. EU drops Shell, BP, Statoil from ethanol benchmark investigation. Shell challenges Exxon dominance with 47 billion-pound bid for BG",
+                meta={
                     "target": "Shell",
                     "sentiment_score": -0.345,
                     "format": "headline",
                 },
             ),
             Document(
-                text="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
-                metadata={
+                content="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
+                meta={
                     "target": "TSLA",
                     "sentiment_score": 0.318,
                     "format": "post",
                 },
             ),
             Document(
-                text="HSBC appoints business leaders to board. HSBC Says Unit to Book $585 Million Charge on Settlement. HSBC Hit by Fresh Details of Tax Evasion Claims. HSBC Hit by Fresh Details of Tax Evasion Claims. Goldman Sachs, Barclays, HSBC downplay Brexit threat.",
-                metadata={
+                content="HSBC appoints business leaders to board. HSBC Says Unit to Book $585 Million Charge on Settlement. HSBC Hit by Fresh Details of Tax Evasion Claims. HSBC Hit by Fresh Details of Tax Evasion Claims. Goldman Sachs, Barclays, HSBC downplay Brexit threat.",
+                meta={
                     "target": "HSBC",
                     "sentiment_score": 0.154,
                     "format": "post",
@@ -151,26 +153,25 @@ class TestPineconeDocumentStore:
             ),
             # Without meta
             Document(
-                text="Aspen to Buy Anaesthetics From AstraZeneca for $520 Million. AstraZeneca wins FDA approval for key new lung cancer pill. AstraZeneca boosts respiratory unit with $575 mln Takeda deal. AstraZeneca Acquires ZS Pharma in $2.7 Billion Deal."
+                content="Aspen to Buy Anaesthetics From AstraZeneca for $520 Million. AstraZeneca wins FDA approval for key new lung cancer pill. AstraZeneca boosts respiratory unit with $575 mln Takeda deal. AstraZeneca Acquires ZS Pharma in $2.7 Billion Deal."
             ),
             Document(
-                text="Anheuser-Busch InBev Increases Offer for Rival SABMiller. Australia clears AB Inbev's $100 billion SABMiller buyout plan.Australia clears AB Inbev's $100 billion SABMiller buyout plan."
+                content="Anheuser-Busch InBev Increases Offer for Rival SABMiller. Australia clears AB Inbev's $100 billion SABMiller buyout plan.Australia clears AB Inbev's $100 billion SABMiller buyout plan."
             ),
             Document(
-                text="The Coca-Cola Company and Coca-Cola FEMSA to Acquire AdeS Soy-Based Beverage Business From Unilever."
+                content="The Coca-Cola Company and Coca-Cola FEMSA to Acquire AdeS Soy-Based Beverage Business From Unilever."
             ),
         ]
-    
+
     @pytest.mark.integration
     def test_ne_filters(self, ds, documents):
         ds.write_documents(documents)
 
         result = ds.get_filter_documents(filters={"format": {"$ne": "headline"}})
-        assert len(result) == 2    
+        assert len(result) == 2
 
     @pytest.mark.integration
     def test_filter_documents_with_extended_filter_eq(self, doc_store_with_docs: PineconeDocumentStore):
-
         eq_docs = doc_store_with_docs.filter_documents(filters={"type": {"$eq": "article"}})
         normal_docs = doc_store_with_docs.filter_documents(filters={"type": "article"})
         assert eq_docs == normal_docs
@@ -183,17 +184,17 @@ class TestPineconeDocumentStore:
     @pytest.mark.integration
     def test_filter_documents_extended_filter_nin(self, doc_store_with_docs: PineconeDocumentStore):
         retrieved_docs = doc_store_with_docs.filter_documents(filters={"format": {"$nin": ["target", "post"]}})
-        assert {"target", "post"}.isdisjoint({d.metadata.get("metadata", None) for d in retrieved_docs})
+        assert {"target", "post"}.isdisjoint({d.meta.get("metadata", None) for d in retrieved_docs})
 
     @pytest.mark.integration
     def test_filter_documents_extended_filter_gt(self, doc_store_with_docs: PineconeDocumentStore):
         retrieved_docs = doc_store_with_docs.filter_documents(filters={"sentiment_score": {"$gt": 3.0}})
-        assert all(d.metadata["sentiment_score"] > 3.0 for d in retrieved_docs)
+        assert all(d.meta["sentiment_score"] > 3.0 for d in retrieved_docs)
 
     @pytest.mark.integration
     def test_filter_documents_extended_filter_gte(self, doc_store_with_docs: PineconeDocumentStore):
         retrieved_docs = doc_store_with_docs.filter_documents(filters={"sentiment_score": {"$gte": 3.0}})
-        assert all(d.metadata["sentiment_score"] >= 3.0 for d in retrieved_docs)
+        assert all(d.meta["sentiment_score"] >= 3.0 for d in retrieved_docs)
 
     @pytest.mark.integration
     def test_filter_documents_extended_filter_compound_and_other_field_simplified(
@@ -326,9 +327,8 @@ class TestPineconeDocumentStore:
         embeddings.
         """
         doc = Document(
-            text="Doc with embedding",
+            content="Doc with embedding",
             embedding=np.random.rand(768).astype(np.float32),
         )
         doc_store_with_docs.write_documents([doc])
         assert doc_store_with_docs.get_embedding_count() == 1
-

--- a/document_stores/pinecone/tests/test_pinecone_document_store.py
+++ b/document_stores/pinecone/tests/test_pinecone_document_store.py
@@ -1,0 +1,334 @@
+import os
+from inspect import getmembers, isclass, isfunction
+from typing import Any, Dict, List, Union
+from unittest.mock import MagicMock
+import numpy as np
+import pytest
+
+from pinecone_haystack.document_store import PineconeDocumentStore
+from pinecone_haystack.errors import (
+    PineconeDocumentStoreError,
+    PineconeDocumentStoreFilterError,
+)
+from haystack.preview.dataclasses import Document
+from haystack.preview.testing.document_store import DocumentStoreBaseTests
+from tests import pinecone_mock
+import pinecone
+
+class TestPineconeDocumentStore:
+    @pytest.fixture
+    def ds(self, monkeypatch, request) -> PineconeDocumentStore:
+        """
+        This fixture provides an empty document store and takes care of cleaning up after each test
+        """
+    
+        for fname, function in getmembers(pinecone_mock, isfunction):
+            monkeypatch.setattr(f"pinecone.{fname}", function, raising=False)
+        for cname, class_ in getmembers(pinecone_mock, isclass):
+            monkeypatch.setattr(f"pinecone.{cname}", class_, raising=False)
+
+        return PineconeDocumentStore(
+            api_key=os.environ.get("PINECONE_API_KEY") or "pinecone-test-key",
+            embedding_dim=768,
+            embedding_field="embedding",
+            index="haystack_tests",
+            similarity="cosine",
+            recreate_index=True,
+        )
+
+    @pytest.fixture
+    def doc_store_with_docs(self, ds: PineconeDocumentStore) -> PineconeDocumentStore:
+        """
+        This fixture provides a pre-populated document store and takes care of cleaning up after each test
+        """
+        documents = [Document(
+                text="Lloyds to cut 945 jobs as part of 3-year restructuring plan, Last month we added to our $GILD position and started a new one in $BWLD We see slow, steady, unspectacular growth going forward near term. Lloyds Banking Group's share price lifts amid reports bank is poised to axe hundreds of UK jobs",
+                metadata={
+                    "target": "Lloyds",
+                    "sentiment_score": -0.532,
+                    "format": "headline",
+                },
+            ),
+            Document(
+                text="FTSE 100 drops 2.5 pct on Glencore, metals price fears. Glencore sees Tripoli-based NOC as sole legal seller of Libyan oil. Glencore Studies Possible IPO for Agricultural Trading Business. Glencore chief blames rivals' overproduction for share price fall.",
+                metadata={
+                    "target": "Glencore",
+                    "sentiment_score": 0.037,
+                    "format": "headline",
+                },
+            ),
+            Document(
+                text="Shell's $70 Billion BG Deal Meets Shareholder Skepticism. Shell and BG Shareholders to Vote on Deal at End of January. EU drops Shell, BP, Statoil from ethanol benchmark investigation. Shell challenges Exxon dominance with 47 billion-pound bid for BG",
+                metadata={
+                    "target": "Shell",
+                    "sentiment_score": -0.345,
+                    "format": "headline",
+                },
+            ),
+            Document(
+                text="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
+                metadata={
+                    "target": "TSLA",
+                    "sentiment_score": 0.318,
+                    "format": "post",
+                },
+            ),
+            Document(
+                text="HSBC appoints business leaders to board. HSBC Says Unit to Book $585 Million Charge on Settlement. HSBC Hit by Fresh Details of Tax Evasion Claims. HSBC Hit by Fresh Details of Tax Evasion Claims. Goldman Sachs, Barclays, HSBC downplay Brexit threat.",
+                metadata={
+                    "target": "HSBC",
+                    "sentiment_score": 0.154,
+                    "format": "post",
+                },
+            ),
+            # Without meta
+            Document(
+                text="Aspen to Buy Anaesthetics From AstraZeneca for $520 Million. AstraZeneca wins FDA approval for key new lung cancer pill. AstraZeneca boosts respiratory unit with $575 mln Takeda deal. AstraZeneca Acquires ZS Pharma in $2.7 Billion Deal."
+            ),
+            Document(
+                text="Anheuser-Busch InBev Increases Offer for Rival SABMiller. Australia clears AB Inbev's $100 billion SABMiller buyout plan.Australia clears AB Inbev's $100 billion SABMiller buyout plan."
+            ),
+            Document(
+                text="The Coca-Cola Company and Coca-Cola FEMSA to Acquire AdeS Soy-Based Beverage Business From Unilever."
+            ),
+        ]
+        ds.write_documents(documents)
+        return ds
+
+    @pytest.fixture
+    def mocked_ds(self):
+        class DSMock(PineconeDocumentStore):
+            pass
+
+        pinecone.init = MagicMock()
+        DSMock._create_index = MagicMock()
+        mocked_ds = DSMock(api_key="MOCK")
+
+        return mocked_ds
+
+    def docs_all_formats(self) -> List[Union[Document, Dict[str, Any]]]:
+        return [
+            # Document object
+            Document(
+                text="Lloyds to cut 945 jobs as part of 3-year restructuring plan, Last month we added to our $GILD position and started a new one in $BWLD We see slow, steady, unspectacular growth going forward near term. Lloyds Banking Group's share price lifts amid reports bank is poised to axe hundreds of UK jobs",
+                metadata={
+                    "target": "Lloyds",
+                    "sentiment_score": -0.532,
+                    "format": "headline",
+                },
+            ),
+            Document(
+                text="FTSE 100 drops 2.5 pct on Glencore, metals price fears. Glencore sees Tripoli-based NOC as sole legal seller of Libyan oil. Glencore Studies Possible IPO for Agricultural Trading Business. Glencore chief blames rivals' overproduction for share price fall.",
+                metadata={
+                    "target": "Glencore",
+                    "sentiment_score": 0.037,
+                    "format": "headline",
+                },
+            ),
+            Document(
+                text="Shell's $70 Billion BG Deal Meets Shareholder Skepticism. Shell and BG Shareholders to Vote on Deal at End of January. EU drops Shell, BP, Statoil from ethanol benchmark investigation. Shell challenges Exxon dominance with 47 billion-pound bid for BG",
+                metadata={
+                    "target": "Shell",
+                    "sentiment_score": -0.345,
+                    "format": "headline",
+                },
+            ),
+            Document(
+                text="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
+                metadata={
+                    "target": "TSLA",
+                    "sentiment_score": 0.318,
+                    "format": "post",
+                },
+            ),
+            Document(
+                text="HSBC appoints business leaders to board. HSBC Says Unit to Book $585 Million Charge on Settlement. HSBC Hit by Fresh Details of Tax Evasion Claims. HSBC Hit by Fresh Details of Tax Evasion Claims. Goldman Sachs, Barclays, HSBC downplay Brexit threat.",
+                metadata={
+                    "target": "HSBC",
+                    "sentiment_score": 0.154,
+                    "format": "post",
+                },
+            ),
+            # Without meta
+            Document(
+                text="Aspen to Buy Anaesthetics From AstraZeneca for $520 Million. AstraZeneca wins FDA approval for key new lung cancer pill. AstraZeneca boosts respiratory unit with $575 mln Takeda deal. AstraZeneca Acquires ZS Pharma in $2.7 Billion Deal."
+            ),
+            Document(
+                text="Anheuser-Busch InBev Increases Offer for Rival SABMiller. Australia clears AB Inbev's $100 billion SABMiller buyout plan.Australia clears AB Inbev's $100 billion SABMiller buyout plan."
+            ),
+            Document(
+                text="The Coca-Cola Company and Coca-Cola FEMSA to Acquire AdeS Soy-Based Beverage Business From Unilever."
+            ),
+        ]
+    
+    @pytest.mark.integration
+    def test_ne_filters(self, ds, documents):
+        ds.write_documents(documents)
+
+        result = ds.get_filter_documents(filters={"format": {"$ne": "headline"}})
+        assert len(result) == 2    
+
+    @pytest.mark.integration
+    def test_filter_documents_with_extended_filter_eq(self, doc_store_with_docs: PineconeDocumentStore):
+
+        eq_docs = doc_store_with_docs.filter_documents(filters={"type": {"$eq": "article"}})
+        normal_docs = doc_store_with_docs.filter_documents(filters={"type": "article"})
+        assert eq_docs == normal_docs
+
+    @pytest.mark.integration
+    def test_filter_documents_ids_extended_filter_ne(self, doc_store_with_docs: PineconeDocumentStore):
+        retrieved_docs = doc_store_with_docs.filter_documents(filters={"target": {"$ne": "Glencore"}})
+        assert all(d.meta.get("metadata", None) != "Glencore" for d in retrieved_docs)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_nin(self, doc_store_with_docs: PineconeDocumentStore):
+        retrieved_docs = doc_store_with_docs.filter_documents(filters={"format": {"$nin": ["target", "post"]}})
+        assert {"target", "post"}.isdisjoint({d.metadata.get("metadata", None) for d in retrieved_docs})
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_gt(self, doc_store_with_docs: PineconeDocumentStore):
+        retrieved_docs = doc_store_with_docs.filter_documents(filters={"sentiment_score": {"$gt": 3.0}})
+        assert all(d.metadata["sentiment_score"] > 3.0 for d in retrieved_docs)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_gte(self, doc_store_with_docs: PineconeDocumentStore):
+        retrieved_docs = doc_store_with_docs.filter_documents(filters={"sentiment_score": {"$gte": 3.0}})
+        assert all(d.metadata["sentiment_score"] >= 3.0 for d in retrieved_docs)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_compound_and_other_field_simplified(
+        self, doc_store_with_docs: PineconeDocumentStore
+    ):
+        filters_simplified = {
+            "sentiment_score": {"$lte": 0.2, "$gte": 0.4},
+            "target": ["Shell", "Glencore", "HSBC", "Lloyds", "TSLA"],
+        }
+
+        with pytest.raises(
+            PineconeDocumentStoreFilterError,
+            match=r"Comparison value for '\$[l|g]te' operation must be a float or int.",
+        ):
+            doc_store_with_docs.filter_documents(filters=filters_simplified)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_compound_and_or_explicit(
+        self, doc_store_with_docs: PineconeDocumentStore
+    ):
+        filters = {
+            "$and": {
+                "sentiment_score": {"$lte": 0.2, "$gte": 0.3},
+                "target": {
+                    "name": {"$in": ["HSBC", "Lloyds"]},
+                    "sentiment_score": {"$lte": 5.0},
+                },
+            }
+        }
+
+        with pytest.raises(
+            PineconeDocumentStoreFilterError,
+            match=r"Comparison value for '\$[l|g]te' operation must be a float or int.",
+        ):
+            doc_store_with_docs.filter_documents(filters=filters)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_and_or_simplified(self, doc_store_with_docs: PineconeDocumentStore):
+        filters_simplified = {
+            "sentiment_score": {"$lte": 0.2, "$gte": 0.3},
+            "$or": {"format": ["headline", "post"], "sentiment_score": {"0.318"}},
+        }
+
+        with pytest.raises(
+            PineconeDocumentStoreFilterError,
+            match=r"Comparison value for '\$[l|g]te' operation must be a float or int.",
+        ):
+            doc_store_with_docs.filter_documents(filters=filters_simplified)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_and_or_and_not_explicit(self, doc_store_with_docs: PineconeDocumentStore):
+        filters = {
+            "$and": {
+                "sentiment_score": {"$gte": 0.037},
+                "$or": {
+                    "target": {"$in": ["LLyods", "Glencore", "HSBC", "TSLA", "Shell"]},
+                    "$and": {"format": {"$in": ["headline", "post"]}},
+                },
+            }
+        }
+        with pytest.raises(
+            PineconeDocumentStoreFilterError,
+            match=r"Comparison value for '\$[l|g]te' operation must be a float or int.",
+        ):
+            doc_store_with_docs.filter_documents(filters=filters)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_and_or_and_not_simplified(
+        self, doc_store_with_docs: PineconeDocumentStore
+    ):
+        filters_simplified = {
+            "sentiment_score": {"$lte": "0.037"},
+            "$or": {
+                "target": ["LLyods", "Glencore"],
+                "$and": {"format": {"$lte": "headline"}, "$not": {"format": "post"}},
+            },
+        }
+        with pytest.raises(
+            PineconeDocumentStoreFilterError,
+            match=r"Comparison value for '\$[l|g]te' operation must be a float or int.",
+        ):
+            doc_store_with_docs.filter_documents(filters=filters_simplified)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_compound_nested_not(self, doc_store_with_docs: PineconeDocumentStore):
+        # Test nested logical operations within "$not".
+        filters = {
+            "$not": {
+                "$or": {
+                    "$and": {"target": {"Lloyds"}},
+                    "$not": {"format": {"healdine"}},
+                }
+            }
+        }
+        with pytest.raises(
+            PineconeDocumentStoreFilterError,
+            match=r"Comparison value for '\$[l|g]t' operation must be a float or int.",
+        ):
+            doc_store_with_docs.filter_documents(filters=filters)
+
+    @pytest.mark.integration
+    def test_filter_documents_extended_filter_compound_same_level_not(self, doc_store_with_docs: PineconeDocumentStore):
+        # Test same logical operator twice on the same level.
+        filters = {
+            "$or": [
+                {
+                    "$and": {
+                        "target": ["LLyods", "Glencore", "TSLA", "Shell"],
+                        "format": {"$in": ["post"]},
+                    }
+                },
+                {
+                    "$and": {
+                        "target": ["LLyods", "Glencore", "HSBC", "TSLA", "Shell"],
+                        "format": {"$in": ["headline"]},
+                    }
+                },
+            ]
+        }
+
+        with pytest.raises(
+            PineconeDocumentStoreFilterError,
+            match=r"Comparison value for '\$[l|g]te' operation must be a float or int.",
+        ):
+            doc_store_with_docs.filter_documents(filters=filters)
+
+    def test_get_embedding_count(self, doc_store_with_docs: PineconeDocumentStore):
+        """
+        We expect 1 doc with an embeddings because all documents in already written in doc_store_with_docs contain no
+        embeddings.
+        """
+        doc = Document(
+            text="Doc with embedding",
+            embedding=np.random.rand(768).astype(np.float32),
+        )
+        doc_store_with_docs.write_documents([doc])
+        assert doc_store_with_docs.get_embedding_count() == 1
+

--- a/document_stores/pinecone/tests/test_pinecone_document_store.py
+++ b/document_stores/pinecone/tests/test_pinecone_document_store.py
@@ -2,18 +2,19 @@ import os
 from inspect import getmembers, isclass, isfunction
 from typing import Any, Dict, List, Union
 from unittest.mock import MagicMock
+
 import numpy as np
+import pinecone
 import pytest
+from haystack.preview.dataclasses import Document
+from haystack.preview.testing.document_store import DocumentStoreBaseTests
 
 from pinecone_haystack.document_store import PineconeDocumentStore
 from pinecone_haystack.errors import (
     PineconeDocumentStoreError,
     PineconeDocumentStoreFilterError,
 )
-from haystack.preview.dataclasses import Document
-from haystack.preview.testing.document_store import DocumentStoreBaseTests
 from tests import pinecone_mock
-import pinecone
 
 
 class TestPineconeDocumentStore(DocumentStoreBaseTests):

--- a/document_stores/pinecone/tests/test_retriever.py
+++ b/document_stores/pinecone/tests/test_retriever.py
@@ -1,23 +1,23 @@
 import os
 from inspect import getmembers, isclass, isfunction
-import pinecone
 from typing import Any, Dict, List, Union
-from unittest.mock import MagicMock, Mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
+
 import numpy as np
+import pinecone
 import pytest
-from tests import pinecone_mock
+from haystack.preview import (
+    DeserializationError,
+    Document,
+    component,
+    default_from_dict,
+    default_to_dict,
+)
+from haystack.preview.dataclasses import Document
+
 from pinecone_haystack.document_store import PineconeDocumentStore
 from pinecone_haystack.retriever import PineconeRetriever
-from haystack.preview import (
-    component,
-    Document,
-    default_to_dict,
-    default_from_dict,
-    DeserializationError,
-)
-
-from haystack.preview.dataclasses import Document
+from tests import pinecone_mock
 
 
 class TestPineconeRetriever:
@@ -34,14 +34,16 @@ class TestPineconeRetriever:
     @pytest.mark.unit
     def test_run(self):
         mock_store = Mock(spec=PineconeDocumentStore)
-        mock_store.query_by_embedding.return_value = [Document(
+        mock_store.query_by_embedding.return_value = [
+            Document(
                 content="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
                 meta={
                     "target": "TSLA",
                     "sentiment_score": 0.318,
                     "format": "post",
                 },
-            )]
+            )
+        ]
 
         retriever = PineconeRetriever(document_store=mock_store)
         results = retriever.run(["How many cars is TSLA recalling?"])

--- a/document_stores/pinecone/tests/test_retriever.py
+++ b/document_stores/pinecone/tests/test_retriever.py
@@ -1,0 +1,136 @@
+import os
+from inspect import getmembers, isclass, isfunction
+import pinecone
+from typing import Any, Dict, List, Union
+from unittest.mock import MagicMock
+from unittest.mock import patch
+import numpy as np
+import pytest
+from tests import pinecone_mock
+from pinecone_haystack.document_store import PineconeDocumentStore
+from pinecone_haystack.retriever import PineconeRetriever
+from haystack.preview import (
+    component,
+    Document,
+    default_to_dict,
+    default_from_dict,
+    DeserializationError,
+)
+
+from haystack.preview.dataclasses import Document
+
+class TestPineconeDocumentStore:
+    @pytest.fixture
+    def ds(self, monkeypatch, request) -> PineconeDocumentStore:
+        """
+        This fixture provides an empty document store and takes care of cleaning up after each test
+        """
+    
+        for fname, function in getmembers(pinecone_mock, isfunction):
+            monkeypatch.setattr(f"pinecone.{fname}", function, raising=False)
+        for cname, class_ in getmembers(pinecone_mock, isclass):
+            monkeypatch.setattr(f"pinecone.{cname}", class_, raising=False)
+
+        return PineconeDocumentStore(
+            api_key=os.environ.get("PINECONE_API_KEY") or "pinecone-test-key",
+            embedding_dim=768,
+            embedding_field="embedding",
+            index="haystack_tests",
+            similarity="cosine",
+            recreate_index=True,
+        )
+
+    @pytest.fixture
+    def doc_store_with_docs(self, ds: PineconeDocumentStore) -> PineconeDocumentStore:
+        """
+        This fixture provides a pre-populated document store and takes care of cleaning up after each test
+        """
+        documents = [Document(
+                text="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
+                metadata={
+                    "target": "Lloyds",
+                    "sentiment_score": -0.532,
+                    "format": "headline",
+                }),
+        ]
+        ds.write_documents(documents)
+        return ds
+
+    @pytest.fixture
+    def mocked_ds(self):
+        class DSMock(PineconeDocumentStore):
+            pass
+
+        pinecone.init = MagicMock()
+        DSMock._create_index = MagicMock()
+        mocked_ds = DSMock(api_key="MOCK")
+
+        return mocked_ds
+
+
+class TestPineconeRetriever:
+    @pytest.mark.integration
+    def test_init(self):
+        document_store = PineconeDocumentStore("pinecone-test-key")
+        retriever = PineconeRetriever(document_store=document_store)
+        assert retriever.document_store == document_store
+        assert retriever.filters == None
+        assert retriever.top_k == 10
+        assert retriever.scale_score == True
+        assert retriever.return_embedding == False
+        
+    @pytest.mark.integration
+    def test_run(self):
+        document_store = PineconeDocumentStore("pinecone-test-key")
+        with patch.object(document_store, "query") as mock_query:
+            mock_query.return_value = Document(
+                text="$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in.",
+                metadata={
+                    "target": "TSLA",
+                    "sentiment_score": 0.318,
+                    "format": "post",
+                })
+
+            results = self.retriever.run(["How many cars is TSLA recalling?"])
+        
+            assert len(results["documents"]) == 1
+            assert results["documents"][0][0].text == "$TSLA lots of green on the 5 min, watch the hourly $259.33 possible resistance currently @ $257.00.Tesla is recalling 2,700 Model X cars.Hard to find new buyers of $TSLA at 250. Shorts continue to pile in."
+        
+    @pytest.mark.integration
+    def test_to_dict(self):
+        document_store = PineconeDocumentStore("pinecone-test-key")
+        retriever = PineconeRetriever(document_store=document_store)
+        doc_dict = retriever.to_dict()
+        assert doc_dict == {
+            "init_parameters": {
+                "document_store": "test_document_store",
+                "filters": None,
+                "top_k": 10,
+                "scale_score": "True",
+                "return_embedding": False,
+            }
+        }
+        
+    @pytest.mark.integration
+    def test_from_dict(self):
+        """
+        Test deserialization of this component from a dictionary, using default initialization parameters.
+        """
+        retriever_component_dict = {
+            "type": "PineconeRetriever",
+            "init_parameters": {
+                "document_store": "test_document_store",
+                "filters": None,
+                "top_k": 10,
+                "scale_score": True,
+                "return_embedding": False,
+            }
+        }
+        retriever = PineconeRetriever.from_dict(retriever_component_dict)
+
+        assert retriever.document_store == "test_document_store"
+        assert retriever.filters is None
+        assert retriever.top_k == 10
+        assert retriever.scale_score is True
+        assert retriever.return_embedding is False
+


### PR DESCRIPTION
### Related Issues:
Fixes [#6055](https://github.com/deepset-ai/haystack/issues/6055)


### Pinecone Document store

Based on the basic contract that all DocumentStores are expected to follow, we have implemented the following classes for the document store.

```python
class PineconeDocumentStore:
    def __init__(
        self,
        api_key: str,
        environment: str = "us-west1-gcp",
        pinecone_index: Optional["pinecone.Index"] = None,
        embedding_dim: int = 768,
        batch_size: int = 100,
        return_embedding: bool = False,
        index: str = "document",
        similarity: str = "cosine",
        replicas: int = 1,
        shards: int = 1,
        namespace: Optional[str] = None,
        embedding_field: str = "embedding",
        progress_bar: bool = True,
        duplicate_documents: str = "overwrite",
        recreate_index: bool = False,
        metadata_config: Optional[Dict] = None,
        validate_index_sync: bool = True,
    )   
    def get_index_stats(self) -> [Dict[str, Any]]
    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = "fail") -> None
    def get_document_count(
        self,
        filters: Dict[str, Any] = None,
        index: Optional[str] = None,
        only_documents_without_embedding: bool = False,
        headers: Optional[Dict[str, str]] = None,
        namespace: Optional[str] = None,
        type_metadata: Optional[DocTypeMetadata] = None,
    ) -> int
    def get_embedding_count(
        self,
        filters: Optional[Dict[str, Any]] = None,
        index: Optional[str] = None,
        namespace: Optional[str] = None,
    ) -> int
    def count_documents(self) -> int
    def query_by_embedding(
        self,
        query_embedding: List[float],
        filters: Optional[Dict[str, Any]] = None,
        top_k: int = 10,
        scale_score: bool = True,
        return_embedding: Optional[bool] = None,
    ) -> List[Document]
    def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]
    def get_documents_by_id(
        self,
        ids: List[str],
        index: Optional[str] = None,
        batch_size: int = 100,
        return_embedding: Optional[bool] = None,
        namespace: Optional[str] = None,
        include_type_metadata: Optional[bool] = False,
    ) -> List[Document]:
    def delete_documents(self, document_ids: List[str]) -> None
    def delete_index(self, index: Optional[str]) -> None
   
class PineconeRetriever: 
    def run(
        self,
        query_embedding: List[float],
        filters: Optional[Dict[str, Any]] = None,
        top_k: Optional[int] = None,
        scale_score: Optional[bool] = None,
        return_embedding: Optional[bool] = None,
    ) -> Dict[str, List[Document]]
    def from_dict(cls, data: Dict[str, Any]) -> "PineconeRetriever" 
    def to_dict(self) -> Dict[str, Any]
```

#### Indexing Pipeline

First the document store node is added which initializes the document store. The documents as a list of document objects are added to the document store using the write_documents method. Then the embedder node is added which creates the corresponding embeddings for each document using the DocumentEmbedder. The documents with their embeddings are stored in the document store.

Indexing pipelines prepare your files for search. Their main objective is to convert your files into Haystack Documents, so that they can be saved in a DocumentStore.

During indexing, we do not use any Retriever, but rather a DocumentEmbedder. This class accepts a model name and simply adds embeddings to the Documents it receives.

Embedders encode a list of data points (strings, images, etc.) into a list of vectors (i.e., the embeddings) using a model. The embedders are used both in the indexing (to encode documents) and query pipelines (encode query).

When embedding documents, the Embedder receives a list of Document objects as input. For each item in the list, the corresponding vectors are computed and stored in the embedding field of the item itself. The list is then returned as the output.

The Document class contains the query and the embedding. In v1 the Document class and the embedding were separate. 

When working with documents, there's the possibility to compute embeddings also for the document's metadata. In this case, the Embedder will be responsible for performing any text-manipulation work needed in preparation of the actual embedding process.

#### Query Pipeline

First the document store node is added which has the documents stored in the document store. Then the embedding node is added, the TextEmbedder class will create the embedding of the query. The filter_documents method will retrieve the documents with the specific filters. Then the retriever node is added which will call the run method to retrieve the relevant documents from the document store.  

First the documents with the query and embeddings are created. 
During query, the first step is not a Retriever anymore, but a StringEmbedder. This will convert the query into its embedding representation and forward it over to a Retriever that expects it. When embedding queries, the Embedder receives a list of strings in input that are transformed into a list of vectors returned as output.

The embedders were part of the retreiver in v1. In v2, the embedders will be separate and used for creating embeddings.

Retrievers retrieve Documents from the DocumentStores. They are specific and aware of which Store has been used. For e.g., PineconeRetriever for the PineconeDocumentStore. They will be commonly used in query pipelines (not in indexing pipelines).

**Methods implemented:**

- **get_index_stats**: It returns statistics about the index's contents, including the vector count per namespace and the number of dimensions. New in v2.

- **count_documents**: Returns the no of documents which are present in the document store. Similar to get_all_documents in v1. New in v2.

- **filter_documents**: It takes the input query and embedding as input and returns a list of documents that match the filters. Returns the documents which match the filters provided. Added: Filtering by the query embedding similar to update_embedding in v1. 

- **write_documents**: The write documents now takes only the document objects as input whereas in v1 it would take the embedding and documents as input. It takes a list of documents as input. To store documents in Pinecone, we use dummy embeddings, if the embedding is not passed with the document. We added the functionality of writing the documents if the user does not pass the embedding. We write the documents using the dummy embeddings which is specified by the value of DOCUMENT_WITHOUT_EMBEDDING. 

- **get_documents_by_id**: Retrieves all documents in the index using their IDs. Since Pinecone does not support headers we removed the headers, parameter from the method which was present in v1.

- **delete_documents**: It deletes all the documents with matching document_ids from the document store. Since Pinecone does not support headers we removed the headers parameter from the method which was present in v1.

#### Retriever
Pinecone Retriever Class for retrieving documents from the PineconeDocumentStore. It is similar to the BaseRetriever class of the retriever node in v1. In v1, the BaseRetriever would take the input as string and return the documents that are most relevant to the query. The Pinecone Retreiver takes the embedding of the query as input, and returns a dictionary of the retreived documents.

**Methods implemented:**

- **run**: It takes the embedding of the query, filters, top_k value, scale score as input and returns a dictionary of the retreived documents. New in v2.

- **to_dict**: Serializes the Retriever component to a dictionary. New in v2.

- **from_dict**: Deserializes the Retriever component from a dictionary. New in v2.


### Pinecone Concepts

Pinecone supports dense, sparse, and sparse-dense vectors. Currently, Haystack supports only dense vectors, with support for sparse and sparse-dense vectors forthcoming.

#### Adding vectors:

1. Create a new index. At this time we need to specify the index name, metric ('euclidean', 'cosine', or 'dotproduct'), and dimension. 

2. Wait for the index to be created.

3. Generate vectors using any embedding model.
Each vector generated by the embedding model can be augmented with metadata.
Pinecone supports 40kb of metadata per vector.

4. Upsert the vectors, typically in batches.
Pinecone allows you to partition the records in an index into namespaces, 
which can be specified during the upsert. 
Queries and other operations can then be restricted by namespace.

5. After indexing the data, we can check the number of vectors created

Once our index is populated, queries can be run.

#### Query
The Query operation searches the index using a query vector. It retrieves the IDs of the most similar records in the index, along with their similarity scores.

#### Namespaces
Pinecone allows you to partition the records in an index into namespaces. 
When upserting vectors into Pinecone you can select a namespace you want to upsert the vectors into. 
Namespaces are created automatically the first time they are used to upsert records. If the namespace doesn't exist, it is created implicitly. Namespaces are uniquely identified by a namespace name.
While querying the vector database, you can query based on a specfic namespace. 
Queries and other operations are then limited to one namespace, so different requests can search different subsets of your index.

#### Metadata Filtering

Pinecone lets you attach metadata key-value pairs to vectors in an index, and specify filter expressions when you query the index. Metadata can be included in upsert requests as you insert your vectors. You can limit your vector search based on metadata. 

Searches with metadata filters retrieve exactly the number of nearest-neighbor 
results that match the filters.

Metadata filter expressions can be included with queries to limit the search to only vectors matching the filter expression. Filters can be built using a set of operators that can be applied to strings and/or numbers:
The metadata filters can be combined with AND and OR:
- $eq - Equal to (number, string, boolean)
- $ne - Not equal to (number, string, boolean)
- $gt - Greater than (number)
- $gte - Greater than or equal to (number)
- $lt - Less than (number)
- $lte - Less than or equal to (number)
- $in - In array (string or number)
- $nin - Not in array (string or number)

#### Deleting vectors by metadata filter
Vectors can also be deleted by specifying metadata filters. This is done by passing a metadata filter expression to the delete operation. This deletes all vectors matching the metadata filter expression.

--------------------------------------------------------------------------------------


This code was written collaboratively with @awinml.