### PR TITLE
feat: add customizable index names for pgvector

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -69,10 +69,6 @@ VECTOR_FUNCTION_TO_POSTGRESQL_OPS = {
 
 HNSW_INDEX_CREATION_VALID_KWARGS = ["m", "ef_construction"]
 
-HNSW_DEFAULT_INDEX_NAME = "haystack_hnsw_index"
-
-KEYWORD_DEFAULT_INDEX_NAME = "haystack_keyword_index"
-
 
 class PgvectorDocumentStore:
     """
@@ -91,9 +87,9 @@ class PgvectorDocumentStore:
         search_strategy: Literal["exact_nearest_neighbor", "hnsw"] = "exact_nearest_neighbor",
         hnsw_recreate_index_if_exists: bool = False,
         hnsw_index_creation_kwargs: Optional[Dict[str, int]] = None,
-        hnsw_index_name: str = HNSW_DEFAULT_INDEX_NAME,
+        hnsw_index_name: str = "haystack_hnsw_index",
         hnsw_ef_search: Optional[int] = None,
-        keyword_index_name: str = KEYWORD_DEFAULT_INDEX_NAME,
+        keyword_index_name: str = "haystack_keyword_index",
     ):
         """
         Creates a new PgvectorDocumentStore instance.

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -53,7 +53,9 @@ def test_init(monkeypatch):
         search_strategy="hnsw",
         hnsw_recreate_index_if_exists=True,
         hnsw_index_creation_kwargs={"m": 32, "ef_construction": 128},
+        hnsw_index_name="my_hnsw_index",
         hnsw_ef_search=50,
+        keyword_index_name="my_keyword_index",
     )
 
     assert document_store.table_name == "my_table"
@@ -63,7 +65,9 @@ def test_init(monkeypatch):
     assert document_store.search_strategy == "hnsw"
     assert document_store.hnsw_recreate_index_if_exists
     assert document_store.hnsw_index_creation_kwargs == {"m": 32, "ef_construction": 128}
+    assert document_store.hnsw_index_name == "my_hnsw_index"
     assert document_store.hnsw_ef_search == 50
+    assert document_store.keyword_index_name == "my_keyword_index"
 
 
 @pytest.mark.usefixtures("patches_for_unit_tests")
@@ -78,7 +82,9 @@ def test_to_dict(monkeypatch):
         search_strategy="hnsw",
         hnsw_recreate_index_if_exists=True,
         hnsw_index_creation_kwargs={"m": 32, "ef_construction": 128},
+        hnsw_index_name="my_hnsw_index",
         hnsw_ef_search=50,
+        keyword_index_name="my_keyword_index",
     )
 
     assert document_store.to_dict() == {
@@ -93,7 +99,9 @@ def test_to_dict(monkeypatch):
             "hnsw_recreate_index_if_exists": True,
             "language": "english",
             "hnsw_index_creation_kwargs": {"m": 32, "ef_construction": 128},
+            "hnsw_index_name": "my_hnsw_index",
             "hnsw_ef_search": 50,
+            "keyword_index_name": "my_keyword_index",
         },
     }
 

--- a/integrations/pgvector/tests/test_retrievers.py
+++ b/integrations/pgvector/tests/test_retrievers.py
@@ -48,7 +48,9 @@ class TestEmbeddingRetriever:
                         "hnsw_recreate_index_if_exists": False,
                         "language": "english",
                         "hnsw_index_creation_kwargs": {},
+                        "hnsw_index_name": "haystack_hnsw_index",
                         "hnsw_ef_search": None,
+                        "keyword_index_name": "haystack_keyword_index",
                     },
                 },
                 "filters": {"field": "value"},
@@ -75,7 +77,9 @@ class TestEmbeddingRetriever:
                         "search_strategy": "exact_nearest_neighbor",
                         "hnsw_recreate_index_if_exists": False,
                         "hnsw_index_creation_kwargs": {},
+                        "hnsw_index_name": "haystack_hnsw_index",
                         "hnsw_ef_search": None,
+                        "keyword_index_name": "haystack_keyword_index",
                     },
                 },
                 "filters": {"field": "value"},
@@ -96,7 +100,9 @@ class TestEmbeddingRetriever:
         assert document_store.search_strategy == "exact_nearest_neighbor"
         assert not document_store.hnsw_recreate_index_if_exists
         assert document_store.hnsw_index_creation_kwargs == {}
+        assert document_store.hnsw_index_name == "haystack_hnsw_index"
         assert document_store.hnsw_ef_search is None
+        assert document_store.keyword_index_name == "haystack_keyword_index"
 
         assert retriever.filters == {"field": "value"}
         assert retriever.top_k == 5
@@ -149,7 +155,9 @@ class TestKeywordRetriever:
                         "hnsw_recreate_index_if_exists": False,
                         "language": "english",
                         "hnsw_index_creation_kwargs": {},
+                        "hnsw_index_name": "haystack_hnsw_index",
                         "hnsw_ef_search": None,
+                        "keyword_index_name": "haystack_keyword_index",
                     },
                 },
                 "filters": {"field": "value"},
@@ -175,7 +183,9 @@ class TestKeywordRetriever:
                         "search_strategy": "exact_nearest_neighbor",
                         "hnsw_recreate_index_if_exists": False,
                         "hnsw_index_creation_kwargs": {},
+                        "hnsw_index_name": "haystack_hnsw_index",
                         "hnsw_ef_search": None,
+                        "keyword_index_name": "haystack_keyword_index",
                     },
                 },
                 "filters": {"field": "value"},
@@ -195,7 +205,9 @@ class TestKeywordRetriever:
         assert document_store.search_strategy == "exact_nearest_neighbor"
         assert not document_store.hnsw_recreate_index_if_exists
         assert document_store.hnsw_index_creation_kwargs == {}
+        assert document_store.hnsw_index_name == "haystack_hnsw_index"
         assert document_store.hnsw_ef_search is None
+        assert document_store.keyword_index_name == "haystack_keyword_index"
 
         assert retriever.filters == {"field": "value"}
         assert retriever.top_k == 5


### PR DESCRIPTION
### Related Issues

- fixes #812 

### Proposed Changes:

Added the functionality to use custom names for indexes on pgvector document store.

### How did you test it?

Unit tests, integration tests and manually verification.

### Notes for the reviewer

Feel free to give any feedback, this is my first PR to this project.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
