### PR TITLE
Qdrant - add hybrid retriever

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/__init__.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/__init__.py
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .retriever import QdrantEmbeddingRetriever, QdrantSparseRetriever
+from .retriever import QdrantEmbeddingRetriever, QdrantHybridRetriever, QdrantSparseRetriever
 
-__all__ = ("QdrantEmbeddingRetriever", "QdrantSparseRetriever")
+__all__ = ("QdrantEmbeddingRetriever", "QdrantSparseRetriever", "QdrantHybridRetriever")

--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -19,8 +19,10 @@ class QdrantEmbeddingRetriever:
         ":memory:",
         recreate_index=True,
         return_embedding=True,
-        wait_result_from_api=True,
     )
+
+    document_store.write_documents([Document(content="test", embedding=[0.5]*768)])
+
     retriever = QdrantEmbeddingRetriever(document_store=document_store)
 
     # using a fake vector to keep the example simple
@@ -112,7 +114,7 @@ class QdrantEmbeddingRetriever:
             The retrieved documents.
 
         """
-        docs = self._document_store.query_by_embedding(
+        docs = self._document_store._query_by_embedding(
             query_embedding=query_embedding,
             filters=filters or self._filters,
             top_k=top_k or self._top_k,
@@ -136,10 +138,14 @@ class QdrantSparseRetriever:
 
     document_store = QdrantDocumentStore(
         ":memory:",
+        use_sparse_embeddings=True,
         recreate_index=True,
         return_embedding=True,
-        wait_result_from_api=True,
     )
+
+    doc = Document(content="test", sparse_embedding=SparseEmbedding(indices=[0, 3, 5], values=[0.1, 0.5, 0.12]))
+    document_store.write_documents([doc])
+
     retriever = QdrantSparseRetriever(document_store=document_store)
     sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
     retriever.run(query_sparse_embedding=sparse_embedding)
@@ -196,7 +202,7 @@ class QdrantSparseRetriever:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "QdrantEmbeddingRetriever":
+    def from_dict(cls, data: Dict[str, Any]) -> "QdrantSparseRetriever":
         """
         Deserializes the component from a dictionary.
 
@@ -230,11 +236,132 @@ class QdrantSparseRetriever:
             The retrieved documents.
 
         """
-        docs = self._document_store.query_by_sparse(
+        docs = self._document_store._query_by_sparse(
             query_sparse_embedding=query_sparse_embedding,
             filters=filters or self._filters,
             top_k=top_k or self._top_k,
             scale_score=scale_score or self._scale_score,
+            return_embedding=return_embedding or self._return_embedding,
+        )
+
+        return {"documents": docs}
+
+
+@component
+class QdrantHybridRetriever:
+    """
+    A component for retrieving documents from an QdrantDocumentStore using both dense and sparse vectors
+    and fusing the results using Reciprocal Rank Fusion.
+
+    Usage example:
+    ```python
+    from haystack_integrations.components.retrievers.qdrant import QdrantHybridRetriever
+    from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
+    from haystack.dataclasses.sparse_embedding import SparseEmbedding
+
+    document_store = QdrantDocumentStore(
+        ":memory:",
+        use_sparse_embeddings=True,
+        recreate_index=True,
+        return_embedding=True,
+        wait_result_from_api=True,
+    )
+
+    doc = Document(content="test",
+                   embedding=[0.5]*768,
+                   sparse_embedding=SparseEmbedding(indices=[0, 3, 5], values=[0.1, 0.5, 0.12]))
+
+    document_store.write_documents([doc])
+
+    retriever = QdrantHybridRetriever(document_store=document_store)
+    embedding = [0.1]*768
+    sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
+    retriever.run(query_embedding=embedding, query_sparse_embedding=sparse_embedding)
+    ```
+    """
+
+    def __init__(
+        self,
+        document_store: QdrantDocumentStore,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        return_embedding: bool = False,
+    ):
+        """
+        Create a QdrantHybridRetriever component.
+
+        :param document_store: An instance of QdrantDocumentStore.
+        :param filters: A dictionary with filters to narrow down the search space. Default is None.
+        :param top_k: The maximum number of documents to retrieve. Default is 10.
+        :param return_embedding: Whether to return the embeddings of the retrieved Documents. Default is False.
+
+        :raises ValueError: If 'document_store' is not an instance of QdrantDocumentStore.
+        """
+
+        if not isinstance(document_store, QdrantDocumentStore):
+            msg = "document_store must be an instance of QdrantDocumentStore"
+            raise ValueError(msg)
+
+        self._document_store = document_store
+        self._filters = filters
+        self._top_k = top_k
+        self._return_embedding = return_embedding
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            document_store=self._document_store.to_dict(),
+            filters=self._filters,
+            top_k=self._top_k,
+            return_embedding=self._return_embedding,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "QdrantHybridRetriever":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            Dictionary to deserialize from.
+        :returns:
+            Deserialized component.
+        """
+        document_store = QdrantDocumentStore.from_dict(data["init_parameters"]["document_store"])
+        data["init_parameters"]["document_store"] = document_store
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        query_embedding: List[float],
+        query_sparse_embedding: SparseEmbedding,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        return_embedding: Optional[bool] = None,
+    ):
+        """
+        Run the Sparse Embedding Retriever on the given input data.
+
+        :param query_embedding: Dense embedding of the query.
+        :param query_sparse_embedding: Sparse embedding of the query.
+        :param filters: A dictionary with filters to narrow down the search space.
+        :param top_k: The maximum number of documents to return.
+        :param return_embedding: Whether to return the embedding of the retrieved Documents.
+        :returns:
+            The retrieved documents.
+
+        """
+        docs = self._document_store._query_hybrid(
+            query_embedding=query_embedding,
+            query_sparse_embedding=query_sparse_embedding,
+            filters=filters or self._filters,
+            top_k=top_k or self._top_k,
             return_embedding=return_embedding or self._return_embedding,
         )
 

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -1,18 +1,33 @@
 from typing import List
 
+import numpy as np
 import pytest
 from haystack import Document
+from haystack.dataclasses import SparseEmbedding
 from haystack.document_stores.errors import DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import (
     CountDocumentsTest,
     DeleteDocumentsTest,
     WriteDocumentsTest,
+    _random_embeddings,
 )
-from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
+from haystack_integrations.document_stores.qdrant.document_store import QdrantDocumentStore, QdrantStoreError
 
 
-class TestQdrantStoreBaseTests(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsTest):
+def _generate_mocked_sparse_embedding(n):
+    list_of_sparse_vectors = []
+    for _ in range(n):
+        random_indice_length = np.random.randint(3, 15)
+        data = {
+            "indices": list(range(random_indice_length)),
+            "values": [np.random.random_sample() for _ in range(random_indice_length)],
+        }
+        list_of_sparse_vectors.append(data)
+    return list_of_sparse_vectors
+
+
+class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsTest):
     @pytest.fixture
     def document_store(self) -> QdrantDocumentStore:
         return QdrantDocumentStore(
@@ -20,6 +35,7 @@ class TestQdrantStoreBaseTests(CountDocumentsTest, WriteDocumentsTest, DeleteDoc
             recreate_index=True,
             return_embedding=True,
             wait_result_from_api=True,
+            use_sparse_embeddings=False,
         )
 
     def assert_documents_are_equal(self, received: List[Document], expected: List[Document]):
@@ -39,3 +55,38 @@ class TestQdrantStoreBaseTests(CountDocumentsTest, WriteDocumentsTest, DeleteDoc
         assert document_store.write_documents(docs) == 1
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents(docs, DuplicatePolicy.FAIL)
+
+    def test_query_hybrid(self):
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True)
+
+        docs = []
+        for i in range(20):
+            sparse_embedding = SparseEmbedding.from_dict(_generate_mocked_sparse_embedding(1)[0])
+            docs.append(
+                Document(content=f"doc {i}", sparse_embedding=sparse_embedding, embedding=_random_embeddings(768))
+            )
+
+        document_store.write_documents(docs)
+
+        sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
+        embedding = [0.1] * 768
+
+        results: List[Document] = document_store._query_hybrid(
+            query_sparse_embedding=sparse_embedding, query_embedding=embedding, top_k=10, return_embedding=True
+        )
+        assert len(results) == 10
+
+        for document in results:
+            assert document.sparse_embedding
+            assert document.embedding
+
+    def test_query_hybrid_fail_without_sparse_embedding(self, document_store):
+        sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
+        embedding = [0.1] * 768
+
+        with pytest.raises(QdrantStoreError):
+
+            document_store._query_hybrid(
+                query_sparse_embedding=sparse_embedding,
+                query_embedding=embedding,
+            )

--- a/integrations/qdrant/tests/test_retriever.py
+++ b/integrations/qdrant/tests/test_retriever.py
@@ -1,6 +1,6 @@
 from typing import List
+from unittest.mock import Mock
 
-import numpy as np
 from haystack.dataclasses import Document, SparseEmbedding
 from haystack.testing.document_store import (
     FilterableDocsFixtureMixin,
@@ -8,9 +8,12 @@ from haystack.testing.document_store import (
 )
 from haystack_integrations.components.retrievers.qdrant import (
     QdrantEmbeddingRetriever,
+    QdrantHybridRetriever,
     QdrantSparseRetriever,
 )
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
+
+from .test_document_store import _generate_mocked_sparse_embedding
 
 
 class TestQdrantRetriever(FilterableDocsFixtureMixin):
@@ -222,23 +225,12 @@ class TestQdrantSparseRetriever(FilterableDocsFixtureMixin):
         assert retriever._scale_score is False
         assert retriever._return_embedding is True
 
-    def _generate_mocked_sparse_embedding(self, n):
-        list_of_sparse_vectors = []
-        for _ in range(n):
-            random_indice_length = np.random.randint(3, 15)
-            data = {
-                "indices": list(range(random_indice_length)),
-                "values": [np.random.random_sample() for _ in range(random_indice_length)],
-            }
-            list_of_sparse_vectors.append(data)
-        return list_of_sparse_vectors
-
     def test_run(self, filterable_docs: List[Document]):
         document_store = QdrantDocumentStore(location=":memory:", index="Boi", use_sparse_embeddings=True)
 
         # Add fake sparse embedding to documents
         for doc in filterable_docs:
-            doc.sparse_embedding = SparseEmbedding.from_dict(self._generate_mocked_sparse_embedding(1)[0])
+            doc.sparse_embedding = SparseEmbedding.from_dict(_generate_mocked_sparse_embedding(1)[0])
 
         document_store.write_documents(filterable_docs)
         retriever = QdrantSparseRetriever(document_store=document_store)
@@ -252,3 +244,112 @@ class TestQdrantSparseRetriever(FilterableDocsFixtureMixin):
 
         for document in results:
             assert document.sparse_embedding
+
+
+class TestQdrantHybridRetriever:
+    def test_init_default(self):
+        document_store = QdrantDocumentStore(location=":memory:", index="test", use_sparse_embeddings=True)
+        retriever = QdrantHybridRetriever(document_store=document_store)
+
+        assert retriever._document_store == document_store
+        assert retriever._filters is None
+        assert retriever._top_k == 10
+        assert retriever._return_embedding is False
+
+    def test_to_dict(self):
+        document_store = QdrantDocumentStore(location=":memory:", index="test")
+        retriever = QdrantHybridRetriever(document_store=document_store, top_k=5, return_embedding=True)
+        res = retriever.to_dict()
+        assert res == {
+            "type": "haystack_integrations.components.retrievers.qdrant.retriever.QdrantHybridRetriever",
+            "init_parameters": {
+                "document_store": {
+                    "type": "haystack_integrations.document_stores.qdrant.document_store.QdrantDocumentStore",
+                    "init_parameters": {
+                        "location": ":memory:",
+                        "url": None,
+                        "port": 6333,
+                        "grpc_port": 6334,
+                        "prefer_grpc": False,
+                        "https": None,
+                        "api_key": None,
+                        "prefix": None,
+                        "timeout": None,
+                        "host": None,
+                        "path": None,
+                        "index": "test",
+                        "embedding_dim": 768,
+                        "on_disk": False,
+                        "content_field": "content",
+                        "name_field": "name",
+                        "embedding_field": "embedding",
+                        "use_sparse_embeddings": False,
+                        "similarity": "cosine",
+                        "return_embedding": False,
+                        "progress_bar": True,
+                        "duplicate_documents": "overwrite",
+                        "recreate_index": False,
+                        "shard_number": None,
+                        "replication_factor": None,
+                        "write_consistency_factor": None,
+                        "on_disk_payload": None,
+                        "hnsw_config": None,
+                        "optimizers_config": None,
+                        "wal_config": None,
+                        "quantization_config": None,
+                        "init_from": None,
+                        "wait_result_from_api": True,
+                        "metadata": {},
+                        "write_batch_size": 100,
+                        "scroll_size": 10000,
+                        "payload_fields_to_index": None,
+                    },
+                },
+                "filters": None,
+                "top_k": 5,
+                "return_embedding": True,
+            },
+        }
+
+    def test_from_dict(self):
+        data = {
+            "type": "haystack_integrations.components.retrievers.qdrant.retriever.QdrantHybridRetriever",
+            "init_parameters": {
+                "document_store": {
+                    "init_parameters": {"location": ":memory:", "index": "test"},
+                    "type": "haystack_integrations.document_stores.qdrant.document_store.QdrantDocumentStore",
+                },
+                "filters": None,
+                "top_k": 5,
+                "return_embedding": True,
+            },
+        }
+        retriever = QdrantHybridRetriever.from_dict(data)
+        assert isinstance(retriever._document_store, QdrantDocumentStore)
+        assert retriever._document_store.index == "test"
+        assert retriever._filters is None
+        assert retriever._top_k == 5
+        assert retriever._return_embedding
+
+    def test_run(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
+        mock_store._query_hybrid.return_value = [
+            Document(content="Test doc", embedding=[0.1, 0.2], sparse_embedding=sparse_embedding)
+        ]
+
+        retriever = QdrantHybridRetriever(document_store=mock_store)
+        res = retriever.run(
+            query_embedding=[0.5, 0.7], query_sparse_embedding=SparseEmbedding(indices=[0, 5], values=[0.1, 0.7])
+        )
+
+        call_args = mock_store._query_hybrid.call_args
+        assert call_args[1]["query_embedding"] == [0.5, 0.7]
+        assert call_args[1]["query_sparse_embedding"].indices == [0, 5]
+        assert call_args[1]["query_sparse_embedding"].values == [0.1, 0.7]
+        assert call_args[1]["top_k"] == 10
+        assert call_args[1]["return_embedding"] is False
+
+        assert res["documents"][0].content == "Test doc"
+        assert res["documents"][0].embedding == [0.1, 0.2]
+        assert res["documents"][0].sparse_embedding == sparse_embedding


### PR DESCRIPTION
fixes #664

Introduce a simple `QdrantHybridRetriever` that takes `query_embedding` and `query_sparse_embedding` as input; returns Documents.
Applies Reciprocal Rank Fusion, as defined in the Qdrant Python Client.