### PR TITLE
fix tests

### DIFF
--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -348,7 +348,6 @@ class TestCohereChatGenerator:
 
         assert message.meta["finish_reason"] == "COMPLETE"
 
-        # assert callback.counter > 1
         assert "Paris" in callback.responses
 
         assert message.meta["documents"] is not None

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -348,7 +348,7 @@ class TestCohereChatGenerator:
 
         assert message.meta["finish_reason"] == "COMPLETE"
 
-        assert callback.counter > 1
+        # assert callback.counter > 1
         assert "Paris" in callback.responses
 
         assert message.meta["documents"] is not None

--- a/integrations/cohere/tests/test_cohere_generators.py
+++ b/integrations/cohere/tests/test_cohere_generators.py
@@ -13,7 +13,8 @@ pytestmark = pytest.mark.generators
 
 
 class TestCohereGenerator:
-    def test_init_default(self):
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "foo")
         component = CohereGenerator()
         assert component.api_key == Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"])
         assert component.model == "command"


### PR DESCRIPTION
unit tests should pass without the api key being set, i.e. this command should work without any env var set:

```console
hatch run test -m"not integration"
```

Also removed a flaky check in the connector test (number of times the callback is called might vary)