### PR TITLE
chore: pin unstructured api version

### DIFF
--- a/.github/workflows/unstructured_fileconverter.yml
+++ b/.github/workflows/unstructured_fileconverter.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     services:
       unstructured-api:
-        image: "quay.io/unstructured-io/unstructured-api:0.0.58"
+        image: "quay.io/unstructured-io/unstructured-api:latest"
         ports:
           - 8000:8000
         options: >-

--- a/.github/workflows/unstructured_fileconverter.yml
+++ b/.github/workflows/unstructured_fileconverter.yml
@@ -29,14 +29,14 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     services:
       unstructured-api:
-        image: "quay.io/unstructured-io/unstructured-api:latest"
+        image: "quay.io/unstructured-io/unstructured-api:0.0.59"
         ports:
           - 8000:8000
         options: >-
           --health-cmd "curl --fail http://localhost:8000/healthcheck || exit 1"
           --health-interval 10s
           --health-timeout 1s
-          --health-retries 10                  
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unstructured_fileconverter.yml
+++ b/.github/workflows/unstructured_fileconverter.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     services:
       unstructured-api:
-        image: "quay.io/unstructured-io/unstructured-api:0.0.59"
+        image: "quay.io/unstructured-io/unstructured-api:0.0.58"
         ports:
           - 8000:8000
         options: >-

--- a/integrations/unstructured/fileconverter/pyproject.toml
+++ b/integrations/unstructured/fileconverter/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
   # we distribute the preview version of Haystack 2.0 under the package "haystack-ai"
   "haystack-ai",
-  "unstructured",
+  "unstructured<0.11.4", #  FIXME: investigate why 0.11.4 broke the tests
 ]
 
 [project.urls]


### PR DESCRIPTION
~`latest` docker image broke the tests~
The latest release 0.11.4 broke the tests