### PR TITLE
Deserialize secrets inplace for api_keys in PineconeEmbeddingRetriever

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -7,7 +7,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
-
+from haystack.utils import deserialize_secrets_inplace
 
 @component
 class PineconeEmbeddingRetriever:
@@ -93,6 +93,7 @@ class PineconeEmbeddingRetriever:
         :returns:
             Deserialized component.
         """
+        deserialize_secrets_inplace(data["init_parameters"]['document_store']['init_parameters'], keys=["api_key"])
         data["init_parameters"]["document_store"] = default_from_dict(
             PineconeDocumentStore, data["init_parameters"]["document_store"]
         )


### PR DESCRIPTION
Loading serialised pipeline which includes PineconeEmbeddingRetriever with PineconeDocumentStore currently fails because loading of api keys is not correctly deserialised into Secret class. I propose changes to fix this.