### PR TITLE
[Astra DB] Explicit projection when reading from Astra DB

### DIFF
--- a/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
@@ -208,6 +208,7 @@ class AstraClient:
             filter=find_query.get("filter"),
             sort=find_query.get("sort"),
             options=find_query.get("options"),
+            projection={"*": 1},
         )
 
         if "data" in response_dict and "documents" in response_dict["data"]:
@@ -273,6 +274,7 @@ class AstraClient:
             filter={id_key: document_id},
             update={"$set": document},
             options={"returnDocument": "after"},
+            projection={"*": 1},
         )
 
         document[id_key] = document_id


### PR DESCRIPTION
In view of upcoming changes in the Astra DB Data API, this PR explicitly sets a projection every time a `find` command is executed, in order to ensure all necessary fields of the document are returned by the API.