### PR TITLE
Update Nvidia integration to support new endpoints

### DIFF
--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -22,6 +22,7 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+  NVIDIA_CATALOG_API_KEY: ${{ secrets.NVIDIA_CATALOG_API_KEY }}
 
 jobs:
   run:
@@ -73,7 +74,7 @@ jobs:
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
+            core-integrations failure:
             ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
              - ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -117,7 +117,6 @@ unfixable = [
   # Don't touch unused imports
   "F401",
 ]
-extend-exclude = ["tests", "example"]
 
 [tool.ruff.isort]
 known-first-party = ["src"]

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/__init__.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/__init__.py
@@ -1,7 +1,5 @@
 from .document_embedder import NvidiaDocumentEmbedder
 from .text_embedder import NvidiaTextEmbedder
+from .truncate import TruncateMode
 
-__all__ = [
-    "NvidiaDocumentEmbedder",
-    "NvidiaTextEmbedder",
-]
+__all__ = ["NvidiaDocumentEmbedder", "NvidiaTextEmbedder", "TruncateMode"]

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/__init__.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/__init__.py
@@ -1,5 +1,5 @@
 from .document_embedder import NvidiaDocumentEmbedder
 from .text_embedder import NvidiaTextEmbedder
-from .truncate import TruncateMode
+from .truncate import EmbeddingTruncateMode
 
-__all__ = ["NvidiaDocumentEmbedder", "NvidiaTextEmbedder", "TruncateMode"]
+__all__ = ["NvidiaDocumentEmbedder", "NvidiaTextEmbedder", "EmbeddingTruncateMode"]

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/_nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/_nim_backend.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+from haystack.utils.auth import Secret
 
 from .backend import EmbedderBackend
 
@@ -12,12 +13,17 @@ class NimBackend(EmbedderBackend):
         self,
         model: str,
         api_url: str,
+        api_key: Optional[Secret] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         headers = {
             "Content-Type": "application/json",
             "accept": "application/json",
         }
+
+        if api_key:
+            headers["authorization"] = f"Bearer {api_key.resolve_value()}"
+
         self.session = requests.Session()
         self.session.headers.update(headers)
 

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/_nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/_nim_backend.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
-from haystack.utils.auth import Secret
+from haystack.utils import Secret
 
 from .backend import EmbedderBackend
 

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/_nvcf_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/_nvcf_backend.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
@@ -17,6 +18,7 @@ class NvcfBackend(EmbedderBackend):
         api_key: Secret,
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
+        warnings.warn("Nvidia NGC is deprecated, use Nvidia NIM instead.", DeprecationWarning, stacklevel=2)
         if not model.startswith("playground_"):
             model = f"playground_{model}"
 

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -81,8 +81,8 @@ class NvidiaDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
-        if isinstance(truncate, EmbeddingTruncateMode):
-            truncate = str(truncate)
+        if isinstance(truncate, str):
+            truncate = EmbeddingTruncateMode.from_str(truncate)
         self.truncate = truncate
 
         self.backend: Optional[EmbedderBackend] = None
@@ -104,7 +104,7 @@ class NvidiaDocumentEmbedder:
         else:
             model_kwargs = {"input_type": "passage"}
             if self.truncate is not None:
-                model_kwargs["truncate"] = self.truncate
+                model_kwargs["truncate"] = str(self.truncate)
             self.backend = NimBackend(
                 self.model,
                 api_url=self.api_url,

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -41,6 +41,7 @@ class NvidiaDocumentEmbedder:
         progress_bar: bool = True,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
+        truncate: Literal["NONE", "START", "END"] = "NONE",
     ):
         """
         Create a NvidiaTextEmbedder component.
@@ -64,6 +65,8 @@ class NvidiaDocumentEmbedder:
             List of meta fields that should be embedded along with the Document text.
         :param embedding_separator:
             Separator used to concatenate the meta fields to the Document text.
+        :param truncate:
+            Specifies how inputs longer that the maximum token length should be truncated.
         """
 
         self.api_key = api_key
@@ -75,6 +78,7 @@ class NvidiaDocumentEmbedder:
         self.progress_bar = progress_bar
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
+        self.truncate = truncate
 
         self.backend: Optional[EmbedderBackend] = None
         self._initialized = False
@@ -94,7 +98,7 @@ class NvidiaDocumentEmbedder:
             self.backend = NvcfBackend(self.model, api_key=self.api_key, model_kwargs={"model": "passage"})
         else:
             self.backend = NimBackend(
-                self.model, api_url=self.api_url, api_key=self.api_key, model_kwargs={"input_type": "passage"}
+                self.model, api_url=self.api_url, model_kwargs={"input_type": "passage", "truncate": self.truncate}
             )
 
         self._initialized = True
@@ -117,6 +121,7 @@ class NvidiaDocumentEmbedder:
             progress_bar=self.progress_bar,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
+            truncate=self.truncate,
         )
 
     @classmethod

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -68,7 +68,7 @@ class NvidiaDocumentEmbedder:
             Separator used to concatenate the meta fields to the Document text.
         :param truncate:
             Specifies how inputs longer that the maximum token length should be truncated.
-            If None an error will be raised if the input is too long.
+            If None the behavior is model-dependent, see the official documentation for more information.
         """
 
         self.api_key = api_key

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -93,7 +93,9 @@ class NvidiaDocumentEmbedder:
 
             self.backend = NvcfBackend(self.model, api_key=self.api_key, model_kwargs={"model": "passage"})
         else:
-            self.backend = NimBackend(self.model, api_url=self.api_url, model_kwargs={"input_type": "passage"})
+            self.backend = NimBackend(
+                self.model, api_url=self.api_url, api_key=self.api_key, model_kwargs={"input_type": "passage"}
+            )
 
         self._initialized = True
 

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -77,7 +77,9 @@ class NvidiaTextEmbedder:
 
             self.backend = NvcfBackend(self.model, api_key=self.api_key, model_kwargs={"model": "query"})
         else:
-            self.backend = NimBackend(self.model, api_url=self.api_url, model_kwargs={"input_type": "query"})
+            self.backend = NimBackend(
+                self.model, api_url=self.api_url, api_key=self.api_key, model_kwargs={"input_type": "query"}
+            )
 
         self._initialized = True
 

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -38,6 +38,7 @@ class NvidiaTextEmbedder:
         api_url: Optional[str] = None,
         prefix: str = "",
         suffix: str = "",
+        truncate: Literal["NONE", "START", "END"] = "NONE",
     ):
         """
         Create a NvidiaTextEmbedder component.
@@ -52,6 +53,8 @@ class NvidiaTextEmbedder:
             A string to add to the beginning of each text.
         :param suffix:
             A string to add to the end of each text.
+        :param truncate:
+            Specifies how inputs longer that the maximum token length should be truncated.
         """
 
         self.api_key = api_key
@@ -59,6 +62,7 @@ class NvidiaTextEmbedder:
         self.api_url = api_url
         self.prefix = prefix
         self.suffix = suffix
+        self.truncate = truncate
 
         self.backend: Optional[EmbedderBackend] = None
         self._initialized = False
@@ -78,7 +82,7 @@ class NvidiaTextEmbedder:
             self.backend = NvcfBackend(self.model, api_key=self.api_key, model_kwargs={"model": "query"})
         else:
             self.backend = NimBackend(
-                self.model, api_url=self.api_url, api_key=self.api_key, model_kwargs={"input_type": "query"}
+                self.model, api_url=self.api_url, model_kwargs={"input_type": "query", "truncate": self.truncate}
             )
 
         self._initialized = True
@@ -97,6 +101,7 @@ class NvidiaTextEmbedder:
             api_url=self.api_url,
             prefix=self.prefix,
             suffix=self.suffix,
+            truncate=self.truncate,
         )
 
     @classmethod

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -56,7 +56,7 @@ class NvidiaTextEmbedder:
             A string to add to the end of each text.
         :param truncate:
             Specifies how inputs longer that the maximum token length should be truncated.
-            If None an error will be raised if the input is too long.
+            If None the behavior is model-dependent, see the official documentation for more information.
         """
 
         self.api_key = api_key

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -65,8 +65,8 @@ class NvidiaTextEmbedder:
         self.prefix = prefix
         self.suffix = suffix
 
-        if isinstance(truncate, EmbeddingTruncateMode):
-            truncate = str(truncate)
+        if isinstance(truncate, str):
+            truncate = EmbeddingTruncateMode.from_str(truncate)
         self.truncate = truncate
 
         self.backend: Optional[EmbedderBackend] = None
@@ -88,7 +88,7 @@ class NvidiaTextEmbedder:
         else:
             model_kwargs = {"input_type": "query"}
             if self.truncate is not None:
-                model_kwargs["truncate"] = self.truncate
+                model_kwargs["truncate"] = str(self.truncate)
             self.backend = NimBackend(
                 self.model,
                 api_url=self.api_url,

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -1,0 +1,30 @@
+from enum import Enum
+
+
+class TruncateMode(Enum):
+    """
+    Enum used to specify truncation mode for embeddings.
+    """
+
+    START = "START"
+    END = "END"
+
+    def __str__(self):
+        return self.value
+
+    @classmethod
+    def from_str(cls, string: str) -> "TruncateMode":
+        """
+        Create an truncate mode from a string.
+
+        :param string:
+            String to convert.
+        :returns:
+            Truncate mode.
+        """
+        enum_map = {e.value: e for e in TruncateMode}
+        opt_mode = enum_map.get(string)
+        if opt_mode is None:
+            msg = f"Unknown truncate mode '{string}'. Supported modes are: {list(enum_map.keys())}"
+            raise ValueError(msg)
+        return opt_mode

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -1,9 +1,11 @@
 from enum import Enum
 
 
-class TruncateMode(Enum):
+class EmbeddingTruncateMode(Enum):
     """
-    Enum used to specify truncation mode for embeddings.
+    Specifies how inputs to the NVIDIA embedding components are truncated.
+    If START, the input will be truncated from the start.
+    If END, the input will be truncated from the end.
     """
 
     START = "START"
@@ -13,7 +15,7 @@ class TruncateMode(Enum):
         return self.value
 
     @classmethod
-    def from_str(cls, string: str) -> "TruncateMode":
+    def from_str(cls, string: str) -> "EmbeddingTruncateMode":
         """
         Create an truncate mode from a string.
 
@@ -22,7 +24,7 @@ class TruncateMode(Enum):
         :returns:
             Truncate mode.
         """
-        enum_map = {e.value: e for e in TruncateMode}
+        enum_map = {e.value: e for e in EmbeddingTruncateMode}
         opt_mode = enum_map.get(string)
         if opt_mode is None:
             msg = f"Unknown truncate mode '{string}'. Supported modes are: {list(enum_map.keys())}"

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/_nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/_nim_backend.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+from haystack.utils.auth import Secret
 
 from .backend import GeneratorBackend
 
@@ -12,12 +13,17 @@ class NimBackend(GeneratorBackend):
         self,
         model: str,
         api_url: str,
+        api_key: Optional[Secret] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         headers = {
             "Content-Type": "application/json",
             "accept": "application/json",
         }
+
+        if api_key:
+            headers["authorization"] = f"Bearer {api_key.resolve_value()}"
+
         self.session = requests.Session()
         self.session.headers.update(headers)
 
@@ -26,8 +32,9 @@ class NimBackend(GeneratorBackend):
         self.model_kwargs = model_kwargs or {}
 
     def generate(self, prompt: str) -> Tuple[List[str], List[Dict[str, Any]]]:
-        # We're using the chat completion endpoint as the local containers don't support
+        # We're using the chat completion endpoint as the NVidia API doesn't support
         # the /completions endpoint. So both the non-chat and chat generator will use this.
+        # This is the same for local containers and the cloud API.
         url = f"{self.api_url}/chat/completions"
 
         res = self.session.post(
@@ -57,13 +64,17 @@ class NimBackend(GeneratorBackend):
             replies.append(message["content"])
             choice_meta = {
                 "role": message["role"],
-                "finish_reason": choice["finish_reason"],
                 "usage": {
                     "prompt_tokens": completions["usage"]["prompt_tokens"],
-                    "completion_tokens": completions["usage"]["completion_tokens"],
                     "total_tokens": completions["usage"]["total_tokens"],
                 },
             }
+            # These fields could be null, the others will always be present
+            if "finish_reason" in choice:
+                choice_meta["finish_reason"] = choice["finish_reason"]
+            if "completion_tokens" in completions["usage"]:
+                choice_meta["usage"]["completion_tokens"] = completions["usage"]["completion_tokens"]
+
             meta.append(choice_meta)
 
         return replies, meta

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/_nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/_nim_backend.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
-from haystack.utils.auth import Secret
+from haystack.utils import Secret
 
 from .backend import GeneratorBackend
 
@@ -32,7 +32,7 @@ class NimBackend(GeneratorBackend):
         self.model_kwargs = model_kwargs or {}
 
     def generate(self, prompt: str) -> Tuple[List[str], List[Dict[str, Any]]]:
-        # We're using the chat completion endpoint as the NVidia API doesn't support
+        # We're using the chat completion endpoint as the NIM API doesn't support
         # the /completions endpoint. So both the non-chat and chat generator will use this.
         # This is the same for local containers and the cloud API.
         url = f"{self.api_url}/chat/completions"

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/_nvcf_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/_nvcf_backend.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -14,6 +15,7 @@ class NvcfBackend(GeneratorBackend):
         api_key: Secret,
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
+        warnings.warn("Nvidia NGC is deprecated, use Nvidia NIM instead.", DeprecationWarning, stacklevel=2)
         if not model.startswith("playground_"):
             model = f"playground_{model}"
 

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
@@ -85,6 +85,7 @@ class NvidiaGenerator:
             self._backend = NimBackend(
                 self._model,
                 api_url=self._api_url,
+                api_key=self._api_key,
                 model_kwargs=self._model_arguments,
             )
 

--- a/integrations/nvidia/tests/test_document_embedder.py
+++ b/integrations/nvidia/tests/test_document_embedder.py
@@ -79,7 +79,7 @@ class TestNvidiaDocumentEmbedder:
             progress_bar=False,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
-            truncate="END"
+            truncate="END",
         )
         data = component.to_dict()
         assert data == {

--- a/integrations/nvidia/tests/test_document_embedder.py
+++ b/integrations/nvidia/tests/test_document_embedder.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 from haystack import Document
 from haystack.utils import Secret
-from haystack_integrations.components.embedders.nvidia import NvidiaDocumentEmbedder, TruncateMode
+from haystack_integrations.components.embedders.nvidia import EmbeddingTruncateMode, NvidiaDocumentEmbedder
 
 
 class TestNvidiaDocumentEmbedder:
@@ -79,7 +79,7 @@ class TestNvidiaDocumentEmbedder:
             progress_bar=False,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
-            truncate=TruncateMode.END,
+            truncate=EmbeddingTruncateMode.END,
         )
         data = component.to_dict()
         assert data == {
@@ -124,7 +124,7 @@ class TestNvidiaDocumentEmbedder:
         assert component.progress_bar
         assert component.meta_fields_to_embed == []
         assert component.embedding_separator == "\n"
-        assert component.truncate == TruncateMode.START
+        assert component.truncate == EmbeddingTruncateMode.START
 
     def test_prepare_texts_to_embed_w_metadata(self):
         documents = [

--- a/integrations/nvidia/tests/test_document_embedder.py
+++ b/integrations/nvidia/tests/test_document_embedder.py
@@ -64,6 +64,7 @@ class TestNvidiaDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
+                "truncate": "NONE",
             },
         }
 
@@ -78,6 +79,7 @@ class TestNvidiaDocumentEmbedder:
             progress_bar=False,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
+            truncate="END"
         )
         data = component.to_dict()
         assert data == {
@@ -92,6 +94,7 @@ class TestNvidiaDocumentEmbedder:
                 "progress_bar": False,
                 "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
+                "truncate": "END",
             },
         }
 

--- a/integrations/nvidia/tests/test_document_embedder.py
+++ b/integrations/nvidia/tests/test_document_embedder.py
@@ -355,3 +355,30 @@ class TestNvidiaDocumentEmbedder:
         for doc in docs_with_embeddings:
             assert isinstance(doc.embedding, list)
             assert isinstance(doc.embedding[0], float)
+
+    @pytest.mark.skipif(
+        not os.environ.get("NVIDIA_CATALOG_API_KEY", None),
+        reason="Export an env var called NVIDIA_CATALOG_API_KEY containing the Nvidia API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_run_integration_with_api_catalog(self):
+        embedder = NvidiaDocumentEmbedder(
+            model="NV-Embed-QA",
+            api_url="https://ai.api.nvidia.com/v1/retrieval/nvidia",
+            api_key=Secret.from_env_var("NVIDIA_CATALOG_API_KEY"),
+        )
+        embedder.warm_up()
+
+        docs = [
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
+        ]
+
+        result = embedder.run(docs)
+        docs_with_embeddings = result["documents"]
+
+        assert isinstance(docs_with_embeddings, list)
+        assert len(docs_with_embeddings) == len(docs)
+        for doc in docs_with_embeddings:
+            assert isinstance(doc.embedding, list)
+            assert isinstance(doc.embedding[0], float)

--- a/integrations/nvidia/tests/test_generator.py
+++ b/integrations/nvidia/tests/test_generator.py
@@ -202,3 +202,23 @@ class TestNvidiaGenerator:
 
         assert result["replies"]
         assert result["meta"]
+
+    @pytest.mark.skipif(
+        not os.environ.get("NVIDIA_CATALOG_API_KEY", None),
+        reason="Export an env var called NVIDIA_CATALOG_API_KEY containing the Nvidia API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_run_integration_with_api_catalog(self):
+        generator = NvidiaGenerator(
+            model="meta/llama3-70b-instruct",
+            api_url="https://integrate.api.nvidia.com/v1",
+            api_key=Secret.from_env_var("NVIDIA_CATALOG_API_KEY"),
+            model_arguments={
+                "temperature": 0.2,
+            },
+        )
+        generator.warm_up()
+        result = generator.run(prompt="What is the answer?")
+
+        assert result["replies"]
+        assert result["meta"]

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from haystack.utils import Secret
-from haystack_integrations.components.embedders.nvidia import NvidiaTextEmbedder
+from haystack_integrations.components.embedders.nvidia import NvidiaTextEmbedder, TruncateMode
 
 
 class TestNvidiaTextEmbedder:
@@ -46,7 +46,7 @@ class TestNvidiaTextEmbedder:
                 "model": "nvolveqa_40k",
                 "prefix": "",
                 "suffix": "",
-                "truncate": "NONE",
+                "truncate": None,
             },
         }
 
@@ -56,7 +56,7 @@ class TestNvidiaTextEmbedder:
             model="nvolveqa_40k",
             prefix="prefix",
             suffix="suffix",
-            truncate="START",
+            truncate=TruncateMode.START,
         )
         data = component.to_dict()
         assert data == {
@@ -70,6 +70,26 @@ class TestNvidiaTextEmbedder:
                 "truncate": "START",
             },
         }
+
+    def from_dict(self, monkeypatch):
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+        data = {
+            "type": "haystack_integrations.components.embedders.nvidia.text_embedder.NvidiaTextEmbedder",
+            "init_parameters": {
+                "api_key": {"env_vars": ["NVIDIA_API_KEY"], "strict": True, "type": "env_var"},
+                "api_url": None,
+                "model": "nvolveqa_40k",
+                "prefix": "prefix",
+                "suffix": "suffix",
+                "truncate": "START",
+            },
+        }
+        component = NvidiaTextEmbedder.from_dict(data)
+        assert component.model == "nvolveqa_40k"
+        assert component.api_url is None
+        assert component.prefix == "prefix"
+        assert component.suffix == "suffix"
+        assert component.truncate == TruncateMode.START
 
     @patch("haystack_integrations.components.embedders.nvidia._nvcf_backend.NvidiaCloudFunctionsClient")
     def test_run(self, mock_client_class):

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -46,6 +46,7 @@ class TestNvidiaTextEmbedder:
                 "model": "nvolveqa_40k",
                 "prefix": "",
                 "suffix": "",
+                "truncate": "NONE"
             },
         }
 
@@ -55,6 +56,7 @@ class TestNvidiaTextEmbedder:
             model="nvolveqa_40k",
             prefix="prefix",
             suffix="suffix",
+            truncate="START",
         )
         data = component.to_dict()
         assert data == {
@@ -65,6 +67,7 @@ class TestNvidiaTextEmbedder:
                 "model": "nvolveqa_40k",
                 "prefix": "prefix",
                 "suffix": "suffix",
+                "truncate": "START"
             },
         }
 

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -46,7 +46,7 @@ class TestNvidiaTextEmbedder:
                 "model": "nvolveqa_40k",
                 "prefix": "",
                 "suffix": "",
-                "truncate": "NONE"
+                "truncate": "NONE",
             },
         }
 
@@ -67,7 +67,7 @@ class TestNvidiaTextEmbedder:
                 "model": "nvolveqa_40k",
                 "prefix": "prefix",
                 "suffix": "suffix",
-                "truncate": "START"
+                "truncate": "START",
             },
         }
 

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -150,3 +150,24 @@ class TestNvidiaTextEmbedder:
 
         assert all(isinstance(x, float) for x in embedding)
         assert "usage" in meta
+
+
+    @pytest.mark.skipif(
+        not os.environ.get("NVIDIA_CATALOG_API_KEY", None),
+        reason="Export an env var called NVIDIA_CATALOG_API_KEY containing the Nvidia API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_run_integration_with_api_catalog(self):
+        embedder = NvidiaTextEmbedder(
+            model="NV-Embed-QA",
+            api_url="https://ai.api.nvidia.com/v1/retrieval/nvidia",
+            api_key=Secret.from_env_var("NVIDIA_CATALOG_API_KEY"),
+        )
+        embedder.warm_up()
+
+        result = embedder.run("A transformer is a deep learning architecture")
+        embedding = result["embedding"]
+        meta = result["meta"]
+
+        assert all(isinstance(x, float) for x in embedding)
+        assert "usage" in meta

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from haystack.utils import Secret
-from haystack_integrations.components.embedders.nvidia import NvidiaTextEmbedder, TruncateMode
+from haystack_integrations.components.embedders.nvidia import EmbeddingTruncateMode, NvidiaTextEmbedder
 
 
 class TestNvidiaTextEmbedder:
@@ -56,7 +56,7 @@ class TestNvidiaTextEmbedder:
             model="nvolveqa_40k",
             prefix="prefix",
             suffix="suffix",
-            truncate=TruncateMode.START,
+            truncate=EmbeddingTruncateMode.START,
         )
         data = component.to_dict()
         assert data == {
@@ -89,7 +89,7 @@ class TestNvidiaTextEmbedder:
         assert component.api_url is None
         assert component.prefix == "prefix"
         assert component.suffix == "suffix"
-        assert component.truncate == TruncateMode.START
+        assert component.truncate == "START"
 
     @patch("haystack_integrations.components.embedders.nvidia._nvcf_backend.NvidiaCloudFunctionsClient")
     def test_run(self, mock_client_class):

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -151,7 +151,6 @@ class TestNvidiaTextEmbedder:
         assert all(isinstance(x, float) for x in embedding)
         assert "usage" in meta
 
-
     @pytest.mark.skipif(
         not os.environ.get("NVIDIA_CATALOG_API_KEY", None),
         reason="Export an env var called NVIDIA_CATALOG_API_KEY containing the Nvidia API key to run this test.",


### PR DESCRIPTION
Fixes #696.

This PR updates both Nvidia generator and embedders to support the new [API catalog endpoints](https://build.nvidia.com).

These new endpoints require a different API key from the previous ones so I opted to use an `NVIDIA_CATALOG_API_KEY` env var in tests to differentiate it from the previous one.