### PR TITLE
feat: Add filter_policy to pinecone integration

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -55,11 +55,15 @@ class PineconeEmbeddingRetriever:
         document_store: PineconeDocumentStore,
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 10,
+        filter_policy: Literal["replace", "merge"] = "replace",
     ):
         """
         :param document_store: The Pinecone Document Store.
         :param filters: Filters applied to the retrieved Documents.
         :param top_k: Maximum number of Documents to return.
+        :param filter_policy: Policy to determine how filters are applied. Defaults to "replace".
+            - `replace`: Runtime filters replace init filters.
+            - `merge`: Runtime filters are merged with init filters, with runtime filters overwriting init values.
 
         :raises ValueError: If `document_store` is not an instance of `PineconeDocumentStore`.
         """
@@ -70,6 +74,7 @@ class PineconeEmbeddingRetriever:
         self.document_store = document_store
         self.filters = filters or {}
         self.top_k = top_k
+        self.filter_policy = filter_policy
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -81,6 +86,7 @@ class PineconeEmbeddingRetriever:
             self,
             filters=self.filters,
             top_k=self.top_k,
+            filter_policy=self.filter_policy,
             document_store=self.document_store.to_dict(),
         )
 
@@ -99,16 +105,31 @@ class PineconeEmbeddingRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, query_embedding: List[float]):
+    def run(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+    ):
         """
         Retrieve documents from the `PineconeDocumentStore`, based on their dense embeddings.
 
         :param query_embedding: Embedding of the query.
+        :param filters: Filters applied to the retrieved `Document`s.
+        :param top_k: Maximum number of `Document`s to return.
+
         :returns: List of Document similar to `query_embedding`.
         """
+        if self.filter_policy == "merge" and filters:
+            filters = {**self.filters, **filters}
+        else:
+            filters = filters or self.filters
+
+        top_k = top_k or self.top_k
+
         docs = self.document_store._embedding_retrieval(
             query_embedding=query_embedding,
-            filters=self.filters,
-            top_k=self.top_k,
+            filters=filters,
+            top_k=top_k,
         )
         return {"documents": docs}

--- a/integrations/pinecone/tests/test_embedding_retriever.py
+++ b/integrations/pinecone/tests/test_embedding_retriever.py
@@ -16,6 +16,7 @@ def test_init_default():
     assert retriever.document_store == mock_store
     assert retriever.filters == {}
     assert retriever.top_k == 10
+    assert retriever.filter_policy == "replace"
 
 
 @patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
@@ -53,6 +54,7 @@ def test_to_dict(mock_pinecone, monkeypatch):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
         },
     }
 
@@ -82,6 +84,7 @@ def test_from_dict(mock_pinecone, monkeypatch):
             },
             "filters": {},
             "top_k": 10,
+            "filter_policy": "replace",
         },
     }
 
@@ -100,6 +103,7 @@ def test_from_dict(mock_pinecone, monkeypatch):
 
     assert retriever.filters == {}
     assert retriever.top_k == 10
+    assert retriever.filter_policy == "replace"
 
 
 def test_run():


### PR DESCRIPTION
### Why:
Adds flexible filtering options to pinecone integration. By introducing a filter policy option (`replace` or `merge`), developers can now control how runtime filters are applied relative to initialization time filters. 

- partially fixes https://github.com/deepset-ai/haystack-core-integrations/issues/780

### What:
- Added `filter_policy` parameter with options `replace` and `merge` across multiple retrievers to control filter behavior dynamically.
- Unit tests were updated or added to validate the new functionality.

### How can it be used:

- **Dynamic Filter Behavior Adjustment:**  Users can decide whether to completely override the initial filters set during the retriever's initialization (`replace`) or merge them with runtime filters, with the latter taking precedence (`merge`).

- **Complex Search Scenarios:**  
    - In cases where the context of a query might dictate altering pre-set filters without discarding them, the `merge` option allows for an additive approach.
    - For strict query contexts that require ignoring initial filters, the `replace` option offers a clean slate for filters at runtime.

### How did you test it:
- Unit tests were enhanced or newly created to cover both `replace` and `merge` scenarios for the `filter_policy` parameter. 
- Tests ensure that filter logic is correctly applied based on the policy setting, whether it merges runtime filters with initial filters or replaces them entirely.
- Additional test cases should be considered for complex filter merge scenarios to ensure priority and override mechanisms function as expected.
