### PR TITLE
Add healthcheck to Ollama service

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -33,7 +33,12 @@ jobs:
         image: ollama/ollama:latest
         ports:
           - 11434:11434
-        options: --name ollama
+        options: >-
+          --name ollama
+          --health-cmd "curl --fail http://localhost:11434/ || exit 1"
+          --health-interval 10s
+          --health-timeout 1s
+          --health-retries 10 
         
     steps:
       - name: Pull the LLM in the Ollama service


### PR DESCRIPTION
Sometimes Ollama tests fail because the Ollama service is not fully ready when the next steps in the workflow are executed.
See for example https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7454708762/job/20282535972

This PR adds a healthcheck that should avoid this problem.