### PR TITLE
Elasticsearch DS: temporarily pin `haystack-ai`

### DIFF
--- a/document_stores/elasticsearch/pyproject.toml
+++ b/document_stores/elasticsearch/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   # we distribute the preview version of Haystack 2.0 under the package "haystack-ai"
-  "haystack-ai",
+  "haystack-ai==0.143.0",
   "elasticsearch>=8,<9",
   "typing_extensions", # This is not a direct dependency, but `haystack-ai` is missing it cause `canals` is missing it
 ]


### PR DESCRIPTION
We decided to temporarily pin to avoid breaking changes while working on Elastic.

@silvanocerza will remove this pin when the Document/filters refactoring is finished.