### PR TITLE
chore: `CohereGenerator` - remove warning about `generate` API

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -40,14 +40,8 @@ class CohereGenerator(CohereChatGenerator):
     ):
         """
         Instantiates a `CohereGenerator` component.
-
-        NOTE: Cohere discontinued the `generate` API, so this generator is a mere wrapper
-        around `CohereChatGenerator` provided for backward compatibility.
         """
-        logger.warning(
-            "The 'generate' API is marked as Legacy and is no longer maintained by Cohere. "
-            "We recommend to use the CohereChatGenerator instead."
-        )
+
         # Note we have to call super() like this because of the way components are dynamically built with the decorator
         super(CohereGenerator, self).__init__(api_key, model, streaming_callback, api_base_url, None, **kwargs)  # noqa
 


### PR DESCRIPTION
This Generator is a mere wrapper of the corresponding ChatGenerator but it is useful for simple use cases and we want to keep it.

### Proposed Changes:
Remove the warning message, which was not clear to users.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
