### PR TITLE
fix: remove filters from `MongoDBAtlasDocumentStore.count()` method

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -85,14 +85,12 @@ class MongoDBAtlasDocumentStore:
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["mongo_connection_string"])
         return default_from_dict(cls, data)
-
-    def count_documents(self, filters: Optional[Dict[str, Any]] = None) -> int:
+    
+    def count_documents(self) -> int:
         """
         Returns how many documents are present in the document store.
-
-        :param filters: The filters to apply. It counts only the documents that match the filters.
         """
-        return self.collection.count_documents(filters or {})
+        return self.collection.count_documents()
 
     def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         """

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -85,7 +85,7 @@ class MongoDBAtlasDocumentStore:
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["mongo_connection_string"])
         return default_from_dict(cls, data)
-    
+
     def count_documents(self) -> int:
         """
         Returns how many documents are present in the document store.

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -90,7 +90,7 @@ class MongoDBAtlasDocumentStore:
         """
         Returns how many documents are present in the document store.
         """
-        return self.collection.count_documents()
+        return self.collection.count_documents({})
 
     def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         """


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/haystack-core-integrations/pull/413#discussion_r1491426418

Removed the `filters` parameter from the `MongoDBAtlasDocumentStore.count()` method.