### PR TITLE
fix: Fix langfuse nightly tests

### DIFF
--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -68,7 +68,7 @@ jobs:
         id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run test
       
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
* Fixes langfuse nightly tests

The only test, so far, we have is integration test so let's run all unit/integration tests

Resolves https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8962156252