### PR TITLE
fix: Revert "Allow passing in required project_name (#445)"

### DIFF
--- a/integrations/uptrain/pyproject.toml
+++ b/integrations/uptrain/pyproject.toml
@@ -21,7 +21,12 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.0.0b6", "uptrain==0.5.0"]
+dependencies = [
+  "haystack-ai>=2.0.0b6",
+  "uptrain==0.5.0",
+  "nest_asyncio",
+  "litellm",
+]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/uptrain"

--- a/integrations/uptrain/pyproject.toml
+++ b/integrations/uptrain/pyproject.toml
@@ -21,12 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = [
-  "haystack-ai>=2.0.0b6",
-  "uptrain==0.5.0",
-  "nest_asyncio",
-  "litellm",
-]
+dependencies = ["haystack-ai>=2.0.0b6", "uptrain==0.5.0"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/uptrain"

--- a/integrations/uptrain/src/haystack_integrations/components/evaluators/uptrain/evaluator.py
+++ b/integrations/uptrain/src/haystack_integrations/components/evaluators/uptrain/evaluator.py
@@ -36,7 +36,6 @@ class UpTrainEvaluator:
         api: str = "openai",
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
         api_params: Optional[Dict[str, Any]] = None,
-        project_name: Optional[str] = None,
     ):
         """
         Construct a new UpTrain evaluator.
@@ -53,8 +52,6 @@ class UpTrainEvaluator:
             The API key to use.
         :param api_params:
             Additional parameters to pass to the API client.
-        :param project_name:
-            Name of the project required when using UpTrain API.
         """
         self.metric = metric if isinstance(metric, UpTrainMetric) else UpTrainMetric.from_str(metric)
         self.metric_params = metric_params
@@ -62,7 +59,6 @@ class UpTrainEvaluator:
         self.api = api
         self.api_key = api_key
         self.api_params = api_params
-        self.project_name = project_name
 
         self._init_backend()
         expected_inputs = self.descriptor.input_parameters
@@ -116,7 +112,7 @@ class UpTrainEvaluator:
         if isinstance(self._backend_client, EvalLLM):
             results = self._backend_client.evaluate(**eval_args)
         else:
-            results = self._backend_client.log_and_evaluate(**eval_args, project_name=self.project_name)
+            results = self._backend_client.log_and_evaluate(**eval_args)
 
         OutputConverters.validate_outputs(results)
         converted_results = [
@@ -148,7 +144,6 @@ class UpTrainEvaluator:
             api=self.api,
             api_key=self.api_key.to_dict(),
             api_params=self.api_params,
-            project_name=self.project_name,
         )
 
     @classmethod
@@ -198,9 +193,6 @@ class UpTrainEvaluator:
         if self.api == "openai":
             backend_client = EvalLLM(openai_api_key=api_key)
         elif self.api == "uptrain":
-            if not self.project_name:
-                msg = "project_name not provided. UpTrain API requires a project name."
-                raise ValueError(msg)
             backend_client = APIClient(uptrain_api_key=api_key)
 
         self._backend_metric = backend_metric

--- a/integrations/uptrain/src/haystack_integrations/components/evaluators/uptrain/evaluator.py
+++ b/integrations/uptrain/src/haystack_integrations/components/evaluators/uptrain/evaluator.py
@@ -52,6 +52,8 @@ class UpTrainEvaluator:
             The API key to use.
         :param api_params:
             Additional parameters to pass to the API client.
+
+            Required parameters for the UpTrain API: `project_name`.
         """
         self.metric = metric if isinstance(metric, UpTrainMetric) else UpTrainMetric.from_str(metric)
         self.metric_params = metric_params
@@ -90,7 +92,7 @@ class UpTrainEvaluator:
 
         :param inputs:
             The inputs to evaluate. These are determined by the
-            metric being calculated. See :class:`UpTrainMetric` for more
+            metric being calculated. See `UpTrainMetric` for more
             information.
         :returns:
             A nested list of metric results. Each input can have one or more
@@ -192,7 +194,13 @@ class UpTrainEvaluator:
         assert api_key is not None
         if self.api == "openai":
             backend_client = EvalLLM(openai_api_key=api_key)
+            if self.api_params is not None:
+                msg = "OpenAI API does not support additional parameters"
+                raise ValueError(msg)
         elif self.api == "uptrain":
+            if self.api_params is None or "project_name" not in self.api_params:
+                msg = "UpTrain API requires a 'project_name' API parameter"
+                raise ValueError(msg)
             backend_client = APIClient(uptrain_api_key=api_key)
 
         self._backend_metric = backend_metric

--- a/integrations/uptrain/tests/test_evaluator.py
+++ b/integrations/uptrain/tests/test_evaluator.py
@@ -112,10 +112,7 @@ def test_evaluator_api(monkeypatch):
     assert eval.api_key == Secret.from_env_var("OPENAI_API_KEY")
 
     eval = UpTrainEvaluator(
-        UpTrainMetric.RESPONSE_COMPLETENESS,
-        api="uptrain",
-        api_key=Secret.from_env_var("UPTRAIN_API_KEY"),
-        project_name="test",
+        UpTrainMetric.RESPONSE_COMPLETENESS, api="uptrain", api_key=Secret.from_env_var("UPTRAIN_API_KEY")
     )
     assert eval.api == "uptrain"
     assert eval.api_key == Secret.from_env_var("UPTRAIN_API_KEY")
@@ -159,7 +156,6 @@ def test_evaluator_serde(os_environ_get):
         "api": "uptrain",
         "api_key": Secret.from_env_var("ENV_VAR", strict=False),
         "api_params": {"eval_name": "test"},
-        "project_name": "test",
     }
     eval = UpTrainEvaluator(**init_params)
     serde_data = eval.to_dict()
@@ -170,7 +166,6 @@ def test_evaluator_serde(os_environ_get):
     assert eval.api_key == new_eval.api_key
     assert eval.metric_params == new_eval.metric_params
     assert eval.api_params == new_eval.api_params
-    assert eval.project_name == new_eval.project_name
     assert type(new_eval._backend_client) == type(eval._backend_client)
     assert type(new_eval._backend_metric) == type(eval._backend_metric)
 
@@ -208,7 +203,6 @@ def test_evaluator_valid_inputs(metric, inputs, params):
         "api": "uptrain",
         "api_key": Secret.from_token("Aaa"),
         "api_params": None,
-        "project_name": "test",
     }
     eval = UpTrainEvaluator(**init_params)
     eval._backend_client = MockBackend([metric])
@@ -237,7 +231,6 @@ def test_evaluator_invalid_inputs(metric, inputs, error_string, params):
             "api": "uptrain",
             "api_key": Secret.from_token("Aaa"),
             "api_params": None,
-            "project_name": "test",
         }
         eval = UpTrainEvaluator(**init_params)
         eval._backend_client = MockBackend([metric])
@@ -314,7 +307,6 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params):
         "api": "uptrain",
         "api_key": Secret.from_token("Aaa"),
         "api_params": None,
-        "project_name": "test",
     }
     eval = UpTrainEvaluator(**init_params)
     eval._backend_client = MockBackend([metric])
@@ -334,7 +326,6 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params):
 # This integration test validates the evaluator by running it against the
 # OpenAI API. It is parameterized by the metric, the inputs to the evalutor
 # and the metric parameters.
-@pytest.mark.integration
 @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
 @pytest.mark.parametrize(
     "metric, inputs, metric_params",

--- a/integrations/uptrain/tests/test_evaluator.py
+++ b/integrations/uptrain/tests/test_evaluator.py
@@ -112,16 +112,34 @@ def test_evaluator_api(monkeypatch):
     assert eval.api_key == Secret.from_env_var("OPENAI_API_KEY")
 
     eval = UpTrainEvaluator(
-        UpTrainMetric.RESPONSE_COMPLETENESS, api="uptrain", api_key=Secret.from_env_var("UPTRAIN_API_KEY")
+        UpTrainMetric.RESPONSE_COMPLETENESS,
+        api="uptrain",
+        api_key=Secret.from_env_var("UPTRAIN_API_KEY"),
+        api_params={"project_name": "test"},
     )
     assert eval.api == "uptrain"
     assert eval.api_key == Secret.from_env_var("UPTRAIN_API_KEY")
+    assert eval.api_params == {"project_name": "test"}
 
     with pytest.raises(ValueError, match="Unsupported API"):
         UpTrainEvaluator(UpTrainMetric.CONTEXT_RELEVANCE, api="cohere")
 
     with pytest.raises(ValueError, match="None of the following authentication environment variables are set"):
         UpTrainEvaluator(UpTrainMetric.CONTEXT_RELEVANCE, api="uptrain", api_key=Secret.from_env_var("asd39920qqq"))
+
+    with pytest.raises(ValueError, match="does not support additional parameters"):
+        UpTrainEvaluator(
+            UpTrainMetric.CONTEXT_RELEVANCE,
+            api_params={"project_name": "test"},
+            api="openai",
+        )
+
+    with pytest.raises(ValueError, match="requires .* API parameter"):
+        UpTrainEvaluator(
+            UpTrainMetric.CONTEXT_RELEVANCE,
+            api_params=None,
+            api="uptrain",
+        )
 
 
 def test_evaluator_metric_init_params():
@@ -155,7 +173,7 @@ def test_evaluator_serde(os_environ_get):
         "metric_params": {"method": "rouge"},
         "api": "uptrain",
         "api_key": Secret.from_env_var("ENV_VAR", strict=False),
-        "api_params": {"eval_name": "test"},
+        "api_params": {"project_name": "test"},
     }
     eval = UpTrainEvaluator(**init_params)
     serde_data = eval.to_dict()
@@ -171,7 +189,7 @@ def test_evaluator_serde(os_environ_get):
 
     with pytest.raises(DeserializationError, match=r"cannot serialize the API/metric parameters"):
         init_params3 = copy.deepcopy(init_params)
-        init_params3["api_params"] = {"arg": Unserializable("")}
+        init_params3["api_params"] = {"arg": Unserializable(""), "project_name": "test"}
         eval = UpTrainEvaluator(**init_params3)
         eval.to_dict()
 
@@ -200,7 +218,6 @@ def test_evaluator_valid_inputs(metric, inputs, params):
     init_params = {
         "metric": metric,
         "metric_params": params,
-        "api": "uptrain",
         "api_key": Secret.from_token("Aaa"),
         "api_params": None,
     }
@@ -228,7 +245,6 @@ def test_evaluator_invalid_inputs(metric, inputs, error_string, params):
         init_params = {
             "metric": metric,
             "metric_params": params,
-            "api": "uptrain",
             "api_key": Secret.from_token("Aaa"),
             "api_params": None,
         }
@@ -304,7 +320,6 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params):
     init_params = {
         "metric": metric,
         "metric_params": metric_params,
-        "api": "uptrain",
         "api_key": Secret.from_token("Aaa"),
         "api_params": None,
     }
@@ -326,6 +341,7 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params):
 # This integration test validates the evaluator by running it against the
 # OpenAI API. It is parameterized by the metric, the inputs to the evalutor
 # and the metric parameters.
+@pytest.mark.integration
 @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
 @pytest.mark.parametrize(
     "metric, inputs, metric_params",


### PR DESCRIPTION
This reverts commit ffe86a9 as it adds a superfluous parameter - API-specific params like `project_name` can be already be passed with the `api_params` init parameter.

This PR additionally clarifies this in the component's docstring and adds a sanity check to make sure the required API params are correctly passed.