### PR TITLE
docs: update category slug

### DIFF
--- a/integrations/amazon_bedrock/pydoc/config.yml
+++ b/integrations/amazon_bedrock/pydoc/config.yml
@@ -19,7 +19,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Amazon Bedrock integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Amazon Bedrock
   slug: integrations-amazon-bedrock
   order: 10

--- a/integrations/amazon_sagemaker/pydoc/config.yml
+++ b/integrations/amazon_sagemaker/pydoc/config.yml
@@ -16,7 +16,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Amazon Sagemaker integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Amazon Sagemaker
   slug: integrations-amazon-sagemaker
   order: 15

--- a/integrations/astra/pydoc/config.yml
+++ b/integrations/astra/pydoc/config.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Astra integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Astra
   slug: integrations-astra
   order: 20

--- a/integrations/chroma/pydoc/config.yml
+++ b/integrations/chroma/pydoc/config.yml
@@ -19,7 +19,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Chroma integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Chroma
   slug: integrations-chroma
   order: 1

--- a/integrations/cohere/pydoc/config.yml
+++ b/integrations/cohere/pydoc/config.yml
@@ -20,7 +20,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Cohere integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Cohere
   slug: integrations-cohere
   order: 40

--- a/integrations/deepeval/pydoc/config.yml
+++ b/integrations/deepeval/pydoc/config.yml
@@ -20,7 +20,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: DeepEval integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: DeepEval
   slug: integrations-deepeval
   order: 45

--- a/integrations/elasticsearch/pydoc/config.yml
+++ b/integrations/elasticsearch/pydoc/config.yml
@@ -19,7 +19,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Elasticsearch integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Elasticsearch
   slug: integrations-elasticsearch
   order: 50

--- a/integrations/fastembed/pydoc/config.yml
+++ b/integrations/fastembed/pydoc/config.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: FastEmbed integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: FastEmbed
   slug: fastembed-embedders
   order: 55

--- a/integrations/google_ai/pydoc/config.yml
+++ b/integrations/google_ai/pydoc/config.yml
@@ -17,7 +17,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Google AI integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Google AI
   slug: integrations-google-ai
   order: 60

--- a/integrations/google_vertex/pydoc/config.yml
+++ b/integrations/google_vertex/pydoc/config.yml
@@ -22,7 +22,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Google Vertex integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Google Vertex
   slug: integrations-google-vertex
   order: 70

--- a/integrations/gradient/pydoc/config.yml
+++ b/integrations/gradient/pydoc/config.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Cohere integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Gradient
   slug: integrations-gradient
   order: 80

--- a/integrations/instructor_embedders/pydoc/config.yml
+++ b/integrations/instructor_embedders/pydoc/config.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Instructor embedders integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Instructor Embedders
   slug: integrations-instructor-embedders
   order: 90

--- a/integrations/jina/pydoc/config.yml
+++ b/integrations/jina/pydoc/config.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Jina integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Jina
   slug: integrations-jina
   order: 1

--- a/integrations/llama_cpp/pydoc/config.yml
+++ b/integrations/llama_cpp/pydoc/config.yml
@@ -16,7 +16,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Llama.cpp integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Llama.cpp
   slug: integrations-llama-cpp
   order: 110

--- a/integrations/mistral/pydoc/config.yml
+++ b/integrations/mistral/pydoc/config.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Mistral integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Mistral
   slug: integrations-mistral
   order: 40

--- a/integrations/mongodb_atlas/pydoc/config.yml
+++ b/integrations/mongodb_atlas/pydoc/config.yml
@@ -17,7 +17,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: MongoDB Atlas integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: MongoDB Atlas
   slug: integrations-mongodb-atlas
   order: 140

--- a/integrations/ollama/pydoc/config.yml
+++ b/integrations/ollama/pydoc/config.yml
@@ -17,7 +17,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Ollama integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Ollama
   slug: integrations-ollama
   order: 120

--- a/integrations/opensearch/pydoc/config.yml
+++ b/integrations/opensearch/pydoc/config.yml
@@ -19,7 +19,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: OpenSearch integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: OpenSearch
   slug: integrations-opensearch
   order: 130

--- a/integrations/pgvector/pydoc/config.yml
+++ b/integrations/pgvector/pydoc/config.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Pgvector integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Pgvector
   slug: integrations-pgvector
   order: 140

--- a/integrations/pinecone/pydoc/config.yml
+++ b/integrations/pinecone/pydoc/config.yml
@@ -20,7 +20,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Pinecone integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Pinecone
   slug: integrations-pinecone
   order: 150

--- a/integrations/qdrant/pydoc/config.yml
+++ b/integrations/qdrant/pydoc/config.yml
@@ -20,7 +20,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Qdrant integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Qdrant
   slug: integrations-qdrant
   order: 160

--- a/integrations/ragas/pydoc/config.yml
+++ b/integrations/ragas/pydoc/config.yml
@@ -20,7 +20,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Ragas integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Ragas
   slug: integrations-ragas
   order: 45

--- a/integrations/unstructured/pydoc/config.yml
+++ b/integrations/unstructured/pydoc/config.yml
@@ -16,7 +16,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Unstructured integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Unstructured
   slug: integrations-unstructured
   order: 170

--- a/integrations/uptrain/pydoc/config.yml
+++ b/integrations/uptrain/pydoc/config.yml
@@ -20,7 +20,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: UpTrain integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: UpTrain
   slug: integrations-uptrain
   order: 175

--- a/integrations/weaviate/pydoc/config.yml
+++ b/integrations/weaviate/pydoc/config.yml
@@ -20,7 +20,7 @@ processors:
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
   excerpt: Weaviate integration for Haystack
-  category_slug: haystack-integrations
+  category_slug: integrations-api
   title: Weaviate
   slug: integrations-weaviate
   order: 180


### PR DESCRIPTION
`category_slug` changed on Readme from Haystack Integrations to Integrations API, which prevented docs from syncing