### PR TITLE
feat: Non-api version of Unstrctured file converter

### DIFF
--- a/integrations/unstructured/README.md
+++ b/integrations/unstructured/README.md
@@ -18,6 +18,14 @@
 pip install unstructured-fileconverter-haystack
 ```
 
+## Usage
+
+You can use `UnstructuredFileConverter` and `UnstructuredLocalFileConverter` by importing as:
+
+```python
+from unstructured_fileconverter_haystack.converter import UnstructuredLocalFileConverter, UnstructuredFileConverter
+```
+
 ## License
 
 `unstructured-fileconverter-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "unstructured<0.11.4", #  FIXME: investigate why 0.11.4 broke the tests
+  "unstructured[pdf]<0.11.4", #  FIXME: investigate why 0.11.4 broke the tests
 ]
 
 [project.urls]

--- a/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/__init__.py
+++ b/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from .converter import UnstructuredFileConverter
+from .converter import UnstructuredFileConverter, UnstructuredLocalFileConverter
 
-__all__ = ["UnstructuredFileConverter"]
+__all__ = ["UnstructuredFileConverter", "UnstructuredLocalFileConverter"]

--- a/integrations/unstructured/tests/test_converter.py
+++ b/integrations/unstructured/tests/test_converter.py
@@ -4,7 +4,10 @@
 from pathlib import Path
 
 import pytest
-from haystack_integrations.components.converters.unstructured import UnstructuredFileConverter, UnstructuredLocalFileConverter
+from haystack_integrations.components.converters.unstructured import (
+    UnstructuredFileConverter,
+    UnstructuredLocalFileConverter,
+)
 
 
 @pytest.fixture

--- a/integrations/unstructured/tests/test_converter.py
+++ b/integrations/unstructured/tests/test_converter.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 
 import pytest
-from haystack_integrations.components.converters.unstructured import UnstructuredFileConverter
+from haystack_integrations.components.converters.unstructured import UnstructuredFileConverter, UnstructuredLocalFileConverter
 
 
 @pytest.fixture
@@ -178,6 +178,152 @@ class TestUnstructuredFileConverter:
             api_url="http://localhost:8000/general/v0/general", document_creation_mode="one-doc-per-element"
         )
 
+        documents = local_converter.run(paths=pdf_path, meta=meta)["documents"]
+
+        assert len(documents) > 4
+        for doc in documents:
+            assert "file_path" in doc.meta
+            assert "page_number" in doc.meta
+            # elements have a category attribute that is saved in the document meta
+            assert "category" in doc.meta
+            assert "common_meta" in doc.meta
+            assert doc.meta["common_meta"] == "common"
+
+
+class TestUnstructuredLocalFileConverter:
+    def test_init_default(self):
+        converter = UnstructuredLocalFileConverter()
+        assert converter.document_creation_mode == "one-doc-per-file"
+        assert converter.separator == "\n\n"
+        assert converter.unstructured_kwargs == {}
+        assert converter.progress_bar
+
+    def test_init_with_parameters(self):
+        converter = UnstructuredLocalFileConverter(
+            document_creation_mode="one-doc-per-element",
+            separator="|",
+            unstructured_kwargs={"foo": "bar"},
+            progress_bar=False,
+        )
+        assert converter.document_creation_mode == "one-doc-per-element"
+        assert converter.separator == "|"
+        assert converter.unstructured_kwargs == {"foo": "bar"}
+        assert not converter.progress_bar
+
+    def test_to_dict(self):
+        converter = UnstructuredLocalFileConverter()
+        converter_dict = converter.to_dict()
+
+        assert converter_dict == {
+            "type": "haystack_integrations.components.converters.unstructured.converter.UnstructuredLocalFileConverter",
+            "init_parameters": {
+                "document_creation_mode": "one-doc-per-file",
+                "separator": "\n\n",
+                "unstructured_kwargs": {},
+                "progress_bar": True,
+            },
+        }
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_file(self, samples_path):
+        pdf_path = samples_path / "sample_pdf.pdf"
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-file")
+        documents = local_converter.run([pdf_path])["documents"]
+        assert len(documents) == 1
+        assert documents[0].meta == {"file_path": str(pdf_path)}
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_page(self, samples_path):
+        pdf_path = samples_path / "sample_pdf.pdf"
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-page")
+        documents = local_converter.run([pdf_path])["documents"]
+
+        assert len(documents) == 4
+        for i, doc in enumerate(documents, start=1):
+            assert doc.meta["file_path"] == str(pdf_path)
+            assert doc.meta["page_number"] == i
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_element(self, samples_path):
+        pdf_path = samples_path / "sample_pdf.pdf"
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-element")
+        documents = local_converter.run([pdf_path])["documents"]
+
+        assert len(documents) > 4
+        for doc in documents:
+            assert doc.meta["file_path"] == str(pdf_path)
+            assert "page_number" in doc.meta
+
+            # elements have a category attribute that is saved in the document meta
+            assert "category" in doc.meta
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_file_with_meta(self, samples_path):
+        pdf_path = samples_path / "sample_pdf.pdf"
+        meta = {"custom_meta": "foobar"}
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-file")
+        documents = local_converter.run(paths=[pdf_path], meta=meta)["documents"]
+
+        assert len(documents) == 1
+        assert documents[0].meta["file_path"] == str(pdf_path)
+        assert "custom_meta" in documents[0].meta
+        assert documents[0].meta["custom_meta"] == "foobar"
+        assert documents[0].meta == {"file_path": str(pdf_path), "custom_meta": "foobar"}
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_page_with_meta(self, samples_path):
+        pdf_path = samples_path / "sample_pdf.pdf"
+        meta = {"custom_meta": "foobar"}
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-page")
+
+        documents = local_converter.run(paths=[pdf_path], meta=meta)["documents"]
+
+        assert len(documents) == 4
+        for i, doc in enumerate(documents, start=1):
+            assert doc.meta["file_path"] == str(pdf_path)
+            assert doc.meta["page_number"] == i
+            assert "custom_meta" in doc.meta
+            assert doc.meta["custom_meta"] == "foobar"
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_element_with_meta(self, samples_path):
+        pdf_path = samples_path / "sample_pdf.pdf"
+        meta = {"custom_meta": "foobar"}
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-element")
+        documents = local_converter.run(paths=[pdf_path], meta=meta)["documents"]
+
+        assert len(documents) > 4
+        for doc in documents:
+            assert doc.meta["file_path"] == str(pdf_path)
+            assert "page_number" in doc.meta
+
+            # elements have a category attribute that is saved in the document meta
+            assert "category" in doc.meta
+            assert "custom_meta" in doc.meta
+            assert doc.meta["custom_meta"] == "foobar"
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_element_with_meta_list_two_files(self, samples_path):
+        pdf_path = [samples_path / "sample_pdf.pdf", samples_path / "sample_pdf2.pdf"]
+        meta = [{"custom_meta": "foobar", "common_meta": "common"}, {"other_meta": "barfoo", "common_meta": "common"}]
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-element")
+
+        documents = local_converter.run(paths=pdf_path, meta=meta)["documents"]
+
+        assert len(documents) > 4
+        for doc in documents:
+            assert "file_path" in doc.meta
+            assert "page_number" in doc.meta
+            # elements have a category attribute that is saved in the document meta
+            assert "category" in doc.meta
+            assert "common_meta" in doc.meta
+            assert doc.meta["common_meta"] == "common"
+
+    @pytest.mark.integration
+    def test_run_one_doc_per_element_with_meta_list_folder(self, samples_path):
+        pdf_path = [samples_path]
+        meta = [{"custom_meta": "foobar", "common_meta": "common"}, {"other_meta": "barfoo", "common_meta": "common"}]
+        local_converter = UnstructuredLocalFileConverter(document_creation_mode="one-doc-per-element")
         documents = local_converter.run(paths=pdf_path, meta=meta)["documents"]
 
         assert len(documents) > 4


### PR DESCRIPTION
I added a version of the Unstructured File Converter that runs without the docker image.

I believe it is nice to provide a choice to the user if they would like to use a hosted version of Unstructured versus non-hosted in case their environment does not allow them to start an additional hosted service through Docker. 

The change to make this work is very minimal but does lead to some questions for me about best practices with integrations. 

**Questions:**
1. The new version requires additional python dependencies. So we went from `pip install unstructured` to `pip install unstructured[pdf]`. Is it all right to require this new dependency or would it be better to follow something like Haystack's dependency management where the `[pdf]` part is optional using something like LazyImport?
2. Would it make sense to rename the original `UnstructuredFileConverter` to `UnstructuredAPIFileConverter` to make it clearer that it uses the hosted version of Unstructured? Then the new `Local` version could be named `UnstructuredFileConverter`.

**Additional Comments**
* If we are okay with keeping these in the same package (refer to question 1.), I'll spend the time to refactor the testing code to parametrize it to reduce the duplicate code. 
