### PR TITLE
Fix: typo on Sparse embedders. The parameter should be "progress_bar" …

### DIFF
--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -159,7 +159,7 @@ class FastembedSparseDocumentEmbedder:
         embeddings = self.embedding_backend.embed(
             texts_to_embed,
             batch_size=self.batch_size,
-            show_progress_bar=self.progress_bar,
+            progress_bar=self.progress_bar,
             parallel=self.parallel,
         )
 

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -111,7 +111,7 @@ class FastembedSparseTextEmbedder:
 
         embedding = self.embedding_backend.embed(
             [text],
-            show_progress_bar=self.progress_bar,
+            progress_bar=self.progress_bar,
             parallel=self.parallel,
         )[0]
         return {"sparse_embedding": embedding}

--- a/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
@@ -270,7 +270,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
                 "meta_value 4\ndocument-number 4",
             ],
             batch_size=32,
-            show_progress_bar=True,
+            progress_bar=True,
             parallel=None,
         )
 


### PR DESCRIPTION
…instead of "show_progress_bar"

### Proposed Changes:

Bug:
When creating a FastembedSparseTextEmbedder or a FastembedSparseDocumentEmbedder with progress_bar=False, the progress bar is still shown.
example: FastembedSparseTextEmbedder(model="prithivida/Splade_PP_en_v1", local_files_only=True, progress_bar=False)
We don't have the same behavior on FastembedTextEmbedder or FastembedDocumentEmbedder.

The bug is a typo on the name of the parameters sent to the fastembed object. It was show_progress_bar instead of progress_bar

### How did you test it?

Manually. I used a FastembedSparseTextEmbedder with progress_bar=False with the current code and it showed the progress bar.
I put the new version of FastembedSparseTextEmbedder  with the same calling code and the progress bar is not shown.
Then, I modified to use progress_bar=True and the bar was shown.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
