### PR TITLE
fix: make unit tests pass

### DIFF
--- a/integrations/astra/pyproject.toml
+++ b/integrations/astra/pyproject.toml
@@ -80,12 +80,12 @@ dependencies = [
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [
   "black {args:.}",
-  "ruff --fix {args:.}",
+  "ruff check --fix {args:.}",
   "style",
 ]
 all = [
@@ -104,7 +104,7 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py38"
 line-length = 120
-select = [
+lint.select = [
   "A",
   "ARG",
   "B",
@@ -131,7 +131,7 @@ select = [
   "W",
   "YTT",
 ]
-ignore = [
+lint.ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
   # Allow boolean positional values in function calls, like `dict.get(... True)`
@@ -141,19 +141,19 @@ ignore = [
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
 ]
-unfixable = [
+lint.unfixable = [
   # Don't touch unused imports
   "F401",
 ]
-exclude = ["example"]
+lint.exclude = ["example"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["haystack_integrations"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "parents"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 

--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -10,11 +10,18 @@ from haystack import Document
 from haystack.document_stores.errors import MissingDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
+from haystack.utils import Secret
 
 from haystack_integrations.document_stores.astra import AstraDocumentStore
 
 
-def test_namespace_init():
+@pytest.fixture
+def mock_auth(monkeypatch):
+    monkeypatch.setenv("ASTRA_DB_API_ENDPOINT", "http://example.com")
+    monkeypatch.setenv("ASTRA_DB_APPLICATION_TOKEN", "test_token")
+
+
+def test_namespace_init(mock_auth):
     with mock.patch("haystack_integrations.document_stores.astra.astra_client.AstraDB") as client:
         AstraDocumentStore()
         assert "namespace" in client.call_args.kwargs
@@ -25,7 +32,7 @@ def test_namespace_init():
         assert client.call_args.kwargs["namespace"] == "foo"
 
 
-def test_to_dict():
+def test_to_dict(mock_auth):
     with mock.patch("haystack_integrations.document_stores.astra.astra_client.AstraDB"):
         ds = AstraDocumentStore()
         result = ds.to_dict()

--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -10,7 +10,6 @@ from haystack import Document
 from haystack.document_stores.errors import MissingDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
-from haystack.utils import Secret
 
 from haystack_integrations.document_stores.astra import AstraDocumentStore
 
@@ -21,7 +20,7 @@ def mock_auth(monkeypatch):
     monkeypatch.setenv("ASTRA_DB_APPLICATION_TOKEN", "test_token")
 
 
-def test_namespace_init(mock_auth):
+def test_namespace_init(mock_auth):  # noqa
     with mock.patch("haystack_integrations.document_stores.astra.astra_client.AstraDB") as client:
         AstraDocumentStore()
         assert "namespace" in client.call_args.kwargs
@@ -32,7 +31,7 @@ def test_namespace_init(mock_auth):
         assert client.call_args.kwargs["namespace"] == "foo"
 
 
-def test_to_dict(mock_auth):
+def test_to_dict(mock_auth):  # noqa
     with mock.patch("haystack_integrations.document_stores.astra.astra_client.AstraDB"):
         ds = AstraDocumentStore()
         result = ds.to_dict()


### PR DESCRIPTION
Fixes nightly tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8977420765/job/24656141167

Unit tests should not depend on actual authentication, this PR mocks the env vars needed.