### PR TITLE
fix: Pin cohere version

### DIFF
--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -21,7 +21,10 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.0.0b6", "cohere"]
+dependencies = [
+  "haystack-ai",
+  "cohere<5",
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"


### PR DESCRIPTION
Cohere just released a major release of their client, and there are several breaking changes. Pinning the version to <5 for now.

Tracking issue: https://github.com/deepset-ai/haystack-core-integrations/issues/608