### PR TITLE
Change default 'input_type' for CohereTextEmbedder

### DIFF
--- a/integrations/cohere/src/cohere_haystack/embedders/text_embedder.py
+++ b/integrations/cohere/src/cohere_haystack/embedders/text_embedder.py
@@ -35,7 +35,7 @@ class CohereTextEmbedder:
         self,
         api_key: Optional[str] = None,
         model_name: str = "embed-english-v2.0",
-        input_type: str = "search_document",
+        input_type: str = "search_query",
         api_base_url: str = COHERE_API_URL,
         truncate: str = "END",
         use_async_client: bool = False,

--- a/integrations/cohere/tests/test_text_embedder.py
+++ b/integrations/cohere/tests/test_text_embedder.py
@@ -20,7 +20,7 @@ class TestCohereTextEmbedder:
 
         assert embedder.api_key == "test-api-key"
         assert embedder.model_name == "embed-english-v2.0"
-        assert embedder.input_type == "search_document"
+        assert embedder.input_type == "search_query"
         assert embedder.api_base_url == COHERE_API_URL
         assert embedder.truncate == "END"
         assert embedder.use_async_client is False
@@ -34,7 +34,7 @@ class TestCohereTextEmbedder:
         embedder = CohereTextEmbedder(
             api_key="test-api-key",
             model_name="embed-multilingual-v2.0",
-            input_type="search_query",
+            input_type="classification",
             api_base_url="https://custom-api-base-url.com",
             truncate="START",
             use_async_client=True,
@@ -43,7 +43,7 @@ class TestCohereTextEmbedder:
         )
         assert embedder.api_key == "test-api-key"
         assert embedder.model_name == "embed-multilingual-v2.0"
-        assert embedder.input_type == "search_query"
+        assert embedder.input_type == "classification"
         assert embedder.api_base_url == "https://custom-api-base-url.com"
         assert embedder.truncate == "START"
         assert embedder.use_async_client is True
@@ -60,7 +60,7 @@ class TestCohereTextEmbedder:
             "type": "cohere_haystack.embedders.text_embedder.CohereTextEmbedder",
             "init_parameters": {
                 "model_name": "embed-english-v2.0",
-                "input_type": "search_document",
+                "input_type": "search_query",
                 "api_base_url": COHERE_API_URL,
                 "truncate": "END",
                 "use_async_client": False,
@@ -76,7 +76,7 @@ class TestCohereTextEmbedder:
         embedder_component = CohereTextEmbedder(
             api_key="test-api-key",
             model_name="embed-multilingual-v2.0",
-            input_type="search_query",
+            input_type="classification",
             api_base_url="https://custom-api-base-url.com",
             truncate="START",
             use_async_client=True,
@@ -88,7 +88,7 @@ class TestCohereTextEmbedder:
             "type": "cohere_haystack.embedders.text_embedder.CohereTextEmbedder",
             "init_parameters": {
                 "model_name": "embed-multilingual-v2.0",
-                "input_type": "search_query",
+                "input_type": "classification",
                 "api_base_url": "https://custom-api-base-url.com",
                 "truncate": "START",
                 "use_async_client": True,


### PR DESCRIPTION
Having `input_type = "search_query"` is a better default value for CohereTextEmbedder according to [Cohere Docs](https://docs.cohere.com/reference/embed)