### PR TITLE
Add VertexAI prefix to GeminiGenerator and GeminiChatGenerator components

### DIFF
--- a/integrations/google_vertex/src/google_vertex_haystack/generators/chat/gemini.py
+++ b/integrations/google_vertex/src/google_vertex_haystack/generators/chat/gemini.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @component
-class GeminiChatGenerator:
+class VertexAIGeminiChatGenerator:
     def __init__(
         self,
         *,
@@ -100,7 +100,7 @@ class GeminiChatGenerator:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GeminiChatGenerator":
+    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIGeminiChatGenerator":
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [Tool.from_dict(t) for t in tools]
         if (generation_config := data["init_parameters"].get("generation_config")) is not None:

--- a/integrations/google_vertex/src/google_vertex_haystack/generators/gemini.py
+++ b/integrations/google_vertex/src/google_vertex_haystack/generators/gemini.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @component
-class GeminiGenerator:
+class VertexAIGeminiGenerator:
     def __init__(
         self,
         *,
@@ -111,7 +111,7 @@ class GeminiGenerator:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GeminiGenerator":
+    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIGeminiGenerator":
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [Tool.from_dict(t) for t in tools]
         if (generation_config := data["init_parameters"].get("generation_config")) is not None:


### PR DESCRIPTION
To differentiate generators using Gemini we add this `VertexAI` prefix as we'd done with the `google-ai-haystack` integration that has the `GoogleAI` prefix for the Gemini generators.