### PR TITLE
Add filter, write and delete documents in Weaviate

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -267,7 +267,7 @@ class WeaviateDocumentStore:
 
         return result["data"]["Get"][collection_name]
 
-    def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
+    def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:  # noqa: ARG002
         properties = self._client.schema.get(self._collection_settings["class"]).get("properties", [])
         properties = [prop["name"] for prop in properties]
 

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -319,7 +319,7 @@ class WeaviateDocumentStore:
             msg = f"Failed to write documents in Weaviate. Errors:\n{msg}"
             raise DocumentStoreError(msg)
 
-        # If the document already exists we can no status message back from Weaviate.
+        # If the document already exists we get no status message back from Weaviate.
         # So we assume that all Documents were written.
         return len(documents)
 


### PR DESCRIPTION
This PR implements the following methods:
* `filter_documents`
* `write_documents`
* `delete_documents`


`filter_documents` as of now doesn't support any filtering and returns all stored Documents, future PRs will add support for filters.

Depends on #269