### PR TITLE
Pinecone: skip `test_write_documents_duplicate_overwrite` test

### DIFF
--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -5,8 +5,6 @@ import pytest
 from haystack import Document
 from haystack.testing.document_store import CountDocumentsTest, DeleteDocumentsTest, WriteDocumentsTest
 from haystack.utils import Secret
-from haystack.document_stores.types import DocumentStore, DuplicatePolicy
-
 
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -5,6 +5,8 @@ import pytest
 from haystack import Document
 from haystack.testing.document_store import CountDocumentsTest, DeleteDocumentsTest, WriteDocumentsTest
 from haystack.utils import Secret
+from haystack.document_stores.types import DocumentStore, DuplicatePolicy
+
 
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
@@ -86,6 +88,9 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, WriteDocumentsT
     def test_write_documents(self, document_store: PineconeDocumentStore):
         docs = [Document(id="1")]
         assert document_store.write_documents(docs) == 1
+
+    @pytest.mark.skip(reason="Pinecone supports overwriting by default, but it takes a while for it to take effect")
+    def test_write_documents_duplicate_overwrite(self, document_store: PineconeDocumentStore): ...
 
     @pytest.mark.skip(reason="Pinecone only supports UPSERT operations")
     def test_write_documents_duplicate_fail(self, document_store: PineconeDocumentStore): ...


### PR DESCRIPTION
Fixes failures like this: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8521010091/job/23338323513#step:7:79

Due to some recent changes on Pinecone, if you write 2 different documents with the same ID,
the overwrite takes effect after some minutes: in the meantime, you have 2 documents with the same ID.

So, I skip the test which tests the overwrite operation.