### PR TITLE
Elasticsearch Document store - embedding retrieval

### DIFF
--- a/document_stores/elasticsearch/docker-compose.yml
+++ b/document_stores/elasticsearch/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:8.10.0"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.11.1"
     ports:
       - 9200:9200
     restart: on-failure

--- a/document_stores/elasticsearch/src/elasticsearch_haystack/bm25_retriever.py
+++ b/document_stores/elasticsearch/src/elasticsearch_haystack/bm25_retriever.py
@@ -18,7 +18,7 @@ class ElasticsearchBM25Retriever:
         filters: Optional[Dict[str, Any]] = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
-        scale_score: bool = True,
+        scale_score: bool = False,
     ):
         if not isinstance(document_store, ElasticsearchDocumentStore):
             msg = "document_store must be an instance of ElasticsearchDocumentStore"

--- a/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
+++ b/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from typing import Any, Dict, List, Mapping, Optional, Union, Literal
+from typing import Any, Dict, List, Literal, Mapping, Optional, Union
 
 import numpy as np
 

--- a/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
+++ b/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 Hosts = Union[str, List[Union[str, Mapping[str, Union[str, int]], NodeConfig]]]
 
 # document scores are essentially unbounded and will be scaled to values between 0 and 1 if scale_score is set to
-# True (default). Scaling uses the expit function (inverse of the logit function) after applying a scaling factor
+# True. Scaling uses the expit function (inverse of the logit function) after applying a scaling factor
 # (e.g., BM25_SCALING_FACTOR for the bm25_retrieval method).
 # Larger scaling factor decreases scaled scores. For example, an input of 10 is scaled to 0.99 with
 # BM25_SCALING_FACTOR=2 but to 0.78 with BM25_SCALING_FACTOR=8 (default). The defaults were chosen empirically.
@@ -248,7 +248,7 @@ class ElasticsearchDocumentStore:
         filters: Optional[Dict[str, Any]] = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
-        scale_score: bool = True,
+        scale_score: bool = False,
     ) -> List[Document]:
         """
         Elasticsearch by defaults uses BM25 search algorithm.
@@ -268,7 +268,7 @@ class ElasticsearchDocumentStore:
                           see the official documentation for valid values:
                           https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param scale_score: If `True` scales the Document`s scores between 0 and 1, defaults to True
+        :param scale_score: If `True` scales the Document`s scores between 0 and 1, defaults to False
         :raises ValueError: If `query` is an empty string
         :return: List of Document that match `query`
         """

--- a/document_stores/elasticsearch/tests/test_bm25_retriever.py
+++ b/document_stores/elasticsearch/tests/test_bm25_retriever.py
@@ -15,7 +15,7 @@ def test_init_default():
     assert retriever._document_store == mock_store
     assert retriever._filters == {}
     assert retriever._top_k == 10
-    assert retriever._scale_score
+    assert retriever._scale_score is False
 
 
 @patch("elasticsearch_haystack.document_store.Elasticsearch")
@@ -33,7 +33,7 @@ def test_to_dict(_mock_elasticsearch_client):
             "filters": {},
             "fuzziness": "AUTO",
             "top_k": 10,
-            "scale_score": True,
+            "scale_score": False,
         },
     }
 
@@ -71,7 +71,7 @@ def test_run():
         filters={},
         fuzziness="AUTO",
         top_k=10,
-        scale_score=True,
+        scale_score=False,
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1

--- a/document_stores/elasticsearch/tests/test_bm25_retriever.py
+++ b/document_stores/elasticsearch/tests/test_bm25_retriever.py
@@ -27,7 +27,11 @@ def test_to_dict(_mock_elasticsearch_client):
         "type": "ElasticsearchBM25Retriever",
         "init_parameters": {
             "document_store": {
-                "init_parameters": {"hosts": "some fake host", "index": "default"},
+                "init_parameters": {
+                    "hosts": "some fake host",
+                    "index": "default",
+                    'embedding_similarity_function': 'cosine',
+                },
                 "type": "ElasticsearchDocumentStore",
             },
             "filters": {},

--- a/document_stores/elasticsearch/tests/test_bm25_retriever.py
+++ b/document_stores/elasticsearch/tests/test_bm25_retriever.py
@@ -30,7 +30,7 @@ def test_to_dict(_mock_elasticsearch_client):
                 "init_parameters": {
                     "hosts": "some fake host",
                     "index": "default",
-                    'embedding_similarity_function': 'cosine',
+                    "embedding_similarity_function": "cosine",
                 },
                 "type": "ElasticsearchDocumentStore",
             },

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
-from elasticsearch.exceptions import BadRequestError
+from elasticsearch.exceptions import BadRequestError  # type: ignore[import-not-found]
 from haystack.preview.dataclasses.document import Document
 from haystack.preview.document_stores.errors import DuplicateDocumentError
 from haystack.preview.document_stores.protocols import DuplicatePolicy

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -6,13 +6,13 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from elasticsearch.exceptions import BadRequestError
 from haystack.preview.dataclasses.document import Document
 from haystack.preview.document_stores.errors import DuplicateDocumentError
 from haystack.preview.document_stores.protocols import DuplicatePolicy
 from haystack.preview.testing.document_store import DocumentStoreBaseTests
 
 from elasticsearch_haystack.document_store import ElasticsearchDocumentStore
-from elasticsearch.exceptions import BadRequestError
 
 
 class TestDocumentStore(DocumentStoreBaseTests):

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -60,11 +60,13 @@ class TestDocumentStore(DocumentStoreBaseTests):
             "init_parameters": {
                 "hosts": "some hosts",
                 "index": "default",
+                "embedding_similarity_function": "cosine",
             },
         }
         document_store = ElasticsearchDocumentStore.from_dict(data)
         assert document_store._hosts == "some hosts"
         assert document_store._index == "default"
+        assert document_store._embedding_similarity_function == "cosine"
 
     def test_bm25_retrieval(self, docstore: ElasticsearchDocumentStore):
         docstore.write_documents(

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -132,7 +132,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         `DocumentStoreBaseTests` declares this test but we override it since we
         want `delete_documents` to be idempotent.
         """
-        doc = Document(text="test doc")
+        doc = Document(content="test doc")
         docstore.write_documents([doc])
 
         docstore.delete_documents([doc.id])
@@ -154,7 +154,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         `DocumentStoreBaseTests` declares this test but we override it since we
         want `delete_documents` to be idempotent.
         """
-        doc = Document(text="test doc")
+        doc = Document(content="test doc")
         docstore.write_documents([doc])
 
         docstore.delete_documents(["non_existing"])

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -32,6 +32,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         index = f"{request.node.name}"
 
         # this similarity function is rarely used in practice, but it is robust for test cases with fake embeddings
+        # in fact, it works fine with vectors like [0.0] * 768, while cosine similarity would raise an exception
         embedding_similarity_function = "max_inner_product"
 
         store = ElasticsearchDocumentStore(
@@ -288,8 +289,5 @@ class TestDocumentStore(DocumentStoreBaseTests):
         docs = [Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4])]
         docstore.write_documents(docs)
 
-        with pytest.raises(
-            BadRequestError,
-            match="search_phase_execution_exception",
-        ):
+        with pytest.raises(BadRequestError):
             docstore._embedding_retrieval(query_embedding=[0.1, 0.1])

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -176,15 +176,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
     def test_in_filter_embedding(self, docstore: ElasticsearchDocumentStore, filterable_docs: List[Document]):
         pass
 
-    def test_ne_filter_embedding(self, docstore: ElasticsearchDocumentStore, filterable_docs: List[Document]):
-        docstore.write_documents(filterable_docs)
-        embedding = [0.0] * 768
-        result = docstore.filter_documents(filters={"embedding": {"$ne": embedding}})
-        assert self.contains_same_docs(
-            result,
-            [doc for doc in filterable_docs if doc.embedding is None or not embedding == doc.embedding],
-        )
-
     @pytest.mark.skip(reason="Not supported")
     def test_nin_filter_table(self, docstore: ElasticsearchDocumentStore, filterable_docs: List[Document]):
         pass

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -31,7 +31,12 @@ class TestDocumentStore(DocumentStoreBaseTests):
         # Use a different index for each test so we can run them in parallel
         index = f"{request.node.name}"
 
-        store = ElasticsearchDocumentStore(hosts=hosts, index=index)
+        # this similarity function is rarely used in practice, but it is robust for test cases with fake embeddings
+        embedding_similarity_function = "max_inner_product"
+
+        store = ElasticsearchDocumentStore(
+            hosts=hosts, index=index, embedding_similarity_function=embedding_similarity_function
+        )
         yield store
         store._client.options(ignore_status=[400, 404]).indices.delete(index=index)
 
@@ -44,6 +49,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
             "init_parameters": {
                 "hosts": "some hosts",
                 "index": "default",
+                "embedding_similarity_function": "cosine",
             },
         }
 
@@ -185,6 +191,26 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
     @pytest.mark.skip(reason="Not supported")
     def test_nin_filter_embedding(self, docstore: ElasticsearchDocumentStore, filterable_docs: List[Document]):
+        pass
+
+    @pytest.mark.skip(reason="Not supported")
+    def test_eq_filter_embedding(self, docstore: ElasticsearchDocumentStore, filterable_docs: List[Document]):
+        """
+        If the embedding field is a dense vector (as expected), raise the following error:
+
+        elasticsearch.BadRequestError: BadRequestError(400, 'search_phase_execution_exception',
+        "failed to create query: Field [embedding] of type [dense_vector] doesn't support term queries")
+        """
+        pass
+
+    @pytest.mark.skip(reason="Not supported")
+    def test_ne_filter_embedding(self, docstore: ElasticsearchDocumentStore, filterable_docs: List[Document]):
+        """
+        If the embedding field is a dense vector (as expected), raise the following error:
+
+        elasticsearch.BadRequestError: BadRequestError(400, 'search_phase_execution_exception',
+        "failed to create query: Field [embedding] of type [dense_vector] doesn't support term queries")
+        """
         pass
 
     def test_gt_filter_non_numeric(self, docstore: ElasticsearchDocumentStore, filterable_docs: List[Document]):


### PR DESCRIPTION
Part of  https://github.com/deepset-ai/haystack/issues/5329

- Add basic support for Embedding retrieval in Elasticsearch Document Store

### Notes for the reviewer
- `ElasticSearchEmbeddingRetriever` will be added in a subsequent PR.

- I chose to support only [Approximate kNN](https://www.elastic.co/guide/en/elasticsearch/reference/8.11/knn-search.html#knn-methods), which is the suggested approach compared to Exact, brute-force kNN.

- This Document Store is compatible with Elasticsearch>=8.11
Configuring vector fields in older versions required more manual effort on the part of the user (e.g., explicitly specifying the vector size at index creation).

- I haven't implemented scaling scores in the range [0, 1]. See #53 

- I would like to test also other unhappy paths, such as trying to write documents with embeddings of different sizes.
Concerning this point, we should rework **error handling** during indexing (`write_documents` method).

  _Update_: I encountered several erroneous `DuplicateDocumentError` while working on embedding retrieval.
If we do not want to spend time reworking this part at the moment, I would propose printing a warning with the obtained errors. It seems less misleading to me. WDYT?