### PR TITLE
retry fixing readme_sync

### DIFF
--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -13,7 +13,7 @@ on:
         default: integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0
 
 env:
-  TAG: ${{ github.inputs.tag || github.ref_name }}
+  TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   sync:


### PR DESCRIPTION
readme_sync still fails when manually triggered: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8386972874/job/22968297987

I hope this PR fixes it :slightly_smiling_face: 