### PR TITLE
ci: add `diff` command

### DIFF
--- a/show_unreleased.sh
+++ b/show_unreleased.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+INTEGRATION=$1
+if [ -z "${INTEGRATION}" ] ; then
+    echo "Please provide the name of an integration, for example:"
+    echo "./$(basename $0) chroma"
+    exit 1
+fi
+LATEST_TAG=$(git tag -l --sort=-creatordate "integrations/${INTEGRATION}-v*" | head -n 1)
+git --no-pager diff $LATEST_TAG..main integrations/${INTEGRATION}


### PR DESCRIPTION
### Related Issues

- fixes the problem of not knowing if an integration has changes in `main` that were not released yet.

### Proposed Changes:

Add a `./show_unreleased.sh` command at the root of the repo that will:
- show the diff of the changes that were not yet released
- show nothing if the integration has no changes in `main` that need to be released

### How did you test it?

Manually tested on a bunch of integrations, e.g.:
```
./show_unreleased.sh chroma
-> no output, means all good
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
