### PR TITLE
Pinecone - Skip `test_comparison_not_equal_with_dataframe`

### DIFF
--- a/integrations/pinecone/tests/test_filters.py
+++ b/integrations/pinecone/tests/test_filters.py
@@ -77,6 +77,9 @@ class TestFilters(FilterDocumentsTest):
     @pytest.mark.skip(reason="Pinecone does not include null values in the result of the $ne operator")
     def test_comparison_not_equal(self, document_store, filterable_docs): ...
 
+    @pytest.mark.skip(reason="Pinecone does not include null values in the result of the $ne operator")
+    def test_comparison_not_equal_with_dataframe(self, document_store, filterable_docs): ...
+
     @pytest.mark.skip(
         reason="Pinecone has inconsistent behavior with respect to other Document Stores with the $or operator"
     )


### PR DESCRIPTION
We recently started to see failures like this: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8592581603/job/23542797620

`document_store.filter_documents(filters={"field": "dataframe", "operator": "!=", "value": pd.DataFrame([1])}`
returns only the Documents with a `dataframe` field with a different value, not Documents where `dataframe` is null.

This happens because of Pinecone's new handling of null values (explained in #590).

Metadata filtering in Pinecone seems to be a work in progress, so I would propose to skip this failing test for the time being and rework the filters when the mechanism is more stable on their end.