### PR TITLE
unstructured: add missing `from_dict` method

### DIFF
--- a/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
+++ b/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
@@ -8,9 +8,9 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from haystack import Document, component, default_to_dict
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.converters.utils import normalize_metadata
-from haystack.utils import Secret
+from haystack.utils import Secret, deserialize_secrets_inplace
 from tqdm import tqdm
 
 from unstructured.documents.elements import Element  # type: ignore[import]
@@ -90,6 +90,18 @@ class UnstructuredFileConverter:
             unstructured_kwargs=self.unstructured_kwargs,
             progress_bar=self.progress_bar,
         )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "UnstructuredFileConverter":
+        """
+        Deserializes the component from a dictionary.
+        :param data:
+            Dictionary to deserialize from.
+        :returns:
+            Deserialized component.
+        """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(

--- a/integrations/unstructured/tests/test_converter.py
+++ b/integrations/unstructured/tests/test_converter.py
@@ -52,6 +52,27 @@ class TestUnstructuredFileConverter:
             },
         }
 
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("UNSTRUCTURED_API_KEY", "test-api-key")
+        converter_dict = {
+            "type": "haystack_integrations.components.converters.unstructured.converter.UnstructuredFileConverter",
+            "init_parameters": {
+                "api_url": "http://custom-url:8000/general",
+                "api_key": {"env_vars": ["UNSTRUCTURED_API_KEY"], "strict": False, "type": "env_var"},
+                "document_creation_mode": "one-doc-per-element",
+                "separator": "|",
+                "unstructured_kwargs": {"foo": "bar"},
+                "progress_bar": False,
+            },
+        }
+        converter = UnstructuredFileConverter.from_dict(converter_dict)
+        assert converter.api_url == "http://custom-url:8000/general"
+        assert converter.api_key.resolve_value() == "test-api-key"
+        assert converter.document_creation_mode == "one-doc-per-element"
+        assert converter.separator == "|"
+        assert converter.unstructured_kwargs == {"foo": "bar"}
+        assert not converter.progress_bar
+
     @pytest.mark.integration
     def test_run_one_doc_per_file(self, samples_path):
         pdf_path = samples_path / "sample_pdf.pdf"


### PR DESCRIPTION
`from_dict` method is missing but it is necessary to properly deserialize the API key.
For example, this fails:
```python
import os
from haystack import default_from_dict
from haystack_integrations.components.converters.unstructured import UnstructuredFileConverter

os.environ["UNSTRUCTURED_API_KEY"] = "test"
conv = UnstructuredFileConverter()

ser_converter = conv.to_dict()

new_conv = default_from_dict(UnstructuredFileConverter, ser_converter)
```

error:
```
api_key_value = api_key.resolve_value() if api_key else None
AttributeError: 'dict' object has no attribute 'resolve_value'
```

---

**I added the missing `from_dict` method** and a related test.