### PR TITLE
Add `COHERE_API_KEY` secret to CI environment

### DIFF
--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -7,8 +7,8 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     paths:
-      - 'integrations/cohere/**'
-      - '.github/workflows/cohere.yml'
+      - "integrations/cohere/**"
+      - ".github/workflows/cohere.yml"
 
 defaults:
   run:
@@ -21,6 +21,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
 
 jobs:
   run:
@@ -30,31 +31,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10"]
 
     steps:
-    - name: Support longpaths
-      if: matrix.os == 'windows-latest'
-      working-directory: .
-      run: git config --system core.longpaths true
+      - name: Support longpaths
+        if: matrix.os == 'windows-latest'
+        working-directory: .
+        run: git config --system core.longpaths true
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Hatch
-      run: pip install --upgrade hatch
+      - name: Install Hatch
+        run: pip install --upgrade hatch
 
-    - name: Lint
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run lint:all
+      - name: Lint
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run lint:all
 
-    - name: Generate docs
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run docs
-
-    - name: Run tests
-      run: hatch run cov
+      - name: Run tests
+        run: hatch run cov


### PR DESCRIPTION
Fixes #338.

Integration tests for Cohere integration are not running as of now, this fixes it.

The `COHERE_API_KEY` has already been added to the repo secrets.