### PR TITLE
Docs workflow - clean up hatch env after docs generation

### DIFF
--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -49,6 +49,7 @@ jobs:
           for d in $ALL_CHANGED_DIRS; do
             cd $d
             hatch run docs
+            hatch env prune # clean up the environment after docs generation
             cd -
           done
           mkdir tmp


### PR DESCRIPTION
Try to prevent failure like this: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/7961842838/job/21733934609
caused by "No space left on device"