### PR TITLE
feat: make get_distance and recreate_collection public, replace deprecated recreate_collection function

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -578,9 +578,15 @@ class QdrantDocumentStore:
         collection_name: str,
         distance,
         embedding_dim: int,
-        on_disk: bool,
-        use_sparse_embeddings: bool,
+        on_disk: Optional[bool] = None,
+        use_sparse_embeddings: Optional[bool] = None,
     ):
+        if on_disk is None:
+            on_disk = self.on_disk
+
+        if use_sparse_embeddings is None:
+            use_sparse_embeddings = self.use_sparse_embeddings
+
         # dense vectors configuration
         vectors_config = rest.VectorParams(size=embedding_dim, on_disk=on_disk, distance=distance)
 

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -596,7 +596,10 @@ class QdrantDocumentStore:
                 ),
             }
 
-        self.client.recreate_collection(
+        if self.client.collection_exists(collection_name):
+            self.client.delete_collection(collection_name)
+
+        self.client.create_collection(
             collection_name=collection_name,
             vectors_config=vectors_config,
             sparse_vectors_config=sparse_vectors_config if use_sparse_embeddings else None,

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -464,7 +464,7 @@ class QdrantDocumentStore:
 
         return results
 
-    def _get_distance(self, similarity: str) -> rest.Distance:
+    def get_distance(self, similarity: str) -> rest.Distance:
         try:
             return self.SIMILARITY[similarity]
         except KeyError as ke:
@@ -498,12 +498,12 @@ class QdrantDocumentStore:
         on_disk: bool = False,
         payload_fields_to_index: Optional[List[dict]] = None,
     ):
-        distance = self._get_distance(similarity)
+        distance = self.get_distance(similarity)
 
         if recreate_collection:
             # There is no need to verify the current configuration of that
             # collection. It might be just recreated again.
-            self._recreate_collection(collection_name, distance, embedding_dim, on_disk, use_sparse_embeddings)
+            self.recreate_collection(collection_name, distance, embedding_dim, on_disk, use_sparse_embeddings)
             # Create Payload index if payload_fields_to_index is provided
             self._create_payload_index(collection_name, payload_fields_to_index)
             return
@@ -519,7 +519,7 @@ class QdrantDocumentStore:
             # Qdrant local raises ValueError if the collection is not found, but
             # with the remote server UnexpectedResponse / RpcError is raised.
             # Until that's unified, we need to catch both.
-            self._recreate_collection(collection_name, distance, embedding_dim, on_disk, use_sparse_embeddings)
+            self.recreate_collection(collection_name, distance, embedding_dim, on_disk, use_sparse_embeddings)
             # Create Payload index if payload_fields_to_index is provided
             self._create_payload_index(collection_name, payload_fields_to_index)
             return
@@ -573,7 +573,7 @@ class QdrantDocumentStore:
             )
             raise ValueError(msg)
 
-    def _recreate_collection(
+    def recreate_collection(
         self,
         collection_name: str,
         distance,


### PR DESCRIPTION
### Proposed Changes:

As mentioned in the discord with @masci, making the get_distance and recreate_collection functions public. I also think the on_disk and use_sparse_embeddings could be optional parameters if there is no reason against this. 

I've also replaced the deprecated recreate_collection function and used the collection_exists check instead of the try-catch. Let me know if there is something that i've overlooked doing this.

### How did you test it?

unit tests, manual verification

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
