### PR TITLE
feat: Create issues to track nightly CI integration failures

### DIFF
--- a/.github/actions/extract-committers/action.yml
+++ b/.github/actions/extract-committers/action.yml
@@ -1,0 +1,31 @@
+name: Extract Random User from Commit Logs
+description: Extracts a random user from commit logs who is also in the predefined list.
+inputs:
+  project_dir:
+    description: "Project directory to scan for committers"
+    required: true
+  names_handles:
+    description: "Mapping of First/Last Name to GitHub handles in JSON format"
+    required: true
+  default_user:
+    description: "Default GitHub user to assign if extraction fails"
+    required: true
+outputs:
+  user:
+    description: "Extracted user"
+    value: ${{ steps.extract-committers.outputs.user }}
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Run the script
+      id: extract-committers
+      run: python .github/actions/extract-committers/main.py
+      env:
+        INPUT_PROJECT_DIR: ${{ inputs.project_dir }}
+        INPUT_NAMES_HANDLES: ${{ inputs.names_handles }}
+        INPUT_DEFAULT_USER: ${{ inputs.default_user }}
+      shell: bash

--- a/.github/actions/extract-committers/main.py
+++ b/.github/actions/extract-committers/main.py
@@ -1,0 +1,45 @@
+import os
+import json
+import subprocess
+import random
+
+
+def get_committers(project_dir: str) -> set:
+    try:
+        result = subprocess.run(
+            ["git", "log", "--pretty=%an", "--", project_dir],
+            check=True,
+            text=True,
+            capture_output=True
+        )
+        return set(result.stdout.strip().split("\n"))
+    except subprocess.CalledProcessError as e:
+        print(f"Error while running git log: {e}")
+        return set()
+
+
+def set_output(name, value):
+    with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+        print(f"{name}={value}", file=fh)
+
+
+def main():
+    project_dir = os.getenv("INPUT_PROJECT_DIR")
+    names_handles_json = os.getenv("INPUT_NAMES_HANDLES")
+    default_user = os.getenv("INPUT_DEFAULT_USER")
+
+    if not names_handles_json:
+        raise ValueError("names_handles_json is None")
+
+    names_handles = json.loads(names_handles_json)
+    committers = get_committers(project_dir)
+
+    filtered_handles = [names_handles[name] for name in committers if name in names_handles]
+
+    random_user = random.choice(filtered_handles) if filtered_handles else default_user
+    print(f"Selected user: {random_user}")
+    set_output("user", random_user)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -72,3 +72,32 @@ jobs:
             ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
              - ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+
+      - name: Extract random contributor to these files (i.e developer who is familiar with the codebase)
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/extract-committers
+        id: random_contributor
+        with:
+          project_dir: integrations/anthropic
+          names_handles: '{"Madeesh Kannan":"shadeMe","Massimiliano Pippi":"masci","Stefano Fiorucci":"anakin87","Vladimir Blagojevic":"vblagoje", "Silvano Cerza": "silvanocerza", "Julian Risch": "julian-risch", "David S. Batista": "davidsbatista"}'
+          default_user: "vblagoje"
+
+      - name: Create Issue for Nightly Failure
+        if: failure() && github.event_name == 'schedule'
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: |
+            Nightly [${{ github.workflow }}] failed
+          assignees: ${{ steps.random_contributor.outputs.user }}
+          body: |
+            ## Nightly Failure Report:
+
+            > [!IMPORTANT]
+            > Details on failed run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            - Branch: `${{ github.ref }}`
+            - Commit: ${{ github.sha }}
+            - Workflow Path: `${{ github.workflow_ref }}`
+
+            - [ ] **Task**: Review failed CI run, fix the issue(s), and re-run until successful.


### PR DESCRIPTION
This is an experiment currently applied only to the Anthropic integration. The goal is to improve the reliability of our CI/CD pipeline by ensuring timely resolution of nightly CI failures. This is achieved by leveraging team members' familiarity with the specific codebase and distributing maintenance tasks fairly among the team.

- Automatically triggered on nightly CI failures.
- Identifies committers familiar with the subproject.
- Randomly selects one from the identified committers (but from our team only, excludes community contributors).
- Creates an issue with CI failure details and assigns it to the selected team member.