### PR TITLE
FIX: proper name for the sort param for Astra DB Integration

### DIFF
--- a/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
@@ -185,7 +185,7 @@ class AstraClient:
     def find_documents(self, find_query):
         response_dict = self._astra_db_collection.find(
             filter=find_query.get("filter"),
-            projection=find_query.get("sort"),
+            sort=find_query.get("sort"),
             options=find_query.get("options"),
         )
 


### PR DESCRIPTION
Small typo in the Astra DB integration to properly handle the sort field.