### PR TITLE
chore!: Rename `model_name` to `model` in the Cohere integration

### DIFF
--- a/integrations/cohere/src/cohere_haystack/chat/chat_generator.py
+++ b/integrations/cohere/src/cohere_haystack/chat/chat_generator.py
@@ -27,7 +27,7 @@ class CohereChatGenerator:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "command",
+        model: str = "command",
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
         api_base_url: Optional[str] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
@@ -37,7 +37,7 @@ class CohereChatGenerator:
         Initialize the CohereChatGenerator instance.
 
         :param api_key: The API key for the Cohere API. If not set, it will be read from the COHERE_API_KEY env var.
-        :param model_name: The name of the model to use. Available models are: [command, command-light, command-nightly,
+        :param model: The name of the model to use. Available models are: [command, command-light, command-nightly,
             command-nightly-light]. Defaults to "command".
         :param streaming_callback: A callback function to be called with the streaming response. Defaults to None.
         :param api_base_url: The base URL of the Cohere API. Defaults to "https://api.cohere.ai".
@@ -82,7 +82,7 @@ class CohereChatGenerator:
         if generation_kwargs is None:
             generation_kwargs = {}
         self.api_key = api_key
-        self.model_name = model_name
+        self.model = model
         self.streaming_callback = streaming_callback
         self.api_base_url = api_base_url
         self.generation_kwargs = generation_kwargs
@@ -93,7 +93,7 @@ class CohereChatGenerator:
         """
         Data that is sent to Posthog for usage analytics.
         """
-        return {"model": self.model_name}
+        return {"model": self.model}
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -103,7 +103,7 @@ class CohereChatGenerator:
         callback_name = serialize_callback_handler(self.streaming_callback) if self.streaming_callback else None
         return default_to_dict(
             self,
-            model_name=self.model_name,
+            model=self.model,
             streaming_callback=callback_name,
             api_base_url=self.api_base_url,
             generation_kwargs=self.generation_kwargs,
@@ -147,7 +147,7 @@ class CohereChatGenerator:
         chat_history = [self._message_to_dict(m) for m in messages[:-1]]
         response = self.client.chat(
             message=messages[-1].content,
-            model=self.model_name,
+            model=self.model,
             stream=self.streaming_callback is not None,
             chat_history=chat_history,
             **generation_kwargs,
@@ -160,7 +160,7 @@ class CohereChatGenerator:
             chat_message = ChatMessage.from_assistant(content=response.texts)
             chat_message.meta.update(
                 {
-                    "model": self.model_name,
+                    "model": self.model,
                     "usage": response.token_count,
                     "index": 0,
                     "finish_reason": response.finish_reason,
@@ -193,7 +193,7 @@ class CohereChatGenerator:
         message = ChatMessage.from_assistant(content=content)
         message.meta.update(
             {
-                "model": self.model_name,
+                "model": self.model,
                 "usage": cohere_response.token_count,
                 "index": 0,
                 "finish_reason": None,

--- a/integrations/cohere/src/cohere_haystack/embedders/document_embedder.py
+++ b/integrations/cohere/src/cohere_haystack/embedders/document_embedder.py
@@ -36,7 +36,7 @@ class CohereDocumentEmbedder:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "embed-english-v2.0",
+        model: str = "embed-english-v2.0",
         input_type: str = "search_document",
         api_base_url: str = COHERE_API_URL,
         truncate: str = "END",
@@ -53,7 +53,7 @@ class CohereDocumentEmbedder:
 
         :param api_key: The Cohere API key. It can be explicitly provided or automatically read from the environment
             variable COHERE_API_KEY (recommended).
-        :param model_name: The name of the model to use, defaults to `"embed-english-v2.0"`. Supported Models are:
+        :param model: The name of the model to use, defaults to `"embed-english-v2.0"`. Supported Models are:
             `"embed-english-v3.0"`, `"embed-english-light-v3.0"`, `"embed-multilingual-v3.0"`,
             `"embed-multilingual-light-v3.0"`, `"embed-english-v2.0"`, `"embed-english-light-v2.0"`,
             `"embed-multilingual-v2.0"`. This list of all supported models can be found in the
@@ -88,7 +88,7 @@ class CohereDocumentEmbedder:
             raise ValueError(msg)
 
         self.api_key = api_key
-        self.model_name = model_name
+        self.model = model
         self.input_type = input_type
         self.api_base_url = api_base_url
         self.truncate = truncate
@@ -106,7 +106,7 @@ class CohereDocumentEmbedder:
         """
         return default_to_dict(
             self,
-            model_name=self.model_name,
+            model=self.model,
             input_type=self.input_type,
             api_base_url=self.api_base_url,
             truncate=self.truncate,
@@ -160,7 +160,7 @@ class CohereDocumentEmbedder:
                 self.api_key, api_url=self.api_base_url, max_retries=self.max_retries, timeout=self.timeout
             )
             all_embeddings, metadata = asyncio.run(
-                get_async_response(cohere_client, texts_to_embed, self.model_name, self.input_type, self.truncate)
+                get_async_response(cohere_client, texts_to_embed, self.model, self.input_type, self.truncate)
             )
         else:
             cohere_client = Client(
@@ -169,7 +169,7 @@ class CohereDocumentEmbedder:
             all_embeddings, metadata = get_response(
                 cohere_client,
                 texts_to_embed,
-                self.model_name,
+                self.model,
                 self.input_type,
                 self.truncate,
                 self.batch_size,

--- a/integrations/cohere/src/cohere_haystack/embedders/text_embedder.py
+++ b/integrations/cohere/src/cohere_haystack/embedders/text_embedder.py
@@ -34,7 +34,7 @@ class CohereTextEmbedder:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "embed-english-v2.0",
+        model: str = "embed-english-v2.0",
         input_type: str = "search_query",
         api_base_url: str = COHERE_API_URL,
         truncate: str = "END",
@@ -47,7 +47,7 @@ class CohereTextEmbedder:
 
         :param api_key: The Cohere API key. It can be explicitly provided or automatically read from the environment
             variable COHERE_API_KEY (recommended).
-        :param model_name: The name of the model to use, defaults to `"embed-english-v2.0"`. Supported Models are:
+        :param model: The name of the model to use, defaults to `"embed-english-v2.0"`. Supported Models are:
             `"embed-english-v3.0"`, `"embed-english-light-v3.0"`, `"embed-multilingual-v3.0"`,
             `"embed-multilingual-light-v3.0"`, `"embed-english-v2.0"`, `"embed-english-light-v2.0"`,
             `"embed-multilingual-v2.0"`. This list of all supported models can be found in the
@@ -77,7 +77,7 @@ class CohereTextEmbedder:
             raise ValueError(msg)
 
         self.api_key = api_key
-        self.model_name = model_name
+        self.model = model
         self.input_type = input_type
         self.api_base_url = api_base_url
         self.truncate = truncate
@@ -91,7 +91,7 @@ class CohereTextEmbedder:
         """
         return default_to_dict(
             self,
-            model_name=self.model_name,
+            model=self.model,
             input_type=self.input_type,
             api_base_url=self.api_base_url,
             truncate=self.truncate,
@@ -117,12 +117,12 @@ class CohereTextEmbedder:
                 self.api_key, api_url=self.api_base_url, max_retries=self.max_retries, timeout=self.timeout
             )
             embedding, metadata = asyncio.run(
-                get_async_response(cohere_client, [text], self.model_name, self.input_type, self.truncate)
+                get_async_response(cohere_client, [text], self.model, self.input_type, self.truncate)
             )
         else:
             cohere_client = Client(
                 self.api_key, api_url=self.api_base_url, max_retries=self.max_retries, timeout=self.timeout
             )
-            embedding, metadata = get_response(cohere_client, [text], self.model_name, self.input_type, self.truncate)
+            embedding, metadata = get_response(cohere_client, [text], self.model, self.input_type, self.truncate)
 
         return {"embedding": embedding[0], "meta": metadata}

--- a/integrations/cohere/src/cohere_haystack/generator.py
+++ b/integrations/cohere/src/cohere_haystack/generator.py
@@ -32,7 +32,7 @@ class CohereGenerator:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "command",
+        model: str = "command",
         streaming_callback: Optional[Callable] = None,
         api_base_url: Optional[str] = None,
         **kwargs,
@@ -41,7 +41,7 @@ class CohereGenerator:
         Instantiates a `CohereGenerator` component.
 
         :param api_key: The API key for the Cohere API. If not set, it will be read from the COHERE_API_KEY env var.
-        :param model_name: The name of the model to use. Available models are: [command, command-light, command-nightly,
+        :param model: The name of the model to use. Available models are: [command, command-light, command-nightly,
             command-nightly-light]. Defaults to "command".
         :param streaming_callback: A callback function to be called with the streaming response. Defaults to None.
         :param api_base_url: The base URL of the Cohere API. Defaults to "https://api.cohere.ai".
@@ -86,7 +86,7 @@ class CohereGenerator:
             api_base_url = COHERE_API_URL
 
         self.api_key = api_key
-        self.model_name = model_name
+        self.model = model
         self.streaming_callback = streaming_callback
         self.api_base_url = api_base_url
         self.model_parameters = kwargs
@@ -107,7 +107,7 @@ class CohereGenerator:
 
         return default_to_dict(
             self,
-            model_name=self.model_name,
+            model=self.model,
             streaming_callback=callback_name,
             api_base_url=self.api_base_url,
             **self.model_parameters,
@@ -142,7 +142,7 @@ class CohereGenerator:
         :param prompt: The prompt to be sent to the generative model.
         """
         response = self.client.generate(
-            model=self.model_name, prompt=prompt, stream=self.streaming_callback is not None, **self.model_parameters
+            model=self.model, prompt=prompt, stream=self.streaming_callback is not None, **self.model_parameters
         )
         if self.streaming_callback:
             metadata_dict: Dict[str, Any] = {}

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -260,9 +260,7 @@ class TestCohereChatGenerator:
     )
     @pytest.mark.integration
     def test_live_run_wrong_model(self, chat_messages):
-        component = CohereChatGenerator(
-            model="something-obviously-wrong", api_key=os.environ.get("COHERE_API_KEY")
-        )
+        component = CohereChatGenerator(model="something-obviously-wrong", api_key=os.environ.get("COHERE_API_KEY"))
         with pytest.raises(cohere.CohereAPIError, match="finetuned model something-obviously-wrong is not valid"):
             component.run(chat_messages)
 

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -57,7 +57,7 @@ class TestCohereChatGenerator:
     def test_init_default(self):
         component = CohereChatGenerator(api_key="test-api-key")
         assert component.api_key == "test-api-key"
-        assert component.model_name == "command"
+        assert component.model == "command"
         assert component.streaming_callback is None
         assert component.api_base_url == cohere.COHERE_API_URL
         assert not component.generation_kwargs
@@ -72,13 +72,13 @@ class TestCohereChatGenerator:
     def test_init_with_parameters(self):
         component = CohereChatGenerator(
             api_key="test-api-key",
-            model_name="command-nightly",
+            model="command-nightly",
             streaming_callback=default_streaming_callback,
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
         assert component.api_key == "test-api-key"
-        assert component.model_name == "command-nightly"
+        assert component.model == "command-nightly"
         assert component.streaming_callback is default_streaming_callback
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -90,7 +90,7 @@ class TestCohereChatGenerator:
         assert data == {
             "type": "cohere_haystack.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model_name": "command",
+                "model": "command",
                 "streaming_callback": None,
                 "api_base_url": "https://api.cohere.ai",
                 "generation_kwargs": {},
@@ -101,7 +101,7 @@ class TestCohereChatGenerator:
     def test_to_dict_with_parameters(self):
         component = CohereChatGenerator(
             api_key="test-api-key",
-            model_name="command-nightly",
+            model="command-nightly",
             streaming_callback=default_streaming_callback,
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
@@ -110,7 +110,7 @@ class TestCohereChatGenerator:
         assert data == {
             "type": "cohere_haystack.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model_name": "command-nightly",
+                "model": "command-nightly",
                 "streaming_callback": "haystack.components.generators.utils.default_streaming_callback",
                 "api_base_url": "test-base-url",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -121,7 +121,7 @@ class TestCohereChatGenerator:
     def test_to_dict_with_lambda_streaming_callback(self):
         component = CohereChatGenerator(
             api_key="test-api-key",
-            model_name="command",
+            model="command",
             streaming_callback=lambda x: x,
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
@@ -130,7 +130,7 @@ class TestCohereChatGenerator:
         assert data == {
             "type": "cohere_haystack.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model_name": "command",
+                "model": "command",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "tests.test_cohere_chat_generator.<lambda>",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -143,14 +143,14 @@ class TestCohereChatGenerator:
         data = {
             "type": "cohere_haystack.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model_name": "command",
+                "model": "command",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.default_streaming_callback",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }
         component = CohereChatGenerator.from_dict(data)
-        assert component.model_name == "command"
+        assert component.model == "command"
         assert component.streaming_callback is default_streaming_callback
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -161,7 +161,7 @@ class TestCohereChatGenerator:
         data = {
             "type": "cohere_haystack.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model_name": "command",
+                "model": "command",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.default_streaming_callback",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -261,7 +261,7 @@ class TestCohereChatGenerator:
     @pytest.mark.integration
     def test_live_run_wrong_model(self, chat_messages):
         component = CohereChatGenerator(
-            model_name="something-obviously-wrong", api_key=os.environ.get("COHERE_API_KEY")
+            model="something-obviously-wrong", api_key=os.environ.get("COHERE_API_KEY")
         )
         with pytest.raises(cohere.CohereAPIError, match="finetuned model something-obviously-wrong is not valid"):
             component.run(chat_messages)

--- a/integrations/cohere/tests/test_cohere_generators.py
+++ b/integrations/cohere/tests/test_cohere_generators.py
@@ -23,7 +23,7 @@ class TestCohereGenerator:
     def test_init_default(self):
         component = CohereGenerator(api_key="test-api-key")
         assert component.api_key == "test-api-key"
-        assert component.model_name == "command"
+        assert component.model == "command"
         assert component.streaming_callback is None
         assert component.api_base_url == COHERE_API_URL
         assert component.model_parameters == {}
@@ -32,14 +32,14 @@ class TestCohereGenerator:
         callback = lambda x: x  # noqa: E731
         component = CohereGenerator(
             api_key="test-api-key",
-            model_name="command-light",
+            model="command-light",
             max_tokens=10,
             some_test_param="test-params",
             streaming_callback=callback,
             api_base_url="test-base-url",
         )
         assert component.api_key == "test-api-key"
-        assert component.model_name == "command-light"
+        assert component.model == "command-light"
         assert component.streaming_callback == callback
         assert component.api_base_url == "test-base-url"
         assert component.model_parameters == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -50,7 +50,7 @@ class TestCohereGenerator:
         assert data == {
             "type": "cohere_haystack.generator.CohereGenerator",
             "init_parameters": {
-                "model_name": "command",
+                "model": "command",
                 "streaming_callback": None,
                 "api_base_url": COHERE_API_URL,
             },
@@ -59,7 +59,7 @@ class TestCohereGenerator:
     def test_to_dict_with_parameters(self):
         component = CohereGenerator(
             api_key="test-api-key",
-            model_name="command-light",
+            model="command-light",
             max_tokens=10,
             some_test_param="test-params",
             streaming_callback=default_streaming_callback,
@@ -69,7 +69,7 @@ class TestCohereGenerator:
         assert data == {
             "type": "cohere_haystack.generator.CohereGenerator",
             "init_parameters": {
-                "model_name": "command-light",
+                "model": "command-light",
                 "max_tokens": 10,
                 "some_test_param": "test-params",
                 "api_base_url": "test-base-url",
@@ -80,7 +80,7 @@ class TestCohereGenerator:
     def test_to_dict_with_lambda_streaming_callback(self):
         component = CohereGenerator(
             api_key="test-api-key",
-            model_name="command",
+            model="command",
             max_tokens=10,
             some_test_param="test-params",
             streaming_callback=lambda x: x,
@@ -90,7 +90,7 @@ class TestCohereGenerator:
         assert data == {
             "type": "cohere_haystack.generator.CohereGenerator",
             "init_parameters": {
-                "model_name": "command",
+                "model": "command",
                 "streaming_callback": "tests.test_cohere_generators.<lambda>",
                 "api_base_url": "test-base-url",
                 "max_tokens": 10,
@@ -103,7 +103,7 @@ class TestCohereGenerator:
         data = {
             "type": "cohere_haystack.generator.CohereGenerator",
             "init_parameters": {
-                "model_name": "command",
+                "model": "command",
                 "max_tokens": 10,
                 "some_test_param": "test-params",
                 "api_base_url": "test-base-url",
@@ -112,7 +112,7 @@ class TestCohereGenerator:
         }
         component: CohereGenerator = CohereGenerator.from_dict(data)
         assert component.api_key == "test-key"
-        assert component.model_name == "command"
+        assert component.model == "command"
         assert component.streaming_callback == default_streaming_callback
         assert component.api_base_url == "test-base-url"
         assert component.model_parameters == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -144,10 +144,10 @@ class TestCohereGenerator:
         reason="Export an env var called COHERE_API_KEY containing the Cohere API key to run this test.",
     )
     @pytest.mark.integration
-    def test_cohere_generator_run_wrong_model_name(self):
+    def test_cohere_generator_run_wrong_model(self):
         import cohere
 
-        component = CohereGenerator(model_name="something-obviously-wrong")
+        component = CohereGenerator(model="something-obviously-wrong")
         with pytest.raises(
             cohere.CohereAPIError,
             match="model not found, make sure the correct model ID was used and that you have access to the model.",

--- a/integrations/cohere/tests/test_document_embedder.py
+++ b/integrations/cohere/tests/test_document_embedder.py
@@ -16,7 +16,7 @@ class TestCohereDocumentEmbedder:
     def test_init_default(self):
         embedder = CohereDocumentEmbedder(api_key="test-api-key")
         assert embedder.api_key == "test-api-key"
-        assert embedder.model_name == "embed-english-v2.0"
+        assert embedder.model == "embed-english-v2.0"
         assert embedder.input_type == "search_document"
         assert embedder.api_base_url == COHERE_API_URL
         assert embedder.truncate == "END"
@@ -31,7 +31,7 @@ class TestCohereDocumentEmbedder:
     def test_init_with_parameters(self):
         embedder = CohereDocumentEmbedder(
             api_key="test-api-key",
-            model_name="embed-multilingual-v2.0",
+            model="embed-multilingual-v2.0",
             input_type="search_query",
             api_base_url="https://custom-api-base-url.com",
             truncate="START",
@@ -44,7 +44,7 @@ class TestCohereDocumentEmbedder:
             embedding_separator="-",
         )
         assert embedder.api_key == "test-api-key"
-        assert embedder.model_name == "embed-multilingual-v2.0"
+        assert embedder.model == "embed-multilingual-v2.0"
         assert embedder.input_type == "search_query"
         assert embedder.api_base_url == "https://custom-api-base-url.com"
         assert embedder.truncate == "START"
@@ -62,7 +62,7 @@ class TestCohereDocumentEmbedder:
         assert component_dict == {
             "type": "cohere_haystack.embedders.document_embedder.CohereDocumentEmbedder",
             "init_parameters": {
-                "model_name": "embed-english-v2.0",
+                "model": "embed-english-v2.0",
                 "input_type": "search_document",
                 "api_base_url": COHERE_API_URL,
                 "truncate": "END",
@@ -79,7 +79,7 @@ class TestCohereDocumentEmbedder:
     def test_to_dict_with_custom_init_parameters(self):
         embedder_component = CohereDocumentEmbedder(
             api_key="test-api-key",
-            model_name="embed-multilingual-v2.0",
+            model="embed-multilingual-v2.0",
             input_type="search_query",
             api_base_url="https://custom-api-base-url.com",
             truncate="START",
@@ -95,7 +95,7 @@ class TestCohereDocumentEmbedder:
         assert component_dict == {
             "type": "cohere_haystack.embedders.document_embedder.CohereDocumentEmbedder",
             "init_parameters": {
-                "model_name": "embed-multilingual-v2.0",
+                "model": "embed-multilingual-v2.0",
                 "input_type": "search_query",
                 "api_base_url": "https://custom-api-base-url.com",
                 "truncate": "START",

--- a/integrations/cohere/tests/test_text_embedder.py
+++ b/integrations/cohere/tests/test_text_embedder.py
@@ -19,7 +19,7 @@ class TestCohereTextEmbedder:
         embedder = CohereTextEmbedder(api_key="test-api-key")
 
         assert embedder.api_key == "test-api-key"
-        assert embedder.model_name == "embed-english-v2.0"
+        assert embedder.model == "embed-english-v2.0"
         assert embedder.input_type == "search_query"
         assert embedder.api_base_url == COHERE_API_URL
         assert embedder.truncate == "END"
@@ -33,7 +33,7 @@ class TestCohereTextEmbedder:
         """
         embedder = CohereTextEmbedder(
             api_key="test-api-key",
-            model_name="embed-multilingual-v2.0",
+            model="embed-multilingual-v2.0",
             input_type="classification",
             api_base_url="https://custom-api-base-url.com",
             truncate="START",
@@ -42,7 +42,7 @@ class TestCohereTextEmbedder:
             timeout=60,
         )
         assert embedder.api_key == "test-api-key"
-        assert embedder.model_name == "embed-multilingual-v2.0"
+        assert embedder.model == "embed-multilingual-v2.0"
         assert embedder.input_type == "classification"
         assert embedder.api_base_url == "https://custom-api-base-url.com"
         assert embedder.truncate == "START"
@@ -59,7 +59,7 @@ class TestCohereTextEmbedder:
         assert component_dict == {
             "type": "cohere_haystack.embedders.text_embedder.CohereTextEmbedder",
             "init_parameters": {
-                "model_name": "embed-english-v2.0",
+                "model": "embed-english-v2.0",
                 "input_type": "search_query",
                 "api_base_url": COHERE_API_URL,
                 "truncate": "END",
@@ -75,7 +75,7 @@ class TestCohereTextEmbedder:
         """
         embedder_component = CohereTextEmbedder(
             api_key="test-api-key",
-            model_name="embed-multilingual-v2.0",
+            model="embed-multilingual-v2.0",
             input_type="classification",
             api_base_url="https://custom-api-base-url.com",
             truncate="START",
@@ -87,7 +87,7 @@ class TestCohereTextEmbedder:
         assert component_dict == {
             "type": "cohere_haystack.embedders.text_embedder.CohereTextEmbedder",
             "init_parameters": {
-                "model_name": "embed-multilingual-v2.0",
+                "model": "embed-multilingual-v2.0",
                 "input_type": "classification",
                 "api_base_url": "https://custom-api-base-url.com",
                 "truncate": "START",


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/227

- Related to https://github.com/deepset-ai/haystack-integrations/pull/128

### Proposed Changes:

- Rename `model_name` to `model` in the generators and embedders of the Cohere integration

### How did you test it?

Local tests run, CI
