### PR TITLE
feat: defer the database connection to when it's needed

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -57,10 +57,10 @@ class OpenSearchDocumentStore:
         if not self._client:
             self._client = OpenSearch(self._hosts, **self._kwargs)
             # Check client connection, this will raise if not connected
-            self._client.info()
+            self._client.info()  # type:ignore
 
             # Create the index if it doesn't exist
-            if not self._client.indices.exists(index=self._index):
+            if not self._client.indices.exists(index=self._index):  # type:ignore
                 # configure fallback mapping for the embedding field
                 method = self._kwargs.get("method", None)
                 embedding_dim = self._kwargs.get("embedding_dim", 768)
@@ -87,7 +87,7 @@ class OpenSearchDocumentStore:
                     "mappings": self._kwargs.get("mappings", default_mappings),
                     "settings": self._kwargs.get("settings", {"index.knn": True}),
                 }
-                self._client.indices.create(index=self._index, body=body)
+                self._client.indices.create(index=self._index, body=body)  # type:ignore
 
         return self._client
 

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -47,45 +47,49 @@ class OpenSearchDocumentStore:
         :param index: Name of index in OpenSearch, if it doesn't exist it will be created. Defaults to "default"
         :param **kwargs: Optional arguments that ``OpenSearch`` takes.
         """
+        self._client = None
         self._hosts = hosts
-        self._client = OpenSearch(hosts, **kwargs)
         self._index = index
         self._kwargs = kwargs
 
-        # Check client connection, this will raise if not connected
-        self._client.info()
+    @property
+    def client(self) -> OpenSearch:
+        if not self._client:
+            self._client = OpenSearch(self._hosts, **self._kwargs)
+            # Check client connection, this will raise if not connected
+            self._client.info()
 
-        # configure mapping for the embedding field
-        embedding_dim = kwargs.get("embedding_dim", 768)
-        method = kwargs.get("method", None)
-
-        mappings: Dict[str, Any] = {
-            "properties": {
-                "embedding": {"type": "knn_vector", "index": True, "dimension": embedding_dim},
-                "content": {"type": "text"},
-            },
-            "dynamic_templates": [
-                {
-                    "strings": {
-                        "match_mapping_type": "string",
-                        "mapping": {
-                            "type": "keyword",
-                        },
-                    }
+            # Create the index if it doesn't exist
+            if not self._client.indices.exists(index=self._index):
+                # configure fallback mapping for the embedding field
+                method = self._kwargs.get("method", None)
+                embedding_dim = self._kwargs.get("embedding_dim", 768)
+                default_mappings: Dict[str, Any] = {
+                    "properties": {
+                        "embedding": {"type": "knn_vector", "index": True, "dimension": embedding_dim},
+                        "content": {"type": "text"},
+                    },
+                    "dynamic_templates": [
+                        {
+                            "strings": {
+                                "match_mapping_type": "string",
+                                "mapping": {
+                                    "type": "keyword",
+                                },
+                            }
+                        }
+                    ],
                 }
-            ],
-        }
-        if method:
-            mappings["properties"]["embedding"]["method"] = method
+                if method:
+                    default_mappings["properties"]["embedding"]["method"] = method
 
-        mappings = kwargs.get("mappings", mappings)
-        settings = kwargs.get("settings", {"index.knn": True})
+                body = {
+                    "mappings": self._kwargs.get("mappings", default_mappings),
+                    "settings": self._kwargs.get("settings", {"index.knn": True}),
+                }
+                self._client.indices.create(index=self._index, body=body)
 
-        body = {"mappings": mappings, "settings": settings}
-
-        # Create the index if it doesn't exist
-        if not self._client.indices.exists(index=index):
-            self._client.indices.create(index=index, body=body)
+        return self._client
 
     def to_dict(self) -> Dict[str, Any]:
         # This is not the best solution to serialise this class but is the fastest to implement.
@@ -121,13 +125,13 @@ class OpenSearchDocumentStore:
         """
         Returns how many documents are present in the document store.
         """
-        return self._client.count(index=self._index)["count"]
+        return self.client.count(index=self._index)["count"]
 
     def _search_documents(self, **kwargs) -> List[Document]:
         """
         Calls the OpenSearch client's search method and handles pagination.
         """
-        res = self._client.search(
+        res = self.client.search(
             index=self._index,
             body=kwargs,
         )
@@ -162,7 +166,7 @@ class OpenSearchDocumentStore:
 
         action = "index" if policy == DuplicatePolicy.OVERWRITE else "create"
         documents_written, errors = bulk(
-            client=self._client,
+            client=self.client,
             actions=(
                 {
                     "_op_type": action,
@@ -225,7 +229,7 @@ class OpenSearchDocumentStore:
         """
 
         bulk(
-            client=self._client,
+            client=self.client,
             actions=({"_op_type": "delete", "_id": id_} for id_ in document_ids),
             refresh="wait_for",
             index=self._index,
@@ -294,7 +298,7 @@ class OpenSearchDocumentStore:
 
         if scale_score:
             for doc in documents:
-                doc.score = float(1 / (1 + np.exp(-np.asarray(doc.score / BM25_SCALING_FACTOR))))
+                doc.score = float(1 / (1 + np.exp(-np.asarray(doc.score / BM25_SCALING_FACTOR))))  # type:ignore
 
         return documents
 

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -41,6 +41,12 @@ def test_from_dict(_mock_opensearch_client):
     assert document_store._index == "default"
 
 
+@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+def test_init_is_lazy(_mock_opensearch_client):
+    OpenSearchDocumentStore(hosts="testhost")
+    _mock_opensearch_client.assert_not_called()
+
+
 @pytest.mark.integration
 class TestDocumentStore(DocumentStoreBaseTests):
     """

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -73,7 +73,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
             method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
         )
         yield store
-        store._client.indices.delete(index=index, params={"ignore": [400, 404]})
+        store.client.indices.delete(index=index, params={"ignore": [400, 404]})
 
     @pytest.fixture
     def document_store_embedding_dim_4(self, request):
@@ -94,7 +94,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
             method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
         )
         yield store
-        store._client.indices.delete(index=index, params={"ignore": [400, 404]})
+        store.client.indices.delete(index=index, params={"ignore": [400, 404]})
 
     def assert_documents_are_equal(self, received: List[Document], expected: List[Document]):
         """


### PR DESCRIPTION
### Related Issues

- fixes #749 

### Proposed Changes:

- Create a `self.client` property returning the client
- Move database connection logic into the property, so it's done when needed and not in the constructor

### How did you test it?

Unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
