### PR TITLE
 chore!: Rename `model_name_or_path` to `model` in the Instructor integration

### DIFF
--- a/integrations/instructor_embedders/instructor_embedders_haystack/instructor_document_embedder.py
+++ b/integrations/instructor_embedders/instructor_embedders_haystack/instructor_document_embedder.py
@@ -26,7 +26,7 @@ class InstructorDocumentEmbedder:
     doc_embedding_instruction = "Represent the Medical Document for retrieval:"
 
     doc_embedder = InstructorDocumentEmbedder(
-        model_name_or_path="hkunlp/instructor-base",
+        model="hkunlp/instructor-base",
         instruction=doc_embedding_instruction,
         batch_size=32,
         device="cpu",
@@ -60,7 +60,7 @@ class InstructorDocumentEmbedder:
 
     def __init__(
         self,
-        model_name_or_path: str = "hkunlp/instructor-base",
+        model: str = "hkunlp/instructor-base",
         device: Optional[str] = None,
         use_auth_token: Union[bool, str, None] = None,
         instruction: str = "Represent the document",
@@ -73,7 +73,7 @@ class InstructorDocumentEmbedder:
         """
         Create an InstructorDocumentEmbedder component.
 
-        :param model_name_or_path: Local path or name of the model in Hugging Face's model hub,
+        :param model: Local path or name of the model in Hugging Face's model hub,
             such as ``'hkunlp/instructor-base'``.
         :param device: Device (like 'cuda' / 'cpu') that should be used for computation.
             If None, checks if a GPU can be used.
@@ -95,7 +95,7 @@ class InstructorDocumentEmbedder:
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         """
 
-        self.model_name_or_path = model_name_or_path
+        self.model = model
         # TODO: remove device parameter and use Haystack's device management once migrated
         self.device = device or "cpu"
         self.use_auth_token = use_auth_token
@@ -112,7 +112,7 @@ class InstructorDocumentEmbedder:
         """
         return default_to_dict(
             self,
-            model_name_or_path=self.model_name_or_path,
+            model=self.model,
             device=self.device,
             use_auth_token=self.use_auth_token,
             instruction=self.instruction,
@@ -136,7 +136,7 @@ class InstructorDocumentEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-                model_name_or_path=self.model_name_or_path, device=self.device, use_auth_token=self.use_auth_token
+                model_name_or_path=self.model, device=self.device, use_auth_token=self.use_auth_token
             )
 
     @component.output_types(documents=List[Document])

--- a/integrations/instructor_embedders/instructor_embedders_haystack/instructor_document_embedder.py
+++ b/integrations/instructor_embedders/instructor_embedders_haystack/instructor_document_embedder.py
@@ -95,7 +95,7 @@ class InstructorDocumentEmbedder:
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         """
 
-        self.model = model
+        self.model_name_or_path = model
         # TODO: remove device parameter and use Haystack's device management once migrated
         self.device = device or "cpu"
         self.use_auth_token = use_auth_token
@@ -112,7 +112,7 @@ class InstructorDocumentEmbedder:
         """
         return default_to_dict(
             self,
-            model=self.model,
+            model=self.model_name_or_path,
             device=self.device,
             use_auth_token=self.use_auth_token,
             instruction=self.instruction,
@@ -136,7 +136,7 @@ class InstructorDocumentEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-                model_name_or_path=self.model, device=self.device, use_auth_token=self.use_auth_token
+                model_name_or_path=self.model_name_or_path, device=self.device, use_auth_token=self.use_auth_token
             )
 
     @component.output_types(documents=List[Document])

--- a/integrations/instructor_embedders/instructor_embedders_haystack/instructor_text_embedder.py
+++ b/integrations/instructor_embedders/instructor_embedders_haystack/instructor_text_embedder.py
@@ -67,7 +67,7 @@ class InstructorTextEmbedder:
         :param normalize_embeddings: If set to true, returned vectors will have the length of 1.
         """
 
-        self.model = model
+        self.model_name_or_path = model
         # TODO: remove device parameter and use Haystack's device management once migrated
         self.device = device or "cpu"
         self.use_auth_token = use_auth_token
@@ -82,7 +82,7 @@ class InstructorTextEmbedder:
         """
         return default_to_dict(
             self,
-            model=self.model,
+            model=self.model_name_or_path,
             device=self.device,
             use_auth_token=self.use_auth_token,
             instruction=self.instruction,
@@ -104,7 +104,7 @@ class InstructorTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-                model_name_or_path=self.model, device=self.device, use_auth_token=self.use_auth_token
+                model_name_or_path=self.model_name_or_path, device=self.device, use_auth_token=self.use_auth_token
             )
 
     @component.output_types(embedding=List[float])

--- a/integrations/instructor_embedders/instructor_embedders_haystack/instructor_text_embedder.py
+++ b/integrations/instructor_embedders/instructor_embedders_haystack/instructor_text_embedder.py
@@ -26,7 +26,7 @@ class InstructorTextEmbedder:
     )
 
     text_embedder = InstructorTextEmbedder(
-        model_name_or_path="hkunlp/instructor-base", instruction=instruction,
+        model="hkunlp/instructor-base", instruction=instruction,
         device="cpu"
     )
 
@@ -36,7 +36,7 @@ class InstructorTextEmbedder:
 
     def __init__(
         self,
-        model_name_or_path: str = "hkunlp/instructor-base",
+        model: str = "hkunlp/instructor-base",
         device: Optional[str] = None,
         use_auth_token: Union[bool, str, None] = None,
         instruction: str = "Represent the sentence",
@@ -47,7 +47,7 @@ class InstructorTextEmbedder:
         """
         Create an InstructorTextEmbedder component.
 
-        :param model_name_or_path: Local path or name of the model in Hugging Face's model hub,
+        :param model: Local path or name of the model in Hugging Face's model hub,
             such as ``'hkunlp/instructor-base'``.
         :param device: Device (like 'cuda' / 'cpu') that should be used for computation.
             If None, checks if a GPU can be used.
@@ -67,7 +67,7 @@ class InstructorTextEmbedder:
         :param normalize_embeddings: If set to true, returned vectors will have the length of 1.
         """
 
-        self.model_name_or_path = model_name_or_path
+        self.model = model
         # TODO: remove device parameter and use Haystack's device management once migrated
         self.device = device or "cpu"
         self.use_auth_token = use_auth_token
@@ -82,7 +82,7 @@ class InstructorTextEmbedder:
         """
         return default_to_dict(
             self,
-            model_name_or_path=self.model_name_or_path,
+            model=self.model,
             device=self.device,
             use_auth_token=self.use_auth_token,
             instruction=self.instruction,
@@ -104,7 +104,7 @@ class InstructorTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-                model_name_or_path=self.model_name_or_path, device=self.device, use_auth_token=self.use_auth_token
+                model_name_or_path=self.model, device=self.device, use_auth_token=self.use_auth_token
             )
 
     @component.output_types(embedding=List[float])

--- a/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
@@ -12,8 +12,8 @@ class TestInstructorDocumentEmbedder:
         """
         Test default initialization parameters for InstructorDocumentEmbedder.
         """
-        embedder = InstructorDocumentEmbedder(model_name_or_path="hkunlp/instructor-base")
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the document"
@@ -28,7 +28,7 @@ class TestInstructorDocumentEmbedder:
         Test custom initialization parameters for InstructorDocumentEmbedder.
         """
         embedder = InstructorDocumentEmbedder(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cuda",
             use_auth_token=True,
             instruction="Represent the 'domain' 'text_type' for 'task_objective'",
@@ -38,7 +38,7 @@ class TestInstructorDocumentEmbedder:
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -52,12 +52,12 @@ class TestInstructorDocumentEmbedder:
         """
         Test serialization of InstructorDocumentEmbedder to a dictionary, using default initialization parameters.
         """
-        embedder = InstructorDocumentEmbedder(model_name_or_path="hkunlp/instructor-base")
+        embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
         embedder_dict = embedder.to_dict()
         assert embedder_dict == {
             "type": "instructor_embedders_haystack.instructor_document_embedder.InstructorDocumentEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cpu",
                 "use_auth_token": None,
                 "instruction": "Represent the document",
@@ -74,7 +74,7 @@ class TestInstructorDocumentEmbedder:
         Test serialization of InstructorDocumentEmbedder to a dictionary, using custom initialization parameters.
         """
         embedder = InstructorDocumentEmbedder(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cuda",
             use_auth_token=True,
             instruction="Represent the financial document for retrieval",
@@ -88,7 +88,7 @@ class TestInstructorDocumentEmbedder:
         assert embedder_dict == {
             "type": "instructor_embedders_haystack.instructor_document_embedder.InstructorDocumentEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cuda",
                 "use_auth_token": True,
                 "instruction": "Represent the financial document for retrieval",
@@ -107,7 +107,7 @@ class TestInstructorDocumentEmbedder:
         embedder_dict = {
             "type": "instructor_embedders_haystack.instructor_document_embedder.InstructorDocumentEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cpu",
                 "use_auth_token": None,
                 "instruction": "Represent the 'domain' 'text_type' for 'task_objective'",
@@ -119,7 +119,7 @@ class TestInstructorDocumentEmbedder:
             },
         }
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -136,7 +136,7 @@ class TestInstructorDocumentEmbedder:
         embedder_dict = {
             "type": "instructor_embedders_haystack.instructor_document_embedder.InstructorDocumentEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cuda",
                 "use_auth_token": True,
                 "instruction": "Represent the financial document for retrieval",
@@ -148,7 +148,7 @@ class TestInstructorDocumentEmbedder:
             },
         }
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the financial document for retrieval"
@@ -163,7 +163,7 @@ class TestInstructorDocumentEmbedder:
         """
         Test for checking embedder instances after warm-up.
         """
-        embedder = InstructorDocumentEmbedder(model_name_or_path="hkunlp/instructor-base")
+        embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
@@ -175,7 +175,7 @@ class TestInstructorDocumentEmbedder:
         """
         Test for checking backend instances after multiple warm-ups.
         """
-        embedder = InstructorDocumentEmbedder(model_name_or_path="hkunlp/instructor-base")
+        embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         embedder.warm_up()
@@ -185,7 +185,7 @@ class TestInstructorDocumentEmbedder:
         """
         Test for checking output dimensions and embedding dimensions.
         """
-        embedder = InstructorDocumentEmbedder(model_name_or_path="hkunlp/instructor-large")
+        embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-large")
         embedder.embedding_backend = MagicMock()
         embedder.embedding_backend.embed = lambda x, **kwargs: np.random.rand(len(x), 16).tolist()  # noqa: ARG005
 
@@ -204,7 +204,7 @@ class TestInstructorDocumentEmbedder:
         """
         Test for checking incorrect input format when creating embedding.
         """
-        embedder = InstructorDocumentEmbedder(model_name_or_path="hkunlp/instructor-base")
+        embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
 
         string_input = "text"
         list_integers_input = [1, 2, 3]
@@ -221,7 +221,7 @@ class TestInstructorDocumentEmbedder:
         with a custom instruction and metadata.
         """
         embedder = InstructorDocumentEmbedder(
-            model_name_or_path="model",
+            model="model",
             instruction="Represent the financial document for retrieval",
             meta_fields_to_embed=["meta_field"],
             embedding_separator="\n",
@@ -248,7 +248,7 @@ class TestInstructorDocumentEmbedder:
     @pytest.mark.integration
     def test_run(self):
         embedder = InstructorDocumentEmbedder(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cpu",
             instruction="Represent the Science document for retrieval",
         )

--- a/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
@@ -13,7 +13,7 @@ class TestInstructorDocumentEmbedder:
         Test default initialization parameters for InstructorDocumentEmbedder.
         """
         embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the document"
@@ -38,7 +38,7 @@ class TestInstructorDocumentEmbedder:
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -119,7 +119,7 @@ class TestInstructorDocumentEmbedder:
             },
         }
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -148,7 +148,7 @@ class TestInstructorDocumentEmbedder:
             },
         }
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the financial document for retrieval"

--- a/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
@@ -11,8 +11,8 @@ class TestInstructorTextEmbedder:
         """
         Test default initialization parameters for InstructorTextEmbedder.
         """
-        embedder = InstructorTextEmbedder(model_name_or_path="hkunlp/instructor-base")
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        embedder = InstructorTextEmbedder(model="hkunlp/instructor-base")
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the sentence"
@@ -25,7 +25,7 @@ class TestInstructorTextEmbedder:
         Test custom initialization parameters for InstructorTextEmbedder.
         """
         embedder = InstructorTextEmbedder(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cuda",
             use_auth_token=True,
             instruction="Represent the 'domain' 'text_type' for 'task_objective'",
@@ -33,7 +33,7 @@ class TestInstructorTextEmbedder:
             progress_bar=False,
             normalize_embeddings=True,
         )
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -45,12 +45,12 @@ class TestInstructorTextEmbedder:
         """
         Test serialization of InstructorTextEmbedder to a dictionary, using default initialization parameters.
         """
-        embedder = InstructorTextEmbedder(model_name_or_path="hkunlp/instructor-base")
+        embedder = InstructorTextEmbedder(model="hkunlp/instructor-base")
         embedder_dict = embedder.to_dict()
         assert embedder_dict == {
             "type": "instructor_embedders_haystack.instructor_text_embedder.InstructorTextEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cpu",
                 "use_auth_token": None,
                 "instruction": "Represent the sentence",
@@ -65,7 +65,7 @@ class TestInstructorTextEmbedder:
         Test serialization of InstructorTextEmbedder to a dictionary, using custom initialization parameters.
         """
         embedder = InstructorTextEmbedder(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cuda",
             use_auth_token=True,
             instruction="Represent the financial document for retrieval",
@@ -77,7 +77,7 @@ class TestInstructorTextEmbedder:
         assert embedder_dict == {
             "type": "instructor_embedders_haystack.instructor_text_embedder.InstructorTextEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cuda",
                 "use_auth_token": True,
                 "instruction": "Represent the financial document for retrieval",
@@ -94,7 +94,7 @@ class TestInstructorTextEmbedder:
         embedder_dict = {
             "type": "instructor_embedders_haystack.instructor_text_embedder.InstructorTextEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cpu",
                 "use_auth_token": None,
                 "instruction": "Represent the 'domain' 'text_type' for 'task_objective'",
@@ -104,7 +104,7 @@ class TestInstructorTextEmbedder:
             },
         }
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -119,7 +119,7 @@ class TestInstructorTextEmbedder:
         embedder_dict = {
             "type": "instructor_embedders_haystack.instructor_text_embedder.InstructorTextEmbedder",
             "init_parameters": {
-                "model_name_or_path": "hkunlp/instructor-base",
+                "model": "hkunlp/instructor-base",
                 "device": "cuda",
                 "use_auth_token": True,
                 "instruction": "Represent the financial document for retrieval",
@@ -129,7 +129,7 @@ class TestInstructorTextEmbedder:
             },
         }
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the financial document for retrieval"
@@ -142,7 +142,7 @@ class TestInstructorTextEmbedder:
         """
         Test for checking embedder instances after warm-up.
         """
-        embedder = InstructorTextEmbedder(model_name_or_path="hkunlp/instructor-base")
+        embedder = InstructorTextEmbedder(model="hkunlp/instructor-base")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
@@ -154,7 +154,7 @@ class TestInstructorTextEmbedder:
         """
         Test for checking backend instances after multiple warm-ups.
         """
-        embedder = InstructorTextEmbedder(model_name_or_path="hkunlp/instructor-base")
+        embedder = InstructorTextEmbedder(model="hkunlp/instructor-base")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         embedder.warm_up()
@@ -164,7 +164,7 @@ class TestInstructorTextEmbedder:
         """
         Test for checking output dimensions and embedding dimensions.
         """
-        embedder = InstructorTextEmbedder(model_name_or_path="hkunlp/instructor-large")
+        embedder = InstructorTextEmbedder(model="hkunlp/instructor-large")
         embedder.embedding_backend = MagicMock()
         embedder.embedding_backend.embed = lambda x, **kwargs: np.random.rand(len(x), 16).tolist()  # noqa: ARG005
 
@@ -180,7 +180,7 @@ class TestInstructorTextEmbedder:
         """
         Test for checking incorrect input format when creating embedding.
         """
-        embedder = InstructorTextEmbedder(model_name_or_path="hkunlp/instructor-large")
+        embedder = InstructorTextEmbedder(model="hkunlp/instructor-large")
         embedder.embedding_backend = MagicMock()
 
         list_integers_input = [1, 2, 3]
@@ -191,7 +191,7 @@ class TestInstructorTextEmbedder:
     @pytest.mark.integration
     def test_run(self):
         embedder = InstructorTextEmbedder(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cpu",
             instruction="Represent the Science sentence for retrieval",
         )

--- a/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
@@ -12,7 +12,7 @@ class TestInstructorTextEmbedder:
         Test default initialization parameters for InstructorTextEmbedder.
         """
         embedder = InstructorTextEmbedder(model="hkunlp/instructor-base")
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the sentence"
@@ -33,7 +33,7 @@ class TestInstructorTextEmbedder:
             progress_bar=False,
             normalize_embeddings=True,
         )
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -104,7 +104,7 @@ class TestInstructorTextEmbedder:
             },
         }
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -129,7 +129,7 @@ class TestInstructorTextEmbedder:
             },
         }
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
-        assert embedder.model == "hkunlp/instructor-base"
+        assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.instruction == "Represent the financial document for retrieval"


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/227
- related to https://github.com/deepset-ai/haystack-integrations/pull/130

### Proposed Changes:

- Rename `model_name_or_path` to `model` in the embedders of the Instructor integration

### How did you test it?

Local tests run, CI
