### PR TITLE
Fastembed: fix readme and examples

### DIFF
--- a/integrations/fastembed/README.md
+++ b/integrations/fastembed/README.md
@@ -21,17 +21,18 @@ pip install fastembed-haystack
 You can use `FastembedTextEmbedder` and `FastembedDocumentEmbedder` by importing as:
 
 ```python
-from fastembed_haystack.fastembed_text_embedder import FastembedTextEmbedder
+from haystack_integrations.components.embedders.fastembed import FastembedTextEmbedder
 
 text = "fastembed is supported by and maintained by Qdrant."
 text_embedder = FastembedTextEmbedder(
     model="BAAI/bge-small-en-v1.5"
 )
-embedding = text_embedder.run(text)
+text_embedder.warm_up()
+embedding = text_embedder.run(text)["embedding"]
 ```
 
 ```python
-from fastembed_haystack.fastembed__document_embedder import FastembedDocumentEmbedder
+from haystack_integrations.components.embedders.fastembed import FastembedDocumentEmbedder
 from haystack.dataclasses import Document
 
 embedder = FastembedDocumentEmbedder(

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_document_embedder.py
@@ -16,7 +16,7 @@ class FastembedDocumentEmbedder:
     # To use this component, install the "fastembed-haystack" package.
     # pip install fastembed-haystack
 
-    from fastembed_haystack.fastembed__document_embedder import FastembedDocumentEmbedder
+    from haystack_integrations.components.embedders.fastembed import FastembedDocumentEmbedder
     from haystack.dataclasses import Document
 
     doc_embedder = FastembedDocumentEmbedder(

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
@@ -12,18 +12,19 @@ class FastembedTextEmbedder:
 
     Usage example:
     ```python
-    # To use this component, install the "fastembed" package.
-    # pip install fastembed
+    # To use this component, install the "fastembed-haystack" package.
+    # pip install fastembed-haystack
 
-    from fastembed_haystack.fastembed_text_embedder import FastembedTextEmbedder
+    from haystack_integrations.components.embedders.fastembed import FastembedTextEmbedder
 
     text = "It clearly says online this will work on a Mac OS system. The disk comes and it does not, only Windows. Do Not order this if you have a Mac!!"
 
     text_embedder = FastembedTextEmbedder(
         model="BAAI/bge-small-en-v1.5"
     )
+    text_embedder.warm_up()
 
-    embedding = text_embedder.run(text)
+    embedding = text_embedder.run(text)["embedding"]
     ```
     """  # noqa: E501
 


### PR DESCRIPTION
Related to #358 
README and some usage examples have wrong import paths.