### PR TITLE
fix: remove support for generate API

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -224,7 +224,7 @@ class CohereChatGenerator:
                 "model": self.model,
                 "usage": total_tokens,
                 "index": 0,
-                "finish_reason": None,
+                "finish_reason": cohere_response.finish_reason,
                 "documents": cohere_response.documents,
                 "citations": cohere_response.citations,
             }

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -6,20 +6,23 @@ from typing import Any, Callable, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.utils import deserialize_callback_handler, serialize_callback_handler
-from haystack.dataclasses import StreamingChunk
+from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
 from haystack.utils import Secret, deserialize_secrets_inplace
 
 from cohere import Client
+
+from .chat.chat_generator import CohereChatGenerator
+
 
 logger = logging.getLogger(__name__)
 
 
 @component
-class CohereGenerator:
+class CohereGenerator(CohereChatGenerator):
     """LLM Generator compatible with Cohere's generate endpoint.
 
-    Queries the LLM using Cohere's API. Invocations are made using 'cohere' package.
-    See [Cohere API](https://docs.cohere.com/reference/generate) for more details.
+    NOTE: Cohere discontinued the `generate` API, so this generator is a mere wrapper
+    around `CohereChatGenerator` provided for backward compatibility.
 
     Example usage:
 
@@ -42,86 +45,14 @@ class CohereGenerator:
         """
         Instantiates a `CohereGenerator` component.
 
-        :param api_key: the API key for the Cohere API.
-        :param model: the name of the model to use. Available models are: [command, command-light, command-nightly,
-            command-nightly-light].
-        :param streaming_callback: A callback function to be called with the streaming response.
-        :param api_base_url: the base URL of the Cohere API.
-        :param kwargs: additional model parameters. These will be used during generation. Refer to
-            https://docs.cohere.com/reference/generate for more details.
-            Some of the parameters are:
-            - 'max_tokens': The maximum number of tokens to be generated. Defaults to 1024.
-            - 'truncate': One of NONE|START|END to specify how the API will handle inputs longer than the maximum token
-                length. Defaults to END.
-            - 'temperature': A non-negative float that tunes the degree of randomness in generation. Lower temperatures
-                mean less random generations.
-            - 'preset': Identifier of a custom preset. A preset is a combination of parameters, such as prompt,
-                temperature etc. You can create presets in the playground.
-            - 'end_sequences': The generated text will be cut at the beginning of the earliest occurrence of an end
-                sequence. The sequence will be excluded from the text.
-            - 'stop_sequences': The generated text will be cut at the end of the earliest occurrence of a stop sequence.
-                The sequence will be included the text.
-            - 'k': Defaults to 0, min value of 0.01, max value of 0.99.
-            - 'p': Ensures that only the most likely tokens, with total probability mass of `p`, are considered for
-                generation at each step. If both `k` and `p` are enabled, `p` acts after `k`.
-            - 'frequency_penalty': Used to reduce repetitiveness of generated tokens. The higher the value, the stronger
-                a penalty is applied to previously present tokens, proportional to how many times they have already
-                appeared in the prompt or prior generation.'
-            - 'presence_penalty': Defaults to 0.0, min value of 0.0, max value of 1.0. Can be used to reduce
-                repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied
-                equally to all tokens that have already appeared, regardless of their exact frequencies.
-            - 'return_likelihoods': One of GENERATION|ALL|NONE to specify how and if the token likelihoods are returned
-                with the response. Defaults to NONE.
-            - 'logit_bias': Used to prevent the model from generating unwanted tokens or to incentivize it to include
-                desired tokens. The format is {token_id: bias} where bias is a float between -10 and 10.
+        NOTE: Cohere discontinued the `generate` API, so this generator is a mere wrapper
+        around `CohereChatGenerator` provided for backward compatibility.
         """
         logger.warning(
             "The 'generate' API is marked as Legacy and is no longer maintained by Cohere. "
             "We recommend to use the CohereChatGenerator instead."
         )
-        if not api_base_url:
-            api_base_url = "https://api.cohere.com"
-
-        self.api_key = api_key
-        self.model = model
-        self.streaming_callback = streaming_callback
-        self.api_base_url = api_base_url
-        self.model_parameters = kwargs
-        self.client = Client(api_key=self.api_key.resolve_value(), base_url=self.api_base_url, client_name="haystack")
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serializes the component to a dictionary.
-
-        :returns:
-            Dictionary with serialized data.
-        """
-        return default_to_dict(
-            self,
-            model=self.model,
-            streaming_callback=serialize_callback_handler(self.streaming_callback) if self.streaming_callback else None,
-            api_base_url=self.api_base_url,
-            api_key=self.api_key.to_dict(),
-            **self.model_parameters,
-        )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "CohereGenerator":
-        """
-        Deserializes the component from a dictionary.
-
-        :param data:
-            Dictionary to deserialize from.
-        :returns:
-           Deserialized component.
-        """
-        init_params = data.get("init_parameters", {})
-        deserialize_secrets_inplace(init_params, ["api_key"])
-        if "streaming_callback" in init_params and init_params["streaming_callback"] is not None:
-            data["init_parameters"]["streaming_callback"] = deserialize_callback_handler(
-                init_params["streaming_callback"]
-            )
-        return default_from_dict(cls, data)
+        super(CohereGenerator, self).__init__(api_key, model, streaming_callback, api_base_url, None, **kwargs)
 
     @component.output_types(replies=List[str], meta=List[Dict[str, Any]])
     def run(self, prompt: str):
@@ -133,38 +64,6 @@ class CohereGenerator:
             - `replies`: the list of replies generated by the model.
             - `meta`: metadata about the request.
         """
-        if self.streaming_callback:
-            response = self.client.generate_stream(model=self.model, prompt=prompt, **self.model_parameters)
-            metadata_dict: Dict[str, Any] = {}
-            generated_text = ""
-            for event in response:
-                if event.event_type == "text-generation":
-                    generated_text += event.text
-                    stream_chunk = self._build_chunk(event)
-                    self.streaming_callback(stream_chunk)
-                elif event.event_type == "stream-end":
-                    metadata_dict["finish_reason"] = event.finish_reason
-                    if event.finish_reason == "MAX_TOKENS":
-                        logger.warning(
-                            "Responses have been truncated before reaching a natural stopping point. "
-                            "Increase the max_tokens parameter to allow for longer completions."
-                        )
-            return {"replies": [generated_text], "meta": [metadata_dict]}
-
-        response = self.client.generate(model=self.model, prompt=prompt, **self.model_parameters)
-        metadata = {"finish_reason": response.finish_reason}
-        if response.finish_reason == "MAX_TOKENS":
-            logger.warning(
-                "Responses have been truncated before reaching a natural stopping point. "
-                "Increase the max_tokens parameter to allow for longer completions."
-            )
-        return {"replies": [response.text], "meta": [metadata]}
-
-    def _build_chunk(self, chunk) -> StreamingChunk:
-        """
-        Converts the response from the Cohere API to a StreamingChunk.
-        :param chunk: The chunk returned by the OpenAI API.
-        :returns: The StreamingChunk.
-        """
-        streaming_chunk = StreamingChunk(content=chunk.text, meta={"index": chunk.index})
-        return streaming_chunk
+        chat_message = ChatMessage(content=prompt, role=ChatRole.USER, name="", meta={})
+        results = super(CohereGenerator, self).run([chat_message])
+        return {"replies": [results["replies"][0].content], "meta": [results["replies"][0].meta]}

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -4,15 +4,11 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
-from haystack import component, default_from_dict, default_to_dict
-from haystack.components.generators.utils import deserialize_callback_handler, serialize_callback_handler
-from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
-from haystack.utils import Secret, deserialize_secrets_inplace
-
-from cohere import Client
+from haystack import component
+from haystack.dataclasses import ChatMessage, ChatRole
+from haystack.utils import Secret
 
 from .chat.chat_generator import CohereChatGenerator
-
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +48,8 @@ class CohereGenerator(CohereChatGenerator):
             "The 'generate' API is marked as Legacy and is no longer maintained by Cohere. "
             "We recommend to use the CohereChatGenerator instead."
         )
-        super(CohereGenerator, self).__init__(api_key, model, streaming_callback, api_base_url, None, **kwargs)
+        # Note we have to call super() like this because of the way components are dynamically built with the decorator
+        super(CohereGenerator, self).__init__(api_key, model, streaming_callback, api_base_url, None, **kwargs)  # noqa
 
     @component.output_types(replies=List[str], meta=List[Dict[str, Any]])
     def run(self, prompt: str):
@@ -65,5 +62,6 @@ class CohereGenerator(CohereChatGenerator):
             - `meta`: metadata about the request.
         """
         chat_message = ChatMessage(content=prompt, role=ChatRole.USER, name="", meta={})
-        results = super(CohereGenerator, self).run([chat_message])
+        # Note we have to call super() like this because of the way components are dynamically built with the decorator
+        results = super(CohereGenerator, self).run([chat_message])  # noqa
         return {"replies": [results["replies"][0].content], "meta": [results["replies"][0].meta]}

--- a/integrations/cohere/tests/test_cohere_generators.py
+++ b/integrations/cohere/tests/test_cohere_generators.py
@@ -43,7 +43,6 @@ class TestCohereGenerator:
         monkeypatch.setenv("COHERE_API_KEY", "test-api-key")
         component = CohereGenerator()
         data = component.to_dict()
-        print(data)
         assert data == {
             "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
             "init_parameters": {
@@ -51,7 +50,7 @@ class TestCohereGenerator:
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "streaming_callback": None,
                 "api_base_url": COHERE_API_URL,
-                'generation_kwargs': {},
+                "generation_kwargs": {},
             },
         }
 
@@ -67,7 +66,6 @@ class TestCohereGenerator:
             api_base_url="test-base-url",
         )
         data = component.to_dict()
-        print(data)
         assert data == {
             "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
             "init_parameters": {
@@ -75,7 +73,7 @@ class TestCohereGenerator:
                 "api_base_url": "test-base-url",
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                'generation_kwargs': {},
+                "generation_kwargs": {},
             },
         }
 
@@ -89,15 +87,14 @@ class TestCohereGenerator:
             api_base_url="test-base-url",
         )
         data = component.to_dict()
-        print(data)
         assert data == {
-            'type': 'haystack_integrations.components.generators.cohere.generator.CohereGenerator',
-            'init_parameters': {
-                'model': 'command',
-                'streaming_callback': 'tests.test_cohere_generators.<lambda>',
-                'api_base_url': 'test-base-url',
-                'api_key': {'type': 'env_var', 'env_vars': ['COHERE_API_KEY', 'CO_API_KEY'], 'strict': True},
-                'generation_kwargs': {},
+            "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
+            "init_parameters": {
+                "model": "command",
+                "streaming_callback": "tests.test_cohere_generators.<lambda>",
+                "api_base_url": "test-base-url",
+                "api_key": {"type": "env_var", "env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True},
+                "generation_kwargs": {},
             },
         }
 

--- a/integrations/cohere/tests/test_cohere_generators.py
+++ b/integrations/cohere/tests/test_cohere_generators.py
@@ -43,6 +43,7 @@ class TestCohereGenerator:
         monkeypatch.setenv("COHERE_API_KEY", "test-api-key")
         component = CohereGenerator()
         data = component.to_dict()
+        print(data)
         assert data == {
             "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
             "init_parameters": {
@@ -50,6 +51,7 @@ class TestCohereGenerator:
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "streaming_callback": None,
                 "api_base_url": COHERE_API_URL,
+                'generation_kwargs': {},
             },
         }
 
@@ -65,15 +67,15 @@ class TestCohereGenerator:
             api_base_url="test-base-url",
         )
         data = component.to_dict()
+        print(data)
         assert data == {
             "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
             "init_parameters": {
                 "model": "command-light",
-                "max_tokens": 10,
-                "some_test_param": "test-params",
                 "api_base_url": "test-base-url",
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                'generation_kwargs': {},
             },
         }
 
@@ -87,15 +89,15 @@ class TestCohereGenerator:
             api_base_url="test-base-url",
         )
         data = component.to_dict()
+        print(data)
         assert data == {
-            "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
-            "init_parameters": {
-                "model": "command",
-                "streaming_callback": "tests.test_cohere_generators.<lambda>",
-                "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
-                "api_base_url": "test-base-url",
-                "max_tokens": 10,
-                "some_test_param": "test-params",
+            'type': 'haystack_integrations.components.generators.cohere.generator.CohereGenerator',
+            'init_parameters': {
+                'model': 'command',
+                'streaming_callback': 'tests.test_cohere_generators.<lambda>',
+                'api_base_url': 'test-base-url',
+                'api_key': {'type': 'env_var', 'env_vars': ['COHERE_API_KEY', 'CO_API_KEY'], 'strict': True},
+                'generation_kwargs': {},
             },
         }
 


### PR DESCRIPTION
### Related Issues

- fixes failing CI after the `generate` API was discontinued by Cohere

### Proposed Changes:

Make the old generator a wrapper around the chat generator to ensure backward compatibility

### How did you test it?

Unit+integration tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
