### PR TITLE
Elasticsearch: add user-agent header

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -13,6 +13,7 @@ from haystack.dataclasses import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils.filters import convert
+from haystack.version import __version__ as haystack_version
 
 from elasticsearch import Elasticsearch, helpers  # type: ignore[import-not-found]
 
@@ -90,7 +91,11 @@ class ElasticsearchDocumentStore:
         :param **kwargs: Optional arguments that ``Elasticsearch`` takes.
         """
         self._hosts = hosts
-        self._client = Elasticsearch(hosts, **kwargs)
+        self._client = Elasticsearch(
+            hosts,
+            headers={"user-agent": f"haystack-py-ds/{haystack_version}"},
+            **kwargs,
+        )
         self._index = index
         self._embedding_similarity_function = embedding_similarity_function
         self._kwargs = kwargs

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -95,6 +95,9 @@ class TestDocumentStore(DocumentStoreBaseTests):
         assert document_store._index == "default"
         assert document_store._embedding_similarity_function == "cosine"
 
+    def test_user_agent_header(self, document_store: ElasticsearchDocumentStore):
+        assert document_store._client._headers["user-agent"].startswith("haystack-py-ds/")
+
     def test_write_documents(self, document_store: ElasticsearchDocumentStore):
         docs = [Document(id="1")]
         assert document_store.write_documents(docs) == 1


### PR DESCRIPTION
[Elastic](https://www.elastic.co/) wants to provide a great developer experience with 3rd party integrations. In order to be able to prioritize maintenance and feature development efforts, we keep track of which integrations are popular by setting the `user-agent` header. We can then see usage statistics in the [Elastic Cloud](https://cloud.elastic.co/) metrics.

We want to gauge the usage of the Haystack integration and hence add a `user-agent` header here.