### PR TITLE
Revert "Change docstring labeler workflow to add Daria as reviewer (#357)"

### DIFF
--- a/.github/workflows/CI_docstring_labeler.yml
+++ b/.github/workflows/CI_docstring_labeler.yml
@@ -54,9 +54,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit ${{ github.event.pull_request.html_url }} --add-label "type:documentation"
-
-      - name: Add reviewer
-        if: ${{ steps.run-check.outputs.should_run == 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit ${{ github.event.pull_request.html_url }} --add-reviewer dfokina


### PR DESCRIPTION
This reverts commit 66bede7bd601c1e6dcd071ba0cae8ef9f4275974.


Workflow that automatically assign @dfokina as reviewer in PR that edit docstrings is failing. 
Revert the change for the time being to avoid blocking other PRs. 

Will investigate and find a different solution.