### PR TITLE
Remove ChromaSingleQueryRetriever

### DIFF
--- a/integrations/chroma/example/example.py
+++ b/integrations/chroma/example/example.py
@@ -23,7 +23,7 @@ indexing.run({"converter": {"sources": file_paths}})
 
 querying = Pipeline()
 querying.add_component("retriever", ChromaQueryRetriever(document_store))
-results = querying.run({"retriever": {"queries": ["Variable declarations"], "top_k": 3}})
+results = querying.run({"retriever": {"query": "Variable declarations", "top_k": 3}})
 
-for d in results["retriever"]["documents"][0]:
+for d in results["retriever"]["documents"]:
     print(d.meta, d.score)

--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/__init__.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/__init__.py
@@ -1,3 +1,3 @@
-from .retriever import ChromaEmbeddingRetriever, ChromaQueryRetriever, ChromaSingleQueryRetriever
+from .retriever import ChromaEmbeddingRetriever, ChromaQueryRetriever
 
-__all__ = ["ChromaQueryRetriever", "ChromaEmbeddingRetriever", "ChromaSingleQueryRetriever"]
+__all__ = ["ChromaQueryRetriever", "ChromaEmbeddingRetriever"]

--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -40,8 +40,8 @@ class ChromaQueryRetriever:
 
         :raises ValueError: If the specified document store is not found or is not a MemoryDocumentStore instance.
         """
-        if not top_k:
-            top_k = 3
+        top_k = top_k or self.top_k
+
         return {"documents": self.document_store.search([query], top_k)[0]}
 
     def to_dict(self) -> Dict[str, Any]:
@@ -77,8 +77,7 @@ class ChromaEmbeddingRetriever(ChromaQueryRetriever):
 
         :raises ValueError: If the specified document store is not found or is not a MemoryDocumentStore instance.
         """
-        if not top_k:
-            top_k = 3
+        top_k = top_k or self.top_k
 
         query_embeddings = [query_embedding]
         return {"documents": self.document_store.search_embeddings(query_embeddings, top_k)[0]}

--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -25,24 +25,24 @@ class ChromaQueryRetriever:
         self.top_k = top_k
         self.document_store = document_store
 
-    @component.output_types(documents=List[List[Document]])
+    @component.output_types(documents=List[Document])
     def run(
         self,
-        queries: List[str],
+        query: str,
         _: Optional[Dict[str, Any]] = None,  # filters not yet supported
         top_k: Optional[int] = None,
     ):
         """
         Run the retriever on the given input data.
 
-        :param queries: The input data for the retriever. In this case, a list of queries.
+        :param query: The input data for the retriever. In this case, a plain-text query.
         :return: The retrieved documents.
 
         :raises ValueError: If the specified document store is not found or is not a MemoryDocumentStore instance.
         """
         if not top_k:
             top_k = 3
-        return {"documents": self.document_store.search(queries, top_k)}
+        return {"documents": self.document_store.search([query], top_k)[0]}
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -58,24 +58,6 @@ class ChromaQueryRetriever:
         document_store = ChromaDocumentStore.from_dict(data["init_parameters"]["document_store"])
         data["init_parameters"]["document_store"] = document_store
         return default_from_dict(cls, data)
-
-
-@component
-class ChromaSingleQueryRetriever(ChromaQueryRetriever):
-    """
-    A convenient wrapper to the standard query retriever that accepts a single query
-    and returns a list of documents
-    """
-
-    @component.output_types(documents=List[Document])
-    def run(
-        self,
-        query: str,
-        filters: Optional[Dict[str, Any]] = None,  # filters not yet supported
-        top_k: Optional[int] = None,
-    ):
-        queries = [query]
-        return super().run(queries, filters, top_k)[0]
 
 
 @component


### PR DESCRIPTION
The retriever was originally introduced when Haystack components expected to receive `List[List[Document]]`, but we lately standardized the format to pass single queries and receive one single list of results. For this reason `ChromaSingleQueryRetriever` is being removed and `ChromaQueryRetriever` changed so it looks like the other retrievers and can be used as a drop-in replacement in existing pipelines.