### PR TITLE
chore: Use ChatMessage to_openai_format, update unit tests, pydocs

### DIFF
--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -68,7 +68,7 @@ jobs:
         id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test
+          hatch run test -m "not integration"
       
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -10,7 +10,7 @@ import langfuse
 
 class LangfuseSpan(Span):
     """
-    Internal class representing a bridge between the Haystack span tracing API and the Langfuse.
+    Internal class representing a bridge between the Haystack span tracing API and Langfuse.
     """
 
     def __init__(self, span: "Union[langfuse.client.StatefulSpanClient, langfuse.client.StatefulTraceClient]") -> None:
@@ -75,7 +75,7 @@ class LangfuseSpan(Span):
 
 class LangfuseTracer(Tracer):
     """
-    Internal class representing a bridge between the Haystack tracer and the Langfuse.
+    Internal class representing a bridge between the Haystack tracer and Langfuse.
     """
 
     def __init__(self, tracer: "langfuse.Langfuse", name: str = "Haystack", public: bool = False) -> None:
@@ -87,7 +87,7 @@ class LangfuseTracer(Tracer):
             Langfuse dashboard.
         :param public: Whether the tracing data should be public or private. If set to `True`, the tracing data will
         be publicly accessible to anyone with the tracing URL. If set to `False`, the tracing data will be private
-        and only accessible to the Langfuse account owner. The default is `False`.
+        and only accessible to the Langfuse account owner.
         """
         self._tracer = tracer
         self._context: list[LangfuseSpan] = []

--- a/integrations/langfuse/tests/test_langfuse_span.py
+++ b/integrations/langfuse/tests/test_langfuse_span.py
@@ -1,0 +1,65 @@
+import os
+
+os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
+
+from unittest.mock import Mock
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.tracing.langfuse.tracer import LangfuseSpan
+
+
+class TestLangfuseSpan:
+
+    #  LangfuseSpan can be initialized with a span object
+    def test_initialized_with_span_object(self):
+        mock_span = Mock()
+        span = LangfuseSpan(mock_span)
+        assert span.raw_span() == mock_span
+
+    #  set_tag method can update metadata of the span object
+    def test_set_tag_updates_metadata(self):
+        mock_span = Mock()
+        span = LangfuseSpan(mock_span)
+
+        span.set_tag("key", "value")
+        mock_span.update.assert_called_once_with(metadata={"key": "value"})
+        assert span._data["key"] == "value"
+
+    #  set_content_tag method can update input and output of the span object
+    def test_set_content_tag_updates_input_and_output(self):
+        mock_span = Mock()
+
+        span = LangfuseSpan(mock_span)
+        span.set_content_tag("input_key", "input_value")
+        assert span._data["input_key"] == "input_value"
+
+        mock_span.reset_mock()
+        span.set_content_tag("output_key", "output_value")
+        assert span._data["output_key"] == "output_value"
+
+    # set_content_tag method can update input and output of the span object with messages/replies
+    def test_set_content_tag_updates_input_and_output_with_messages(self):
+        mock_span = Mock()
+
+        # test message input
+        span = LangfuseSpan(mock_span)
+        span.set_content_tag("key.input", {"messages": [ChatMessage.from_user("message")]})
+        assert mock_span.update.call_count == 1
+        # check we converted ChatMessage to OpenAI format
+        assert mock_span.update.call_args_list[0][1] == {"input": [{"role": "user", "content": "message"}]}
+        assert span._data["key.input"] == {"messages": [ChatMessage.from_user("message")]}
+
+        # test replies ChatMessage list
+        mock_span.reset_mock()
+        span.set_content_tag("key.output", {"replies": [ChatMessage.from_system("reply")]})
+        assert mock_span.update.call_count == 1
+        # check we converted ChatMessage to OpenAI format
+        assert mock_span.update.call_args_list[0][1] == {"output": [{"role": "system", "content": "reply"}]}
+        assert span._data["key.output"] == {"replies": [ChatMessage.from_system("reply")]}
+
+        # test replies string list
+        mock_span.reset_mock()
+        span.set_content_tag("key.output", {"replies": ["reply1", "reply2"]})
+        assert mock_span.update.call_count == 1
+        # check we handle properly string list replies
+        assert mock_span.update.call_args_list[0][1] == {"output": ["reply1", "reply2"]}
+        assert span._data["key.output"] == {"replies": ["reply1", "reply2"]}

--- a/integrations/langfuse/tests/test_tracer.py
+++ b/integrations/langfuse/tests/test_tracer.py
@@ -1,0 +1,81 @@
+from unittest.mock import Mock, MagicMock, patch
+
+from haystack_integrations.tracing.langfuse.tracer import LangfuseTracer
+
+
+class TestLangfuseTracer:
+
+    #  LangfuseTracer can be initialized with a Langfuse instance, a name and a boolean value for public.
+    def test_initialization(self):
+        langfuse_instance = Mock()
+        tracer = LangfuseTracer(tracer=langfuse_instance, name="Haystack", public=True)
+        assert tracer._tracer == langfuse_instance
+        assert tracer._context == []
+        assert tracer._name == "Haystack"
+        assert tracer._public
+
+    # check that the trace method is called on the tracer instance with the provided operation name and tags
+    # check that the span is added to the context and removed after the context manager exits
+    def test_create_new_span(self):
+        mock_raw_span = MagicMock()
+        mock_raw_span.operation_name = "operation_name"
+        mock_raw_span.metadata = {"tag1": "value1", "tag2": "value2"}
+
+        with patch("haystack_integrations.tracing.langfuse.tracer.LangfuseSpan") as MockLangfuseSpan:
+            mock_span_instance = MockLangfuseSpan.return_value
+            mock_span_instance.raw_span.return_value = mock_raw_span
+
+            mock_context_manager = MagicMock()
+            mock_context_manager.__enter__.return_value = mock_span_instance
+
+            mock_tracer = MagicMock()
+            mock_tracer.trace.return_value = mock_context_manager
+
+            tracer = LangfuseTracer(tracer=mock_tracer, name="Haystack", public=False)
+
+            with tracer.trace("operation_name", tags={"tag1": "value1", "tag2": "value2"}) as span:
+                assert len(tracer._context) == 2, "The trace span should have been added to the the root context span"
+                assert span.raw_span().operation_name == "operation_name"
+                assert span.raw_span().metadata == {"tag1": "value1", "tag2": "value2"}
+
+            assert len(tracer._context) == 1, "The trace span should have been popped, leaving root span in the context"
+
+    # check that update method is called on the span instance with the provided key value pairs
+    def test_update_span_with_pipeline_input_output_data(self):
+        class MockTracer:
+
+            def trace(self, name, **kwargs):
+                return MockSpan()
+
+            def flush(self):
+                pass
+
+        class MockSpan:
+            def __init__(self):
+                self._data = {}
+                self._span = self
+                self.operation_name = "operation_name"
+
+            def raw_span(self):
+                return self
+
+            def span(self, name=None):
+                # assert correct operation name passed to the span
+                assert name == "operation_name"
+                return self
+
+            def update(self, **kwargs):
+                self._data.update(kwargs)
+
+            def generation(self, name=None):
+                return self
+
+            def end(self):
+                pass
+
+        tracer = LangfuseTracer(tracer=MockTracer(), name="Haystack", public=False)
+        with tracer.trace(operation_name="operation_name", tags={"haystack.pipeline.input_data": "hello"}) as span:
+            assert span.raw_span()._data["metadata"] == {"haystack.pipeline.input_data": "hello"}
+
+        with tracer.trace(operation_name="operation_name", tags={"haystack.pipeline.output_data": "bye"}) as span:
+            assert span.raw_span()._data["metadata"] == {"haystack.pipeline.output_data": "bye"}


### PR DESCRIPTION
- Updates LangfuseSpan to use `ChatMessage.to_openai_format` from Haystack 2.1.0
- Add unit tests for internal classes
- Adds brief pydocs to internal classes