### PR TITLE
Pinecone - decrease concurrency in tests

### DIFF
--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -54,8 +54,8 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 # Pinecone tests are slow (require HTTP requests), so we run them in parallel
 # with pytest-xdist (https://pytest-xdist.readthedocs.io/en/stable/distribution.html)
-test = "pytest -n auto --maxprocesses=3 {args:tests}"
-test-cov = "coverage run -m pytest -n auto --maxprocesses=3 {args:tests}"
+test = "pytest -n auto --maxprocesses=2 {args:tests}"
+test-cov = "coverage run -m pytest -n auto --maxprocesses=2 {args:tests}"
 cov-report = [
   "- coverage combine",
   "coverage report",

--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -6,7 +6,7 @@ from haystack.document_stores.types import DuplicatePolicy
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
 # This is the approximate time it takes for the documents to be available
-SLEEP_TIME = 25
+SLEEP_TIME = 22
 
 
 @pytest.fixture()

--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -6,7 +6,7 @@ from haystack.document_stores.types import DuplicatePolicy
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
 # This is the approximate time it takes for the documents to be available
-SLEEP_TIME = 22
+SLEEP_TIME = 20
 
 
 @pytest.fixture()


### PR DESCRIPTION
[Pinecone tests keep failing](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7734112772/job/21087510975), despite my recent attempt to fix them in #288.

The error is "Too Many Requests".
So I am doing two things:
- decrease the concurrency in tests (lowering the number of workers from 3 to 2)
- decrease the sleep time a bit, since it does not seem to be responsible for this error