### PR TITLE
fix: Fix streaming_callback serialization in AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -210,6 +210,7 @@ class AmazonBedrockChatGenerator:
         :returns:
             Dictionary with serialized data.
         """
+        callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
         return default_to_dict(
             self,
             aws_access_key_id=self.aws_access_key_id.to_dict() if self.aws_access_key_id else None,
@@ -220,7 +221,7 @@ class AmazonBedrockChatGenerator:
             model=self.model,
             stop_words=self.stop_words,
             generation_kwargs=self.model_adapter.generation_kwargs,
-            streaming_callback=serialize_callable(self.streaming_callback),
+            streaming_callback=callback_name,
         )
 
     @classmethod


### PR DESCRIPTION
### Related Issues
fixes #684 
Proposed Changes: Modified the to_dict method to properly serialize in case when the streaming_callback is None