### PR TITLE
chore: remove LazyImport from integrations

### DIFF
--- a/integrations/gradient/src/gradient_haystack/embedders/gradient_document_embedder.py
+++ b/integrations/gradient/src/gradient_haystack/embedders/gradient_document_embedder.py
@@ -2,10 +2,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from haystack import Document, component, default_to_dict
-from haystack.lazy_imports import LazyImport
-
-with LazyImport(message="Run 'pip install gradientai'") as gradientai_import:
-    from gradientai import Gradient
+from gradientai import Gradient
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +46,6 @@ class GradientDocumentEmbedder:
                              variable GRADIENT_WORKSPACE_ID.
         :param host: The Gradient host. By default it uses https://api.gradient.ai/.
         """
-        gradientai_import.check()
         self._batch_size = batch_size
         self._host = host
         self._model_name = model_name

--- a/integrations/gradient/src/gradient_haystack/embedders/gradient_document_embedder.py
+++ b/integrations/gradient/src/gradient_haystack/embedders/gradient_document_embedder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from haystack import Document, component, default_to_dict
 from gradientai import Gradient
+from haystack import Document, component, default_to_dict
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/gradient/src/gradient_haystack/embedders/gradient_text_embedder.py
+++ b/integrations/gradient/src/gradient_haystack/embedders/gradient_text_embedder.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
-from haystack import component, default_to_dict
 from gradientai import Gradient
+from haystack import component, default_to_dict
 
 
 @component

--- a/integrations/gradient/src/gradient_haystack/embedders/gradient_text_embedder.py
+++ b/integrations/gradient/src/gradient_haystack/embedders/gradient_text_embedder.py
@@ -1,10 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from haystack import component, default_to_dict
-from haystack.lazy_imports import LazyImport
-
-with LazyImport(message="Run 'pip install gradientai'") as gradientai_import:
-    from gradientai import Gradient
+from gradientai import Gradient
 
 
 @component
@@ -43,7 +40,6 @@ class GradientTextEmbedder:
                              variable GRADIENT_WORKSPACE_ID.
         :param host: The Gradient host. By default it uses https://api.gradient.ai/.
         """
-        gradientai_import.check()
         self._host = host
         self._model_name = model_name
 

--- a/integrations/gradient/src/gradient_haystack/generator/base.py
+++ b/integrations/gradient/src/gradient_haystack/generator/base.py
@@ -2,10 +2,8 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from haystack import component, default_to_dict
-from haystack.lazy_imports import LazyImport
+from gradientai import Gradient
 
-with LazyImport(message="Run 'pip install gradientai'") as gradientai_import:
-    from gradientai import Gradient
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +55,6 @@ class GradientGenerator:
         :param workspace_id: The Gradient workspace ID. If not provided it's read from the environment
                              variable GRADIENT_WORKSPACE_ID.
         """
-        gradientai_import.check()
-
         self._access_token = access_token
         self._base_model_slug = base_model_slug
         self._host = host

--- a/integrations/gradient/src/gradient_haystack/generator/base.py
+++ b/integrations/gradient/src/gradient_haystack/generator/base.py
@@ -1,9 +1,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from haystack import component, default_to_dict
 from gradientai import Gradient
-
+from haystack import component, default_to_dict
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/instructor-embedders/instructor_embedders/embedding_backend/instructor_backend.py
+++ b/integrations/instructor-embedders/instructor_embedders/embedding_backend/instructor_backend.py
@@ -3,10 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import ClassVar, Dict, List, Optional, Union
 
-from haystack.lazy_imports import LazyImport
-
-with LazyImport(message="Run 'pip install InstructorEmbedding'") as instructor_embeddings_import:
-    from InstructorEmbedding import INSTRUCTOR
+from InstructorEmbedding import INSTRUCTOR
 
 
 class _InstructorEmbeddingBackendFactory:
@@ -40,7 +37,6 @@ class _InstructorEmbeddingBackend:
     def __init__(
         self, model_name_or_path: str, device: Optional[str] = None, use_auth_token: Union[bool, str, None] = None
     ):
-        instructor_embeddings_import.check()
         self.model = INSTRUCTOR(model_name_or_path=model_name_or_path, device=device, use_auth_token=use_auth_token)
 
     def embed(self, data: List[List[str]], **kwargs) -> List[List[float]]:


### PR DESCRIPTION
Since integration packages depend on the respective external libraries, we should assume the dependency is there, without attempting to lazy-import it.

Note: I didn't remove it from `cohere` because that's done as part of https://github.com/deepset-ai/haystack-core-integrations/pull/80, to avoid conflicts