### PR TITLE
model_name_or_path > model

### DIFF
--- a/integrations/astra/examples/example.py
+++ b/integrations/astra/examples/example.py
@@ -47,7 +47,7 @@ p.add_component(instance=TextFileToDocument(), name="text_file_converter")
 p.add_component(instance=DocumentCleaner(), name="cleaner")
 p.add_component(instance=DocumentSplitter(split_by="word", split_length=150, split_overlap=30), name="splitter")
 p.add_component(
-    instance=SentenceTransformersDocumentEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
+    instance=SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2"),
     name="embedder",
 )
 p.add_component(instance=DocumentWriter(document_store=document_store, policy=DuplicatePolicy.SKIP), name="writer")
@@ -63,7 +63,7 @@ p.run({"file_type_router": {"sources": file_paths}})
 # Create a querying pipeline on the indexed data
 q = Pipeline()
 q.add_component(
-    instance=SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
+    instance=SentenceTransformersTextEmbedder(model="sentence-transformers/all-MiniLM-L6-v2"),
     name="embedder",
 )
 q.add_component("retriever", AstraEmbeddingRetriever(document_store))

--- a/integrations/astra/examples/pipeline_example.py
+++ b/integrations/astra/examples/pipeline_example.py
@@ -62,7 +62,7 @@ documents = [
 ]
 p = Pipeline()
 p.add_component(
-    instance=SentenceTransformersDocumentEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
+    instance=SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2"),
     name="embedder",
 )
 p.add_component(instance=DocumentWriter(document_store=document_store, policy=DuplicatePolicy.SKIP), name="writer")
@@ -74,7 +74,7 @@ p.run({"embedder": {"documents": documents}})
 # Construct rag pipeline
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(
-    instance=SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
+    instance=SentenceTransformersTextEmbedder(model="sentence-transformers/all-MiniLM-L6-v2"),
     name="embedder",
 )
 rag_pipeline.add_component(instance=AstraEmbeddingRetriever(document_store=document_store), name="retriever")

--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -64,13 +64,25 @@ root = "../.."
 git_describe_command = 'git describe --tags --match="integrations/instructor_embedders-v[0-9]*"'
 
 [tool.hatch.envs.default]
-dependencies = ["pytest", "pytest-cov", "haystack-pydoc-tools"]
-
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+  "haystack-pydoc-tools",
+]
 [tool.hatch.envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=instructor-embedders --cov=tests"
-no-cov = "cov --no-cov"
 test = "pytest {args:tests}"
-docs = "pydoc-markdown pydoc/config.yml"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+docs = [
+  "pydoc-markdown pydoc/config.yml"
+]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["38", "39", "310", "311"]

--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -86,10 +86,13 @@ fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
 all = ["style", "typing"]
 
 [tool.coverage.run]
+source = ["haystack_integrations"]
 branch = true
 parallel = true
 
 [tool.coverage.report]
+omit = ["*/tests/*", "*/__init__.py"]
+show_missing=true
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.ruff]

--- a/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
+++ b/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
@@ -33,7 +33,7 @@ class _InstructorEmbeddingBackend:
 
     def __init__(self, model: str, device: Optional[str] = None, token: Optional[Secret] = None):
         self.model = INSTRUCTOR(
-            model=model,
+            model_name_or_path=model,
             device=device,
             use_auth_token=token.resolve_value() if token else None,
         )

--- a/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
+++ b/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
@@ -15,14 +15,14 @@ class _InstructorEmbeddingBackendFactory:
     _instances: ClassVar[Dict[str, "_InstructorEmbeddingBackend"]] = {}
 
     @staticmethod
-    def get_embedding_backend(model_name_or_path: str, device: Optional[str] = None, token: Optional[Secret] = None):
-        embedding_backend_id = f"{model_name_or_path}{device}{token}"
+    def get_embedding_backend(model: str, device: Optional[str] = None, token: Optional[Secret] = None):
+        embedding_backend_id = f"{model}{device}{token}"
 
         if embedding_backend_id in _InstructorEmbeddingBackendFactory._instances:
             return _InstructorEmbeddingBackendFactory._instances[embedding_backend_id]
 
         embedding_backend = _InstructorEmbeddingBackend(
-            model_name_or_path=model_name_or_path, device=device, token=token
+            model=model, device=device, token=token
         )
         _InstructorEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
@@ -33,9 +33,9 @@ class _InstructorEmbeddingBackend:
     Class to manage INSTRUCTOR embeddings.
     """
 
-    def __init__(self, model_name_or_path: str, device: Optional[str] = None, token: Optional[Secret] = None):
+    def __init__(self, model: str, device: Optional[str] = None, token: Optional[Secret] = None):
         self.model = INSTRUCTOR(
-            model_name_or_path=model_name_or_path,
+            model=model,
             device=device,
             use_auth_token=token.resolve_value() if token else None,
         )

--- a/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
+++ b/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import ClassVar, Dict, List, Optional, Union
+from typing import ClassVar, Dict, List, Optional
 
+from haystack.utils.auth import Secret
 from InstructorEmbedding import INSTRUCTOR
 
 
@@ -14,16 +15,14 @@ class _InstructorEmbeddingBackendFactory:
     _instances: ClassVar[Dict[str, "_InstructorEmbeddingBackend"]] = {}
 
     @staticmethod
-    def get_embedding_backend(
-        model_name_or_path: str, device: Optional[str] = None, use_auth_token: Union[bool, str, None] = None
-    ):
-        embedding_backend_id = f"{model_name_or_path}{device}{use_auth_token}"
+    def get_embedding_backend(model_name_or_path: str, device: Optional[str] = None, token: Optional[Secret] = None):
+        embedding_backend_id = f"{model_name_or_path}{device}{token}"
 
         if embedding_backend_id in _InstructorEmbeddingBackendFactory._instances:
             return _InstructorEmbeddingBackendFactory._instances[embedding_backend_id]
 
         embedding_backend = _InstructorEmbeddingBackend(
-            model_name_or_path=model_name_or_path, device=device, use_auth_token=use_auth_token
+            model_name_or_path=model_name_or_path, device=device, token=token
         )
         _InstructorEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
@@ -34,10 +33,12 @@ class _InstructorEmbeddingBackend:
     Class to manage INSTRUCTOR embeddings.
     """
 
-    def __init__(
-        self, model_name_or_path: str, device: Optional[str] = None, use_auth_token: Union[bool, str, None] = None
-    ):
-        self.model = INSTRUCTOR(model_name_or_path=model_name_or_path, device=device, use_auth_token=use_auth_token)
+    def __init__(self, model_name_or_path: str, device: Optional[str] = None, token: Optional[Secret] = None):
+        self.model = INSTRUCTOR(
+            model_name_or_path=model_name_or_path,
+            device=device,
+            use_auth_token=token.resolve_value() if token else None,
+        )
 
     def embed(self, data: List[List[str]], **kwargs) -> List[List[float]]:
         embeddings = self.model.encode(data, **kwargs).tolist()

--- a/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
+++ b/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/embedding_backend/instructor_backend.py
@@ -21,9 +21,7 @@ class _InstructorEmbeddingBackendFactory:
         if embedding_backend_id in _InstructorEmbeddingBackendFactory._instances:
             return _InstructorEmbeddingBackendFactory._instances[embedding_backend_id]
 
-        embedding_backend = _InstructorEmbeddingBackend(
-            model=model, device=device, token=token
-        )
+        embedding_backend = _InstructorEmbeddingBackend(model=model, device=device, token=token)
         _InstructorEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
 

--- a/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/instructor_document_embedder.py
+++ b/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/instructor_document_embedder.py
@@ -96,7 +96,7 @@ class InstructorDocumentEmbedder:
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         """
 
-        self.model_name_or_path = model
+        self.model = model
         # TODO: remove device parameter and use Haystack's device management once migrated
         self.device = device or "cpu"
         self.token = token
@@ -113,7 +113,7 @@ class InstructorDocumentEmbedder:
         """
         return default_to_dict(
             self,
-            model=self.model_name_or_path,
+            model=self.model,
             device=self.device,
             token=self.token.to_dict() if self.token else None,
             instruction=self.instruction,
@@ -138,7 +138,7 @@ class InstructorDocumentEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-                model_name_or_path=self.model_name_or_path, device=self.device, token=self.token
+                model=self.model, device=self.device, token=self.token
             )
 
     @component.output_types(documents=List[Document])

--- a/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/instructor_text_embedder.py
+++ b/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/instructor_text_embedder.py
@@ -66,7 +66,7 @@ class InstructorTextEmbedder:
         :param normalize_embeddings: If set to true, returned vectors will have the length of 1.
         """
 
-        self.model_name_or_path = model
+        self.model = model
         # TODO: remove device parameter and use Haystack's device management once migrated
         self.device = device or "cpu"
         self.token = token
@@ -81,7 +81,7 @@ class InstructorTextEmbedder:
         """
         return default_to_dict(
             self,
-            model=self.model_name_or_path,
+            model=self.model,
             device=self.device,
             token=self.token.to_dict() if self.token else None,
             instruction=self.instruction,
@@ -104,7 +104,7 @@ class InstructorTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-                model_name_or_path=self.model_name_or_path, device=self.device, token=self.token
+                model=self.model, device=self.device, token=self.token
             )
 
     @component.output_types(embedding=List[float])

--- a/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/instructor_text_embedder.py
+++ b/integrations/instructor_embedders/src/haystack_integrations/components/embedders/instructor_embedders/instructor_text_embedder.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 from .embedding_backend.instructor_backend import _InstructorEmbeddingBackendFactory
 
@@ -38,7 +39,7 @@ class InstructorTextEmbedder:
         self,
         model: str = "hkunlp/instructor-base",
         device: Optional[str] = None,
-        use_auth_token: Union[bool, str, None] = None,
+        token: Optional[Secret] = Secret.from_env_var("HF_API_TOKEN", strict=False),  # noqa: B008
         instruction: str = "Represent the sentence",
         batch_size: int = 32,
         progress_bar: bool = True,
@@ -51,9 +52,7 @@ class InstructorTextEmbedder:
             such as ``'hkunlp/instructor-base'``.
         :param device: Device (like 'cuda' / 'cpu') that should be used for computation.
             If None, checks if a GPU can be used.
-        :param use_auth_token: The API token used to download private models from Hugging Face.
-                        If this parameter is set to `True`, then the token generated when running
-                        `transformers-cli login` (stored in ~/.huggingface) will be used.
+        :param token: The API token used to download private models from Hugging Face.
         :param instruction: The instruction string to be used while computing domain-specific embeddings.
             The instruction follows the unified template of the form:
             "Represent the 'domain' 'text_type' for 'task_objective'", where:
@@ -70,7 +69,7 @@ class InstructorTextEmbedder:
         self.model_name_or_path = model
         # TODO: remove device parameter and use Haystack's device management once migrated
         self.device = device or "cpu"
-        self.use_auth_token = use_auth_token
+        self.token = token
         self.instruction = instruction
         self.batch_size = batch_size
         self.progress_bar = progress_bar
@@ -84,7 +83,7 @@ class InstructorTextEmbedder:
             self,
             model=self.model_name_or_path,
             device=self.device,
-            use_auth_token=self.use_auth_token,
+            token=self.token.to_dict() if self.token else None,
             instruction=self.instruction,
             batch_size=self.batch_size,
             progress_bar=self.progress_bar,
@@ -96,6 +95,7 @@ class InstructorTextEmbedder:
         """
         Deserialize this component from a dictionary.
         """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
         return default_from_dict(cls, data)
 
     def warm_up(self):
@@ -104,7 +104,7 @@ class InstructorTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-                model_name_or_path=self.model_name_or_path, device=self.device, use_auth_token=self.use_auth_token
+                model_name_or_path=self.model_name_or_path, device=self.device, token=self.token
             )
 
     @component.output_types(embedding=List[float])

--- a/integrations/instructor_embedders/tests/test_instructor_backend.py
+++ b/integrations/instructor_embedders/tests/test_instructor_backend.py
@@ -11,11 +11,11 @@ from haystack_integrations.components.embedders.instructor_embedders.embedding_b
 )
 def test_factory_behavior(mock_instructor):  # noqa: ARG001
     embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-        model_name_or_path="hkunlp/instructor-large", device="cpu"
+        model="hkunlp/instructor-large", device="cpu"
     )
     same_embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend("hkunlp/instructor-large", "cpu")
     another_embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-        model_name_or_path="hkunlp/instructor-base", device="cpu"
+        model="hkunlp/instructor-base", device="cpu"
     )
 
     assert same_embedding_backend is embedding_backend
@@ -30,10 +30,10 @@ def test_factory_behavior(mock_instructor):  # noqa: ARG001
 )
 def test_model_initialization(mock_instructor):
     _InstructorEmbeddingBackendFactory.get_embedding_backend(
-        model_name_or_path="hkunlp/instructor-base", device="cpu", token=Secret.from_token("fake-api-token")
+        model="hkunlp/instructor-base", device="cpu", token=Secret.from_token("fake-api-token")
     )
     mock_instructor.assert_called_once_with(
-        model_name_or_path="hkunlp/instructor-base", device="cpu", use_auth_token="fake-api-token"
+        model="hkunlp/instructor-base", device="cpu", use_auth_token="fake-api-token"
     )
     # restore the factory state
     _InstructorEmbeddingBackendFactory._instances = {}
@@ -44,7 +44,7 @@ def test_model_initialization(mock_instructor):
 )
 def test_embedding_function_with_kwargs(mock_instructor):  # noqa: ARG001
     embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-        model_name_or_path="hkunlp/instructor-base"
+        model="hkunlp/instructor-base"
     )
 
     data = [["instruction", "sentence1"], ["instruction", "sentence2"]]

--- a/integrations/instructor_embedders/tests/test_instructor_backend.py
+++ b/integrations/instructor_embedders/tests/test_instructor_backend.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from haystack.utils.auth import Secret
 from haystack_integrations.components.embedders.instructor_embedders.embedding_backend.instructor_backend import (
     _InstructorEmbeddingBackendFactory,
 )
@@ -29,10 +30,10 @@ def test_factory_behavior(mock_instructor):  # noqa: ARG001
 )
 def test_model_initialization(mock_instructor):
     _InstructorEmbeddingBackendFactory.get_embedding_backend(
-        model_name_or_path="hkunlp/instructor-base", device="cpu", use_auth_token="huggingface_auth_token"
+        model_name_or_path="hkunlp/instructor-base", device="cpu", token=Secret.from_token("fake-api-token")
     )
     mock_instructor.assert_called_once_with(
-        model_name_or_path="hkunlp/instructor-base", device="cpu", use_auth_token="huggingface_auth_token"
+        model_name_or_path="hkunlp/instructor-base", device="cpu", use_auth_token="fake-api-token"
     )
     # restore the factory state
     _InstructorEmbeddingBackendFactory._instances = {}

--- a/integrations/instructor_embedders/tests/test_instructor_backend.py
+++ b/integrations/instructor_embedders/tests/test_instructor_backend.py
@@ -33,7 +33,7 @@ def test_model_initialization(mock_instructor):
         model="hkunlp/instructor-base", device="cpu", token=Secret.from_token("fake-api-token")
     )
     mock_instructor.assert_called_once_with(
-        model="hkunlp/instructor-base", device="cpu", use_auth_token="fake-api-token"
+        model_name_or_path="hkunlp/instructor-base", device="cpu", use_auth_token="fake-api-token"
     )
     # restore the factory state
     _InstructorEmbeddingBackendFactory._instances = {}

--- a/integrations/instructor_embedders/tests/test_instructor_backend.py
+++ b/integrations/instructor_embedders/tests/test_instructor_backend.py
@@ -43,9 +43,7 @@ def test_model_initialization(mock_instructor):
     "haystack_integrations.components.embedders.instructor_embedders.embedding_backend.instructor_backend.INSTRUCTOR"
 )
 def test_embedding_function_with_kwargs(mock_instructor):  # noqa: ARG001
-    embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(
-        model="hkunlp/instructor-base"
-    )
+    embedding_backend = _InstructorEmbeddingBackendFactory.get_embedding_backend(model="hkunlp/instructor-base")
 
     data = [["instruction", "sentence1"], ["instruction", "sentence2"]]
     embedding_backend.embed(data=data, normalize_embeddings=True)

--- a/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 from haystack import Document
+from haystack.utils import Secret
 from haystack_integrations.components.embedders.instructor_embedders import InstructorDocumentEmbedder
 
 
@@ -14,7 +15,7 @@ class TestInstructorDocumentEmbedder:
         embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
-        assert embedder.use_auth_token is None
+        assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the document"
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
@@ -29,7 +30,7 @@ class TestInstructorDocumentEmbedder:
         embedder = InstructorDocumentEmbedder(
             model="hkunlp/instructor-base",
             device="cuda",
-            use_auth_token=True,
+            token=Secret.from_token("fake-api-token"),
             instruction="Represent the 'domain' 'text_type' for 'task_objective'",
             batch_size=64,
             progress_bar=False,
@@ -39,7 +40,7 @@ class TestInstructorDocumentEmbedder:
         )
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
-        assert embedder.use_auth_token is True
+        assert embedder.token == Secret.from_token("fake-api-token")
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
@@ -58,7 +59,7 @@ class TestInstructorDocumentEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cpu",
-                "use_auth_token": None,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the document",
                 "batch_size": 32,
                 "progress_bar": True,
@@ -75,7 +76,6 @@ class TestInstructorDocumentEmbedder:
         embedder = InstructorDocumentEmbedder(
             model="hkunlp/instructor-base",
             device="cuda",
-            use_auth_token=True,
             instruction="Represent the financial document for retrieval",
             batch_size=64,
             progress_bar=False,
@@ -89,7 +89,7 @@ class TestInstructorDocumentEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cuda",
-                "use_auth_token": True,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the financial document for retrieval",
                 "batch_size": 64,
                 "progress_bar": False,
@@ -108,7 +108,7 @@ class TestInstructorDocumentEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cpu",
-                "use_auth_token": None,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the 'domain' 'text_type' for 'task_objective'",
                 "batch_size": 32,
                 "progress_bar": True,
@@ -120,7 +120,7 @@ class TestInstructorDocumentEmbedder:
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
-        assert embedder.use_auth_token is None
+        assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
@@ -137,7 +137,7 @@ class TestInstructorDocumentEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cuda",
-                "use_auth_token": True,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the financial document for retrieval",
                 "batch_size": 64,
                 "progress_bar": False,
@@ -149,7 +149,7 @@ class TestInstructorDocumentEmbedder:
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
-        assert embedder.use_auth_token is True
+        assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the financial document for retrieval"
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
@@ -168,7 +168,9 @@ class TestInstructorDocumentEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name_or_path="hkunlp/instructor-base", device="cpu", use_auth_token=None
+            model_name_or_path="hkunlp/instructor-base",
+            device="cpu",
+            token=Secret.from_env_var("HF_API_TOKEN", strict=False),
         )
 
     @patch(

--- a/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
@@ -13,7 +13,7 @@ class TestInstructorDocumentEmbedder:
         Test default initialization parameters for InstructorDocumentEmbedder.
         """
         embedder = InstructorDocumentEmbedder(model="hkunlp/instructor-base")
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the document"
@@ -38,7 +38,7 @@ class TestInstructorDocumentEmbedder:
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.token == Secret.from_token("fake-api-token")
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -118,7 +118,7 @@ class TestInstructorDocumentEmbedder:
             },
         }
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -147,7 +147,7 @@ class TestInstructorDocumentEmbedder:
             },
         }
         embedder = InstructorDocumentEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the financial document for retrieval"
@@ -168,7 +168,7 @@ class TestInstructorDocumentEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cpu",
             token=Secret.from_env_var("HF_API_TOKEN", strict=False),
         )

--- a/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from haystack.utils import Secret
 from haystack_integrations.components.embedders.instructor_embedders import InstructorTextEmbedder
 
 
@@ -13,7 +14,7 @@ class TestInstructorTextEmbedder:
         embedder = InstructorTextEmbedder(model="hkunlp/instructor-base")
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
-        assert embedder.use_auth_token is None
+        assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the sentence"
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
@@ -26,7 +27,7 @@ class TestInstructorTextEmbedder:
         embedder = InstructorTextEmbedder(
             model="hkunlp/instructor-base",
             device="cuda",
-            use_auth_token=True,
+            token=Secret.from_token("fake-api-token"),
             instruction="Represent the 'domain' 'text_type' for 'task_objective'",
             batch_size=64,
             progress_bar=False,
@@ -34,7 +35,7 @@ class TestInstructorTextEmbedder:
         )
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
-        assert embedder.use_auth_token is True
+        assert embedder.token == Secret.from_token("fake-api-token")
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
@@ -51,7 +52,7 @@ class TestInstructorTextEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cpu",
-                "use_auth_token": None,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the sentence",
                 "batch_size": 32,
                 "progress_bar": True,
@@ -66,7 +67,6 @@ class TestInstructorTextEmbedder:
         embedder = InstructorTextEmbedder(
             model="hkunlp/instructor-base",
             device="cuda",
-            use_auth_token=True,
             instruction="Represent the financial document for retrieval",
             batch_size=64,
             progress_bar=False,
@@ -78,7 +78,7 @@ class TestInstructorTextEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cuda",
-                "use_auth_token": True,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the financial document for retrieval",
                 "batch_size": 64,
                 "progress_bar": False,
@@ -95,7 +95,7 @@ class TestInstructorTextEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cpu",
-                "use_auth_token": None,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the 'domain' 'text_type' for 'task_objective'",
                 "batch_size": 32,
                 "progress_bar": True,
@@ -105,7 +105,7 @@ class TestInstructorTextEmbedder:
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
-        assert embedder.use_auth_token is None
+        assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
@@ -120,7 +120,7 @@ class TestInstructorTextEmbedder:
             "init_parameters": {
                 "model": "hkunlp/instructor-base",
                 "device": "cuda",
-                "use_auth_token": True,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "instruction": "Represent the financial document for retrieval",
                 "batch_size": 64,
                 "progress_bar": False,
@@ -130,7 +130,7 @@ class TestInstructorTextEmbedder:
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
         assert embedder.model_name_or_path == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
-        assert embedder.use_auth_token is True
+        assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the financial document for retrieval"
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
@@ -147,7 +147,9 @@ class TestInstructorTextEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name_or_path="hkunlp/instructor-base", device="cpu", use_auth_token=None
+            model_name_or_path="hkunlp/instructor-base",
+            device="cpu",
+            token=Secret.from_env_var("HF_API_TOKEN", strict=False),
         )
 
     @patch(

--- a/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
@@ -12,7 +12,7 @@ class TestInstructorTextEmbedder:
         Test default initialization parameters for InstructorTextEmbedder.
         """
         embedder = InstructorTextEmbedder(model="hkunlp/instructor-base")
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the sentence"
@@ -33,7 +33,7 @@ class TestInstructorTextEmbedder:
             progress_bar=False,
             normalize_embeddings=True,
         )
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.token == Secret.from_token("fake-api-token")
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -103,7 +103,7 @@ class TestInstructorTextEmbedder:
             },
         }
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cpu"
         assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the 'domain' 'text_type' for 'task_objective'"
@@ -128,7 +128,7 @@ class TestInstructorTextEmbedder:
             },
         }
         embedder = InstructorTextEmbedder.from_dict(embedder_dict)
-        assert embedder.model_name_or_path == "hkunlp/instructor-base"
+        assert embedder.model == "hkunlp/instructor-base"
         assert embedder.device == "cuda"
         assert embedder.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
         assert embedder.instruction == "Represent the financial document for retrieval"
@@ -147,7 +147,7 @@ class TestInstructorTextEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name_or_path="hkunlp/instructor-base",
+            model="hkunlp/instructor-base",
             device="cpu",
             token=Secret.from_env_var("HF_API_TOKEN", strict=False),
         )

--- a/integrations/llama_cpp/README.md
+++ b/integrations/llama_cpp/README.md
@@ -161,7 +161,7 @@ Index the documents to the `InMemoryDocumentStore` using the `SentenceTransforme
 
 ```python
 doc_store = InMemoryDocumentStore(embedding_similarity_function="cosine")
-doc_embedder = SentenceTransformersDocumentEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
+doc_embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
 
 # Indexing Pipeline
 indexing_pipeline = Pipeline()
@@ -188,7 +188,7 @@ GPT4 Correct Assistant:
 
 rag_pipeline = Pipeline()
 
-text_embedder = SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
+text_embedder = SentenceTransformersTextEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
 
 # Load the LLM using LlamaCppGenerator
 model_path = "openchat-3.5-1210.Q3_K_S.gguf"

--- a/integrations/llama_cpp/examples/rag_pipeline_example.py
+++ b/integrations/llama_cpp/examples/rag_pipeline_example.py
@@ -23,7 +23,7 @@ docs = [
 ]
 
 doc_store = InMemoryDocumentStore(embedding_similarity_function="cosine")
-doc_embedder = SentenceTransformersDocumentEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
+doc_embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
 
 
 # Indexing Pipeline
@@ -47,7 +47,7 @@ GPT4 Correct Assistant:
 """
 rag_pipeline = Pipeline()
 
-text_embedder = SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
+text_embedder = SentenceTransformersTextEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
 
 model_path = "openchat-3.5-1210.Q3_K_S.gguf"
 generator = LlamaCppGenerator(model_path=model_path, n_ctx=4096, n_batch=128)


### PR DESCRIPTION
Based on #417 - please **do not merge** until the base branch has been merged

Migration to `model` was done in #229.

- Some examples are erroneously using the old `model_name_or_path`.
- For Instructor embedders, I am changing the attributes' names just because I found them confusing
