### PR TITLE
Add typing_extensions pin to Chroma integration

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
   "haystack-ai",
   "chromadb<0.4.20",  #  FIXME: investigate why filtering tests broke on 0.4.20
+  "typing_extensions>=4.8.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
The integration doesn't work with `typing_extensions<4.8.0`. This PR pins `typing_extensions>=4.8.0` to make sure the requirement is respected.