### PR TITLE
CI: push docs when releasing a new version

### DIFF
--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -2,8 +2,18 @@ name: Core / Sync docs with Readme
 
 on:
   push:
+    tags:
+      - "**-v[0-9].[0-9]+.[0-9]+"
+  workflow_dispatch: # Activate this workflow manually
+    inputs:
+      ref:
+        description: "Tag with this format: integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0"
+        required: true
+        type: string
+        default: integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0
+  pull_request:
     branches:
-      - main
+      - push-docs-on-release
 
 jobs:
   sync:
@@ -11,9 +21,6 @@ jobs:
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
-        with:
-          # This will tell tj-actions/changed-files to compare the current pushed commit with the latest in main
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -25,39 +32,33 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U haystack-pydoc-tools hatch
 
-      # We look into the changeset in order to understand
-      # which integrations were modified by the last commit.
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v43
-        with:
-          files: integrations/**
-          # Output unique changed directories instead of filenames
-          dir_names: true
-          # We only care about the name of the integration, i.e. integrations/FOO
-          dir_names_max_depth: 2
+      - name: Get project folder
+        id: pathfinder
+        shell: python
+        run: |
+          tmp_path = "${{ github.ref_name }}"
+          if "integrations" not in tmp_path:
+            print("using default path")
+            tmp_path = "integrations/fastembed-v0.0.6"
+          import os
+          project_path = "${{ github.ref_name }}".rsplit("-", maxsplit=1)[0]
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            print(f'project_path={project_path}', file=f)          
 
       - name: Generate docs
-        if: steps.changed-files.outputs.all_changed_files != ''
+        working-directory: ${{ steps.pathfinder.outputs.project_path }}
         env:
           # This is necessary to fetch the documentation categories
           # from Readme.io as we need them to associate the slug
           # in config files with their id.
           README_API_KEY: ${{ secrets.README_API_KEY }}
-          ALL_CHANGED_DIRS: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          for d in $ALL_CHANGED_DIRS; do
-            cd $d
-            hatch run docs
-            hatch env prune # clean up the environment after docs generation
-            cd -
-          done
+          hatch run docs
           mkdir tmp
           find . -name "_readme_*.md" -exec cp "{}" tmp \;
           ls tmp
 
       - name: Sync API docs
-        if: steps.changed-files.outputs.all_changed_files != ''
         uses: readmeio/rdme@v8
         with:
-          rdme: docs ./tmp --key=${{ secrets.README_API_KEY }} --version=2.0
+          rdme: docs ${{ steps.pathfinder.outputs.project_path }}/tmp --key=${{ secrets.README_API_KEY }} --version=2.0

--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches:
       - push-docs-on-release
+      - main
 
 jobs:
   sync:

--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -42,7 +42,7 @@ jobs:
             print("using default path")
             tmp_path = "integrations/fastembed-v0.0.6"
           import os
-          project_path = "${{ github.ref_name }}".rsplit("-", maxsplit=1)[0]
+          project_path = tmp_path.rsplit("-", maxsplit=1)[0]
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             print(f'project_path={project_path}', file=f)          
 

--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -11,10 +11,6 @@ on:
         required: true
         type: string
         default: integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0
-  pull_request:
-    branches:
-      - push-docs-on-release
-      - main
 
 jobs:
   sync:
@@ -37,12 +33,8 @@ jobs:
         id: pathfinder
         shell: python
         run: |
-          tmp_path = "${{ github.ref_name }}"
-          if "integrations" not in tmp_path:
-            print("using default path")
-            tmp_path = "integrations/fastembed-v0.0.6"
           import os
-          project_path = tmp_path.rsplit("-", maxsplit=1)[0]
+          project_path = "${{ github.ref_name }}".rsplit("-", maxsplit=1)[0]
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             print(f'project_path={project_path}', file=f)          
 


### PR DESCRIPTION
fixes #479

I modified the existing "Core / Sync docs with Readme" workflow
- does not run on main
- runs when pushing release tags or is manually activated
- only generates docs for the specified integration

I tested the workflow in this PR and seems to work properly: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8356934800/job/22875054669
