### PR TITLE
chore: add retry action for integration tests

### DIFF
--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -63,26 +63,27 @@ jobs:
         run: hatch run docs
 
       - name: Run unit tests
-        id: unit-tests
-        run: hatch run cov -m "not integration"        
+        run: hatch run cov -m "not integration"
 
       # Do not authenticate on pull requests from forks
-      - name: AWS authentication        
-        if: github.event.pull_request.head.repo.full_name == github.repository      
+      - name: AWS authentication
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
 
       # Do not run integration tests on pull requests from forks
-      - name: Run integration tests
-        if: github.event.pull_request.head.repo.full_name == github.repository      
-        id: integration-tests
-        run: hatch run cov -m "integration"
+      - name: Run integration tests with retry
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov -m "integration"
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
@@ -92,7 +93,5 @@ jobs:
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure:
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -54,25 +54,25 @@ jobs:
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run docs        
+        run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Run tests with retry
         uses: Wandalen/wretry.action@v3
         with:
-          command: "hatch run cov"
+          command: |
+            hatch run cov
           attempt_limit: 3
           attempt_delay: 2000
 

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -53,22 +53,27 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run lint:all
 
-      - name: Run tests
-        run: hatch run cov
+      - name: Generate docs
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run docs
+
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run tests with retry
         uses: Wandalen/wretry.action@v3
         with:
-          command: hatch run cov
+          command: "hatch run cov"
           attempt_limit: 3
           attempt_delay: 2000
 

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -7,8 +7,8 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     paths:
-      - 'integrations/astra/**'
-      - '.github/workflows/astra.yml'
+      - "integrations/astra/**"
+      - ".github/workflows/astra.yml"
 
 defaults:
   run:
@@ -31,52 +31,52 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10"]
 
     steps:
-    - name: Support longpaths
-      if: matrix.os == 'windows-latest'
-      working-directory: .
-      run: git config --system core.longpaths true
+      - name: Support longpaths
+        if: matrix.os == 'windows-latest'
+        working-directory: .
+        run: git config --system core.longpaths true
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Hatch
-      run: pip install --upgrade hatch
+      - name: Install Hatch
+        run: pip install --upgrade hatch
 
-    - name: Lint
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run lint:all
+      - name: Lint
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run lint:all
 
-    - name: Generate docs
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run docs
+      - name: Generate docs
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run docs
 
-    - name: Run tests
-      env:
-        ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
-        ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
-      id: tests
-      run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        env:
+          ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
+          ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
-    - name: Nightly - run unit tests with Haystack main branch
-      if: github.event_name == 'schedule'
-      id: nightly-haystack-main
-      run: |
-        hatch run pip install git+https://github.com/deepset-ai/haystack.git
-        hatch run test -m "not integration"
+      - name: Nightly - run unit tests with Haystack main branch
+        if: github.event_name == 'schedule'
+        run: |
+          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run test -m "not integration"
 
-    - name: Send event to Datadog for nightly failures
-      if: failure() && github.event_name == 'schedule'
-      uses: ./.github/actions/send_failure
-      with:
-        title: |
-          core-integrations failure:
-          ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-            - ${{ github.workflow }}
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+      - name: Send event to Datadog for nightly failures
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/send_failure
+        with:
+          title: |
+            Core integrations nightly tests failure: ${{ github.workflow }}
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -7,8 +7,8 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     paths:
-      - 'integrations/chroma/**'
-      - '.github/workflows/chroma.yml'
+      - "integrations/chroma/**"
+      - ".github/workflows/chroma.yml"
 
 defaults:
   run:
@@ -30,49 +30,45 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - name: Support longpaths
-      if: matrix.os == 'windows-latest'
-      working-directory: .
-      run: git config --system core.longpaths true
+      - name: Support longpaths
+        if: matrix.os == 'windows-latest'
+        working-directory: .
+        run: git config --system core.longpaths true
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Hatch
-      run: pip install --upgrade hatch
+      - name: Install Hatch
+        run: pip install --upgrade hatch
 
-    - name: Lint
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run lint:all
+      - name: Lint
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run lint:all
 
-    - name: Generate docs
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run docs
+      - name: Generate docs
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run docs
 
-    - name: Run tests
-      id: tests
-      run: hatch run cov
+      - name: Run tests
+        run: hatch run cov
 
-    - name: Nightly - run unit tests with Haystack main branch
-      if: github.event_name == 'schedule'
-      id: nightly-haystack-main
-      run: |
-        hatch run pip install git+https://github.com/deepset-ai/haystack.git
-        hatch run test -m "not integration"
-    
-    - name: Send event to Datadog for nightly failures
-      if: failure() && github.event_name == 'schedule'
-      uses: ./.github/actions/send_failure
-      with:
-        title: |
-          core-integrations failure: 
-          ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-            - ${{ github.workflow }}
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+      - name: Nightly - run unit tests with Haystack main branch
+        if: github.event_name == 'schedule'
+        run: |
+          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run test -m "not integration"
+
+      - name: Send event to Datadog for nightly failures
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/send_failure
+        with:
+          title: |
+            Core integrations nightly tests failure: ${{ github.workflow }}
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -55,25 +55,25 @@ jobs:
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run docs        
+        run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -57,23 +57,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Run ElasticSearch container
+        run: docker-compose up -d
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -47,30 +50,27 @@ jobs:
         if: matrix.python-version == '3.9'
         run: hatch run lint:all
 
-      - name: Run ElasticSearch container
-        run: docker-compose up -d
-
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9","3.10","3.11"]
-        
-    steps:   
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -39,25 +39,25 @@ jobs:
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run docs          
+        run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov        
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -57,23 +57,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/google_vertex.yml
+++ b/.github/workflows/google_vertex.yml
@@ -56,23 +56,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/gradient.yml
+++ b/.github/workflows/gradient.yml
@@ -7,8 +7,8 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     paths:
-      - 'integrations/gradient/**'
-      - '.github/workflows/gradient.yml'
+      - "integrations/gradient/**"
+      - ".github/workflows/gradient.yml"
 
 defaults:
   run:
@@ -32,49 +32,49 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10"]
 
     steps:
-    - name: Support longpaths
-      if: matrix.os == 'windows-latest'
-      working-directory: .
-      run: git config --system core.longpaths true
+      - name: Support longpaths
+        if: matrix.os == 'windows-latest'
+        working-directory: .
+        run: git config --system core.longpaths true
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Hatch
-      run: pip install --upgrade hatch
+      - name: Install Hatch
+        run: pip install --upgrade hatch
 
-    - name: Lint
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run lint:all
+      - name: Lint
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run lint:all
 
-    - name: Generate docs
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run docs
+      - name: Generate docs
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run docs
 
-    - name: Run tests
-      id: tests
-      run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
-    - name: Nightly - run unit tests with Haystack main branch
-      if: github.event_name == 'schedule'
-      id: nightly-haystack-main
-      run: |
-        hatch run pip install git+https://github.com/deepset-ai/haystack.git
-        hatch run test -m "not integration"
+      - name: Nightly - run unit tests with Haystack main branch
+        if: github.event_name == 'schedule'
+        run: |
+          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run test -m "not integration"
 
-    - name: Send event to Datadog for nightly failures
-      if: failure() && github.event_name == 'schedule'
-      uses: ./.github/actions/send_failure
-      with:
-        title: |
-          core-integrations failure:
-          ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-            - ${{ github.workflow }}
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+      - name: Send event to Datadog for nightly failures
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/send_failure
+        with:
+          title: |
+            Core integrations nightly tests failure: ${{ github.workflow }}
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -34,23 +34,23 @@ jobs:
         if: runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -56,23 +56,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -54,28 +54,28 @@ jobs:
       - name: Lint
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run lint:all
-      
+
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -7,8 +7,8 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     paths:
-      - 'integrations/llama_cpp/**'
-      - '.github/workflows/llama_cpp.yml'
+      - "integrations/llama_cpp/**"
+      - ".github/workflows/llama_cpp.yml"
 
 defaults:
   run:
@@ -30,49 +30,49 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10"]
 
     steps:
-    - name: Support longpaths
-      if: matrix.os == 'windows-latest'
-      working-directory: .
-      run: git config --system core.longpaths true
+      - name: Support longpaths
+        if: matrix.os == 'windows-latest'
+        working-directory: .
+        run: git config --system core.longpaths true
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Hatch
-      run: pip install --upgrade hatch
+      - name: Install Hatch
+        run: pip install --upgrade hatch
 
-    - name: Lint
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run lint:all
+      - name: Lint
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run lint:all
 
-    - name: Generate docs
-      if: matrix.python-version == '3.9' && runner.os == 'Linux'
-      run: hatch run docs
+      - name: Generate docs
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        run: hatch run docs
 
-    - name: Run tests
-      id: tests
-      run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
-    - name: Nightly - run unit tests with Haystack main branch
-      if: github.event_name == 'schedule'
-      id: nightly-haystack-main
-      run: |
-        hatch run pip install git+https://github.com/deepset-ai/haystack.git
-        hatch run test -m "not integration"
-    
-    - name: Send event to Datadog for nightly failures
-      if: failure() && github.event_name == 'schedule'
-      uses: ./.github/actions/send_failure
-      with:
-        title: |
-          core-integrations failure: 
-          ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-            - ${{ github.workflow }}
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+      - name: Nightly - run unit tests with Haystack main branch
+        if: github.event_name == 'schedule'
+        run: |
+          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run test -m "not integration"
+
+      - name: Send event to Datadog for nightly failures
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/send_failure
+        with:
+          title: |
+            Core integrations nightly tests failure: ${{ github.workflow }}
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -52,28 +52,28 @@ jobs:
       - name: Lint
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run lint:all
-      
+
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -53,23 +53,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -54,9 +54,12 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run lint:all
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
@@ -64,7 +67,6 @@ jobs:
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
@@ -74,7 +76,5 @@ jobs:
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure:
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -32,16 +32,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9","3.10","3.11"]
-        
-    steps:   
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
       - uses: actions/checkout@v4
 
       - name: Install Ollama and pull the required models
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
           ollama serve &
-          
+
           # Check if the service is up and running with a timeout of 60 seconds
           timeout=60
           while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
@@ -54,7 +54,7 @@ jobs:
             echo "Timed out waiting for Ollama service to start."
             exit 1
           fi
-          
+
           ollama pull ${{ env.LLM_FOR_TESTS }}
           ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
 
@@ -74,23 +74,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -20,7 +20,7 @@ env:
 
 defaults:
   run:
-    working-directory: integrations/opensearch  
+    working-directory: integrations/opensearch
 
 jobs:
   run:
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Run opensearch container
+        run: docker-compose up -d
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -47,30 +50,27 @@ jobs:
         if: matrix.python-version == '3.9'
         run: hatch run lint:all
 
-      - name: Run opensearch container
-        run: docker-compose up -d
-
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run docs        
+        run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -56,23 +56,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -20,7 +20,7 @@ env:
 
 defaults:
   run:
-    working-directory: integrations/pgvector  
+    working-directory: integrations/pgvector
 
 jobs:
   run:
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9","3.10","3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     services:
       pgvector:
         image: ankane/pgvector:latest
@@ -40,8 +40,8 @@ jobs:
           POSTGRES_DB: postgres
         ports:
           - 5432:5432
-        
-    steps:   
+
+    steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -58,25 +58,25 @@ jobs:
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run docs          
+        run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -60,25 +60,25 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
         env:
           INDEX_NAME: ${{ matrix.INDEX_NAME }}
-        run: hatch run cov
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -56,23 +56,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}  
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
 jobs:
   run:
@@ -57,23 +57,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -8,11 +8,11 @@ on:
   pull_request:
     paths:
       - "integrations/unstructured/**"
-      - ".github/workflows/unstructured.yml" 
+      - ".github/workflows/unstructured.yml"
 
 defaults:
   run:
-    working-directory: integrations/unstructured    
+    working-directory: integrations/unstructured
 
 concurrency:
   group: unstructured-${{ github.head_ref }}
@@ -48,7 +48,7 @@ jobs:
             --health-interval 10s \
             --health-timeout 1s \
             --health-retries 10 \
-            quay.io/unstructured-io/unstructured-api:latest       
+            quay.io/unstructured-io/unstructured-api:latest
 
       - uses: actions/checkout@v4
 
@@ -68,23 +68,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -53,23 +53,23 @@ jobs:
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
-      - name: Run tests
-        id: tests
-        run: hatch run cov
+      - name: Run tests with retry
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: hatch run cov
+          attempt_limit: 3
+          attempt_delay: 2000
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        id: nightly-haystack-main
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
           hatch run test -m "not integration"
-      
+
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'
         uses: ./.github/actions/send_failure
         with:
           title: |
-            core-integrations failure: 
-            ${{ (steps.tests.conclusion == 'nightly-haystack-main') && 'nightly-haystack-main' || 'tests' }}
-             - ${{ github.workflow }}
+            Core integrations nightly tests failure: ${{ github.workflow }}
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}


### PR DESCRIPTION
### Related Issues

- fixes #799 

### Proposed Changes:

- Retry the steps of the workflows running integration tests

### How did you test it?

Not tested

### Notes for the reviewer

- Given the duplication provided by having many integrations, I thought it would be less invasive to change the CI job instead of the python code for the tests
- I also fixed the Datadog alert, the conditional on the title wasn't working and I got rid of it entirely across the board. I think it's ok since we receive the link to the failed workflow, from which it's easy to spot what went wrong in particular.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
