### PR TITLE
feat: Add filter_policy init parameter to all retrievers

### DIFF
--- a/integrations/astra/tests/test_retriever.py
+++ b/integrations/astra/tests/test_retriever.py
@@ -21,6 +21,7 @@ def test_retriever_to_json(*_):
         "init_parameters": {
             "filters": {"foo": "bar"},
             "top_k": 99,
+            "filter_policy": "replace",
             "document_store": {
                 "type": "haystack_integrations.document_stores.astra.document_store.AstraDocumentStore",
                 "init_parameters": {
@@ -48,6 +49,7 @@ def test_retriever_from_json(*_):
         "init_parameters": {
             "filters": {"bar": "baz"},
             "top_k": 42,
+            "filter_policy": "replace",
             "document_store": {
                 "type": "haystack_integrations.document_stores.astra.document_store.AstraDocumentStore",
                 "init_parameters": {

--- a/integrations/chroma/tests/test_retriever.py
+++ b/integrations/chroma/tests/test_retriever.py
@@ -17,6 +17,7 @@ def test_retriever_to_json(request):
         "init_parameters": {
             "filters": {"foo": "bar"},
             "top_k": 99,
+            "filter_policy": "replace",
             "document_store": {
                 "type": "haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore",
                 "init_parameters": {
@@ -37,6 +38,7 @@ def test_retriever_from_json(request):
         "init_parameters": {
             "filters": {"bar": "baz"},
             "top_k": 42,
+            "filter_policy": "replace",
             "document_store": {
                 "type": "haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore",
                 "init_parameters": {
@@ -55,3 +57,4 @@ def test_retriever_from_json(request):
     assert retriever.document_store._persist_path == "."
     assert retriever.filters == {"bar": "baz"}
     assert retriever.top_k == 42
+    assert retriever.filter_policy == "replace"

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -48,6 +48,7 @@ class ElasticsearchBM25Retriever:
         fuzziness: str = "AUTO",
         top_k: int = 10,
         scale_score: bool = False,
+        filter_policy: Literal["replace", "merge"] = "replace",
     ):
         """
         Initialize ElasticsearchBM25Retriever with an instance ElasticsearchDocumentStore.
@@ -60,6 +61,9 @@ class ElasticsearchBM25Retriever:
             for more details.
         :param top_k: Maximum number of Documents to return.
         :param scale_score: If `True` scales the Document`s scores between 0 and 1.
+        :param filter_policy: Policy to determine how filters are applied. Defaults to "replace".
+                - `replace`: Runtime filters replace init filters.
+                - `merge`: Runtime filters are merged with init filters, with runtime filters overwriting init values.
         :raises ValueError: If `document_store` is not an instance of `ElasticsearchDocumentStore`.
         """
 
@@ -72,6 +76,7 @@ class ElasticsearchBM25Retriever:
         self._fuzziness = fuzziness
         self._top_k = top_k
         self._scale_score = scale_score
+        self._filter_policy = filter_policy
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -86,6 +91,7 @@ class ElasticsearchBM25Retriever:
             fuzziness=self._fuzziness,
             top_k=self._top_k,
             scale_score=self._scale_score,
+            filter_policy=self._filter_policy,
             document_store=self._document_store.to_dict(),
         )
 
@@ -115,9 +121,14 @@ class ElasticsearchBM25Retriever:
         :returns: A dictionary with the following keys:
             - `documents`: List of `Document`s that match the query.
         """
+        if self._filter_policy == "merge" and filters:
+            filters = {**self._filters, **filters}
+        else:
+            filters = filters or self._filters
+
         docs = self._document_store._bm25_retrieval(
             query=query,
-            filters=filters or self._filters,
+            filters=filters,
             fuzziness=self._fuzziness,
             top_k=top_k or self._top_k,
             scale_score=self._scale_score,

--- a/integrations/elasticsearch/tests/test_bm25_retriever.py
+++ b/integrations/elasticsearch/tests/test_bm25_retriever.py
@@ -80,7 +80,6 @@ def test_run():
         fuzziness="AUTO",
         top_k=10,
         scale_score=False,
-        filter_policy="replace",
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1

--- a/integrations/elasticsearch/tests/test_bm25_retriever.py
+++ b/integrations/elasticsearch/tests/test_bm25_retriever.py
@@ -14,6 +14,7 @@ def test_init_default():
     assert retriever._document_store == mock_store
     assert retriever._filters == {}
     assert retriever._top_k == 10
+    assert retriever._filter_policy == "replace"
     assert not retriever._scale_score
 
 
@@ -38,6 +39,7 @@ def test_to_dict(_mock_elasticsearch_client):
             "fuzziness": "AUTO",
             "top_k": 10,
             "scale_score": False,
+            "filter_policy": "replace",
         },
     }
 
@@ -55,6 +57,7 @@ def test_from_dict(_mock_elasticsearch_client):
             "fuzziness": "AUTO",
             "top_k": 10,
             "scale_score": True,
+            "filter_policy": "replace",
         },
     }
     retriever = ElasticsearchBM25Retriever.from_dict(data)
@@ -63,6 +66,7 @@ def test_from_dict(_mock_elasticsearch_client):
     assert retriever._fuzziness == "AUTO"
     assert retriever._top_k == 10
     assert retriever._scale_score
+    assert retriever._filter_policy == "replace"
 
 
 def test_run():
@@ -76,6 +80,7 @@ def test_run():
         fuzziness="AUTO",
         top_k=10,
         scale_score=False,
+        filter_policy="replace",
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1

--- a/integrations/elasticsearch/tests/test_embedding_retriever.py
+++ b/integrations/elasticsearch/tests/test_embedding_retriever.py
@@ -37,6 +37,7 @@ def test_to_dict(_mock_elasticsearch_client):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
             "num_candidates": None,
         },
     }
@@ -54,6 +55,7 @@ def test_from_dict(_mock_elasticsearch_client):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
             "num_candidates": None,
         },
     }

--- a/integrations/mongodb_atlas/tests/test_retriever.py
+++ b/integrations/mongodb_atlas/tests/test_retriever.py
@@ -31,6 +31,7 @@ class TestRetriever:
         assert retriever.document_store == mock_store
         assert retriever.filters == {}
         assert retriever.top_k == 10
+        assert retriever.filter_policy == "replace"
 
     def test_init(self):
         mock_store = Mock(spec=MongoDBAtlasDocumentStore)
@@ -42,6 +43,7 @@ class TestRetriever:
         assert retriever.document_store == mock_store
         assert retriever.filters == {"field": "value"}
         assert retriever.top_k == 5
+        assert retriever.filter_policy == "replace"
 
     def test_to_dict(self, mock_client, monkeypatch):  # noqa: ARG002  mock_client appears unused but is required
         monkeypatch.setenv("MONGO_CONNECTION_STRING", "test_conn_str")
@@ -72,6 +74,7 @@ class TestRetriever:
                 },
                 "filters": {"field": "value"},
                 "top_k": 5,
+                "filter_policy": "replace",
             },
         }
 
@@ -96,6 +99,7 @@ class TestRetriever:
                 },
                 "filters": {"field": "value"},
                 "top_k": 5,
+                "filter_policy": "replace",
             },
         }
 
@@ -109,6 +113,7 @@ class TestRetriever:
         assert document_store.vector_search_index == "cosine_index"
         assert retriever.filters == {"field": "value"}
         assert retriever.top_k == 5
+        assert retriever.filter_policy == "replace"
 
     def test_run(self):
         mock_store = Mock(spec=MongoDBAtlasDocumentStore)

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -114,10 +114,16 @@ class OpenSearchBM25Retriever:
         else:
             filters = filters or self._filters
 
-        all_terms_must_match = all_terms_must_match or self._all_terms_must_match
-        top_k = top_k or self._top_k
-        fuzziness = fuzziness or self._fuzziness
-        scale_score = scale_score or self._scale_score
+        if filters is None:
+            filters = self._filters
+        if all_terms_must_match is None:
+            all_terms_must_match = self._all_terms_must_match
+        if top_k is None:
+            top_k = self._top_k
+        if fuzziness is None:
+            fuzziness = self._fuzziness
+        if scale_score is None:
+            scale_score = self._scale_score
 
         docs = self._document_store._bm25_retrieval(
             query=query,

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -16,7 +16,7 @@ def test_init_default():
     assert retriever._filters == {}
     assert retriever._top_k == 10
     assert not retriever._scale_score
-
+    assert retriever._filter_policy == "replace"
 
 @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
 def test_to_dict(_mock_opensearch_client):
@@ -50,6 +50,7 @@ def test_to_dict(_mock_opensearch_client):
             "fuzziness": "AUTO",
             "top_k": 10,
             "scale_score": False,
+            "filter_policy": "replace",
         },
     }
 
@@ -67,6 +68,7 @@ def test_from_dict(_mock_opensearch_client):
             "fuzziness": "AUTO",
             "top_k": 10,
             "scale_score": True,
+            "filter_policy": "replace",
         },
     }
     retriever = OpenSearchBM25Retriever.from_dict(data)
@@ -75,6 +77,7 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever._fuzziness == "AUTO"
     assert retriever._top_k == 10
     assert retriever._scale_score
+    assert retriever._filter_policy == "replace"
 
 
 def test_run():

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -18,6 +18,7 @@ def test_init_default():
     assert not retriever._scale_score
     assert retriever._filter_policy == "replace"
 
+
 @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
 def test_to_dict(_mock_opensearch_client):
     document_store = OpenSearchDocumentStore(hosts="some fake host")

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -15,6 +15,7 @@ def test_init_default():
     assert retriever._document_store == mock_store
     assert retriever._filters == {}
     assert retriever._top_k == 10
+    assert retriever._filter_policy == "replace"
 
 
 @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
@@ -63,6 +64,7 @@ def test_to_dict(_mock_opensearch_client):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
         },
     }
 
@@ -79,6 +81,7 @@ def test_from_dict(_mock_opensearch_client):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
         },
     }
     retriever = OpenSearchEmbeddingRetriever.from_dict(data)

--- a/integrations/pgvector/tests/test_retrievers.py
+++ b/integrations/pgvector/tests/test_retrievers.py
@@ -16,6 +16,7 @@ class TestEmbeddingRetriever:
         assert retriever.document_store == mock_store
         assert retriever.filters == {}
         assert retriever.top_k == 10
+        assert retriever.filter_policy == "replace"
         assert retriever.vector_function == mock_store.vector_function
 
     def test_init(self, mock_store):
@@ -25,6 +26,7 @@ class TestEmbeddingRetriever:
         assert retriever.document_store == mock_store
         assert retriever.filters == {"field": "value"}
         assert retriever.top_k == 5
+        assert retriever.filter_policy == "replace"
         assert retriever.vector_function == "l2_distance"
 
     def test_to_dict(self, mock_store):
@@ -54,6 +56,7 @@ class TestEmbeddingRetriever:
                 "filters": {"field": "value"},
                 "top_k": 5,
                 "vector_function": "l2_distance",
+                "filter_policy": "replace",
             },
         }
 
@@ -81,6 +84,7 @@ class TestEmbeddingRetriever:
                 "filters": {"field": "value"},
                 "top_k": 5,
                 "vector_function": "l2_distance",
+                "filter_policy": "replace",
             },
         }
 
@@ -100,6 +104,7 @@ class TestEmbeddingRetriever:
 
         assert retriever.filters == {"field": "value"}
         assert retriever.top_k == 5
+        assert retriever.filter_policy == "replace"
         assert retriever.vector_function == "l2_distance"
 
     def test_run(self):
@@ -154,6 +159,7 @@ class TestKeywordRetriever:
                 },
                 "filters": {"field": "value"},
                 "top_k": 5,
+                "filter_policy": "replace",
             },
         }
 
@@ -180,6 +186,7 @@ class TestKeywordRetriever:
                 },
                 "filters": {"field": "value"},
                 "top_k": 5,
+                "filter_policy": "replace",
             },
         }
 

--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -55,11 +55,15 @@ class PineconeEmbeddingRetriever:
         document_store: PineconeDocumentStore,
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 10,
+        filter_policy: Literal["replace", "merge"] = "replace",
     ):
         """
         :param document_store: The Pinecone Document Store.
         :param filters: Filters applied to the retrieved Documents.
         :param top_k: Maximum number of Documents to return.
+        :param filter_policy: Policy to determine how filters are applied. Defaults to "replace".
+            - `replace`: Runtime filters replace init filters.
+            - `merge`: Runtime filters are merged with init filters, with runtime filters overwriting init values.
 
         :raises ValueError: If `document_store` is not an instance of `PineconeDocumentStore`.
         """
@@ -70,6 +74,7 @@ class PineconeEmbeddingRetriever:
         self.document_store = document_store
         self.filters = filters or {}
         self.top_k = top_k
+        self.filter_policy = filter_policy
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -81,6 +86,7 @@ class PineconeEmbeddingRetriever:
             self,
             filters=self.filters,
             top_k=self.top_k,
+            filter_policy=self.filter_policy,
             document_store=self.document_store.to_dict(),
         )
 
@@ -99,16 +105,31 @@ class PineconeEmbeddingRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, query_embedding: List[float]):
+    def run(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+    ):
         """
         Retrieve documents from the `PineconeDocumentStore`, based on their dense embeddings.
 
         :param query_embedding: Embedding of the query.
+        :param filters: Filters applied to the retrieved `Document`s.
+        :param top_k: Maximum number of `Document`s to return.
+
         :returns: List of Document similar to `query_embedding`.
         """
+        if self.filter_policy == "merge" and filters:
+            filters = {**self.filters, **filters}
+        else:
+            filters = filters or self.filters
+
+        top_k = top_k or self.top_k
+
         docs = self.document_store._embedding_retrieval(
             query_embedding=query_embedding,
-            filters=self.filters,
-            top_k=self.top_k,
+            filters=filters,
+            top_k=top_k,
         )
         return {"documents": docs}

--- a/integrations/pinecone/tests/test_embedding_retriever.py
+++ b/integrations/pinecone/tests/test_embedding_retriever.py
@@ -16,6 +16,7 @@ def test_init_default():
     assert retriever.document_store == mock_store
     assert retriever.filters == {}
     assert retriever.top_k == 10
+    assert retriever.filter_policy == "replace"
 
 
 @patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
@@ -53,6 +54,7 @@ def test_to_dict(mock_pinecone, monkeypatch):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
         },
     }
 
@@ -82,6 +84,7 @@ def test_from_dict(mock_pinecone, monkeypatch):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
         },
     }
 
@@ -100,6 +103,7 @@ def test_from_dict(mock_pinecone, monkeypatch):
 
     assert retriever.filters == {}
     assert retriever.top_k == 10
+    assert retriever.filter_policy == "replace"
 
 
 def test_run():

--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
@@ -39,6 +39,7 @@ class QdrantEmbeddingRetriever:
         top_k: int = 10,
         scale_score: bool = True,
         return_embedding: bool = False,
+        filter_policy: Literal["replace", "merge"] = "replace",
     ):
         """
         Create a QdrantEmbeddingRetriever component.
@@ -48,6 +49,9 @@ class QdrantEmbeddingRetriever:
         :param top_k: The maximum number of documents to retrieve.
         :param scale_score: Whether to scale the scores of the retrieved documents or not.
         :param return_embedding: Whether to return the embedding of the retrieved Documents.
+        :param filter_policy: Policy to determine how filters are applied. Defaults to "replace".
+            - `replace`: Runtime filters replace init filters.
+            - `merge`: Runtime filters are merged with init filters, with runtime filters overwriting init values.
 
         :raises ValueError: If `document_store` is not an instance of `QdrantDocumentStore`.
         """
@@ -57,10 +61,11 @@ class QdrantEmbeddingRetriever:
             raise ValueError(msg)
 
         self._document_store = document_store
-        self._filters = filters
+        self._filters = filters or {}
         self._top_k = top_k
         self._scale_score = scale_score
         self._return_embedding = return_embedding
+        self._filter_policy = filter_policy
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -116,11 +121,17 @@ class QdrantEmbeddingRetriever:
             The retrieved documents.
 
         """
+        if self._filter_policy == "merge" and filters:
+            filters = {**self._filters, **filters}
+        else:
+            filters = filters or self._filters
+
         docs = self._document_store._query_by_embedding(
             query_embedding=query_embedding,
-            filters=filters or self._filters,
+            filters=filters,
             top_k=top_k or self._top_k,
             scale_score=scale_score or self._scale_score,
+            filter_policy=self._filter_policy,
             return_embedding=return_embedding or self._return_embedding,
         )
 
@@ -161,6 +172,7 @@ class QdrantSparseEmbeddingRetriever:
         top_k: int = 10,
         scale_score: bool = True,
         return_embedding: bool = False,
+        filter_policy: Literal["replace", "merge"] = "replace",
     ):
         """
         Create a QdrantSparseEmbeddingRetriever component.
@@ -170,6 +182,9 @@ class QdrantSparseEmbeddingRetriever:
         :param top_k: The maximum number of documents to retrieve.
         :param scale_score: Whether to scale the scores of the retrieved documents or not.
         :param return_embedding: Whether to return the sparse embedding of the retrieved Documents.
+        :param filter_policy: Policy to determine how filters are applied. Defaults to "replace".
+            - `replace`: Runtime filters replace init filters.
+            - `merge`: Runtime filters are merged with init filters, with runtime filters overwriting init values.
 
         :raises ValueError: If `document_store` is not an instance of `QdrantDocumentStore`.
         """
@@ -179,10 +194,11 @@ class QdrantSparseEmbeddingRetriever:
             raise ValueError(msg)
 
         self._document_store = document_store
-        self._filters = filters
+        self._filters = filters or {}
         self._top_k = top_k
         self._scale_score = scale_score
         self._return_embedding = return_embedding
+        self._filter_policy = filter_policy
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -197,6 +213,7 @@ class QdrantSparseEmbeddingRetriever:
             filters=self._filters,
             top_k=self._top_k,
             scale_score=self._scale_score,
+            filter_policy=self._filter_policy,
             return_embedding=self._return_embedding,
         )
         d["init_parameters"]["document_store"] = self._document_store.to_dict()
@@ -238,9 +255,14 @@ class QdrantSparseEmbeddingRetriever:
             The retrieved documents.
 
         """
+        if self._filter_policy == "merge" and filters:
+            filters = {**self._filters, **filters}
+        else:
+            filters = filters or self._filters
+
         docs = self._document_store._query_by_sparse(
             query_sparse_embedding=query_sparse_embedding,
-            filters=filters or self._filters,
+            filters=filters,
             top_k=top_k or self._top_k,
             scale_score=scale_score or self._scale_score,
             return_embedding=return_embedding or self._return_embedding,
@@ -288,6 +310,7 @@ class QdrantHybridRetriever:
         filters: Optional[Union[Dict[str, Any], models.Filter]] = None,
         top_k: int = 10,
         return_embedding: bool = False,
+        filter_policy: Literal["replace", "merge"] = "replace",
     ):
         """
         Create a QdrantHybridRetriever component.
@@ -296,6 +319,9 @@ class QdrantHybridRetriever:
         :param filters: A dictionary with filters to narrow down the search space.
         :param top_k: The maximum number of documents to retrieve.
         :param return_embedding: Whether to return the embeddings of the retrieved Documents.
+        :param filter_policy: Policy to determine how filters are applied. Defaults to "replace".
+            - `replace`: Runtime filters replace init filters.
+            - `merge`: Runtime filters are merged with init filters, with runtime filters overwriting init values.
 
         :raises ValueError: If 'document_store' is not an instance of QdrantDocumentStore.
         """
@@ -305,9 +331,10 @@ class QdrantHybridRetriever:
             raise ValueError(msg)
 
         self._document_store = document_store
-        self._filters = filters
+        self._filters = filters or {}
         self._top_k = top_k
         self._return_embedding = return_embedding
+        self._filter_policy = filter_policy
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -321,6 +348,7 @@ class QdrantHybridRetriever:
             document_store=self._document_store.to_dict(),
             filters=self._filters,
             top_k=self._top_k,
+            filter_policy=self._filter_policy,
             return_embedding=self._return_embedding,
         )
 
@@ -359,10 +387,15 @@ class QdrantHybridRetriever:
             The retrieved documents.
 
         """
+        if self._filter_policy == "merge" and filters:
+            filters = {**self._filters, **filters}
+        else:
+            filters = filters or self._filters
+
         docs = self._document_store._query_hybrid(
             query_embedding=query_embedding,
             query_sparse_embedding=query_sparse_embedding,
-            filters=filters or self._filters,
+            filters=filters,
             top_k=top_k or self._top_k,
             return_embedding=return_embedding or self._return_embedding,
         )

--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -61,7 +61,7 @@ class QdrantEmbeddingRetriever:
             raise ValueError(msg)
 
         self._document_store = document_store
-        self._filters = filters or {}
+        self._filters = filters
         self._top_k = top_k
         self._scale_score = scale_score
         self._return_embedding = return_embedding
@@ -79,6 +79,7 @@ class QdrantEmbeddingRetriever:
             document_store=self._document_store,
             filters=self._filters,
             top_k=self._top_k,
+            filter_policy=self._filter_policy,
             scale_score=self._scale_score,
             return_embedding=self._return_embedding,
         )
@@ -122,7 +123,7 @@ class QdrantEmbeddingRetriever:
 
         """
         if self._filter_policy == "merge" and filters:
-            filters = {**self._filters, **filters}
+            filters = {**(self._filters or {}), **filters}
         else:
             filters = filters or self._filters
 
@@ -131,7 +132,6 @@ class QdrantEmbeddingRetriever:
             filters=filters,
             top_k=top_k or self._top_k,
             scale_score=scale_score or self._scale_score,
-            filter_policy=self._filter_policy,
             return_embedding=return_embedding or self._return_embedding,
         )
 
@@ -194,7 +194,7 @@ class QdrantSparseEmbeddingRetriever:
             raise ValueError(msg)
 
         self._document_store = document_store
-        self._filters = filters or {}
+        self._filters = filters
         self._top_k = top_k
         self._scale_score = scale_score
         self._return_embedding = return_embedding
@@ -256,7 +256,7 @@ class QdrantSparseEmbeddingRetriever:
 
         """
         if self._filter_policy == "merge" and filters:
-            filters = {**self._filters, **filters}
+            filters = {**(self._filters or {}), **filters}
         else:
             filters = filters or self._filters
 
@@ -331,7 +331,7 @@ class QdrantHybridRetriever:
             raise ValueError(msg)
 
         self._document_store = document_store
-        self._filters = filters or {}
+        self._filters = filters
         self._top_k = top_k
         self._return_embedding = return_embedding
         self._filter_policy = filter_policy
@@ -388,7 +388,7 @@ class QdrantHybridRetriever:
 
         """
         if self._filter_policy == "merge" and filters:
-            filters = {**self._filters, **filters}
+            filters = {**(self._filters or {}), **filters}
         else:
             filters = filters or self._filters
 

--- a/integrations/qdrant/tests/test_retriever.py
+++ b/integrations/qdrant/tests/test_retriever.py
@@ -21,6 +21,7 @@ class TestQdrantRetriever(FilterableDocsFixtureMixin):
         assert retriever._document_store == document_store
         assert retriever._filters is None
         assert retriever._top_k == 10
+        assert retriever._filter_policy == "replace"
         assert retriever._return_embedding is False
 
     def test_to_dict(self):
@@ -75,6 +76,7 @@ class TestQdrantRetriever(FilterableDocsFixtureMixin):
                 },
                 "filters": None,
                 "top_k": 10,
+                "filter_policy": "replace",
                 "scale_score": True,
                 "return_embedding": False,
             },
@@ -90,6 +92,7 @@ class TestQdrantRetriever(FilterableDocsFixtureMixin):
                 },
                 "filters": None,
                 "top_k": 5,
+                "filter_policy": "replace",
                 "scale_score": False,
                 "return_embedding": True,
             },
@@ -99,6 +102,7 @@ class TestQdrantRetriever(FilterableDocsFixtureMixin):
         assert retriever._document_store.index == "test"
         assert retriever._filters is None
         assert retriever._top_k == 5
+        assert retriever._filter_policy == "replace"
         assert retriever._scale_score is False
         assert retriever._return_embedding is True
 
@@ -144,6 +148,7 @@ class TestQdrantSparseEmbeddingRetriever(FilterableDocsFixtureMixin):
         assert retriever._document_store == document_store
         assert retriever._filters is None
         assert retriever._top_k == 10
+        assert retriever._filter_policy == "replace"
         assert retriever._return_embedding is False
 
     def test_to_dict(self):
@@ -200,6 +205,7 @@ class TestQdrantSparseEmbeddingRetriever(FilterableDocsFixtureMixin):
                 "top_k": 10,
                 "scale_score": True,
                 "return_embedding": False,
+                "filter_policy": "replace",
             },
         }
 
@@ -215,6 +221,7 @@ class TestQdrantSparseEmbeddingRetriever(FilterableDocsFixtureMixin):
                 "top_k": 5,
                 "scale_score": False,
                 "return_embedding": True,
+                "filter_policy": "replace",
             },
         }
         retriever = QdrantSparseEmbeddingRetriever.from_dict(data)
@@ -222,6 +229,7 @@ class TestQdrantSparseEmbeddingRetriever(FilterableDocsFixtureMixin):
         assert retriever._document_store.index == "test"
         assert retriever._filters is None
         assert retriever._top_k == 5
+        assert retriever._filter_policy == "replace"
         assert retriever._scale_score is False
         assert retriever._return_embedding is True
 
@@ -254,6 +262,7 @@ class TestQdrantHybridRetriever:
         assert retriever._document_store == document_store
         assert retriever._filters is None
         assert retriever._top_k == 10
+        assert retriever._filter_policy == "replace"
         assert retriever._return_embedding is False
 
     def test_to_dict(self):
@@ -308,6 +317,7 @@ class TestQdrantHybridRetriever:
                 },
                 "filters": None,
                 "top_k": 5,
+                "filter_policy": "replace",
                 "return_embedding": True,
             },
         }
@@ -322,6 +332,7 @@ class TestQdrantHybridRetriever:
                 },
                 "filters": None,
                 "top_k": 5,
+                "filter_policy": "replace",
                 "return_embedding": True,
             },
         }
@@ -330,6 +341,7 @@ class TestQdrantHybridRetriever:
         assert retriever._document_store.index == "test"
         assert retriever._filters is None
         assert retriever._top_k == 5
+        assert retriever._filter_policy == "replace"
         assert retriever._return_embedding
 
     def test_run(self):

--- a/integrations/weaviate/tests/test_bm25_retriever.py
+++ b/integrations/weaviate/tests/test_bm25_retriever.py
@@ -10,6 +10,7 @@ def test_init_default():
     assert retriever._document_store == mock_document_store
     assert retriever._filters == {}
     assert retriever._top_k == 10
+    assert retriever._filter_policy == "replace"
 
 
 @patch("haystack_integrations.document_stores.weaviate.document_store.weaviate")
@@ -21,6 +22,7 @@ def test_to_dict(_mock_weaviate):
         "init_parameters": {
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
             "document_store": {
                 "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                 "init_parameters": {
@@ -55,6 +57,7 @@ def test_from_dict(_mock_weaviate):
             "init_parameters": {
                 "filters": {},
                 "top_k": 10,
+                "filter_policy": "replace",
                 "document_store": {
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {

--- a/integrations/weaviate/tests/test_embedding_retriever.py
+++ b/integrations/weaviate/tests/test_embedding_retriever.py
@@ -11,6 +11,7 @@ def test_init_default():
     assert retriever._document_store == mock_document_store
     assert retriever._filters == {}
     assert retriever._top_k == 10
+    assert retriever._filter_policy == "replace"
     assert retriever._distance is None
     assert retriever._certainty is None
 
@@ -30,6 +31,7 @@ def test_to_dict(_mock_weaviate):
         "init_parameters": {
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
             "distance": None,
             "certainty": None,
             "document_store": {
@@ -66,6 +68,7 @@ def test_from_dict(_mock_weaviate):
             "init_parameters": {
                 "filters": {},
                 "top_k": 10,
+                "filter_policy": "replace",
                 "distance": None,
                 "certainty": None,
                 "document_store": {


### PR DESCRIPTION
### Why:
The changes across various integrations (Astra, Chroma, Elasticsearch, MongoDB Atlas, OpenSearch, pgvector, Pinecone, Qdrant, and Weaviate) address a common need for more flexible filtering options within the retrieval process. By introducing a filter policy option (`replace` or `merge`), developers can now control how runtime filters are applied relative to initialization time filters. 

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/780

### What:
- Added `filter_policy` parameter with options `replace` and `merge` across multiple retrievers to control filter behavior dynamically.
- Adjustments made to initialize, serialize (to_dict), and run methods to support the new `filter conservatively` policy behavior.
- Unit tests were updated or added to validate the new functionality.

### How can it be used:

- **Dynamic Filter Behavior Adjustment:**  Users can decide whether to completely override the initial filters set during the retriever's initialization (`replace`) or merge them with runtime filters, with the latter taking precedence (`merge`).
    ```python
    # Example: Using the filter_policy parameter
    retriever = SomeRetriever(document_store=my_doc_store, filters={"status": "active"}, filter_policy="merge")
    ```

- **Complex Search Scenarios:**  
    - In cases where the context of a query might dictate altering pre-set filters without discarding them, the `merge` option allows for an additive approach.
    - For strict query contexts that require ignoring initial filters, the `replace` option offers a clean slate for filters at runtime.

### How did you test it:
- Unit tests were enhanced or newly created to cover both `replace` and `merge` scenarios for the `filter_policy` parameter. 
- Tests ensure that filter logic is correctly applied based on the policy setting, whether it merges runtime filters with initial filters or replaces them entirely.
- Additional test cases should be considered for complex filter merge scenarios to ensure priority and override mechanisms function as expected.

### Notes for the reviewer:
- Make sure all retrievers in the project are accounted and appropriately adjusted 
- Pay special attention all retrievers have the same new init param + proper pydoc
- Verify unit tests were adjusted appropriately
- Pay special attention to Qdrant  retrievers, there we needed (or not, I'm not 100% sure) to keep attribute filters as None
- It's essential to ensure backward compatibility; existing implementations should default to `replace` to maintain current behavior unless explicitly set to `merge`.