### PR TITLE
feat: defer database connection to the first usage

### DIFF
--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -26,6 +26,11 @@ class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocu
             use_sparse_embeddings=False,
         )
 
+    def test_init_is_lazy(self):
+        with patch("haystack_integrations.document_stores.qdrant.document_store.qdrant_client") as mocked_qdrant:
+            QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True)
+            mocked_qdrant.assert_not_called()
+
     def assert_documents_are_equal(self, received: List[Document], expected: List[Document]):
         """
         Assert that two lists of Documents are equal.


### PR DESCRIPTION
fixes #747 

Move the qdrant client access to the `client` property and defer database connection to the first usage of `self.client`

See the tracking issue for the details