### PR TITLE
Amazon Sagemaker - create API docs

### DIFF
--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -52,5 +52,9 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run lint:all
 
+      - name: Generate docs
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run docs        
+
       - name: Run tests
         run: hatch run cov

--- a/integrations/amazon_sagemaker/pydoc/config.yml
+++ b/integrations/amazon_sagemaker/pydoc/config.yml
@@ -16,7 +16,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Amazon Sagemaker integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Amazon Sagemaker
   slug: integrations-amazon-sagemaker
   order: 15

--- a/integrations/amazon_sagemaker/pydoc/config.yml
+++ b/integrations/amazon_sagemaker/pydoc/config.yml
@@ -16,7 +16,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Amazon Sagemaker integration for Haystack
-  category_slug: integrations-api
+  category_slug: haystack-integrations
   title: Amazon Sagemaker
   slug: integrations-amazon-sagemaker
   order: 15

--- a/integrations/amazon_sagemaker/pydoc/config.yml
+++ b/integrations/amazon_sagemaker/pydoc/config.yml
@@ -1,0 +1,28 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../src]
+    modules: [
+      "haystack_integrations.components.generators.amazon_sagemaker.sagemaker",
+    ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  excerpt: Amazon Sagemaker integration for Haystack
+  category_slug: haystack-integrations
+  title: Amazon Sagemaker
+  slug: integrations-amazon-sagemaker
+  order: 15
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: _readme_amazon_sagemaker.md

--- a/integrations/amazon_sagemaker/pyproject.toml
+++ b/integrations/amazon_sagemaker/pyproject.toml
@@ -52,6 +52,7 @@ git_describe_command = 'git describe --tags --match="integrations/amazon_sagemak
 dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
+  "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
@@ -63,6 +64,10 @@ cov-report = [
 cov = [
   "test-cov",
   "cov-report",
+]
+
+docs = [
+  "pydoc-markdown pydoc/config.yml"
 ]
 
 [[tool.hatch.envs.all.matrix]]


### PR DESCRIPTION
From a [recent failed workflow](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7957150243/job/21719290510), I noticed that the API docs machinery was missing for Amazon Sagemaker integration.

I'm adding it.