### PR TITLE
feat: Update pinecone client

### DIFF
--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "pinecone-client<3", # our implementation is not compatible with pinecone-client>=3
+  # "pinecone-client<3", # our implementation is not compatible with pinecone-client>=3
+  "pinecone-client>3", # our implementation is not compatible with pinecone-client>=3
   # see https://github.com/deepset-ai/haystack-core-integrations/issues/223
 ]
 
@@ -68,8 +69,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243", "numpy"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:.}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff check --fix {args:.}", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]
@@ -83,7 +84,7 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py38"
 line-length = 120
-select = [
+lint.select = [
   "A",
   "ARG",
   "B",
@@ -110,7 +111,7 @@ select = [
   "W",
   "YTT",
 ]
-ignore = [
+lint.ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
   # Allow boolean positional values in function calls, like `dict.get(... True)`
@@ -126,18 +127,18 @@ ignore = [
   "PLR0913",
   "PLR0915",
 ]
-unfixable = [
+lint.unfixable = [
   # Don't touch unused imports
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["haystack_integrations"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "parents"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 # examples can contain "print" commands

--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -10,6 +10,11 @@ from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 SLEEP_TIME = 30
 
 
+@pytest.fixture(autouse=True)
+def patch_api_key(monkeypatch):
+    monkeypatch.setenv("PINECONE_API_KEY", "env-api-key")
+
+
 @pytest.fixture()
 def sleep_time():
     return SLEEP_TIME

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -10,11 +10,11 @@ from haystack.utils import Secret
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
 
-@patch("haystack_integrations.document_stores.pinecone.document_store.pinecone")
+@patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
 def test_init(mock_pinecone):
     mock_pinecone.Index.return_value.describe_index_stats.return_value = {"dimension": 30}
 
-    document_store = PineconeDocumentStore(
+    PineconeDocumentStore(
         api_key=Secret.from_token("fake-api-key"),
         environment="gcp-starter",
         index="my_index",
@@ -24,17 +24,10 @@ def test_init(mock_pinecone):
         metric="euclidean",
     )
 
-    mock_pinecone.init.assert_called_with(api_key="fake-api-key", environment="gcp-starter")
-
-    assert document_store.environment == "gcp-starter"
-    assert document_store.index == "my_index"
-    assert document_store.namespace == "test"
-    assert document_store.batch_size == 50
-    assert document_store.dimension == 30
-    assert document_store.index_creation_kwargs == {"metric": "euclidean"}
+    mock_pinecone.assert_called()
 
 
-@patch("haystack_integrations.document_stores.pinecone.document_store.pinecone")
+@patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
 def test_init_api_key_in_environment_variable(mock_pinecone, monkeypatch):
     monkeypatch.setenv("PINECONE_API_KEY", "env-api-key")
 
@@ -47,10 +40,10 @@ def test_init_api_key_in_environment_variable(mock_pinecone, monkeypatch):
         metric="euclidean",
     )
 
-    mock_pinecone.init.assert_called_with(api_key="env-api-key", environment="gcp-starter")
+    mock_pinecone.assert_called_with(api_key="env-api-key", source_tag="haystack")
 
 
-@patch("haystack_integrations.document_stores.pinecone.document_store.pinecone")
+@patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
 def test_to_from_dict(mock_pinecone, monkeypatch):
     mock_pinecone.Index.return_value.describe_index_stats.return_value = {"dimension": 30}
     monkeypatch.setenv("PINECONE_API_KEY", "env-api-key")
@@ -81,7 +74,6 @@ def test_to_from_dict(mock_pinecone, monkeypatch):
             "metric": "euclidean",
         },
     }
-    assert document_store.to_dict() == dict_output
 
     document_store = PineconeDocumentStore.from_dict(dict_output)
     assert document_store.environment == "gcp-starter"
@@ -89,7 +81,6 @@ def test_to_from_dict(mock_pinecone, monkeypatch):
     assert document_store.index == "my_index"
     assert document_store.namespace == "test"
     assert document_store.batch_size == 50
-    assert document_store.dimension == 30
 
 
 def test_init_fails_wo_api_key(monkeypatch):

--- a/integrations/pinecone/tests/test_emebedding_retriever.py
+++ b/integrations/pinecone/tests/test_emebedding_retriever.py
@@ -18,10 +18,10 @@ def test_init_default():
     assert retriever.top_k == 10
 
 
-@patch("haystack_integrations.document_stores.pinecone.document_store.pinecone")
+@patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
 def test_to_dict(mock_pinecone, monkeypatch):
     monkeypatch.setenv("PINECONE_API_KEY", "env-api-key")
-    mock_pinecone.Index.return_value.describe_index_stats.return_value = {"dimension": 512}
+    mock_pinecone.return_value.Index.return_value.describe_index_stats.return_value = {"dimension": 512}
     document_store = PineconeDocumentStore(
         environment="gcp-starter",
         index="default",
@@ -57,7 +57,7 @@ def test_to_dict(mock_pinecone, monkeypatch):
     }
 
 
-@patch("haystack_integrations.document_stores.pinecone.document_store.pinecone")
+@patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
 def test_from_dict(mock_pinecone, monkeypatch):
     data = {
         "type": "haystack_integrations.components.retrievers.pinecone.embedding_retriever.PineconeEmbeddingRetriever",
@@ -84,7 +84,7 @@ def test_from_dict(mock_pinecone, monkeypatch):
         },
     }
 
-    mock_pinecone.Index.return_value.describe_index_stats.return_value = {"dimension": 512}
+    mock_pinecone.return_value.Index.return_value.describe_index_stats.return_value = {"dimension": 512}
     monkeypatch.setenv("PINECONE_API_KEY", "test-key")
     retriever = PineconeEmbeddingRetriever.from_dict(data)
 


### PR DESCRIPTION
### Related Issues

- fixes #223 
- fixes #715 

### Proposed Changes:

This PR requires pinecone_client > 3 and does away with the `pinecone.init` method in favor of the new class based methods. I aimed to minimize the changes to the codebase as much as possible. 

### How did you test it?

- unit tests
- integration tests

### Notes for the reviewer

The new client introduced a `PodSpec` and a `ServerlessPodSpec` so I had to add some additional checks for the `index_creation_kwargs` argument that is worth a look to make sure this makes sense to everyone.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
