### PR TITLE
Document Stores: fix protocol import

### DIFF
--- a/integrations/chroma/src/chroma_haystack/__about__.py
+++ b/integrations/chroma/src/chroma_haystack/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/integrations/chroma/src/chroma_haystack/document_store.py
+++ b/integrations/chroma/src/chroma_haystack/document_store.py
@@ -9,7 +9,7 @@ import chromadb
 import numpy as np
 from chromadb.api.types import GetResult, QueryResult, validate_where, validate_where_document
 from haystack.dataclasses import Document
-from haystack.document_stores.protocols import DuplicatePolicy
+from haystack.document_stores.protocol import DuplicatePolicy
 
 from chroma_haystack.errors import ChromaDocumentStoreFilterError
 from chroma_haystack.utils import get_embedding_function

--- a/integrations/elasticsearch/src/elasticsearch_haystack/__about__.py
+++ b/integrations/elasticsearch/src/elasticsearch_haystack/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -10,7 +10,7 @@ import pytest
 from elasticsearch.exceptions import BadRequestError  # type: ignore[import-not-found]
 from haystack.dataclasses.document import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
-from haystack.document_stores.protocols import DuplicatePolicy
+from haystack.document_stores.protocol import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
 
 from elasticsearch_haystack.document_store import ElasticsearchDocumentStore

--- a/integrations/opensearch/src/opensearch_haystack/__about__.py
+++ b/integrations/opensearch/src/opensearch_haystack/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 from haystack.dataclasses.document import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
-from haystack.document_stores.protocols import DuplicatePolicy
+from haystack.document_stores.protocol import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
 from opensearchpy.exceptions import RequestError
 


### PR DESCRIPTION
- document_store/protocol was renamed in https://github.com/deepset-ai/haystack/pull/6448

- this PR fixes the import in the Document Stores (fixes errors like this: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7094348178)

- increased the version numbers to prepare the new releases