### PR TITLE
Feat: Add filters to run function in retrievers of elasticsearch

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -94,6 +94,7 @@ class ElasticsearchBM25Retriever:
         Retrieve documents using the BM25 keyword-based algorithm.
 
         :param query: String to search in Documents' text.
+        :param filters: Filters applied to the retrieved Documents.
         :param top_k: Maximum number of Documents to return.
         :return: List of Documents that match the query.
         """

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -89,7 +89,7 @@ class ElasticsearchBM25Retriever:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, query: str, top_k: Optional[int] = None):
+    def run(self, query: str, filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = None):
         """
         Retrieve documents using the BM25 keyword-based algorithm.
 
@@ -99,7 +99,7 @@ class ElasticsearchBM25Retriever:
         """
         docs = self._document_store._bm25_retrieval(
             query=query,
-            filters=self._filters,
+            filters=filters or self._filters,
             fuzziness=self._fuzziness,
             top_k=top_k or self._top_k,
             scale_score=self._scale_score,

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
@@ -63,7 +63,7 @@ class ElasticsearchEmbeddingRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, query_embedding: List[float], top_k: Optional[int] = None):
+    def run(self, query_embedding: List[float], filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = None):
         """
         Retrieve documents using a vector similarity metric.
 
@@ -73,7 +73,7 @@ class ElasticsearchEmbeddingRetriever:
         """
         docs = self._document_store._embedding_retrieval(
             query_embedding=query_embedding,
-            filters=self._filters,
+            filters=filters or self._filters,
             top_k=top_k or self._top_k,
             num_candidates=self._num_candidates,
         )

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
@@ -68,6 +68,7 @@ class ElasticsearchEmbeddingRetriever:
         Retrieve documents using a vector similarity metric.
 
         :param query_embedding: Embedding of the query.
+        :param filters: Filters applied to the retrieved Documents.
         :param top_k: Maximum number of Documents to return.
         :return: List of Documents similar to `query_embedding`.
         """


### PR DESCRIPTION
The retrievers of elasticsearch only accept filters on initialization. They should also accept filters as argument to the `run` function. 