### PR TITLE
[Elasticsearch Document Store] improve error handling in `write_documents`

### DIFF
--- a/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
+++ b/document_stores/elasticsearch/src/elasticsearch_haystack/document_store.py
@@ -245,14 +245,12 @@ class ElasticsearchDocumentStore:
             duplicate_errors_ids = []
             other_errors = []
             for e in errors:
-                if e["create"]["error"]["type"] == "version_conflict_engine_exception":
-                    if policy == DuplicatePolicy.FAIL:
-                        duplicate_errors_ids.append(e["create"]["_id"])
-                    elif policy == DuplicatePolicy.SKIP:
-                        # when the policy is skip, these errors are OK and we should not raise an exception
-                        continue
-                    else:
-                        other_errors.append(e)
+                error_type = e["create"]["error"]["type"]
+                if policy == DuplicatePolicy.FAIL and error_type == "version_conflict_engine_exception":
+                    duplicate_errors_ids.append(e["create"]["_id"])
+                elif policy == DuplicatePolicy.SKIP and error_type == "version_conflict_engine_exception":
+                    # when the policy is skip, duplication errors are OK and we should not raise an exception
+                    continue
                 else:
                     other_errors.append(e)
 

--- a/document_stores/elasticsearch/tests/test_document_store.py
+++ b/document_stores/elasticsearch/tests/test_document_store.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 from elasticsearch.exceptions import BadRequestError  # type: ignore[import-not-found]
 from haystack.preview.dataclasses.document import Document
-from haystack.preview.document_stores.errors import DuplicateDocumentError
+from haystack.preview.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.preview.document_stores.protocols import DuplicatePolicy
 from haystack.preview.testing.document_store import DocumentStoreBaseTests
 
@@ -291,3 +291,15 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
         with pytest.raises(BadRequestError):
             docstore._embedding_retrieval(query_embedding=[0.1, 0.1])
+
+    def test_write_documents_different_embedding_sizes_fail(self, docstore: ElasticsearchDocumentStore):
+        """
+        Test that write_documents fails if the documents have different embedding sizes.
+        """
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(content="Hello world", embedding=[0.1, 0.2]),
+        ]
+
+        with pytest.raises(DocumentStoreError):
+            docstore.write_documents(docs)


### PR DESCRIPTION
Fixes #58

We now distinguish the errors into `DuplicateDocumentError` and generic `DocumentStoreError`.

The `DuplicateDocumentError` is raised only at the appropriate Elasticsearch exception and when the duplicate policy is FAIL.

(Added a test that raises `DocumentStoreError`).