### PR TITLE
chore: Drop support for Python 3.8 for Unstructured integration

### DIFF
--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Free up disk space

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -7,7 +7,7 @@ name = "unstructured-fileconverter-haystack"
 dynamic = ["version"]
 description = 'Haystack 2.x component to convert files into Documents using the Unstructured API'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "Apache-2.0"
 keywords = []
 authors = [
@@ -17,7 +17,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -68,7 +67,7 @@ docs = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11"]
 
 [tool.hatch.envs.lint]
 detached = true


### PR DESCRIPTION
Unstructured library doesn't support Python 3.8 as can be seen in [latest nightly test failure](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/9376015101/job/25815211259#step:9:58).

This is also made clear by [their `setup.py`](https://github.com/Unstructured-IO/unstructured/blob/fdb27378cb7fc25bcae66bf52bcfc16e051a42a8/setup.py#L96).