### PR TITLE
chore!: Rename model_name to model in the Jina integration

### DIFF
--- a/integrations/jina/src/jina_haystack/document_embedder.py
+++ b/integrations/jina/src/jina_haystack/document_embedder.py
@@ -36,7 +36,7 @@ class JinaDocumentEmbedder:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "jina-embeddings-v2-base-en",
+        model: str = "jina-embeddings-v2-base-en",
         prefix: str = "",
         suffix: str = "",
         batch_size: int = 32,
@@ -48,7 +48,7 @@ class JinaDocumentEmbedder:
         Create a JinaDocumentEmbedder component.
         :param api_key: The Jina API key. It can be explicitly provided or automatically read from the
             environment variable JINA_API_KEY (recommended).
-        :param model_name: The name of the Jina model to use. Check the list of available models on `https://jina.ai/embeddings/`
+        :param model: The name of the Jina model to use. Check the list of available models on `https://jina.ai/embeddings/`
         :param prefix: A string to add to the beginning of each text.
         :param suffix: A string to add to the end of each text.
         :param batch_size: Number of Documents to encode at once.
@@ -67,7 +67,7 @@ class JinaDocumentEmbedder:
             )
             raise ValueError(msg)
 
-        self.model_name = model_name
+        self.model_name = model
         self.prefix = prefix
         self.suffix = suffix
         self.batch_size = batch_size
@@ -96,7 +96,7 @@ class JinaDocumentEmbedder:
         """
         return default_to_dict(
             self,
-            model_name=self.model_name,
+            model=self.model_name,
             prefix=self.prefix,
             suffix=self.suffix,
             batch_size=self.batch_size,

--- a/integrations/jina/src/jina_haystack/text_embedder.py
+++ b/integrations/jina/src/jina_haystack/text_embedder.py
@@ -34,7 +34,7 @@ class JinaTextEmbedder:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "jina-embeddings-v2-base-en",
+        model: str = "jina-embeddings-v2-base-en",
         prefix: str = "",
         suffix: str = "",
     ):
@@ -43,7 +43,7 @@ class JinaTextEmbedder:
 
         :param api_key: The Jina API key. It can be explicitly provided or automatically read from the
             environment variable JINA_API_KEY (recommended).
-        :param model_name: The name of the Jina model to use. Check the list of available models on `https://jina.ai/embeddings/`
+        :param model: The name of the Jina model to use. Check the list of available models on `https://jina.ai/embeddings/`
         :param prefix: A string to add to the beginning of each text.
         :param suffix: A string to add to the end of each text.
         """
@@ -57,7 +57,7 @@ class JinaTextEmbedder:
             )
             raise ValueError(msg)
 
-        self.model_name = model_name
+        self.model_name = model
         self.prefix = prefix
         self.suffix = suffix
         self._session = requests.Session()
@@ -81,7 +81,7 @@ class JinaTextEmbedder:
         to the constructor.
         """
 
-        return default_to_dict(self, model_name=self.model_name, prefix=self.prefix, suffix=self.suffix)
+        return default_to_dict(self, model=self.model_name, prefix=self.prefix, suffix=self.suffix)
 
     @component.output_types(embedding=List[float], meta=Dict[str, Any])
     def run(self, text: str):

--- a/integrations/jina/tests/test_document_embedder.py
+++ b/integrations/jina/tests/test_document_embedder.py
@@ -40,7 +40,7 @@ class TestJinaDocumentEmbedder:
     def test_init_with_parameters(self):
         embedder = JinaDocumentEmbedder(
             api_key="fake-api-key",
-            model_name="model",
+            model="model",
             prefix="prefix",
             suffix="suffix",
             batch_size=64,
@@ -67,7 +67,7 @@ class TestJinaDocumentEmbedder:
         assert data == {
             "type": "jina_haystack.document_embedder.JinaDocumentEmbedder",
             "init_parameters": {
-                "model_name": "jina-embeddings-v2-base-en",
+                "model": "jina-embeddings-v2-base-en",
                 "prefix": "",
                 "suffix": "",
                 "batch_size": 32,
@@ -80,7 +80,7 @@ class TestJinaDocumentEmbedder:
     def test_to_dict_with_custom_init_parameters(self):
         component = JinaDocumentEmbedder(
             api_key="fake-api-key",
-            model_name="model",
+            model="model",
             prefix="prefix",
             suffix="suffix",
             batch_size=64,
@@ -92,7 +92,7 @@ class TestJinaDocumentEmbedder:
         assert data == {
             "type": "jina_haystack.document_embedder.JinaDocumentEmbedder",
             "init_parameters": {
-                "model_name": "model",
+                "model": "model",
                 "prefix": "prefix",
                 "suffix": "suffix",
                 "batch_size": 64,
@@ -141,7 +141,7 @@ class TestJinaDocumentEmbedder:
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
 
         with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
-            embedder = JinaDocumentEmbedder(api_key="fake-api-key", model_name="model")
+            embedder = JinaDocumentEmbedder(api_key="fake-api-key", model="model")
 
             embeddings, metadata = embedder._embed_batch(texts_to_embed=texts, batch_size=2)
 
@@ -164,7 +164,7 @@ class TestJinaDocumentEmbedder:
         with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
             embedder = JinaDocumentEmbedder(
                 api_key="fake-api-key",
-                model_name=model,
+                model=model,
                 prefix="prefix ",
                 suffix=" suffix",
                 meta_fields_to_embed=["topic"],
@@ -194,7 +194,7 @@ class TestJinaDocumentEmbedder:
         with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
             embedder = JinaDocumentEmbedder(
                 api_key="fake-api-key",
-                model_name=model,
+                model=model,
                 prefix="prefix ",
                 suffix=" suffix",
                 meta_fields_to_embed=["topic"],

--- a/integrations/jina/tests/test_text_embedder.py
+++ b/integrations/jina/tests/test_text_embedder.py
@@ -22,7 +22,7 @@ class TestJinaTextEmbedder:
     def test_init_with_parameters(self):
         embedder = JinaTextEmbedder(
             api_key="fake-api-key",
-            model_name="model",
+            model="model",
             prefix="prefix",
             suffix="suffix",
         )
@@ -50,7 +50,7 @@ class TestJinaTextEmbedder:
     def test_to_dict_with_custom_init_parameters(self):
         component = JinaTextEmbedder(
             api_key="fake-api-key",
-            model_name="model",
+            model="model",
             prefix="prefix",
             suffix="suffix",
         )
@@ -58,7 +58,7 @@ class TestJinaTextEmbedder:
         assert data == {
             "type": "jina_haystack.text_embedder.JinaTextEmbedder",
             "init_parameters": {
-                "model_name": "model",
+                "model": "model",
                 "prefix": "prefix",
                 "suffix": "suffix",
             },
@@ -81,7 +81,7 @@ class TestJinaTextEmbedder:
 
             mock_post.return_value = mock_response
 
-            embedder = JinaTextEmbedder(api_key="fake-api-key", model_name=model, prefix="prefix ", suffix=" suffix")
+            embedder = JinaTextEmbedder(api_key="fake-api-key", model=model, prefix="prefix ", suffix=" suffix")
             result = embedder.run(text="The food was delicious")
 
         assert len(result["embedding"]) == 3

--- a/integrations/jina/tests/test_text_embedder.py
+++ b/integrations/jina/tests/test_text_embedder.py
@@ -41,7 +41,7 @@ class TestJinaTextEmbedder:
         assert data == {
             "type": "jina_haystack.text_embedder.JinaTextEmbedder",
             "init_parameters": {
-                "model_name": "jina-embeddings-v2-base-en",
+                "model": "jina-embeddings-v2-base-en",
                 "prefix": "",
                 "suffix": "",
             },


### PR DESCRIPTION
### Related Issues:

- part of  https://github.com/deepset-ai/haystack-core-integrations/issues/227
- related to https://github.com/deepset-ai/haystack-integrations/pull/131

### Proposed Changes:

- Rename model_name to model in the embedders of the Jina integration

### How did you test it?

Local tests run, CI