### PR TITLE
Fix project URLs

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -28,9 +28,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/masci/chroma-haystack#readme"
-Issues = "https://github.com/masci/chroma-haystack/issues"
-Source = "https://github.com/masci/chroma-haystack"
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma"
 
 [tool.hatch.version]
 path = "src/chroma_haystack/__about__.py"

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/unknown/cohere-haystack#readme"
-Issues = "https://github.com/unknown/cohere-haystack/issues"
-Source = "https://github.com/unknown/cohere-haystack"
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere"
 
 [tool.hatch.version]
 path = "src/cohere_haystack/__about__.py"

--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -29,9 +29,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/document_stores/elasticsearch#readme"
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/elasticsearch#readme"
 Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
-Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/document_stores/elasticsearch"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/elasticsearch"
 
 [tool.hatch.version]
 path = "src/elasticsearch_haystack/__about__.py"

--- a/integrations/gradient/pyproject.toml
+++ b/integrations/gradient/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/unknown/gradient-haystack#readme"
-Issues = "https://github.com/unknown/gradient-haystack/issues"
-Source = "https://github.com/unknown/gradient-haystack"
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/gradient#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/gradient"
 
 [tool.hatch.version]
 path = "src/gradient_haystack/__about__.py"

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 dependencies = ["requests", "haystack-ai"]
 
 [project.urls]
-Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina/jina-haystack#readme"
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina#readme"
 Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
-Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina/jina-haystack"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina"
 
 [tool.hatch.version]
 path = "src/jina_haystack/__about__.py"

--- a/integrations/unstructured/fileconverter/pyproject.toml
+++ b/integrations/unstructured/fileconverter/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/components/converters/unstructured_fileconverter#readme"
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/unstructured/fileconverter#readme"
 Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
-Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/components/converters/unstructured_fileconverter"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/unstructured/fileconverter"
 
 [tool.hatch.version]
 path = "src/unstructured_fileconverter_haystack/__about__.py"

--- a/nodes/text2speech/pyproject.toml
+++ b/nodes/text2speech/pyproject.toml
@@ -43,9 +43,9 @@ dynamic = ["version"]
 dev = ["pytest", "pylint", "black"]
 
 [project.urls]
-Documentation = "https://github.com/deepset-ai/haystack-extras/tree/main/nodes/text2speech#readme"
-Issues = "https://github.com/deepset-ai/haystack-extras/issues"
-Source = "https://github.com/deepset-ai/haystack-extras/tree/main/nodes/text2speech"
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/nodes/text2speech#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/nodes/text2speech"
 
 [tool.hatch.version]
 path = "text2speech/__about__.py"


### PR DESCRIPTION
Several integrations have outdated or wrong project URLs...

I'm leaving out `instructor-embedders`, since the URLs of this integration will be fixed in #95.