### PR TITLE
Elastiscsearch BM25Retriever: set `scale_score` default value to False

### DIFF
--- a/document_stores/elasticsearch/src/elasticsearch_haystack/bm25_retriever.py
+++ b/document_stores/elasticsearch/src/elasticsearch_haystack/bm25_retriever.py
@@ -18,7 +18,7 @@ class ElasticsearchBM25Retriever:
         filters: Optional[Dict[str, Any]] = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
-        scale_score: bool = True,
+        scale_score: bool = False,
     ):
         if not isinstance(document_store, ElasticsearchDocumentStore):
             msg = "document_store must be an instance of ElasticsearchDocumentStore"

--- a/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
+++ b/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 Hosts = Union[str, List[Union[str, Mapping[str, Union[str, int]], NodeConfig]]]
 
 # document scores are essentially unbounded and will be scaled to values between 0 and 1 if scale_score is set to
-# True (default). Scaling uses the expit function (inverse of the logit function) after applying a scaling factor
+# True. Scaling uses the expit function (inverse of the logit function) after applying a scaling factor
 # (e.g., BM25_SCALING_FACTOR for the bm25_retrieval method).
 # Larger scaling factor decreases scaled scores. For example, an input of 10 is scaled to 0.99 with
 # BM25_SCALING_FACTOR=2 but to 0.78 with BM25_SCALING_FACTOR=8 (default). The defaults were chosen empirically.
@@ -248,7 +248,7 @@ class ElasticsearchDocumentStore:
         filters: Optional[Dict[str, Any]] = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
-        scale_score: bool = True,
+        scale_score: bool = False,
     ) -> List[Document]:
         """
         Elasticsearch by defaults uses BM25 search algorithm.
@@ -268,7 +268,7 @@ class ElasticsearchDocumentStore:
                           see the official documentation for valid values:
                           https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param scale_score: If `True` scales the Document`s scores between 0 and 1, defaults to True
+        :param scale_score: If `True` scales the Document`s scores between 0 and 1, defaults to False
         :raises ValueError: If `query` is an empty string
         :return: List of Document that match `query`
         """

--- a/document_stores/elasticsearch/tests/test_bm25_retriever.py
+++ b/document_stores/elasticsearch/tests/test_bm25_retriever.py
@@ -15,7 +15,7 @@ def test_init_default():
     assert retriever._document_store == mock_store
     assert retriever._filters == {}
     assert retriever._top_k == 10
-    assert retriever._scale_score
+    assert retriever._scale_score is False
 
 
 @patch("elasticsearch_haystack.document_store.Elasticsearch")
@@ -33,7 +33,7 @@ def test_to_dict(_mock_elasticsearch_client):
             "filters": {},
             "fuzziness": "AUTO",
             "top_k": 10,
-            "scale_score": True,
+            "scale_score": False,
         },
     }
 
@@ -71,7 +71,7 @@ def test_run():
         filters={},
         fuzziness="AUTO",
         top_k=10,
-        scale_score=True,
+        scale_score=False,
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1

--- a/document_stores/elasticsearch/tests/test_bm25_retriever.py
+++ b/document_stores/elasticsearch/tests/test_bm25_retriever.py
@@ -15,7 +15,7 @@ def test_init_default():
     assert retriever._document_store == mock_store
     assert retriever._filters == {}
     assert retriever._top_k == 10
-    assert retriever._scale_score is False
+    assert not retriever._scale_score
 
 
 @patch("elasticsearch_haystack.document_store.Elasticsearch")

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -132,7 +132,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         `DocumentStoreBaseTests` declares this test but we override it since we
         want `delete_documents` to be idempotent.
         """
-        doc = Document(text="test doc")
+        doc = Document(content="test doc")
         docstore.write_documents([doc])
 
         docstore.delete_documents([doc.id])
@@ -154,7 +154,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         `DocumentStoreBaseTests` declares this test but we override it since we
         want `delete_documents` to be idempotent.
         """
-        doc = Document(text="test doc")
+        doc = Document(content="test doc")
         docstore.write_documents([doc])
 
         docstore.delete_documents(["non_existing"])


### PR DESCRIPTION
Related to https://github.com/deepset-ai/haystack/issues/6271

(I also fixed a test that used `text` instead of `content` in Document initialization).