### PR TITLE
Instructor embedders: pin Sentence Transformers

### DIFF
--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "requests>=2.26.0",
   "scikit_learn>=1.0.2",
   "scipy",
-  "sentence_transformers>=2.2.0",
+  "sentence_transformers>=2.2.0,<2.3.0",
   "torch",
   "tqdm",
   "rich",


### PR DESCRIPTION
After a year and a half, a new version of Sentence Transformers (2.3.0) was released yesterday.

Unfortunately, it is not compatible with Instructor Embedders. See the errors: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7704162608/job/20995940719
Related: https://github.com/xlang-ai/instructor-embedding/issues/106

With this PR, I am pinning Sentence Transformers for this package.