### PR TITLE
LlamaCPP: fix failing tests

### DIFF
--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "llama-cpp-python<0.2.56"
+  "llama-cpp-python<0.2.58"
 ]
 
 [project.urls]

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "llama-cpp-python"
+  "llama-cpp-python<0.2.56"
 ]
 
 [project.urls]

--- a/integrations/llama_cpp/tests/test_generator.py
+++ b/integrations/llama_cpp/tests/test_generator.py
@@ -32,9 +32,9 @@ class TestLlamaCppGenerator:
     @pytest.fixture
     def generator(self, model_path, capsys):
         ggml_model_path = (
-            "https://huggingface.co/lmstudio-ai/gemma-2b-it-GGUF/resolve/main/gemma-2b-it-q4_k_m.gguf"
+            "https://huggingface.co/TheBloke/openchat-3.5-1210-GGUF/resolve/main/openchat-3.5-1210.Q3_K_S.gguf"
         )
-        filename = "gemma-2b-it-q4_k_m.gguf"
+        filename = "openchat-3.5-1210.Q3_K_S.gguf"
 
         # Download GGUF model from HuggingFace
         download_file(ggml_model_path, str(model_path / filename), capsys)

--- a/integrations/llama_cpp/tests/test_generator.py
+++ b/integrations/llama_cpp/tests/test_generator.py
@@ -32,9 +32,9 @@ class TestLlamaCppGenerator:
     @pytest.fixture
     def generator(self, model_path, capsys):
         ggml_model_path = (
-            "https://huggingface.co/TheBloke/openchat-3.5-1210-GGUF/resolve/main/openchat-3.5-1210.Q3_K_S.gguf"
+            "https://huggingface.co/lmstudio-ai/gemma-2b-it-GGUF/resolve/main/gemma-2b-it-q4_k_m.gguf"
         )
-        filename = "openchat-3.5-1210.Q3_K_S.gguf"
+        filename = "gemma-2b-it-q4_k_m.gguf"
 
         # Download GGUF model from HuggingFace
         download_file(ggml_model_path, str(model_path / filename), capsys)


### PR DESCRIPTION
Try to fix errors like this: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8515449565/job/23345387417
Segmentation fault (core dumped)

- Using a smaller model or changing the batch size do not help
- Pinning `llama-cpp-python<0.2.58` fixes the failing tests

I also opened an issue on llama-cpp-python: https://github.com/abetlen/llama-cpp-python/issues/1319

@awinml do you have any ideas?