### PR TITLE
Choere - remove matching error message from tests

### DIFF
--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -274,10 +274,7 @@ class TestCohereChatGenerator:
     @pytest.mark.integration
     def test_live_run_wrong_model(self, chat_messages):
         component = CohereChatGenerator(model="something-obviously-wrong")
-        with pytest.raises(
-            cohere.CohereAPIError,
-            match="model not found, make sure the correct model ID was used and that you have access to the model.",
-        ):
+        with pytest.raises(cohere.CohereAPIError):
             component.run(chat_messages)
 
     @pytest.mark.skipif(

--- a/integrations/cohere/tests/test_cohere_generators.py
+++ b/integrations/cohere/tests/test_cohere_generators.py
@@ -149,10 +149,7 @@ class TestCohereGenerator:
         import cohere
 
         component = CohereGenerator(model="something-obviously-wrong")
-        with pytest.raises(
-            cohere.CohereAPIError,
-            match="model not found, make sure the correct model ID was used and that you have access to the model.",
-        ):
+        with pytest.raises(cohere.CohereAPIError):
             component.run(prompt="What's the capital of France?")
 
     @pytest.mark.skipif(

--- a/integrations/cohere/tests/test_document_embedder.py
+++ b/integrations/cohere/tests/test_document_embedder.py
@@ -136,9 +136,9 @@ class TestCohereDocumentEmbedder:
     def test_run_wrong_input_format(self):
         embedder = CohereDocumentEmbedder(api_key=Secret.from_token("test-api-key"))
 
-        with pytest.raises(TypeError, match="CohereDocumentEmbedder expects a list of Documents as input"):
+        with pytest.raises(TypeError):
             embedder.run(documents="text")
-        with pytest.raises(TypeError, match="CohereDocumentEmbedder expects a list of Documents as input"):
+        with pytest.raises(TypeError):
             embedder.run(documents=[1, 2, 3])
 
         assert embedder.run(documents=[]) == {"documents": [], "meta": {}}

--- a/integrations/cohere/tests/test_text_embedder.py
+++ b/integrations/cohere/tests/test_text_embedder.py
@@ -106,7 +106,7 @@ class TestCohereTextEmbedder:
         embedder = CohereTextEmbedder(api_key=Secret.from_token("test-api-key"))
         list_integers_input = ["text_snippet_1", "text_snippet_2"]
 
-        with pytest.raises(TypeError, match="CohereTextEmbedder expects a string as input"):
+        with pytest.raises(TypeError):
             embedder.run(text=list_integers_input)
 
     @pytest.mark.skipif(


### PR DESCRIPTION
- generally, we don't want to match the error message
- it causes errors like [this](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7909096256/job/21589539454): the error message of the Cohere API can easily change over time

(I also removed the match clause from other tests)