### PR TITLE
fix: disabling SSL for local OpenSearch docker

### DIFF
--- a/integrations/opensearch/docker-compose.yml
+++ b/integrations/opensearch/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     restart: on-failure
     environment:
       - discovery.type=single-node
+      - plugins.security.disabled=true
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     healthcheck:
         test: curl --fail https://localhost:9200/_cat/health -ku admin:admin || exit 1


### PR DESCRIPTION
- disabling the SSL for the local Docker Image since I was getting this error:

```
ConnectionError([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)) caused by: SSLError([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129))
```