### PR TITLE
make hosted nim default

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
@@ -10,20 +10,21 @@ from ._nim_backend import NimBackend
 from ._nvcf_backend import NvcfBackend
 from .backend import GeneratorBackend
 
+_DEFAULT_API_URL = "https://integrate.api.nvidia.com/v1"
+
 
 @component
 class NvidiaGenerator:
     """
     A component for generating text using generative models provided by
-    [NVIDIA AI Foundation Endpoints](https://www.nvidia.com/en-us/ai-data-science/foundation-models/)
-    and NVIDIA Inference Microservices.
+    [NVIDIA NIMs](https://ai.nvidia.com).
 
     Usage example:
     ```python
     from haystack_integrations.components.generators.nvidia import NvidiaGenerator
 
     generator = NvidiaGenerator(
-        model="nv_llama2_rlhf_70b",
+        model="meta/llama3-70b-instruct",
         model_arguments={
             "temperature": 0.2,
             "top_p": 0.7,
@@ -42,7 +43,7 @@ class NvidiaGenerator:
     def __init__(
         self,
         model: str,
-        api_url: Optional[str] = None,
+        api_url: Optional[str] = _DEFAULT_API_URL,
         api_key: Optional[Secret] = Secret.from_env_var("NVIDIA_API_KEY"),
         model_arguments: Optional[Dict[str, Any]] = None,
     ):
@@ -51,7 +52,7 @@ class NvidiaGenerator:
 
         :param model:
             Name of the model to use for text generation.
-            See the [Nvidia catalog](https://catalog.ngc.nvidia.com/ai-foundation-models)
+            See the [NVIDIA NIMs](https://ai.nvidia.com)
             for more information on the supported models.
         :param api_key:
             API key for the NVIDIA AI Foundation Endpoints.
@@ -59,7 +60,7 @@ class NvidiaGenerator:
             Custom API URL for the NVIDIA Inference Microservices.
         :param model_arguments:
             Additional arguments to pass to the model provider. Different models accept different arguments.
-            Search your model in the [Nvidia catalog](https://catalog.ngc.nvidia.com/ai-foundation-models)
+            Search your model in the [NVIDIA NIMs](https://ai.nvidia.com)
             to know the supported arguments.
         """
         self._model = model
@@ -82,6 +83,9 @@ class NvidiaGenerator:
                 raise ValueError(msg)
             self._backend = NvcfBackend(self._model, api_key=self._api_key, model_kwargs=self._model_arguments)
         else:
+            if self._api_url == _DEFAULT_API_URL and self._api_key is None:
+                msg = "API key is required for hosted NVIDIA NIMs."
+                raise ValueError(msg)
             self._backend = NimBackend(
                 self._model,
                 api_url=self._api_url,


### PR DESCRIPTION
all inference calls should be directed to integrate.api.nvidia.com. the nvcf inference is deprecated and will be removed.

this allows for users to get on integrate.api.nvidia.com now and avoid any disruptions.