### PR TITLE
Unstructured: prevent "no space left on device" in tests

### DIFF
--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -27,18 +27,23 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-    services:
-      unstructured-api:
-        image: "quay.io/unstructured-io/unstructured-api:latest"
-        ports:
-          - 8000:8000
-        options: >-
-          --health-cmd "curl --fail http://localhost:8000/healthcheck || exit 1"
-          --health-interval 10s
-          --health-timeout 1s
-          --health-retries 10
 
     steps:
+      - name: Free up disk space
+        run: |
+          sudo docker image prune --all --force
+
+      - name: Run Unstructured API (docker)
+        run: |
+          docker run -d \
+            --name unstructured-api \
+            -p 8000:8000 \
+            --health-cmd "curl --fail http://localhost:8000/healthcheck || exit 1" \
+            --health-interval 10s \
+            --health-timeout 1s \
+            --health-retries 10 \
+            quay.io/unstructured-io/unstructured-api:latest       
+
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7807901669/job/21297174729

- I introduced a "Free up disk space" initial step.
- I moved the Docker container run from `services` to a workflow `step`, just to start after the "free up" step.