### PR TITLE
Pass in Questions to Ground Truth Matching

### DIFF
--- a/integrations/uptrain/src/haystack_integrations/components/evaluators/uptrain/metrics.py
+++ b/integrations/uptrain/src/haystack_integrations/components/evaluators/uptrain/metrics.py
@@ -57,7 +57,7 @@ class UpTrainMetric(Enum):
     GUIDELINE_ADHERENCE = "guideline_adherence"
 
     #: Response matching.\
-    #: Inputs - `responses: List[str], ground_truths: List[str]`\
+    #: Inputs - `questions: List[str], responses: List[str], ground_truths: List[str]`\
     #: Parameters - `method: str`
     RESPONSE_MATCHING = "response_matching"
 
@@ -236,12 +236,13 @@ class InputConverters:
 
     @staticmethod
     def response_ground_truth(
+        questions: List[str],
         responses: List[str],
         ground_truths: List[str],
     ) -> Iterable[Dict[str, str]]:
-        InputConverters._validate_input_elements(ground_truths=ground_truths, responses=responses)
-        for r, gt in zip(responses, ground_truths):  # type: ignore
-            yield {"response": r, "ground_truth": gt}
+        InputConverters._validate_input_elements(questions=questions, ground_truths=ground_truths, responses=responses)
+        for q, r, gt in zip(questions, responses, ground_truths):  # type: ignore
+            yield {"question": q, "response": r, "ground_truth": gt}
 
 
 class OutputConverters:


### PR DESCRIPTION
According to [UpTrain's documentation](https://docs.uptrain.ai/predefined-evaluations/ground-truth-comparison/response-matching), questions is necessary.

If it is not passed in, it errors.

```2024-03-10 21:10:52.742 | INFO     | uptrain.framework.evalllm:evaluate:100 - Sending evaluation request for rows 0 to <50 to the Uptrain
2024-03-10 21:10:53.253 | ERROR    | uptrain.framework.remote:raise_or_return:32 - {"detail":"Error running the evaluation: 500: Error running the evaluation: concurrent.futures.process._RemoteTraceback: \n\"\"\"\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.10/concurrent/futures/process.py\", line 246, in _process_worker\n    r = call_item.fn(*call_item.args, **call_item.kwargs)\n  File \"/app/uptrain_server/worker.py\", line 429, in _run_log_and_eval\n    res = func(settings, dataset, **filtered_args)\n  File \"/app/uptrain_server/evals/chatgpt.py\", line 1534, in score_response_matching\n    question = row[\"question\"]\nKeyError: 'question'\n\"\"\"\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/app/uptrain_server/worker.py\", line 959, in run_eval_v2\n    result = future.result()\n  File \"/usr/local/lib/python3.10/concurrent/futures/_base.py\", line 451, in result\n    return self.__get_result()\n  File \"/usr/local/lib/python3.10/concurrent/futures/_base.py\", line 403, in __get_result\n    raise self._exception\nKeyError: 'question'\n"}
2024-03-10 21:10:53.254 | ERROR    | uptrain.framework.remote:evaluate:74 - Evaluation failed with error: Server error '500 Internal Server Error' for url 'https://demo.uptrain.ai/api/open/evaluate_no_auth'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
```
More changes elsewhere might be needed.