### PR TITLE
Cohere: increase version to prepare release

### DIFF
--- a/integrations/cohere/src/cohere_haystack/__about__.py
+++ b/integrations/cohere/src/cohere_haystack/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.1.1"
+__version__ = "0.2.0"


### PR DESCRIPTION
Support for Cohere V3 models was added in #89.

It's time to release a new version and I'm simply increasing the version number...