### PR TITLE
docs: add missing api references

### DIFF
--- a/integrations/anthropic/pydoc/config.yml
+++ b/integrations/anthropic/pydoc/config.yml
@@ -20,7 +20,7 @@ renderer:
   category_slug: integrations-api
   title: Anthropic
   slug: integrations-anthropic
-  order: 22
+  order: 23
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true

--- a/integrations/langfuse/pydoc/config.yml
+++ b/integrations/langfuse/pydoc/config.yml
@@ -20,7 +20,7 @@ renderer:
   category_slug: integrations-api
   title: langfuse
   slug: integrations-langfuse
-  order: 135
+  order: 136
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/integrations/nvidia/pydoc/config.yml
+++ b/integrations/nvidia/pydoc/config.yml
@@ -22,7 +22,7 @@ renderer:
   category_slug: integrations-api
   title: Nvidia
   slug: integrations-nvidia
-  order: 50
+  order: 165
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/integrations/pgvector/pydoc/config.yml
+++ b/integrations/pgvector/pydoc/config.yml
@@ -3,6 +3,7 @@ loaders:
     search_path: [../src]
     modules: [
       "haystack_integrations.components.retrievers.pgvector.embedding_retriever",
+      "haystack_integrations.components.retrievers.pgvector.keyword_retriever",
       "haystack_integrations.document_stores.pgvector.document_store",
     ]
     ignore_when_discovered: ["__init__"]


### PR DESCRIPTION
Pushing minor changes to those integration pydocs which are missing in Haystack documentation –– to force the new workflow.