### PR TITLE
Cohere: remove unused constant

### DIFF
--- a/integrations/cohere/src/cohere_haystack/embedders/utils.py
+++ b/integrations/cohere/src/cohere_haystack/embedders/utils.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, List, Tuple
 from cohere import AsyncClient, Client, CohereError
 from tqdm import tqdm
 
-API_BASE_URL = "https://api.cohere.ai/v1/embed"
-
 
 async def get_async_response(cohere_async_client: AsyncClient, texts: List[str], model_name, truncate):
     all_embeddings: List[List[float]] = []


### PR DESCRIPTION
`API_BASE_URL` is unused and contains an outdated value.
It should be removed to avoid confusion.