### PR TITLE
chore: sync integrations docs with all the available Haystack versions

### DIFF
--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -18,6 +18,11 @@ env:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        hs-docs-version: ['2.0', '2.1', '2.2-unstable']
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
@@ -39,7 +44,7 @@ jobs:
           import os
           project_path = os.environ["TAG"].rsplit("-", maxsplit=1)[0]
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-            print(f'project_path={project_path}', file=f)          
+            print(f'project_path={project_path}', file=f)
 
       - name: Generate docs
         working-directory: ${{ steps.pathfinder.outputs.project_path }}
@@ -54,7 +59,7 @@ jobs:
           find . -name "_readme_*.md" -exec cp "{}" tmp \;
           ls tmp
 
-      - name: Sync API docs
+      - name: Sync API docs with Haystack docs version ${{ matrix.hs-docs-version }}
         uses: readmeio/rdme@v8
         with:
-          rdme: docs ${{ steps.pathfinder.outputs.project_path }}/tmp --key=${{ secrets.README_API_KEY }} --version=2.0
+          rdme: docs ${{ steps.pathfinder.outputs.project_path }}/tmp --key=${{ secrets.README_API_KEY }} --version=${{ matrix.hs-docs-version }}

--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        hs-docs-version: ${{ needs.get-versions.outputs.versions }}
+        hs-docs-version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4

--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -16,13 +16,26 @@ env:
   TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
+  get-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.version_finder.outputs.versions }}
+    steps:
+      - name: Get Haystack Docs versions
+        id: version_finder
+        run: |
+          curl https://dash.readme.com/api/v1/version --header 'authorization: Basic ${{ secrets.README_API_KEY }}' > out
+          VERSIONS=$(jq '[ .[] | select(.version | startswith("2."))| .version ]' out)
+          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
+
   sync:
     runs-on: ubuntu-latest
+    needs: get-versions
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        hs-docs-version: ['2.0', '2.1', '2.2-unstable']
+        hs-docs-version: ${{ needs.get-versions.outputs.versions }}
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Sync docs with all the Haystack versions available on Readme.