### PR TITLE
Use the local_files_only option available as of fastembed==0.2.7. It …

### DIFF
--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -26,7 +26,9 @@ class _FastembedEmbeddingBackendFactory:
         if embedding_backend_id in _FastembedEmbeddingBackendFactory._instances:
             return _FastembedEmbeddingBackendFactory._instances[embedding_backend_id]
 
-        embedding_backend = _FastembedEmbeddingBackend(model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only)
+        embedding_backend = _FastembedEmbeddingBackend(
+            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only
+        )
         _FastembedEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
 
@@ -43,7 +45,9 @@ class _FastembedEmbeddingBackend:
         threads: Optional[int] = None,
         local_files_only: bool = False,
     ):
-        self.model = TextEmbedding(model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only)
+        self.model = TextEmbedding(
+            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only
+        )
 
     def embed(self, data: List[str], progress_bar=True, **kwargs) -> List[List[float]]:
         # the embed method returns a Iterable[np.ndarray], so we convert it to a list of lists
@@ -94,7 +98,9 @@ class _FastembedSparseEmbeddingBackend:
         threads: Optional[int] = None,
         local_files_only: bool = False,
     ):
-        self.model = SparseTextEmbedding(model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only)
+        self.model = SparseTextEmbedding(
+            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only
+        )
 
     def embed(self, data: List[List[str]], progress_bar=True, **kwargs) -> List[SparseEmbedding]:
         # The embed method returns a Iterable[SparseEmbedding], so we convert to Haystack SparseEmbedding type.

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -19,13 +19,14 @@ class _FastembedEmbeddingBackendFactory:
         model_name: str,
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
+        local_files_only: bool = False,
     ):
         embedding_backend_id = f"{model_name}{cache_dir}{threads}"
 
         if embedding_backend_id in _FastembedEmbeddingBackendFactory._instances:
             return _FastembedEmbeddingBackendFactory._instances[embedding_backend_id]
 
-        embedding_backend = _FastembedEmbeddingBackend(model_name=model_name, cache_dir=cache_dir, threads=threads)
+        embedding_backend = _FastembedEmbeddingBackend(model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only)
         _FastembedEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
 
@@ -40,8 +41,9 @@ class _FastembedEmbeddingBackend:
         model_name: str,
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
+        local_files_only: bool = False,
     ):
-        self.model = TextEmbedding(model_name=model_name, cache_dir=cache_dir, threads=threads)
+        self.model = TextEmbedding(model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only)
 
     def embed(self, data: List[str], progress_bar=True, **kwargs) -> List[List[float]]:
         # the embed method returns a Iterable[np.ndarray], so we convert it to a list of lists
@@ -66,6 +68,7 @@ class _FastembedSparseEmbeddingBackendFactory:
         model_name: str,
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
+        local_files_only: bool = False,
     ):
         embedding_backend_id = f"{model_name}{cache_dir}{threads}"
 
@@ -73,7 +76,7 @@ class _FastembedSparseEmbeddingBackendFactory:
             return _FastembedSparseEmbeddingBackendFactory._instances[embedding_backend_id]
 
         embedding_backend = _FastembedSparseEmbeddingBackend(
-            model_name=model_name, cache_dir=cache_dir, threads=threads
+            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only
         )
         _FastembedSparseEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
@@ -89,8 +92,9 @@ class _FastembedSparseEmbeddingBackend:
         model_name: str,
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
+        local_files_only: bool = False,
     ):
-        self.model = SparseTextEmbedding(model_name=model_name, cache_dir=cache_dir, threads=threads)
+        self.model = SparseTextEmbedding(model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only)
 
     def embed(self, data: List[List[str]], progress_bar=True, **kwargs) -> List[SparseEmbedding]:
         # The embed method returns a Iterable[SparseEmbedding], so we convert to Haystack SparseEmbedding type.

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_document_embedder.py
@@ -65,6 +65,7 @@ class FastembedDocumentEmbedder:
         batch_size: int = 256,
         progress_bar: bool = True,
         parallel: Optional[int] = None,
+        local_files_only: bool = False,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
     ):
@@ -80,11 +81,12 @@ class FastembedDocumentEmbedder:
         :param prefix: A string to add to the beginning of each text.
         :param suffix: A string to add to the end of each text.
         :param batch_size: Number of strings to encode at once.
-        :param progress_bar: If true, displays progress bar during embedding.
+        :param progress_bar: If `True`, displays progress bar during embedding.
         :param parallel:
                 If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
+        :param local_files_only: If `True`, only use the model files in the `cache_dir`.
         :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         """
@@ -97,6 +99,7 @@ class FastembedDocumentEmbedder:
         self.batch_size = batch_size
         self.progress_bar = progress_bar
         self.parallel = parallel
+        self.local_files_only = local_files_only
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
@@ -116,6 +119,7 @@ class FastembedDocumentEmbedder:
             batch_size=self.batch_size,
             progress_bar=self.progress_bar,
             parallel=self.parallel,
+            local_files_only=self.local_files_only,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
@@ -126,7 +130,10 @@ class FastembedDocumentEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _FastembedEmbeddingBackendFactory.get_embedding_backend(
-                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads
+                model_name=self.model_name,
+                cache_dir=self.cache_dir,
+                threads=self.threads,
+                local_files_only=self.local_files_only,
             )
 
     def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -59,6 +59,7 @@ class FastembedSparseDocumentEmbedder:
         batch_size: int = 32,
         progress_bar: bool = True,
         parallel: Optional[int] = None,
+        local_files_only: bool = False,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
     ):
@@ -77,6 +78,7 @@ class FastembedSparseDocumentEmbedder:
                 If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
+        :param local_files_only: If `True`, only use the model files in the `cache_dir`.
         :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         """
@@ -87,6 +89,7 @@ class FastembedSparseDocumentEmbedder:
         self.batch_size = batch_size
         self.progress_bar = progress_bar
         self.parallel = parallel
+        self.local_files_only = local_files_only
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
@@ -104,6 +107,7 @@ class FastembedSparseDocumentEmbedder:
             batch_size=self.batch_size,
             progress_bar=self.progress_bar,
             parallel=self.parallel,
+            local_files_only=self.local_files_only,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
@@ -114,7 +118,10 @@ class FastembedSparseDocumentEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _FastembedSparseEmbeddingBackendFactory.get_embedding_backend(
-                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads
+                model_name=self.model_name,
+                cache_dir=self.cache_dir,
+                threads=self.threads,
+                local_files_only=self.local_files_only,
             )
 
     def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -82,7 +82,10 @@ class FastembedSparseTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _FastembedSparseEmbeddingBackendFactory.get_embedding_backend(
-                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads, local_files_only=self.local_files_only
+                model_name=self.model_name,
+                cache_dir=self.cache_dir,
+                threads=self.threads,
+                local_files_only=self.local_files_only,
             )
 
     @component.output_types(sparse_embedding=SparseEmbedding)

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -44,12 +44,12 @@ class FastembedSparseTextEmbedder:
                 Can be set using the `FASTEMBED_CACHE_PATH` env variable.
                 Defaults to `fastembed_cache` in the system's temp directory.
         :param threads: The number of threads single onnxruntime session can use. Defaults to None.
-        :param progress_bar: If true, displays progress bar during embedding.
+        :param progress_bar: If `True`, displays progress bar during embedding.
         :param parallel:
                 If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
-        :param local_files_only: If true, only use the model files in the cache_dir
+        :param local_files_only: If `True`, only use the model files in the `cache_dir`.
         """
 
         self.model_name = model

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -34,6 +34,7 @@ class FastembedSparseTextEmbedder:
         threads: Optional[int] = None,
         progress_bar: bool = True,
         parallel: Optional[int] = None,
+        local_files_only: bool = False,
     ):
         """
         Create a FastembedSparseTextEmbedder component.
@@ -48,6 +49,7 @@ class FastembedSparseTextEmbedder:
                 If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
+        :param local_files_only: If true, only use the model files in the cache_dir
         """
 
         self.model_name = model
@@ -55,6 +57,7 @@ class FastembedSparseTextEmbedder:
         self.threads = threads
         self.progress_bar = progress_bar
         self.parallel = parallel
+        self.local_files_only = local_files_only
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -70,6 +73,7 @@ class FastembedSparseTextEmbedder:
             threads=self.threads,
             progress_bar=self.progress_bar,
             parallel=self.parallel,
+            local_files_only=self.local_files_only,
         )
 
     def warm_up(self):
@@ -78,7 +82,7 @@ class FastembedSparseTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _FastembedSparseEmbeddingBackendFactory.get_embedding_backend(
-                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads
+                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads, local_files_only=self.local_files_only
             )
 
     @component.output_types(sparse_embedding=SparseEmbedding)

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
@@ -35,6 +35,7 @@ class FastembedTextEmbedder:
         suffix: str = "",
         progress_bar: bool = True,
         parallel: Optional[int] = None,
+        local_files_only: bool = False,
     ):
         """
         Create a FastembedTextEmbedder component.
@@ -51,6 +52,7 @@ class FastembedTextEmbedder:
                 If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
+        :param local_files_only: If true, only use the model files in the cache_dir
         """
 
         self.model_name = model
@@ -60,6 +62,7 @@ class FastembedTextEmbedder:
         self.suffix = suffix
         self.progress_bar = progress_bar
         self.parallel = parallel
+        self.local_files_only = local_files_only
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -77,6 +80,7 @@ class FastembedTextEmbedder:
             suffix=self.suffix,
             progress_bar=self.progress_bar,
             parallel=self.parallel,
+            local_files_only=self.local_files_only,
         )
 
     def warm_up(self):
@@ -85,7 +89,7 @@ class FastembedTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _FastembedEmbeddingBackendFactory.get_embedding_backend(
-                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads
+                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads, local_files_only=self.local_files_only,
             )
 
     @component.output_types(embedding=List[float])

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
@@ -89,7 +89,10 @@ class FastembedTextEmbedder:
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _FastembedEmbeddingBackendFactory.get_embedding_backend(
-                model_name=self.model_name, cache_dir=self.cache_dir, threads=self.threads, local_files_only=self.local_files_only,
+                model_name=self.model_name,
+                cache_dir=self.cache_dir,
+                threads=self.threads,
+                local_files_only=self.local_files_only,
             )
 
     @component.output_types(embedding=List[float])

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
@@ -47,12 +47,12 @@ class FastembedTextEmbedder:
         :param threads: The number of threads single onnxruntime session can use. Defaults to None.
         :param prefix: A string to add to the beginning of each text.
         :param suffix: A string to add to the end of each text.
-        :param progress_bar: If true, displays progress bar during embedding.
+        :param progress_bar: If `True`, displays progress bar during embedding.
         :param parallel:
                 If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
-        :param local_files_only: If true, only use the model files in the cache_dir
+        :param local_files_only: If `True`, only use the model files in the `cache_dir`.
         """
 
         self.model_name = model

--- a/integrations/fastembed/tests/test_fastembed_backend.py
+++ b/integrations/fastembed/tests/test_fastembed_backend.py
@@ -27,7 +27,7 @@ def test_model_initialization(mock_instructor):
     _FastembedEmbeddingBackendFactory.get_embedding_backend(
         model_name="BAAI/bge-small-en-v1.5",
     )
-    mock_instructor.assert_called_once_with(model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None)
+    mock_instructor.assert_called_once_with(model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None, local_files_only=False)
     # restore the factory state
     _FastembedEmbeddingBackendFactory._instances = {}
 

--- a/integrations/fastembed/tests/test_fastembed_backend.py
+++ b/integrations/fastembed/tests/test_fastembed_backend.py
@@ -27,7 +27,9 @@ def test_model_initialization(mock_instructor):
     _FastembedEmbeddingBackendFactory.get_embedding_backend(
         model_name="BAAI/bge-small-en-v1.5",
     )
-    mock_instructor.assert_called_once_with(model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None, local_files_only=False)
+    mock_instructor.assert_called_once_with(
+        model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None, local_files_only=False
+    )
     # restore the factory state
     _FastembedEmbeddingBackendFactory._instances = {}
 

--- a/integrations/fastembed/tests/test_fastembed_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_document_embedder.py
@@ -22,6 +22,7 @@ class TestFastembedDocumentEmbedder:
         assert embedder.batch_size == 256
         assert embedder.progress_bar is True
         assert embedder.parallel is None
+        assert not embedder.local_files_only
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
@@ -38,6 +39,7 @@ class TestFastembedDocumentEmbedder:
             batch_size=64,
             progress_bar=False,
             parallel=1,
+            local_files_only=True,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
@@ -49,6 +51,7 @@ class TestFastembedDocumentEmbedder:
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
         assert embedder.parallel == 1
+        assert embedder.local_files_only
         assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
@@ -69,6 +72,7 @@ class TestFastembedDocumentEmbedder:
                 "batch_size": 256,
                 "progress_bar": True,
                 "parallel": None,
+                "local_files_only": False,
                 "embedding_separator": "\n",
                 "meta_fields_to_embed": [],
             },
@@ -87,6 +91,7 @@ class TestFastembedDocumentEmbedder:
             batch_size=64,
             progress_bar=False,
             parallel=1,
+            local_files_only=True,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
@@ -102,6 +107,7 @@ class TestFastembedDocumentEmbedder:
                 "batch_size": 64,
                 "progress_bar": False,
                 "parallel": 1,
+                "local_files_only": True,
                 "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
             },
@@ -122,6 +128,7 @@ class TestFastembedDocumentEmbedder:
                 "batch_size": 256,
                 "progress_bar": True,
                 "parallel": None,
+                "local_files_only": False,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
             },
@@ -135,6 +142,7 @@ class TestFastembedDocumentEmbedder:
         assert embedder.batch_size == 256
         assert embedder.progress_bar is True
         assert embedder.parallel is None
+        assert not embedder.local_files_only
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
@@ -153,6 +161,7 @@ class TestFastembedDocumentEmbedder:
                 "batch_size": 64,
                 "progress_bar": False,
                 "parallel": 1,
+                "local_files_only": True,
                 "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
             },
@@ -166,6 +175,7 @@ class TestFastembedDocumentEmbedder:
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
         assert embedder.parallel == 1
+        assert embedder.local_files_only
         assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
@@ -180,7 +190,7 @@ class TestFastembedDocumentEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None
+            model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None, local_files_only=False
         )
 
     @patch(

--- a/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
@@ -21,6 +21,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
         assert embedder.parallel is None
+        assert not embedder.local_files_only
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
@@ -35,6 +36,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
             batch_size=64,
             progress_bar=False,
             parallel=1,
+            local_files_only=True,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
@@ -44,6 +46,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
         assert embedder.parallel == 1
+        assert embedder.local_files_only
         assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
@@ -62,6 +65,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
                 "batch_size": 32,
                 "progress_bar": True,
                 "parallel": None,
+                "local_files_only": False,
                 "embedding_separator": "\n",
                 "meta_fields_to_embed": [],
             },
@@ -78,6 +82,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
             batch_size=64,
             progress_bar=False,
             parallel=1,
+            local_files_only=True,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
@@ -91,6 +96,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
                 "batch_size": 64,
                 "progress_bar": False,
                 "parallel": 1,
+                "local_files_only": True,
                 "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
             },
@@ -110,6 +116,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
                 "batch_size": 32,
                 "progress_bar": True,
                 "parallel": None,
+                "local_files_only": False,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
             },
@@ -121,6 +128,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
         assert embedder.parallel is None
+        assert not embedder.local_files_only
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
@@ -138,6 +146,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
                 "batch_size": 64,
                 "progress_bar": False,
                 "parallel": 1,
+                "local_files_only": True,
                 "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
             },
@@ -149,6 +158,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
         assert embedder.parallel == 1
+        assert embedder.local_files_only
         assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
@@ -163,7 +173,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="prithvida/Splade_PP_en_v1", cache_dir=None, threads=None
+            model_name="prithvida/Splade_PP_en_v1", cache_dir=None, threads=None, local_files_only=False
         )
 
     @patch(

--- a/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
@@ -52,6 +52,7 @@ class TestFastembedSparseTextEmbedder:
                 "threads": None,
                 "progress_bar": True,
                 "parallel": None,
+                "local_files_only": False,
             },
         }
 
@@ -65,6 +66,7 @@ class TestFastembedSparseTextEmbedder:
             threads=2,
             progress_bar=False,
             parallel=1,
+            local_files_only=True,
         )
         embedder_dict = embedder.to_dict()
         assert embedder_dict == {
@@ -75,6 +77,7 @@ class TestFastembedSparseTextEmbedder:
                 "threads": 2,
                 "progress_bar": False,
                 "parallel": 1,
+                "local_files_only": True,
             },
         }
 
@@ -131,7 +134,7 @@ class TestFastembedSparseTextEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="prithvida/Splade_PP_en_v1", cache_dir=None, threads=None
+            model_name="prithvida/Splade_PP_en_v1", cache_dir=None, threads=None, local_files_only=False
         )
 
     @patch(

--- a/integrations/fastembed/tests/test_fastembed_text_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_text_embedder.py
@@ -59,6 +59,7 @@ class TestFastembedTextEmbedder:
                 "suffix": "",
                 "progress_bar": True,
                 "parallel": None,
+                "local_files_only": False,
             },
         }
 
@@ -74,6 +75,7 @@ class TestFastembedTextEmbedder:
             suffix="suffix",
             progress_bar=False,
             parallel=1,
+            local_files_only=True,
         )
         embedder_dict = embedder.to_dict()
         assert embedder_dict == {
@@ -86,6 +88,7 @@ class TestFastembedTextEmbedder:
                 "suffix": "suffix",
                 "progress_bar": False,
                 "parallel": 1,
+                "local_files_only": True,
             },
         }
 
@@ -150,7 +153,7 @@ class TestFastembedTextEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None
+            model_name="BAAI/bge-small-en-v1.5", cache_dir=None, threads=None, local_files_only=False
         )
 
     @patch(


### PR DESCRIPTION
[fastembed](https://github.com/qdrant/fastembed/tree/main) has a new feature "local_files_only" as of version 0.2.7 (see https://github.com/qdrant/fastembed/issues/229). It allows to use the model files that were already cached without looking online if there is a new version.
This change allows to optionnaly use this feature on the fastembed embedders (FastembedTextEmbedder, FastembedDocumentEmbedder,  FastembedSparseTextEmbedder, FastembedSparseDocumentEmbedder).