### PR TITLE
Disable nightly tests for uptrain

### DIFF
--- a/.github/workflows/uptrain.yml
+++ b/.github/workflows/uptrain.yml
@@ -3,8 +3,9 @@
 name: Test / uptrain
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  # Temporarily disable nightly tests as failures are currently expected
+  # schedule:
+  #   - cron: "0 0 * * *"
   pull_request:
     paths:
       - "integrations/uptrain/**"
@@ -21,7 +22,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
 jobs:
   run:
@@ -63,13 +64,13 @@ jobs:
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
+            core-integrations failure:
             ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
              - ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}


### PR DESCRIPTION
Tests are currently expected to fail, disabling nightlies