### PR TITLE
fix: Weaviate schema class name conversion which preserves PascalCase

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -166,7 +166,9 @@ class WeaviateDocumentStore:
             }
         else:
             # Set the class if not set
-            collection_settings["class"] = collection_settings.get("class", "default").capitalize()
+            _class_name = collection_settings.get("class", "Default")
+            _class_name = _class_name[0].upper() + _class_name[1:]
+            collection_settings["class"] = _class_name
             # Set the properties if they're not set
             collection_settings["properties"] = collection_settings.get("properties", DOCUMENT_COLLECTION_PROPERTIES)
 


### PR DESCRIPTION
Fixes #706 by implementing a class name conversion which capitalizes the first letter but otherwise preserves casing of the remainder of the class name string.

It should be noted that raising a `ValueError` for class names which do not start with a capital letter would be preferable; the `WeaviateDocumentStore` constructor should not really be mutating the user input. However, this would technically be a breaking change at this point so is probably less appealing.