### PR TITLE
fix: handle opensearch write_documents error handling

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -193,8 +193,6 @@ class OpenSearchDocumentStore:
                     error_type = None 
                 if policy == DuplicatePolicy.FAIL and error_type == "version_conflict_engine_exception":
                     duplicate_errors_ids.append(e["create"]["_id"])
-                if policy == DuplicatePolicy.FAIL and error_type == "version_conflict_engine_exception":
-                    duplicate_errors_ids.append(e["create"]["_id"])
                 elif policy == DuplicatePolicy.SKIP and error_type == "version_conflict_engine_exception":
                     # when the policy is skip, duplication errors are OK and we should not raise an exception
                     continue

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -190,7 +190,7 @@ class OpenSearchDocumentStore:
                 try:
                     error_type = e["create"]["error"]["type"]
                 except KeyError:
-                    error_type = None 
+                    error_type = None
                 if policy == DuplicatePolicy.FAIL and error_type == "version_conflict_engine_exception":
                     duplicate_errors_ids.append(e["create"]["_id"])
                 elif policy == DuplicatePolicy.SKIP and error_type == "version_conflict_engine_exception":

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -186,7 +186,13 @@ class OpenSearchDocumentStore:
                 if "create" not in e:
                     other_errors.append(e)
                     continue
-                error_type = e["create"]["error"]["type"]
+                # get the error if exists
+                try:
+                    error_type = e["create"]["error"]["type"]
+                except KeyError:
+                    error_type = None 
+                if policy == DuplicatePolicy.FAIL and error_type == "version_conflict_engine_exception":
+                    duplicate_errors_ids.append(e["create"]["_id"])
                 if policy == DuplicatePolicy.FAIL and error_type == "version_conflict_engine_exception":
                     duplicate_errors_ids.append(e["create"]["_id"])
                 elif policy == DuplicatePolicy.SKIP and error_type == "version_conflict_engine_exception":


### PR DESCRIPTION
Fix error handling in opensearch `write_documents`

It seems only to be failing on haystack 2.0 🤔 
Error:

```
packages/haystack_integrations/document_stores/opensearch/document_store.py\", line 171, in write_documents\n    error_type = e[\"create\"][\"error\"][\"type\"]\nKeyError: 'create'",
```