### PR TITLE
Fix: max_tokens typo in Mistral Chat

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -336,7 +336,7 @@ class MistralChatAdapter(BedrockModelChatAdapter):
         self.prompt_handler = DefaultPromptHandler(
             tokenizer=tokenizer,
             model_max_length=model_max_length,
-            max_length=self.generation_kwargs.get("max_gen_len") or 512,
+            max_length=self.generation_kwargs.get("max_tokens") or 512,
         )
 
     def prepare_body(self, messages: List[ChatMessage], **inference_kwargs) -> Dict[str, Any]:


### PR DESCRIPTION
ALLOWED_PARAMS has `max_tokens` but generation_kwargs was using `max_gen_len`.

Closes Issue : https://github.com/deepset-ai/haystack-core-integrations/issues/741