### PR TITLE
Pinecone - change dummy vector

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -85,7 +85,7 @@ class PineconeDocumentStore:
             )
         self.dimension = actual_dimension or dimension
 
-        self._dummy_vector = [0.0] * self.dimension
+        self._dummy_vector = [-10.0] * self.dimension
         self.environment = environment
         self.index = index
         self.namespace = namespace


### PR DESCRIPTION
Fixes #300.

I only changed the dummy vector from `[0.0] * self.dimension` to `[-10.0] * self.dimension`.

It is important to choose a highly improbable value for the user-supplied vectors, because this value is removed during retrieval.