### PR TITLE
feat: return_embeddings flag for opensearch

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -39,6 +39,7 @@ class OpenSearchDocumentStore:
         index: str = "default",
         max_chunk_bytes: int = DEFAULT_MAX_CHUNK_BYTES,
         embedding_dim: int = 768,
+        return_embedding: bool = False,
         method: Optional[Dict[str, Any]] = None,
         mappings: Optional[Dict[str, Any]] = None,
         settings: Optional[Dict[str, Any]] = DEFAULT_SETTINGS,
@@ -56,6 +57,8 @@ class OpenSearchDocumentStore:
         :param index: Name of index in OpenSearch, if it doesn't exist it will be created. Defaults to "default"
         :param max_chunk_bytes: Maximum size of the requests in bytes. Defaults to 100MB
         :param embedding_dim: Dimension of the embeddings. Defaults to 768
+        :param return_embedding:
+            Whether to return the embedding of the retrieved Documents.
         :param method: The method definition of the underlying configuration of the approximate k-NN algorithm. Please
             see the [official OpenSearch docs](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#method-definitions)
             for more information. Defaults to None
@@ -72,6 +75,7 @@ class OpenSearchDocumentStore:
         self._index = index
         self._max_chunk_bytes = max_chunk_bytes
         self._embedding_dim = embedding_dim
+        self._return_embedding = return_embedding
         self._method = method
         self._mappings = mappings or self._get_default_mappings()
         self._settings = settings
@@ -325,6 +329,11 @@ class OpenSearchDocumentStore:
 
         if filters:
             body["query"]["bool"]["filter"] = normalize_filters(filters)
+
+        # For some applications not returning the embedding can save a lot of bandwidth
+        # if you don't need this data not retrieving it can be a good idea
+        if not self._return_embedding:
+            body["_source"] = {"excludes": ["embedding"]}
 
         documents = self._search_documents(**body)
 

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -384,3 +384,40 @@ class TestDocumentStore(DocumentStoreBaseTests):
         document_store.write_documents([Document(content="Hello world")])
 
         assert mock_bulk.call_args.kwargs["max_chunk_bytes"] == DEFAULT_MAX_CHUNK_BYTES
+
+    @pytest.fixture
+    def document_store_no_embbding_returned(self, request) -> None:
+        """
+        This is the most basic requirement for the child class: provide
+        an instance of this document store so the base class can use it.
+        """
+        hosts = ["https://localhost:9200"]
+        # Use a different index for each test so we can run them in parallel
+        index = f"{request.node.name}"
+
+        store = OpenSearchDocumentStore(
+            hosts=hosts,
+            index=index,
+            http_auth=("admin", "admin"),
+            verify_certs=False,
+            embedding_dim=768,
+            return_embedding=False,
+            method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
+        )
+        yield store
+        store.client.indices.delete(index=index, params={"ignore": [400, 404]})
+
+    def test_embedding_retrieval_but_dont_return_embeddings(
+        self, document_store_no_embbding_returned: OpenSearchDocumentStore
+    ):
+        docs = [
+            Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
+            Document(content="Not very similar document", embedding=[0.0, 0.8, 0.3, 0.9]),
+        ]
+        document_store_no_embbding_returned.write_documents(docs)
+        results = document_store_no_embbding_returned._embedding_retrieval(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=2, filters={}
+        )
+        assert len(results) == 2
+        assert results[0].embedding is None


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/657

### Proposed Changes:
- add flag to Opensearch init to return or skip embeddings

### How did you test it?
- integration test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
