### PR TITLE
fix Astra tests

### DIFF
--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -29,7 +29,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         return AstraDocumentStore(
             collection_name="haystack_integration",
             duplicates_policy=DuplicatePolicy.OVERWRITE,
-            embedding_dim=768,
+            embedding_dimension=768,
         )
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
the `embedding_dim` was renamed to `embedding_dimension` in #428,
but the document store fixture was not changed accordingly.

trying to fix...