### PR TITLE
feat(unstructured): add element index as metadata

### DIFF
--- a/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
+++ b/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
@@ -175,9 +175,10 @@ class UnstructuredFileConverter:
             docs = [Document(content=texts_per_page[page], meta=meta_per_page[page]) for page in texts_per_page.keys()]
 
         elif document_creation_mode == "one-doc-per-element":
-            for el in elements:
+            for index, el in enumerate(elements):
                 metadata = copy.deepcopy(meta)
                 metadata["file_path"] = str(filepath)
+                metadata["element_index"] = index
                 if hasattr(el, "metadata"):
                     metadata.update(el.metadata.to_dict())
                 if hasattr(el, "category"):

--- a/integrations/unstructured/tests/test_converter.py
+++ b/integrations/unstructured/tests/test_converter.py
@@ -123,7 +123,6 @@ class TestUnstructuredFileConverter:
         )
 
         documents = local_converter.run(paths=[pdf_path], meta=meta)["documents"]
-
         assert len(documents) == 4
         for i, doc in enumerate(documents, start=1):
             assert doc.meta["file_path"] == str(pdf_path)
@@ -142,6 +141,7 @@ class TestUnstructuredFileConverter:
         documents = local_converter.run(paths=[pdf_path], meta=meta)["documents"]
 
         assert len(documents) > 4
+        first_element_index = 0
         for doc in documents:
             assert doc.meta["file_path"] == str(pdf_path)
             assert "page_number" in doc.meta
@@ -150,6 +150,8 @@ class TestUnstructuredFileConverter:
             assert "category" in doc.meta
             assert "custom_meta" in doc.meta
             assert doc.meta["custom_meta"] == "foobar"
+            assert doc.meta["element_index"] == first_element_index
+            first_element_index += 1
 
     @pytest.mark.integration
     def test_run_one_doc_per_element_with_meta_list_two_files(self, samples_path):


### PR DESCRIPTION
Adding element index in the metadata when partition mode is by element
Close feature request: https://github.com/deepset-ai/haystack-core-integrations/issues/378

> Is your feature request related to a problem? Please describe.
> With unstructured we can do partition: one doc per file, one doc per page or one doc per elem.
> When doing one doc per elem there is no way to track orders of element coming from a same doucment.
> This informations can be usefull for example for a ContextExpander component.
> Let's say you retrieve an element, you can retrieve also the previous and next element to expand the current context .
> 
> Describe the solution you'd like
> Just automatically add index metadata.
> I will do a PR.