### PR TITLE
fix: align tests and docs on NVIDIA_API_KEY (instead of NVIDIA_CATALOG_API_KEY)

### DIFF
--- a/integrations/nvidia/tests/test_document_embedder.py
+++ b/integrations/nvidia/tests/test_document_embedder.py
@@ -388,15 +388,15 @@ class TestNvidiaDocumentEmbedder:
             assert isinstance(doc.embedding[0], float)
 
     @pytest.mark.skipif(
-        not os.environ.get("NVIDIA_CATALOG_API_KEY", None),
-        reason="Export an env var called NVIDIA_CATALOG_API_KEY containing the Nvidia API key to run this test.",
+        not os.environ.get("NVIDIA_API_KEY", None),
+        reason="Export an env var called NVIDIA_API_KEY containing the NVIDIA API key to run this test.",
     )
     @pytest.mark.integration
     def test_run_integration_with_api_catalog(self):
         embedder = NvidiaDocumentEmbedder(
             model="NV-Embed-QA",
             api_url="https://ai.api.nvidia.com/v1/retrieval/nvidia",
-            api_key=Secret.from_env_var("NVIDIA_CATALOG_API_KEY"),
+            api_key=Secret.from_env_var("NVIDIA_API_KEY"),
         )
         embedder.warm_up()
 

--- a/integrations/nvidia/tests/test_generator.py
+++ b/integrations/nvidia/tests/test_generator.py
@@ -204,15 +204,15 @@ class TestNvidiaGenerator:
         assert result["meta"]
 
     @pytest.mark.skipif(
-        not os.environ.get("NVIDIA_CATALOG_API_KEY", None),
-        reason="Export an env var called NVIDIA_CATALOG_API_KEY containing the Nvidia API key to run this test.",
+        not os.environ.get("NVIDIA_API_KEY", None),
+        reason="Export an env var called NVIDIA_API_KEY containing the NVIDIA API key to run this test.",
     )
     @pytest.mark.integration
     def test_run_integration_with_api_catalog(self):
         generator = NvidiaGenerator(
             model="meta/llama3-70b-instruct",
             api_url="https://integrate.api.nvidia.com/v1",
-            api_key=Secret.from_env_var("NVIDIA_CATALOG_API_KEY"),
+            api_key=Secret.from_env_var("NVIDIA_API_KEY"),
             model_arguments={
                 "temperature": 0.2,
             },

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -175,15 +175,15 @@ class TestNvidiaTextEmbedder:
         assert "usage" in meta
 
     @pytest.mark.skipif(
-        not os.environ.get("NVIDIA_CATALOG_API_KEY", None),
-        reason="Export an env var called NVIDIA_CATALOG_API_KEY containing the Nvidia API key to run this test.",
+        not os.environ.get("NVIDIA_API_KEY", None),
+        reason="Export an env var called NVIDIA_API_KEY containing the NVIDIA API key to run this test.",
     )
     @pytest.mark.integration
     def test_run_integration_with_api_catalog(self):
         embedder = NvidiaTextEmbedder(
             model="NV-Embed-QA",
             api_url="https://ai.api.nvidia.com/v1/retrieval/nvidia",
-            api_key=Secret.from_env_var("NVIDIA_CATALOG_API_KEY"),
+            api_key=Secret.from_env_var("NVIDIA_API_KEY"),
         )
         embedder.warm_up()
 


### PR DESCRIPTION
README.md says `Note: integration tests will be skipped unless the env var NVIDIA_API_KEY is set.`

with this MR, the statement is now true for all cases.