### PR TITLE
fixed: The default model of VertexAIImagegenerator

### DIFF
--- a/integrations/google_vertex/src/google_vertex_haystack/generators/image_generator.py
+++ b/integrations/google_vertex/src/google_vertex_haystack/generators/image_generator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 @component
 class VertexAIImageGenerator:
-    def __init__(self, *, model: str = "imagetext", project_id: str, location: Optional[str] = None, **kwargs):
+    def __init__(self, *, model: str = "imagegeneration", project_id: str, location: Optional[str] = None, **kwargs):
         """
         Generates images using a Google Vertex AI model.
 
@@ -21,7 +21,7 @@ class VertexAIImageGenerator:
         https://cloud.google.com/docs/authentication/provide-credentials-adc
 
         :param project_id: ID of the GCP project to use.
-        :param model: Name of the model to use, defaults to "imagetext".
+        :param model: Name of the model to use, defaults to "imagegeneration".
         :param location: The default location to use when making API calls, if not set uses us-central-1.
             Defaults to None.
         :param kwargs: Additional keyword arguments to pass to the model.


### PR DESCRIPTION
fixes: #151 

This PR addresses a discrepancy in the default model used by VertexAIImageGenerator. According to the Vertex AI documentation, the correct default model for image generation is `imagegeneration`. However, the current default model is set to `imagetext`, which is designed for image captioning.

Updated the default model for VertexAIImageGenerator to `imagegeneration` to align with the Vertex AI documentation.