### PR TITLE
Fix Readme sync

### DIFF
--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - massi/readme
 
 jobs:
   sync:

--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - massi/readme
 
 jobs:
   sync:

--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -55,10 +55,8 @@ jobs:
           find . -name "_readme_*.md" -exec cp "{}" tmp \;
           ls tmp
 
-      - name: Sync preview docs with 2.0
+      - name: Sync API docs
         if: steps.changed-files.outputs.all_changed_files != ''
-        uses: readmeio/rdme@8.6.6
-        env:
-          README_API_KEY: ${{ secrets.README_API_KEY }}
+        uses: readmeio/rdme@v8
         with:
-          rdme: docs ./tmp --key="$README_API_KEY" --version=2.0
+          rdme: docs ./tmp --key=${{ secrets.README_API_KEY }} --version=2.0

--- a/integrations/chroma/README.md
+++ b/integrations/chroma/README.md
@@ -1,5 +1,3 @@
-TEST
-
 # Chroma Document Store for Haystack
 
 [![PyPI - Version](https://img.shields.io/pypi/v/chroma-haystack.svg)](https://pypi.org/project/chroma-haystack)

--- a/integrations/chroma/README.md
+++ b/integrations/chroma/README.md
@@ -1,3 +1,5 @@
+TEST
+
 # Chroma Document Store for Haystack
 
 [![PyPI - Version](https://img.shields.io/pypi/v/chroma-haystack.svg)](https://pypi.org/project/chroma-haystack)


### PR DESCRIPTION
- The env variable seemed to mess up with the API key contents, now passing the secret directly to `--key`, as per Readme's offical docs
- Also pin the action less aggressively, so we can pull updates more frequently (dependabot was late and made us make a big version jump)

Test workflow passed with this new configuration: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7948402876/job/21698363580

