### PR TITLE
Ollama: change testing workflow

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -41,7 +41,20 @@ jobs:
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
           ollama serve &
-          sleep 10
+          
+          # Check if the service is up and running with a timeout of 60 seconds
+          timeout=60
+          while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
+            echo "Waiting for Ollama service to start..."
+            sleep 5
+            ((timeout-=5))
+          done
+
+          if [ $timeout -eq 0 ]; then
+            echo "Timed out waiting for Ollama service to start."
+            exit 1
+          fi
+          
           ollama pull ${{ env.LLM_FOR_TESTS }}
           ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
 

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -33,15 +33,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9","3.10","3.11"]
-    services:
-      ollama:
-        image: ollama/ollama:latest
-        options: --name ollama
-        ports:
-          - 11434:11434
         
     steps:   
       - uses: actions/checkout@v4
+
+      - name: Install Ollama and pull the required models
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve &
+          sleep 10
+          ollama pull ${{ env.LLM_FOR_TESTS }}
+          ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -54,12 +56,6 @@ jobs:
       - name: Lint
         if: matrix.python-version == '3.9'
         run: hatch run lint:all
-
-      - name: Pull the LLM in the Ollama service
-        run: docker exec ollama ollama pull ${{ env.LLM_FOR_TESTS }}    
-
-      - name: Pull the Embedding Model in the Ollama service
-        run: docker exec ollama ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -157,20 +157,17 @@ ban-relative-imports = "parents"
 
 
 [tool.coverage.run]
-source_pkgs = ["src", "tests"]
+source = ["haystack_integrations"]
 branch = true
-parallel = true
-
-
-[tool.coverage.paths]
-ollama_haystack = ["src/haystack_integrations", "*/ollama-haystack/src"]
-tests = ["tests", "*/ollama-haystack/tests"]
+parallel = false
 
 [tool.coverage.report]
+omit = ["*/tests/*", "*/__init__.py"]
+show_missing=true
 exclude_lines = [
-    "no cov",
-    "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:",
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
- testing Ollama using Docker started failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8164727809
- the integrations works correctly (locally tested)
- Github services are sometimes unreliable and Ollama can be installed without Docker

So I am dropping the installation via Docker and I'm installing it following [the official instructions](https://github.com/ollama/ollama?tab=readme-ov-file#linux).