### PR TITLE
feat: add create_index option to OpenSearchDocumentStore

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -119,10 +119,15 @@ class OpenSearchDocumentStore:
         elif self._create_index:
             # Create the index if it doesn't exist
             body = {"mappings": self._mappings, "settings": self._settings}
-            self._client.indices.create(index=self._index, body=body)
+            self._client.indices.create(index=self._index, body=body)  # type:ignore
         return self._client
-    
-    def create_index(self, index: Optional[str] = None, mappings: Optional[Dict[str, Any]] = None, settings: Optional[Dict[str, Any]] = None) -> None:
+
+    def create_index(
+        self,
+        index: Optional[str] = None,
+        mappings: Optional[Dict[str, Any]] = None,
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """
         Creates an index in OpenSearch.
 
@@ -141,7 +146,7 @@ class OpenSearchDocumentStore:
             mappings = self._mappings
         if not settings:
             settings = self._settings
-        
+
         if not self.client.indices.exists(index=index):
             self.client.indices.create(index=index, body={"mappings": mappings, "settings": settings})
 

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -119,9 +119,31 @@ class OpenSearchDocumentStore:
         elif self._create_index:
             # Create the index if it doesn't exist
             body = {"mappings": self._mappings, "settings": self._settings}
-
-            self._client.indices.create(index=self._index, body=body)  # type:ignore
+            self._client.indices.create(index=self._index, body=body)
         return self._client
+    
+    def create_index(self, index: Optional[str] = None, mappings: Optional[Dict[str, Any]] = None, settings: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Creates an index in OpenSearch.
+
+        Note that this method ignores the `create_index` argument from the constructor.
+
+        :param index: Name of the index to create. If None, the index name from the constructor is used.
+        :param mappings: The mapping of how the documents are stored and indexed. Please see the [official OpenSearch docs](https://opensearch.org/docs/latest/field-types/)
+            for more information. If None, it uses the embedding_dim and method arguments to create default mappings.
+            Defaults to None
+        :param settings: The settings of the index to be created. Please see the [official OpenSearch docs](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#index-settings)
+            for more information. Defaults to {"index.knn": True}
+        """
+        if not index:
+            index = self._index
+        if not mappings:
+            mappings = self._mappings
+        if not settings:
+            settings = self._settings
+        
+        if not self.client.indices.exists(index=index):
+            self.client.indices.create(index=index, body={"mappings": mappings, "settings": settings})
 
     def to_dict(self) -> Dict[str, Any]:
         # This is not the best solution to serialise this class but is the fastest to implement.

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -135,10 +135,9 @@ class OpenSearchDocumentStore:
 
         :param index: Name of the index to create. If None, the index name from the constructor is used.
         :param mappings: The mapping of how the documents are stored and indexed. Please see the [official OpenSearch docs](https://opensearch.org/docs/latest/field-types/)
-            for more information. If None, it uses the embedding_dim and method arguments to create default mappings.
-            Defaults to None
+            for more information. If None, the mappings from the constructor are used.
         :param settings: The settings of the index to be created. Please see the [official OpenSearch docs](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#index-settings)
-            for more information. Defaults to {"index.knn": True}
+            for more information. If None, the settings from the constructor are used.
         """
         if not index:
             index = self._index

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -43,6 +43,7 @@ class OpenSearchDocumentStore:
         method: Optional[Dict[str, Any]] = None,
         mappings: Optional[Dict[str, Any]] = None,
         settings: Optional[Dict[str, Any]] = DEFAULT_SETTINGS,
+        create_index: bool = True,
         **kwargs,
     ):
         """
@@ -67,6 +68,7 @@ class OpenSearchDocumentStore:
             Defaults to None
         :param settings: The settings of the index to be created. Please see the [official OpenSearch docs](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#index-settings)
             for more information. Defaults to {"index.knn": True}
+        :param create_index: Whether to create the index if it doesn't exist. Defaults to True
         :param **kwargs: Optional arguments that ``OpenSearch`` takes. For the full list of supported kwargs,
             see the [official OpenSearch reference](https://opensearch-project.github.io/opensearch-py/api-ref/clients/opensearch_client.html)
         """
@@ -79,6 +81,7 @@ class OpenSearchDocumentStore:
         self._method = method
         self._mappings = mappings or self._get_default_mappings()
         self._settings = settings
+        self._create_index = create_index
         self._kwargs = kwargs
 
     def _get_default_mappings(self) -> Dict[str, Any]:
@@ -113,7 +116,7 @@ class OpenSearchDocumentStore:
                 "`settings` values will be ignored.",
                 self._index,
             )
-        else:
+        elif self._create_index:
             # Create the index if it doesn't exist
             body = {"mappings": self._mappings, "settings": self._settings}
 
@@ -139,6 +142,8 @@ class OpenSearchDocumentStore:
             method=self._method,
             mappings=self._mappings,
             settings=self._settings,
+            create_index=self._create_index,
+            return_embedding=self._return_embedding,
             **self._kwargs,
         )
 

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -43,6 +43,8 @@ def test_to_dict(_mock_opensearch_client):
                     "max_chunk_bytes": DEFAULT_MAX_CHUNK_BYTES,
                     "method": None,
                     "settings": {"index.knn": True},
+                    "return_embedding": False,
+                    "create_index": True,
                 },
                 "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
             },

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -202,7 +202,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
     def test_write_documents_readonly(self, document_store_readonly: OpenSearchDocumentStore):
         docs = [Document(id="1")]
-        with pytest.raises(DocumentStoreError, match="no such index"):
+        with pytest.raises(DocumentStoreError, match="index_not_found_exception"):
             document_store_readonly.write_documents(docs)
 
     def test_create_index(self, document_store_readonly: OpenSearchDocumentStore):

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -45,7 +45,14 @@ def test_to_dict(_mock_opensearch_client):
 def test_from_dict(_mock_opensearch_client):
     data = {
         "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
-        "init_parameters": {"hosts": "some hosts", "index": "default", "max_chunk_bytes": 1000, "embedding_dim": 1536, "create_index": False, "return_embedding": True},
+        "init_parameters": {
+            "hosts": "some hosts", 
+            "index": "default", 
+            "max_chunk_bytes": 1000, 
+            "embedding_dim": 1536, 
+            "create_index": False, 
+            "return_embedding": True
+        },
     }
     document_store = OpenSearchDocumentStore.from_dict(data)
     assert document_store._hosts == "some hosts"

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -207,7 +207,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
     def test_create_index(self, document_store_readonly: OpenSearchDocumentStore):
         document_store_readonly.create_index()
-        assert document_store_readonly.client.indices.exists(index=document_store_readonly.index)
+        assert document_store_readonly.client.indices.exists(index=document_store_readonly._index)
 
     def test_bm25_retrieval(self, document_store: OpenSearchDocumentStore):
         document_store.write_documents(

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -46,12 +46,12 @@ def test_from_dict(_mock_opensearch_client):
     data = {
         "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
         "init_parameters": {
-            "hosts": "some hosts", 
-            "index": "default", 
-            "max_chunk_bytes": 1000, 
-            "embedding_dim": 1536, 
-            "create_index": False, 
-            "return_embedding": True
+            "hosts": "some hosts",
+            "index": "default",
+            "max_chunk_bytes": 1000,
+            "embedding_dim": 1536,
+            "create_index": False,
+            "return_embedding": True,
         },
     }
     document_store = OpenSearchDocumentStore.from_dict(data)

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -35,6 +35,8 @@ def test_to_dict(_mock_opensearch_client):
             "max_chunk_bytes": DEFAULT_MAX_CHUNK_BYTES,
             "method": None,
             "settings": {"index.knn": True},
+            "return_embedding": False,
+            "create_index": True,
         },
     }
 
@@ -43,7 +45,7 @@ def test_to_dict(_mock_opensearch_client):
 def test_from_dict(_mock_opensearch_client):
     data = {
         "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
-        "init_parameters": {"hosts": "some hosts", "index": "default", "max_chunk_bytes": 1000, "embedding_dim": 1536},
+        "init_parameters": {"hosts": "some hosts", "index": "default", "max_chunk_bytes": 1000, "embedding_dim": 1536, "create_index": False, "return_embedding": True},
     }
     document_store = OpenSearchDocumentStore.from_dict(data)
     assert document_store._hosts == "some hosts"
@@ -66,6 +68,8 @@ def test_from_dict(_mock_opensearch_client):
         ],
     }
     assert document_store._settings == {"index.knn": True}
+    assert document_store._return_embedding is True
+    assert document_store._create_index is False
 
 
 @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
@@ -112,6 +116,29 @@ class TestDocumentStore(DocumentStoreBaseTests):
         )
         yield store
         store.client.indices.delete(index=index, params={"ignore": [400, 404]})
+
+    @pytest.fixture
+    def document_store_readonly(self, request):
+        """
+        This is the most basic requirement for the child class: provide
+        an instance of this document store so the base class can use it.
+        """
+        hosts = ["https://localhost:9200"]
+        # Use a different index for each test so we can run them in parallel
+        index = f"{request.node.name}"
+
+        store = OpenSearchDocumentStore(
+            hosts=hosts,
+            index=index,
+            http_auth=("admin", "admin"),
+            verify_certs=False,
+            embedding_dim=768,
+            method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
+            create_index=False,
+        )
+        store.client.cluster.put_settings(body={"transient": {"action.auto_create_index": False}})
+        yield store
+        store.client.cluster.put_settings(body={"transient": {"action.auto_create_index": True}})
 
     @pytest.fixture
     def document_store_embedding_dim_4(self, request):
@@ -164,6 +191,11 @@ class TestDocumentStore(DocumentStoreBaseTests):
         assert document_store.write_documents(docs) == 1
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents(docs, DuplicatePolicy.FAIL)
+
+    def test_write_documents_readonly(self, document_store_readonly: OpenSearchDocumentStore):
+        docs = [Document(id="1")]
+        with pytest.raises(DocumentStoreError, match="no such index"):
+            document_store_readonly.write_documents(docs)
 
     def test_bm25_retrieval(self, document_store: OpenSearchDocumentStore):
         document_store.write_documents(

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -146,6 +146,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         store.client.cluster.put_settings(body={"transient": {"action.auto_create_index": False}})
         yield store
         store.client.cluster.put_settings(body={"transient": {"action.auto_create_index": True}})
+        store.client.indices.delete(index=index, params={"ignore": [400, 404]})
 
     @pytest.fixture
     def document_store_embedding_dim_4(self, request):
@@ -203,6 +204,10 @@ class TestDocumentStore(DocumentStoreBaseTests):
         docs = [Document(id="1")]
         with pytest.raises(DocumentStoreError, match="no such index"):
             document_store_readonly.write_documents(docs)
+
+    def test_create_index(self, document_store_readonly: OpenSearchDocumentStore):
+        document_store_readonly.create_index()
+        assert document_store_readonly.client.indices.exists(index=document_store_readonly.index)
 
     def test_bm25_retrieval(self, document_store: OpenSearchDocumentStore):
         document_store.write_documents(

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -58,6 +58,8 @@ def test_to_dict(_mock_opensearch_client):
                     "settings": {
                         "index.knn": True,
                     },
+                    "return_embedding": False,
+                    "create_index": True,
                 },
                 "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
             },


### PR DESCRIPTION
### Related Issues

- fixes having left-over indexes due to unintended index creations

### Proposed Changes:
- add `create_index` init param to disable automatic index creation
- add `create_index()` method for more control over (manually) creating indexes

### How did you test it?
- added integration test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
