### PR TITLE
Update WeaviateDocumentStore authentication to use new Secret class

### DIFF
--- a/integrations/weaviate/pydoc/config.yml
+++ b/integrations/weaviate/pydoc/config.yml
@@ -3,6 +3,7 @@ loaders:
     search_path: [../src]
     modules:
       [
+        "haystack_integrations.document_stores.weaviate.auth",
         "haystack_integrations.document_stores.weaviate.document_store",
         "haystack_integrations.components.retrievers.weaviate.bm25_retriever",
         "haystack_integrations.components.retrievers.weaviate.embedding_retriever",

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/__init__.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/__init__.py
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from .auth import AuthApiKey, AuthBearerToken, AuthClientCredentials, AuthClientPassword, AuthCredentials
 from .document_store import WeaviateDocumentStore
 
-__all__ = ["WeaviateDocumentStore"]
+__all__ = [
+    "WeaviateDocumentStore",
+    "AuthApiKey",
+    "AuthBearerToken",
+    "AuthClientCredentials",
+    "AuthClientPassword",
+    "AuthCredentials",
+]

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
@@ -1,0 +1,170 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field, fields
+from typing import Any, Dict
+
+from haystack.core.errors import DeserializationError
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.utils.auth import Secret, deserialize_secrets_inplace
+
+from weaviate.auth import AuthApiKey as WeaviateAuthApiKey
+from weaviate.auth import AuthBearerToken as WeaviateAuthBearerToken
+from weaviate.auth import AuthClientCredentials as WeaviateAuthClientCredentials
+from weaviate.auth import AuthClientPassword as WeaviateAuthClientPassword
+
+
+@dataclass
+class AuthCredentials(ABC):
+    """
+    Base class for all auth credentials supported by WeaviateDocumentStore.
+    Can be used to deserialize from dict any of the supported auth credentials.
+    """
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Converts the object to a dictionary representation for serialization.
+        """
+        # We assume all fields are Secret instances
+        _fields = {f.name: getattr(self, f.name).to_dict() for f in fields(self)}
+
+        return default_to_dict(
+            self,
+            **_fields,
+        )
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "AuthCredentials":
+        """
+        Converts a dictionary representation to an auth credentials object.
+        """
+        if "type" not in data:
+            msg = "Missing 'type' in serialization data"
+            raise DeserializationError(msg)
+        return _AUTH_CLASSES[data["type"]]._from_dict(data)
+
+    @classmethod
+    @abstractmethod
+    def _from_dict(cls, data: Dict[str, Any]):
+        """
+        Internal method to convert a dictionary representation to an auth credentials object.
+        All subclasses must implement this method.
+        """
+
+    @abstractmethod
+    def resolve_value(self):
+        """
+        Resolves all the secrets in the auth credentials object and returns the corresponding Weaviate object.
+        All subclasses must implement this method.
+        """
+
+
+@dataclass
+class AuthApiKey(AuthCredentials):
+    """
+    AuthCredentials for API key authentication.
+    By default it will load `api_key` from the environment variable `WEAVIATE_API_KEY`.
+    """
+
+    api_key: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_API_KEY"]))
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any]) -> "AuthApiKey":
+        deserialize_secrets_inplace(data["init_parameters"], ["api_key"])
+        return default_from_dict(cls, data)
+
+    def resolve_value(self) -> WeaviateAuthApiKey:
+        return WeaviateAuthApiKey(api_key=self.api_key.resolve_value())
+
+
+@dataclass
+class AuthBearerToken(AuthCredentials):
+    """
+    AuthCredentials for Bearer token authentication.
+    By default it will load `access_token` from the environment variable `WEAVIATE_ACCESS_TOKEN`,
+    `expires_in` from the environment variable `WEAVIATE_EXPIRES_IN`, and `refresh_token` from the environment variable
+    `WEAVIATE_REFRESH_TOKEN`.
+    `WEAVIATE_EXPIRES_IN` environment variable is optional, if set must be an integer.
+    `WEAVIATE_REFRESH_TOKEN` environment variable is optional.
+    """
+
+    access_token: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_ACCESS_TOKEN"]))
+    expires_in: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_EXPIRES_IN"], strict=False))
+    refresh_token: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_REFRESH_TOKEN"], strict=False))
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any]) -> "AuthBearerToken":
+        deserialize_secrets_inplace(data["init_parameters"], ["access_token", "expires_in", "refresh_token"])
+        return default_from_dict(cls, data)
+
+    def resolve_value(self) -> WeaviateAuthBearerToken:
+        access_token = self.access_token.resolve_value()
+        expires_in = self.expires_in.resolve_value()
+        refresh_token = self.refresh_token.resolve_value()
+        expires_in = int(expires_in) if expires_in else 60
+
+        return WeaviateAuthBearerToken(
+            access_token=access_token,
+            expires_in=expires_in,
+            refresh_token=refresh_token,
+        )
+
+
+@dataclass
+class AuthClientCredentials(AuthCredentials):
+    """
+    AuthCredentials for client credentials authentication.
+    By default it will load `client_secret` from the environment variable `WEAVIATE_CLIENT_SECRET`, and
+    `scope` from the environment variable `WEAVIATE_SCOPE`.
+    `WEAVIATE_SCOPE` environment variable is optional, if set it can either be a string or a list of space
+    separated strings. e.g "scope1" or "scope1 scope2".
+    """
+
+    client_secret: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_CLIENT_SECRET"]))
+    scope: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_SCOPE"], strict=False))
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any]) -> "AuthClientCredentials":
+        deserialize_secrets_inplace(data["init_parameters"], ["client_secret", "scope"])
+        return default_from_dict(cls, data)
+
+    def resolve_value(self) -> WeaviateAuthClientCredentials:
+        return WeaviateAuthClientCredentials(
+            client_secret=self.client_secret.resolve_value(),
+            scope=self.scope.resolve_value(),
+        )
+
+
+@dataclass
+class AuthClientPassword(AuthCredentials):
+    """
+    AuthCredentials for username and password authentication.
+    By default it will load `username` from the environment variable `WEAVIATE_USERNAME`,
+    `password` from the environment variable `WEAVIATE_PASSWORD`, and
+    `scope` from the environment variable `WEAVIATE_SCOPE`.
+    `WEAVIATE_SCOPE` environment variable is optional, if set it can either be a string or a list of space
+    separated strings. e.g "scope1" or "scope1 scope2".
+    """
+
+    username: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_USERNAME"]))
+    password: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_PASSWORD"]))
+    scope: Secret = field(default_factory=lambda: Secret.from_env_var(["WEAVIATE_SCOPE"], strict=False))
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any]) -> "AuthClientPassword":
+        deserialize_secrets_inplace(data["init_parameters"], ["username", "password", "scope"])
+        return default_from_dict(cls, data)
+
+    def resolve_value(self) -> WeaviateAuthClientPassword:
+        return WeaviateAuthClientPassword(
+            username=self.username.resolve_value(),
+            password=self.password.resolve_value(),
+            scope=self.scope.resolve_value(),
+        )
+
+
+# This simplifies a bit how we handle deserialization of the auth credentials.
+_AUTH_CLASSES = {
+    "haystack_integrations.document_stores.weaviate.auth.AuthClientCredentials": AuthClientCredentials,
+    "haystack_integrations.document_stores.weaviate.auth.AuthClientPassword": AuthClientPassword,
+    "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken": AuthBearerToken,
+    "haystack_integrations.document_stores.weaviate.auth.AuthApiKey": AuthApiKey,
+}

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Any, Dict, Type
 
 from haystack.core.errors import DeserializationError
-from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.utils.auth import Secret, deserialize_secrets_inplace
 
 from weaviate.auth import AuthApiKey as WeaviateAuthApiKey
@@ -49,11 +48,11 @@ class AuthCredentials(ABC):
         Converts the object to a dictionary representation for serialization.
         """
         _fields = {}
-        for field in fields(self):
-            if field.type is Secret:
-                _fields[field.name] = getattr(self, field.name).to_dict()
+        for _field in fields(self):
+            if _field.type is Secret:
+                _fields[_field.name] = getattr(self, _field.name).to_dict()
             else:
-                _fields[field.name] = getattr(self, field.name)
+                _fields[_field.name] = getattr(self, _field.name)
 
         return {"type": str(SupportedAuthTypes.from_class(self.__class__)), "init_parameters": _fields}
 

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
-from typing import Any, Dict
+from typing import Any, Dict, Type
 
 from haystack.core.errors import DeserializationError
 from haystack.core.serialization import default_from_dict, default_to_dict
@@ -162,7 +162,7 @@ class AuthClientPassword(AuthCredentials):
 
 
 # This simplifies a bit how we handle deserialization of the auth credentials.
-_AUTH_CLASSES = {
+_AUTH_CLASSES: Dict[str, Type[AuthCredentials]] = {
     "haystack_integrations.document_stores.weaviate.auth.AuthClientCredentials": AuthClientCredentials,
     "haystack_integrations.document_stores.weaviate.auth.AuthClientPassword": AuthClientPassword,
     "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken": AuthBearerToken,

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/auth.py
@@ -37,7 +37,7 @@ class SupportedAuthTypes(Enum):
         return auth_types[auth_class]
 
 
-@dataclass
+@dataclass(frozen=True)
 class AuthCredentials(ABC):
     """
     Base class for all auth credentials supported by WeaviateDocumentStore.
@@ -91,7 +91,7 @@ class AuthCredentials(ABC):
         """
 
 
-@dataclass
+@dataclass(frozen=True)
 class AuthApiKey(AuthCredentials):
     """
     AuthCredentials for API key authentication.
@@ -109,7 +109,7 @@ class AuthApiKey(AuthCredentials):
         return WeaviateAuthApiKey(api_key=self.api_key.resolve_value())
 
 
-@dataclass
+@dataclass(frozen=True)
 class AuthBearerToken(AuthCredentials):
     """
     AuthCredentials for Bearer token authentication.
@@ -139,7 +139,7 @@ class AuthBearerToken(AuthCredentials):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class AuthClientCredentials(AuthCredentials):
     """
     AuthCredentials for client credentials authentication.
@@ -164,7 +164,7 @@ class AuthClientCredentials(AuthCredentials):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class AuthClientPassword(AuthCredentials):
     """
     AuthCredentials for username and password authentication.

--- a/integrations/weaviate/tests/test_auth.py
+++ b/integrations/weaviate/tests/test_auth.py
@@ -49,8 +49,7 @@ class TestAuthBearerToken:
         credentials = AuthBearerToken()
         assert credentials.access_token._env_vars == ["WEAVIATE_ACCESS_TOKEN"]
         assert credentials.access_token._strict
-        assert credentials.expires_in._env_vars == ["WEAVIATE_EXPIRES_IN"]
-        assert not credentials.expires_in._strict
+        assert credentials.expires_in == 60
         assert credentials.refresh_token._env_vars == ["WEAVIATE_REFRESH_TOKEN"]
         assert not credentials.refresh_token._strict
 
@@ -60,7 +59,7 @@ class TestAuthBearerToken:
             "type": "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken",
             "init_parameters": {
                 "access_token": {"env_vars": ["WEAVIATE_ACCESS_TOKEN"], "strict": True, "type": "env_var"},
-                "expires_in": {"env_vars": ["WEAVIATE_EXPIRES_IN"], "strict": False, "type": "env_var"},
+                "expires_in": 60,
                 "refresh_token": {"env_vars": ["WEAVIATE_REFRESH_TOKEN"], "strict": False, "type": "env_var"},
             },
         }
@@ -71,23 +70,21 @@ class TestAuthBearerToken:
                 "type": "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken",
                 "init_parameters": {
                     "access_token": {"env_vars": ["WEAVIATE_ACCESS_TOKEN"], "strict": True, "type": "env_var"},
-                    "expires_in": {"env_vars": ["WEAVIATE_EXPIRES_IN"], "strict": False, "type": "env_var"},
+                    "expires_in": 10,
                     "refresh_token": {"env_vars": ["WEAVIATE_REFRESH_TOKEN"], "strict": False, "type": "env_var"},
                 },
             }
         )
         assert credentials.access_token._env_vars == ["WEAVIATE_ACCESS_TOKEN"]
         assert credentials.access_token._strict
-        assert credentials.expires_in._env_vars == ["WEAVIATE_EXPIRES_IN"]
-        assert not credentials.expires_in._strict
+        assert credentials.expires_in == 10
         assert credentials.refresh_token._env_vars == ["WEAVIATE_REFRESH_TOKEN"]
         assert not credentials.refresh_token._strict
 
     def test_resolve_value(self, monkeypatch):
         monkeypatch.setenv("WEAVIATE_ACCESS_TOKEN", "fake_key")
-        monkeypatch.setenv("WEAVIATE_EXPIRES_IN", "10")
         monkeypatch.setenv("WEAVIATE_REFRESH_TOKEN", "fake_refresh_token")
-        credentials = AuthBearerToken()
+        credentials = AuthBearerToken(expires_in=10)
         resolved = credentials.resolve_value()
         assert isinstance(resolved, WeaviateAuthBearerToken)
         assert resolved.access_token == "fake_key"

--- a/integrations/weaviate/tests/test_auth.py
+++ b/integrations/weaviate/tests/test_auth.py
@@ -20,7 +20,7 @@ class TestAuthApiKey:
     def test_to_dict(self):
         credentials = AuthApiKey()
         assert credentials.to_dict() == {
-            "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+            "type": "api_key",
             "init_parameters": {"api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}},
         }
 
@@ -28,7 +28,7 @@ class TestAuthApiKey:
         monkeypatch.setenv("WEAVIATE_API_KEY", "fake_key")
         credentials = AuthCredentials.from_dict(
             {
-                "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+                "type": "api_key",
                 "init_parameters": {"api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}},
             }
         )
@@ -56,7 +56,7 @@ class TestAuthBearerToken:
     def test_to_dict(self):
         credentials = AuthBearerToken()
         assert credentials.to_dict() == {
-            "type": "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken",
+            "type": "bearer",
             "init_parameters": {
                 "access_token": {"env_vars": ["WEAVIATE_ACCESS_TOKEN"], "strict": True, "type": "env_var"},
                 "expires_in": 60,
@@ -67,7 +67,7 @@ class TestAuthBearerToken:
     def test_from_dict(self):
         credentials = AuthCredentials.from_dict(
             {
-                "type": "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken",
+                "type": "bearer",
                 "init_parameters": {
                     "access_token": {"env_vars": ["WEAVIATE_ACCESS_TOKEN"], "strict": True, "type": "env_var"},
                     "expires_in": 10,
@@ -103,7 +103,7 @@ class TestAuthClientCredentials:
     def test_to_dict(self):
         credentials = AuthClientCredentials()
         assert credentials.to_dict() == {
-            "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientCredentials",
+            "type": "client_credentials",
             "init_parameters": {
                 "client_secret": {"env_vars": ["WEAVIATE_CLIENT_SECRET"], "strict": True, "type": "env_var"},
                 "scope": {"env_vars": ["WEAVIATE_SCOPE"], "strict": False, "type": "env_var"},
@@ -113,7 +113,7 @@ class TestAuthClientCredentials:
     def test_from_dict(self):
         credentials = AuthCredentials.from_dict(
             {
-                "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientCredentials",
+                "type": "client_credentials",
                 "init_parameters": {
                     "client_secret": {"env_vars": ["WEAVIATE_CLIENT_SECRET"], "strict": True, "type": "env_var"},
                     "scope": {"env_vars": ["WEAVIATE_SCOPE"], "strict": False, "type": "env_var"},
@@ -148,7 +148,7 @@ class TestAuthClientPassword:
     def test_to_dict(self):
         credentials = AuthClientPassword()
         assert credentials.to_dict() == {
-            "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientPassword",
+            "type": "client_password",
             "init_parameters": {
                 "username": {"env_vars": ["WEAVIATE_USERNAME"], "strict": True, "type": "env_var"},
                 "password": {"env_vars": ["WEAVIATE_PASSWORD"], "strict": True, "type": "env_var"},
@@ -159,7 +159,7 @@ class TestAuthClientPassword:
     def test_from_dict(self):
         credentials = AuthCredentials.from_dict(
             {
-                "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientPassword",
+                "type": "client_password",
                 "init_parameters": {
                     "username": {"env_vars": ["WEAVIATE_USERNAME"], "strict": True, "type": "env_var"},
                     "password": {"env_vars": ["WEAVIATE_PASSWORD"], "strict": True, "type": "env_var"},

--- a/integrations/weaviate/tests/test_auth.py
+++ b/integrations/weaviate/tests/test_auth.py
@@ -1,0 +1,189 @@
+from haystack_integrations.document_stores.weaviate.auth import (
+    AuthApiKey,
+    AuthBearerToken,
+    AuthClientCredentials,
+    AuthClientPassword,
+    AuthCredentials,
+)
+from weaviate.auth import AuthApiKey as WeaviateAuthApiKey
+from weaviate.auth import AuthBearerToken as WeaviateAuthBearerToken
+from weaviate.auth import AuthClientCredentials as WeaviateAuthClientCredentials
+from weaviate.auth import AuthClientPassword as WeaviateAuthClientPassword
+
+
+class TestAuthApiKey:
+    def test_init(self):
+        credentials = AuthApiKey()
+        assert credentials.api_key._env_vars == ["WEAVIATE_API_KEY"]
+        assert credentials.api_key._strict
+
+    def test_to_dict(self):
+        credentials = AuthApiKey()
+        assert credentials.to_dict() == {
+            "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+            "init_parameters": {"api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}},
+        }
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("WEAVIATE_API_KEY", "fake_key")
+        credentials = AuthCredentials.from_dict(
+            {
+                "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+                "init_parameters": {"api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}},
+            }
+        )
+        assert isinstance(credentials, AuthApiKey)
+        assert credentials.api_key._env_vars == ["WEAVIATE_API_KEY"]
+        assert credentials.api_key._strict
+
+    def test_resolve_value(self, monkeypatch):
+        monkeypatch.setenv("WEAVIATE_API_KEY", "fake_key")
+        credentials = AuthApiKey()
+        resolved = credentials.resolve_value()
+        assert isinstance(resolved, WeaviateAuthApiKey)
+        assert resolved.api_key == "fake_key"
+
+
+class TestAuthBearerToken:
+    def test_init(self):
+        credentials = AuthBearerToken()
+        assert credentials.access_token._env_vars == ["WEAVIATE_ACCESS_TOKEN"]
+        assert credentials.access_token._strict
+        assert credentials.expires_in._env_vars == ["WEAVIATE_EXPIRES_IN"]
+        assert not credentials.expires_in._strict
+        assert credentials.refresh_token._env_vars == ["WEAVIATE_REFRESH_TOKEN"]
+        assert not credentials.refresh_token._strict
+
+    def test_to_dict(self):
+        credentials = AuthBearerToken()
+        assert credentials.to_dict() == {
+            "type": "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken",
+            "init_parameters": {
+                "access_token": {"env_vars": ["WEAVIATE_ACCESS_TOKEN"], "strict": True, "type": "env_var"},
+                "expires_in": {"env_vars": ["WEAVIATE_EXPIRES_IN"], "strict": False, "type": "env_var"},
+                "refresh_token": {"env_vars": ["WEAVIATE_REFRESH_TOKEN"], "strict": False, "type": "env_var"},
+            },
+        }
+
+    def test_from_dict(self):
+        credentials = AuthCredentials.from_dict(
+            {
+                "type": "haystack_integrations.document_stores.weaviate.auth.AuthBearerToken",
+                "init_parameters": {
+                    "access_token": {"env_vars": ["WEAVIATE_ACCESS_TOKEN"], "strict": True, "type": "env_var"},
+                    "expires_in": {"env_vars": ["WEAVIATE_EXPIRES_IN"], "strict": False, "type": "env_var"},
+                    "refresh_token": {"env_vars": ["WEAVIATE_REFRESH_TOKEN"], "strict": False, "type": "env_var"},
+                },
+            }
+        )
+        assert credentials.access_token._env_vars == ["WEAVIATE_ACCESS_TOKEN"]
+        assert credentials.access_token._strict
+        assert credentials.expires_in._env_vars == ["WEAVIATE_EXPIRES_IN"]
+        assert not credentials.expires_in._strict
+        assert credentials.refresh_token._env_vars == ["WEAVIATE_REFRESH_TOKEN"]
+        assert not credentials.refresh_token._strict
+
+    def test_resolve_value(self, monkeypatch):
+        monkeypatch.setenv("WEAVIATE_ACCESS_TOKEN", "fake_key")
+        monkeypatch.setenv("WEAVIATE_EXPIRES_IN", "10")
+        monkeypatch.setenv("WEAVIATE_REFRESH_TOKEN", "fake_refresh_token")
+        credentials = AuthBearerToken()
+        resolved = credentials.resolve_value()
+        assert isinstance(resolved, WeaviateAuthBearerToken)
+        assert resolved.access_token == "fake_key"
+        assert resolved.expires_in == 10
+        assert resolved.refresh_token == "fake_refresh_token"
+
+
+class TestAuthClientCredentials:
+    def test_init(self):
+        credentials = AuthClientCredentials()
+        assert credentials.client_secret._env_vars == ["WEAVIATE_CLIENT_SECRET"]
+        assert credentials.client_secret._strict
+        assert credentials.scope._env_vars == ["WEAVIATE_SCOPE"]
+        assert not credentials.scope._strict
+
+    def test_to_dict(self):
+        credentials = AuthClientCredentials()
+        assert credentials.to_dict() == {
+            "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientCredentials",
+            "init_parameters": {
+                "client_secret": {"env_vars": ["WEAVIATE_CLIENT_SECRET"], "strict": True, "type": "env_var"},
+                "scope": {"env_vars": ["WEAVIATE_SCOPE"], "strict": False, "type": "env_var"},
+            },
+        }
+
+    def test_from_dict(self):
+        credentials = AuthCredentials.from_dict(
+            {
+                "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientCredentials",
+                "init_parameters": {
+                    "client_secret": {"env_vars": ["WEAVIATE_CLIENT_SECRET"], "strict": True, "type": "env_var"},
+                    "scope": {"env_vars": ["WEAVIATE_SCOPE"], "strict": False, "type": "env_var"},
+                },
+            }
+        )
+        assert credentials.client_secret._env_vars == ["WEAVIATE_CLIENT_SECRET"]
+        assert credentials.client_secret._strict
+        assert credentials.scope._env_vars == ["WEAVIATE_SCOPE"]
+        assert not credentials.scope._strict
+
+    def test_resolve_value(self, monkeypatch):
+        monkeypatch.setenv("WEAVIATE_CLIENT_SECRET", "fake_secret")
+        monkeypatch.setenv("WEAVIATE_SCOPE", "fake_scope another_fake_scope")
+        credentials = AuthClientCredentials()
+        resolved = credentials.resolve_value()
+        assert isinstance(resolved, WeaviateAuthClientCredentials)
+        assert resolved.client_secret == "fake_secret"
+        assert resolved.scope_list == ["fake_scope", "another_fake_scope"]
+
+
+class TestAuthClientPassword:
+    def test_init(self):
+        credentials = AuthClientPassword()
+        assert credentials.username._env_vars == ["WEAVIATE_USERNAME"]
+        assert credentials.username._strict
+        assert credentials.password._env_vars == ["WEAVIATE_PASSWORD"]
+        assert credentials.password._strict
+        assert credentials.scope._env_vars == ["WEAVIATE_SCOPE"]
+        assert not credentials.scope._strict
+
+    def test_to_dict(self):
+        credentials = AuthClientPassword()
+        assert credentials.to_dict() == {
+            "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientPassword",
+            "init_parameters": {
+                "username": {"env_vars": ["WEAVIATE_USERNAME"], "strict": True, "type": "env_var"},
+                "password": {"env_vars": ["WEAVIATE_PASSWORD"], "strict": True, "type": "env_var"},
+                "scope": {"env_vars": ["WEAVIATE_SCOPE"], "strict": False, "type": "env_var"},
+            },
+        }
+
+    def test_from_dict(self):
+        credentials = AuthCredentials.from_dict(
+            {
+                "type": "haystack_integrations.document_stores.weaviate.auth.AuthClientPassword",
+                "init_parameters": {
+                    "username": {"env_vars": ["WEAVIATE_USERNAME"], "strict": True, "type": "env_var"},
+                    "password": {"env_vars": ["WEAVIATE_PASSWORD"], "strict": True, "type": "env_var"},
+                    "scope": {"env_vars": ["WEAVIATE_SCOPE"], "strict": False, "type": "env_var"},
+                },
+            }
+        )
+        assert credentials.username._env_vars == ["WEAVIATE_USERNAME"]
+        assert credentials.username._strict
+        assert credentials.password._env_vars == ["WEAVIATE_PASSWORD"]
+        assert credentials.password._strict
+        assert credentials.scope._env_vars == ["WEAVIATE_SCOPE"]
+        assert not credentials.scope._strict
+
+    def test_resolve_value(self, monkeypatch):
+        monkeypatch.setenv("WEAVIATE_USERNAME", "fake_username")
+        monkeypatch.setenv("WEAVIATE_PASSWORD", "fake_password")
+        monkeypatch.setenv("WEAVIATE_SCOPE", "fake_scope another_fake_scope")
+        credentials = AuthClientPassword()
+        resolved = credentials.resolve_value()
+        assert isinstance(resolved, WeaviateAuthClientPassword)
+        assert resolved.username == "fake_username"
+        assert resolved.password == "fake_password"
+        assert resolved.scope_list == ["fake_scope", "another_fake_scope"]

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -15,6 +15,7 @@ from haystack.testing.document_store import (
     FilterDocumentsTest,
     WriteDocumentsTest,
 )
+from haystack_integrations.document_stores.weaviate.auth import AuthApiKey
 from haystack_integrations.document_stores.weaviate.document_store import (
     DOCUMENT_COLLECTION_PROPERTIES,
     WeaviateDocumentStore,
@@ -23,7 +24,7 @@ from numpy import array as np_array
 from numpy import array_equal as np_array_equal
 from numpy import float32 as np_float32
 from pandas import DataFrame
-from weaviate.auth import AuthApiKey
+from weaviate.auth import AuthApiKey as WeaviateAuthApiKey
 from weaviate.config import Config
 from weaviate.embedded import (
     DEFAULT_BINARY_PATH,
@@ -145,15 +146,15 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                 assert received_meta.get(key) == expected_meta.get(key)
 
     @patch("haystack_integrations.document_stores.weaviate.document_store.weaviate.Client")
-    def test_init(self, mock_weaviate_client_class):
+    def test_init(self, mock_weaviate_client_class, monkeypatch):
         mock_client = MagicMock()
         mock_client.schema.exists.return_value = False
         mock_weaviate_client_class.return_value = mock_client
-
+        monkeypatch.setenv("WEAVIATE_API_KEY", "my_api_key")
         WeaviateDocumentStore(
             url="http://localhost:8080",
             collection_settings={"class": "My_collection"},
-            auth_client_secret=AuthApiKey("my_api_key"),
+            auth_client_secret=AuthApiKey(),
             proxies={"http": "http://proxy:1234"},
             additional_headers={"X-HuggingFace-Api-Key": "MY_HUGGINGFACE_KEY"},
             embedded_options=EmbeddedOptions(
@@ -168,7 +169,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         # Verify client is created with correct parameters
         mock_weaviate_client_class.assert_called_once_with(
             url="http://localhost:8080",
-            auth_client_secret=AuthApiKey("my_api_key"),
+            auth_client_secret=WeaviateAuthApiKey("my_api_key"),
             timeout_config=(10, 60),
             proxies={"http": "http://proxy:1234"},
             trust_env=False,
@@ -191,10 +192,11 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         )
 
     @patch("haystack_integrations.document_stores.weaviate.document_store.weaviate")
-    def test_to_dict(self, _mock_weaviate):
+    def test_to_dict(self, _mock_weaviate, monkeypatch):
+        monkeypatch.setenv("WEAVIATE_API_KEY", "my_api_key")
         document_store = WeaviateDocumentStore(
             url="http://localhost:8080",
-            auth_client_secret=AuthApiKey("my_api_key"),
+            auth_client_secret=AuthApiKey(),
             proxies={"http": "http://proxy:1234"},
             additional_headers={"X-HuggingFace-Api-Key": "MY_HUGGINGFACE_KEY"},
             embedded_options=EmbeddedOptions(
@@ -222,8 +224,10 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                     ],
                 },
                 "auth_client_secret": {
-                    "type": "weaviate.auth.AuthApiKey",
-                    "init_parameters": {"api_key": "my_api_key"},
+                    "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+                    "init_parameters": {
+                        "api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}
+                    },
                 },
                 "timeout_config": (10, 60),
                 "proxies": {"http": "http://proxy:1234"},
@@ -250,7 +254,8 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         }
 
     @patch("haystack_integrations.document_stores.weaviate.document_store.weaviate")
-    def test_from_dict(self, _mock_weaviate):
+    def test_from_dict(self, _mock_weaviate, monkeypatch):
+        monkeypatch.setenv("WEAVIATE_API_KEY", "my_api_key")
         document_store = WeaviateDocumentStore.from_dict(
             {
                 "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
@@ -258,8 +263,10 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                     "url": "http://localhost:8080",
                     "collection_settings": None,
                     "auth_client_secret": {
-                        "type": "weaviate.auth.AuthApiKey",
-                        "init_parameters": {"api_key": "my_api_key"},
+                        "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+                        "init_parameters": {
+                            "api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}
+                        },
                     },
                     "timeout_config": [10, 60],
                     "proxies": {"http": "http://proxy:1234"},
@@ -299,7 +306,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                 {"name": "score", "dataType": ["number"]},
             ],
         }
-        assert document_store._auth_client_secret == AuthApiKey("my_api_key")
+        assert document_store._auth_client_secret == AuthApiKey()
         assert document_store._timeout_config == (10, 60)
         assert document_store._proxies == {"http": "http://proxy:1234"}
         assert not document_store._trust_env

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -224,7 +224,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                     ],
                 },
                 "auth_client_secret": {
-                    "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+                    "type": "api_key",
                     "init_parameters": {
                         "api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}
                     },
@@ -263,7 +263,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                     "url": "http://localhost:8080",
                     "collection_settings": None,
                     "auth_client_secret": {
-                        "type": "haystack_integrations.document_stores.weaviate.auth.AuthApiKey",
+                        "type": "api_key",
                         "init_parameters": {
                             "api_key": {"env_vars": ["WEAVIATE_API_KEY"], "strict": True, "type": "env_var"}
                         },


### PR DESCRIPTION
Fixes #369.

Weaviate supports different manner of authentication via some utility dataclasses. 
Cause of this it wasn't feasible to use an init parameterer for each possible secret, so we mirrored a bit their utility classes structures to use the `Secret` class.

You'll notice that I used a `default_factory` in all dataclasses fields cause we can't use `default` as `Secret` is not a frozen dataclass in the latest beta. When that changes we should be able to use `default`.