### PR TITLE
fix: pass namespace in the docstore init

### DIFF
--- a/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
@@ -55,6 +55,7 @@ class AstraDocumentStore:
         embedding_dimension: int = 768,
         duplicates_policy: DuplicatePolicy = DuplicatePolicy.NONE,
         similarity: str = "cosine",
+        namespace: Optional[str] = None,
     ):
         """
         The connection to Astra DB is established and managed through the JSON API.
@@ -99,6 +100,8 @@ class AstraDocumentStore:
         self.embedding_dimension = embedding_dimension
         self.duplicates_policy = duplicates_policy
         self.similarity = similarity
+        if namespace:
+            self.namespace = namespace
 
         self.index = AstraClient(
             resolved_api_endpoint,
@@ -106,6 +109,7 @@ class AstraDocumentStore:
             self.collection_name,
             self.embedding_dimension,
             self.similarity,
+            namespace,
         )
 
     @classmethod

--- a/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
@@ -100,8 +100,7 @@ class AstraDocumentStore:
         self.embedding_dimension = embedding_dimension
         self.duplicates_policy = duplicates_policy
         self.similarity = similarity
-        if namespace:
-            self.namespace = namespace
+        self.namespace = namespace
 
         self.index = AstraClient(
             resolved_api_endpoint,
@@ -132,6 +131,7 @@ class AstraDocumentStore:
         :returns:
             Dictionary with serialized data.
         """
+
         return default_to_dict(
             self,
             api_endpoint=self.api_endpoint.to_dict(),
@@ -140,6 +140,7 @@ class AstraDocumentStore:
             embedding_dimension=self.embedding_dimension,
             duplicates_policy=self.duplicates_policy.name,
             similarity=self.similarity,
+            namespace=self.namespace,
         )
 
     def write_documents(

--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -25,6 +25,22 @@ def test_namespace_init():
         assert client.call_args.kwargs["namespace"] == "foo"
 
 
+def test_to_dict():
+    with mock.patch("haystack_integrations.document_stores.astra.astra_client.AstraDB"):
+        ds = AstraDocumentStore()
+        result = ds.to_dict()
+        assert result["type"] == "haystack_integrations.document_stores.astra.document_store.AstraDocumentStore"
+        assert set(result["init_parameters"]) == {
+            "api_endpoint",
+            "token",
+            "collection_name",
+            "embedding_dimension",
+            "duplicates_policy",
+            "similarity",
+            "namespace",
+        }
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(
     os.environ.get("ASTRA_DB_APPLICATION_TOKEN", "") == "", reason="ASTRA_DB_APPLICATION_TOKEN env var not set"

--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 from typing import List
+from unittest import mock
 
 import pytest
 from haystack import Document
@@ -11,6 +12,17 @@ from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
 
 from haystack_integrations.document_stores.astra import AstraDocumentStore
+
+
+def test_namespace_init():
+    with mock.patch("haystack_integrations.document_stores.astra.astra_client.AstraDB") as client:
+        AstraDocumentStore()
+        assert "namespace" in client.call_args.kwargs
+        assert client.call_args.kwargs["namespace"] is None
+
+        AstraDocumentStore(namespace="foo")
+        assert "namespace" in client.call_args.kwargs
+        assert client.call_args.kwargs["namespace"] == "foo"
 
 
 @pytest.mark.integration

--- a/integrations/astra/tests/test_retriever.py
+++ b/integrations/astra/tests/test_retriever.py
@@ -30,6 +30,7 @@ def test_retriever_to_json(*_):
                     "embedding_dimension": 768,
                     "duplicates_policy": "NONE",
                     "similarity": "cosine",
+                    "namespace": None,
                 },
             },
         },
@@ -42,7 +43,6 @@ def test_retriever_to_json(*_):
 )
 @patch("haystack_integrations.document_stores.astra.document_store.AstraClient")
 def test_retriever_from_json(*_):
-
     data = {
         "type": "haystack_integrations.components.retrievers.astra.retriever.AstraEmbeddingRetriever",
         "init_parameters": {


### PR DESCRIPTION
Fixes #682 

It's now possible to pass the namespace to the document store constructor.