### PR TITLE
Change Google AI concurrency group for tests

### DIFF
--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -15,7 +15,7 @@ defaults:
     working-directory: integrations/google_ai
 
 concurrency:
-  group: google-vertex-${{ github.head_ref }}
+  group: google-ai-${{ github.head_ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
This integration was mistakenly assigned to the same concurrency group as Google Vertex.

This sometimes caused tests to be skipped for no good reason...