### PR TITLE
Revert "Bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts deepset-ai/haystack-core-integrations#78

Updating the labeler config to v5 didn't work following the documentation: https://github.com/deepset-ai/haystack-core-integrations/pull/84
There is a already an open issue: https://github.com/actions/labeler/issues/712