### PR TITLE
test: Amazon Bedrock - skip integration tests from forks

### DIFF
--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -63,11 +63,14 @@ jobs:
         run: hatch run docs
 
       - name: Set IS_FORK environment variable
-        run: echo "IS_FORK=$([[ ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.repository }} ]] && echo true || echo false)" >> $GITHUB_ENV
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "IS_FORK=true" >> $GITHUB_ENV
+          fi
 
 
       - name: AWS authentication
-        if: env.IS_FORK == 'false'      
+        if: env.IS_FORK != 'true'      
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -74,7 +74,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
 
-        # Do not run integration tests on pull requests from forks
+      # Do not run integration tests on pull requests from forks
       - name: Run integration tests
         if: github.event.pull_request.head.repo.full_name == github.repository      
         id: integration-tests

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -62,31 +62,22 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Set IS_FORK environment variable (Unix-like)
-        if: runner.os != 'Windows'
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "IS_FORK=true" >> $GITHUB_ENV
-          fi
-
-      - name: Set IS_FORK environment variable (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          if ($Env:GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME -ne $Env:GITHUB_REPOSITORY) {
-            echo "IS_FORK=true" >> $Env:GITHUB_ENV
-          }
-
+      - name: Run unit tests
+        id: unit-tests
+        run: hatch run cov -m "not integration"        
 
       - name: AWS authentication
-        if: env.IS_FORK != 'true'      
+        if: github.event.pull_request.head.repo.full_name == github.repository      
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run integration tests
+        # Do not run integration tests on pull requests from forks
+        if: github.event.pull_request.head.repo.full_name == github.repository      
+        id: integration-tests
+        run: hatch run cov -m "integration"
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -66,15 +66,16 @@ jobs:
         id: unit-tests
         run: hatch run cov -m "not integration"        
 
-      - name: AWS authentication
+      # Do not authenticate on pull requests from forks
+      - name: AWS authentication        
         if: github.event.pull_request.head.repo.full_name == github.repository      
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
 
-      - name: Run integration tests
         # Do not run integration tests on pull requests from forks
+      - name: Run integration tests
         if: github.event.pull_request.head.repo.full_name == github.repository      
         id: integration-tests
         run: hatch run cov -m "integration"

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -62,7 +62,12 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
+      - name: Set IS_FORK environment variable
+        run: echo "IS_FORK=$([[ ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.repository }} ]] && echo true || echo false)" >> $GITHUB_ENV
+
+
       - name: AWS authentication
+        if: env.IS_FORK == 'false'      
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -62,11 +62,19 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Set IS_FORK environment variable
+      - name: Set IS_FORK environment variable (Unix-like)
+        if: runner.os != 'Windows'
         run: |
           if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
             echo "IS_FORK=true" >> $GITHUB_ENV
           fi
+
+      - name: Set IS_FORK environment variable (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          if ($Env:GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME -ne $Env:GITHUB_REPOSITORY) {
+            echo "IS_FORK=true" >> $Env:GITHUB_ENV
+          }
 
 
       - name: AWS authentication

--- a/integrations/amazon_bedrock/tests/conftest.py
+++ b/integrations/amazon_bedrock/tests/conftest.py
@@ -1,12 +1,6 @@
-import os
 from unittest.mock import patch
 
 import pytest
-
-
-def pytest_runtest_setup(item):
-    if os.getenv("IS_FORK") == "true" and "integration" in item.keywords:
-        pytest.skip("Skipping integration test since it's running in a forked repository")
 
 
 @pytest.fixture

--- a/integrations/amazon_bedrock/tests/conftest.py
+++ b/integrations/amazon_bedrock/tests/conftest.py
@@ -1,6 +1,11 @@
 from unittest.mock import patch
 
+import os
 import pytest
+
+def pytest_runtest_setup(item):
+    if os.getenv("IS_FORK") == "true" and "integration" in item.keywords:
+        pytest.skip("Skipping integration test since it's running in a forked repository")
 
 
 @pytest.fixture

--- a/integrations/amazon_bedrock/tests/conftest.py
+++ b/integrations/amazon_bedrock/tests/conftest.py
@@ -1,7 +1,8 @@
+import os
 from unittest.mock import patch
 
-import os
 import pytest
+
 
 def pytest_runtest_setup(item):
     if os.getenv("IS_FORK") == "true" and "integration" in item.keywords:

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Type
 
 import pytest
@@ -182,6 +183,13 @@ class TestAnthropicClaudeAdapter:
         assert body == expected_body
 
 
+@pytest.mark.skipif(
+    not os.environ.get("HF_API_TOKEN", None),
+    reason=(
+        "To run this test, you need to set the HF_API_TOKEN environment variable. The associated account must also "
+        "have requested access to the gated model `mistralai/Mistral-7B-Instruct-v0.1`"
+    ),
+)
 class TestMistralAdapter:
     def test_prepare_body_with_default_params(self) -> None:
         layer = MistralChatAdapter(generation_kwargs={})


### PR DESCRIPTION
### Related Issues

- fixes #689

### Proposed Changes:

- when running from a fork, skip AWS authentication and integration tests
- slightly unrelated: also skip Mistral test if `HF_API_TOKEN` env var is not set (we can remove this once #732 is fixed)

### How did you test it?
CI: this PR comes from a fork.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
