### PR TITLE
[Elasticsearch] - BM25 retrieval: not all terms must mandatorily match

### DIFF
--- a/integrations/elasticsearch/src/elasticsearch_haystack/document_store.py
+++ b/integrations/elasticsearch/src/elasticsearch_haystack/document_store.py
@@ -108,8 +108,6 @@ class ElasticsearchDocumentStore:
         if top_k is None and "knn" in kwargs and "k" in kwargs["knn"]:
             top_k = kwargs["knn"]["k"]
 
-        print(top_k)
-
         documents: List[Document] = []
         from_ = 0
         # Handle pagination
@@ -119,8 +117,6 @@ class ElasticsearchDocumentStore:
                 from_=from_,
                 **kwargs,
             )
-
-            print(res)
 
             documents.extend(self._deserialize_document(hit) for hit in res["hits"]["hits"])
             from_ = len(documents)
@@ -267,7 +263,7 @@ class ElasticsearchDocumentStore:
                                 "query": query,
                                 "fuzziness": fuzziness,
                                 "type": "most_fields",
-                                "operator": "AND",
+                                "operator": "OR",
                             }
                         }
                     ]

--- a/integrations/elasticsearch/src/elasticsearch_haystack/document_store.py
+++ b/integrations/elasticsearch/src/elasticsearch_haystack/document_store.py
@@ -108,6 +108,8 @@ class ElasticsearchDocumentStore:
         if top_k is None and "knn" in kwargs and "k" in kwargs["knn"]:
             top_k = kwargs["knn"]["k"]
 
+        print(top_k)
+
         documents: List[Document] = []
         from_ = 0
         # Handle pagination
@@ -117,6 +119,8 @@ class ElasticsearchDocumentStore:
                 from_=from_,
                 **kwargs,
             )
+
+            print(res)
 
             documents.extend(self._deserialize_document(hit) for hit in res["hits"]["hits"])
             from_ = len(documents)

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -182,6 +182,25 @@ class TestDocumentStore(DocumentStoreBaseTests):
         assert "functional" in res[1].content
         assert "functional" in res[2].content
 
+    def test_bm25_not_all_terms_must_match(self, document_store: ElasticsearchDocumentStore):
+        """
+        Test that not all terms must mandatorily match for BM25 retrieval to return a result.
+        """
+        documents = [
+            Document(content="There are over 7,000 languages spoken around the world today."),
+            Document(
+                content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors."
+            ),
+            Document(
+                content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves."
+            ),
+        ]
+        document_store.write_documents(documents)
+
+        res = document_store._bm25_retrieval("How much self awareness do elephants have?", top_k=3)
+        assert len(res) == 1
+        assert res[0] == documents[1]
+
     def test_embedding_retrieval(self, document_store: ElasticsearchDocumentStore):
         docs = [
             Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -190,11 +190,17 @@ class TestDocumentStore(DocumentStoreBaseTests):
             Document(id=1, content="There are over 7,000 languages spoken around the world today."),
             Document(
                 id=2,
-                content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors.",
+                content=(
+                    "Elephants have been observed to behave in a way that indicates a high level of self-awareness"
+                    " such as recognizing themselves in mirrors."
+                ),
             ),
             Document(
                 id=3,
-                content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.",
+                content=(
+                    "In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness"
+                    " the phenomenon of bioluminescent waves."
+                ),
             ),
         ]
         document_store.write_documents(documents)

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -187,19 +187,21 @@ class TestDocumentStore(DocumentStoreBaseTests):
         Test that not all terms must mandatorily match for BM25 retrieval to return a result.
         """
         documents = [
-            Document(content="There are over 7,000 languages spoken around the world today."),
+            Document(id=1, content="There are over 7,000 languages spoken around the world today."),
             Document(
-                content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors."
+                id=2,
+                content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors.",
             ),
             Document(
-                content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves."
+                id=3,
+                content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.",
             ),
         ]
         document_store.write_documents(documents)
 
         res = document_store._bm25_retrieval("How much self awareness do elephants have?", top_k=3)
         assert len(res) == 1
-        assert res[0] == documents[1]
+        assert res[0].id == 2
 
     def test_embedding_retrieval(self, document_store: ElasticsearchDocumentStore):
         docs = [


### PR DESCRIPTION
Fixes #124.

Details in the original issue.

 