### PR TITLE
docs: update paths and titles

### DIFF
--- a/integrations/deepeval/pydoc/config.yml
+++ b/integrations/deepeval/pydoc/config.yml
@@ -19,9 +19,9 @@ renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: DeepEval integration for Haystack
   category_slug: haystack-integrations
-  title: Chroma
+  title: DeepEval
   slug: integrations-deepeval
-  order: 1
+  order: 45
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true

--- a/integrations/fastembed/pydoc/config.yml
+++ b/integrations/fastembed/pydoc/config.yml
@@ -3,8 +3,9 @@ loaders:
     search_path: [../src]
     modules:
       [
-        "haystack_integrations.components.embedders.fastembed",
-        "haystack_integrations.components.embedders.fastembed.embedding_backend",
+        "haystack_integrations.components.embedders.fastembed.fastembed_document_embedder",
+        "haystack_integrations.components.embedders.fastembed.fastembed_text_embedder",
+        "haystack_integrations.components.embedders.fastembed.embedding_backend.fastembed_backend",
       ]
     ignore_when_discovered: ["__init__"]
 processors:
@@ -17,9 +18,9 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
-  excerpt: Embedders integration for Haystack
+  excerpt: FastEmbed integration for Haystack
   category_slug: haystack-integrations
-  title: Embedders
+  title: FastEmbed
   slug: fastembed-embedders
   order: 300
   markdown:

--- a/integrations/instructor_embedders/pydoc/config.yml
+++ b/integrations/instructor_embedders/pydoc/config.yml
@@ -3,8 +3,9 @@ loaders:
     search_path: [../src]
     modules:
       [
-        "haystack_integrations.components.embedders.instructor_embedders",
-        "haystack_integrations.components.embedders.instructor_embedders.embedding_backend",
+        "haystack_integrations.components.embedders.instructor_embedders.instructor_document_embedder",
+        "haystack_integrations.components.embedders.instructor_embedders.instructor_text_embedder",
+        "haystack_integrations.components.embedders.instructor_embedders.embedding_backend.instructor_backend",
       ]
     ignore_when_discovered: ["__init__"]
 processors:
@@ -17,9 +18,9 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
-  excerpt: Embedders integration for Haystack
+  excerpt: Instructor integration for Haystack
   category_slug: haystack-integrations
-  title: Embedders
+  title: Instructor
   slug: integrations-instructor-embedders
   order: 90
   markdown:

--- a/integrations/jina/pydoc/config.yml
+++ b/integrations/jina/pydoc/config.yml
@@ -1,7 +1,11 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../src]
-    modules: ["haystack_integrations.components.embedders.jina"]
+    modules: 
+      [
+        "haystack_integrations.components.embedders.jina.document_embedder",
+        "haystack_integrations.components.embedders.jina.text_embedder",
+      ]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/integrations/uptrain/pydoc/config.yml
+++ b/integrations/uptrain/pydoc/config.yml
@@ -21,7 +21,7 @@ renderer:
   category_slug: haystack-integrations
   title: UpTrain
   slug: integrations-uptrain
-  order: 1
+  order: 175
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true


### PR DESCRIPTION
Updated:

- Correct order for the pydocs (to follow alphabetical order)
- Paths to docstrings
- Distinct names for Embedders