### PR TITLE
bump Instructor Embedders version

### DIFF
--- a/components/instructor-embedders/instructor_embedders/__about__.py
+++ b/components/instructor-embedders/instructor_embedders/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.0.1"
+__version__ = "0.0.2"


### PR DESCRIPTION
I'm bumping the version,
so that I can release v0.0.2 with the recent refactoring (#44).