### PR TITLE
CI: Add script and workflow to label PRs that edit docstrings

### DIFF
--- a/.github/utils/docstrings_checksum.py
+++ b/.github/utils/docstrings_checksum.py
@@ -1,0 +1,45 @@
+import ast
+import hashlib
+from pathlib import Path
+from typing import Iterator
+
+
+def docstrings_checksum(python_files: Iterator[Path]):
+    files_content = (f.read_text() for f in python_files)
+    trees = (ast.parse(c) for c in files_content)
+
+    # Get all docstrings from async functions, functions,
+    # classes and modules definitions
+    docstrings = []
+    for tree in trees:
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef, ast.Module)
+            ):
+                # Skip all node types that can't have docstrings to prevent failures
+                continue
+            docstring = ast.get_docstring(node)
+            if docstring:
+                docstrings.append(docstring)
+
+    # Sort them to be safe, since ast.walk() returns
+    # nodes in no specified order.
+    # See https://docs.python.org/3/library/ast.html#ast.walk
+    docstrings.sort()
+
+    return hashlib.md5(str(docstrings).encode("utf-8")).hexdigest()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", help="Project root folder", required=True, type=Path)
+    args = parser.parse_args()
+
+    # Get all Python files
+    root: Path = args.root.absolute()
+    python_files = root.glob("integrations/**/*.py")
+
+    md5 = docstrings_checksum(python_files)
+    print(md5)

--- a/.github/workflows/CI_docstring_labeler.yml
+++ b/.github/workflows/CI_docstring_labeler.yml
@@ -1,0 +1,56 @@
+name: Core / Add label on docstrings edit
+
+on:
+  pull_request_target:
+    paths:
+      - "integrations/**/*.py"
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout base commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Copy file
+        # We copy our script after base ref checkout so we keep executing
+        # the same version even after checking out the HEAD ref.
+        # This is done to prevent executing malicious code in forks' PRs.
+        run: cp .github/utils/docstrings_checksum.py "${{ runner.temp }}/docstrings_checksum.py"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Get docstrings
+        id: base-docstrings
+        run: |
+          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ github.workspace }}")
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout HEAD commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          # This must be set to correctly checkout a fork
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Get docstrings
+        id: head-docstrings
+        run: |
+          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ github.workspace }}")
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+
+      - name: Check if we should label
+        id: run-check
+        run: echo "should_run=${{ steps.base-docstrings.outputs.checksum != steps.head-docstrings.outputs.checksum }}" >> "$GITHUB_OUTPUT"
+
+      - name: Add label
+        if: ${{ steps.run-check.outputs.should_run == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit ${{ github.event.pull_request.html_url }} --add-label "type:documentation"


### PR DESCRIPTION
This PR adds a workflow and a script to label PRs that edit in any way a Python docstring.

The workflow is identical to the one used in Haystack core repository. 
The `docstrings_checksum.py` script has been slightly adjusted for this repo structure.