### PR TITLE
fix: weaviate filter error

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -12,6 +12,7 @@ from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses.document import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types.policy import DuplicatePolicy
+from haystack.utils.filters import convert
 
 import weaviate
 from weaviate.collections.classes.data import DataObject
@@ -374,6 +375,9 @@ class WeaviateDocumentStore:
         :param filters: The filters to apply to the document list.
         :returns: A list of Documents that match the given filters.
         """
+        if filters and "operator" not in filters and "conditions" not in filters:
+            filters = convert(filters)
+
         result = []
         if filters:
             result = self._query_with_filters(filters)

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -655,6 +655,15 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         with pytest.raises(ValueError):
             document_store._embedding_retrieval(query_embedding=[], distance=0.1, certainty=0.1)
 
+    def test_filter_documents_with_legacy_filters(self, document_store):
+        docs = []
+        for index in range(10):
+            docs.append(Document(content="This is some content", meta={"index": index}))
+        document_store.write_documents(docs)
+        result = document_store.filter_documents({"content": {"$eq": "This is some content"}})
+
+        assert len(result) == 10
+
     def test_filter_documents_below_default_limit(self, document_store):
         docs = []
         for index in range(9998):


### PR DESCRIPTION
### Related Issues

- fixes #810 

### Proposed Changes:

A FilterError is raised when using legacy filters or used with other components like `CacheChecker`. 
This is because of the missing `convert(filters)` in `WeaviateDocumentStore`.
This PR adds the `convert` function.

### How did you test it?

- Added test
- Resolves #810 after the applying the changes in the PR

### Notes for the reviewer
N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
