### PR TITLE
chore: pin chromadb>=0.5.0

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "chromadb",
+  "chromadb>=0.5.0",
   "typing_extensions>=4.8.0"
 ]
 


### PR DESCRIPTION
### Related Issues
https://github.com/deepset-ai/haystack/actions/runs/9314071721/job/25642900567

Our current integration is only compatible with `chromadb>=0.5.0`, where the support for Ollama was introduced

### Proposed Changes:
pin `chromadb>=0.5.0`
