### PR TITLE
increase pinecone sleep time

### DIFF
--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -6,7 +6,7 @@ from haystack.document_stores.types import DuplicatePolicy
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
 # This is the approximate time it takes for the documents to be available
-SLEEP_TIME = 20
+SLEEP_TIME = 25
 
 
 @pytest.fixture()


### PR DESCRIPTION
Pinecone tests are often failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7704216518

I hope that errors can be avoided by increasing the sleep time: the time between a write operation and the next read to verify a condition.