### PR TITLE
feat: add custom_query param to OpenSearch retrievers

### DIFF
--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -61,7 +61,7 @@ python = ["3.8", "3.9", "3.10", "3.11"]
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243", "jinja2"]
+dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
 style = ["ruff {args:.}", "black --check --diff {args:.}"]

--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -61,7 +61,7 @@ python = ["3.8", "3.9", "3.10", "3.11"]
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
+dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243", "jinja2"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
 style = ["ruff {args:.}", "black --check --diff {args:.}"]

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -19,7 +19,7 @@ class OpenSearchBM25Retriever:
         top_k: int = 10,
         scale_score: bool = False,
         all_terms_must_match: bool = False,
-        custom_query: Optional[str] = None,
+        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
     ):
         """
         Create the OpenSearchBM25Retriever component.
@@ -32,7 +32,7 @@ class OpenSearchBM25Retriever:
             This is useful when comparing documents across different indexes. Defaults to False.
         :param all_terms_must_match: If True, all terms in the query string must be present in the retrieved documents.
             This is useful when searching for short text where even one term can make a difference. Defaults to False.
-        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
+        :param custom_query: The query containing a mandatory `$query` and an optional `$filters` placeholder
 
             **An example custom_query:**
 
@@ -41,10 +41,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": ${query},                 // mandatory query placeholder
+                            "query": $query,                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": ${filters}                  // optional filter placeholder
+                        "filter": $filters                  // optional filter placeholder
                     }
                 }
             }
@@ -113,7 +113,7 @@ class OpenSearchBM25Retriever:
         top_k: Optional[int] = None,
         fuzziness: Optional[str] = None,
         scale_score: Optional[bool] = None,
-        custom_query: Optional[str] = None,
+        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
     ):
         """
         Retrieve documents using BM25 retrieval.
@@ -125,7 +125,7 @@ class OpenSearchBM25Retriever:
         :param fuzziness: Fuzziness parameter for full-text queries.
         :param scale_score: Whether to scale the score of retrieved documents between 0 and 1.
             This is useful when comparing documents across different indexes.
-        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
+        :param custom_query: The query containing a mandatory `$query` and an optional `$filters` placeholder
 
             **An example custom_query:**
 
@@ -134,10 +134,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": ${query},                 // mandatory query placeholder
+                            "query": $query,                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": ${filters}                  // optional filter placeholder
+                        "filter": $filters                  // optional filter placeholder
                     }
                 }
             }

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -19,6 +19,7 @@ class OpenSearchBM25Retriever:
         top_k: int = 10,
         scale_score: bool = False,
         all_terms_must_match: bool = False,
+        custom_query: Optional[str] = None,
     ):
         """
         Create the OpenSearchBM25Retriever component.
@@ -31,6 +32,32 @@ class OpenSearchBM25Retriever:
             This is useful when comparing documents across different indexes. Defaults to False.
         :param all_terms_must_match: If True, all terms in the query string must be present in the retrieved documents.
             This is useful when searching for short text where even one term can make a difference. Defaults to False.
+        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder.
+
+            **An example custom_query:**
+
+            ```python
+            {
+                "size": 10,
+                "query": {
+                    "bool": {
+                        "should": [{"multi_match": {
+                            "query": ${query},                 // mandatory query placeholder
+                            "type": "most_fields",
+                            "fields": ["content", "title"]}}],
+                        "filter": ${filters}                  // optional filter placeholder
+                    }
+                }
+            }
+            ```
+
+        **For this custom_query, a sample `run()` could be:**
+
+        ```python
+        retriever.run(query="Why did the revenue increase?",
+                        filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
+        ```
+
         :raises ValueError: If `document_store` is not an instance of OpenSearchDocumentStore.
 
         """
@@ -44,6 +71,7 @@ class OpenSearchBM25Retriever:
         self._top_k = top_k
         self._scale_score = scale_score
         self._all_terms_must_match = all_terms_must_match
+        self._custom_query = custom_query
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -121,5 +149,6 @@ class OpenSearchBM25Retriever:
             top_k=top_k,
             scale_score=scale_score,
             all_terms_must_match=all_terms_must_match,
+            custom_query=self._custom_query,
         )
         return {"documents": docs}

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -32,8 +32,7 @@ class OpenSearchBM25Retriever:
             This is useful when comparing documents across different indexes. Defaults to False.
         :param all_terms_must_match: If True, all terms in the query string must be present in the retrieved documents.
             This is useful when searching for short text where even one term can make a difference. Defaults to False.
-        :param custom_query: The query string containing a mandatory `{{ query }}` and an optional `{{ filters }}`
-            placeholder
+        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
 
             **An example custom_query:**
 
@@ -42,10 +41,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": {{ query }},                 // mandatory query placeholder
+                            "query": ${query},                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": {{ filters }}                  // optional filter placeholder
+                        "filter": ${filters}                  // optional filter placeholder
                     }
                 }
             }
@@ -126,8 +125,7 @@ class OpenSearchBM25Retriever:
         :param fuzziness: Fuzziness parameter for full-text queries.
         :param scale_score: Whether to scale the score of retrieved documents between 0 and 1.
             This is useful when comparing documents across different indexes.
-        :param custom_query: The query string containing a mandatory `{{ query }}` and an optional `{{ filters }}`
-            placeholder
+        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
 
             **An example custom_query:**
 
@@ -136,10 +134,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": {{ query }},                 // mandatory query placeholder
+                            "query": ${query},                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": {{ filters }}                  // optional filter placeholder
+                        "filter": ${filters}                  // optional filter placeholder
                     }
                 }
             }
@@ -151,6 +149,7 @@ class OpenSearchBM25Retriever:
         retriever.run(query="Why did the revenue increase?",
                         filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
         ```
+
 
         :returns:
             A dictionary containing the retrieved documents with the following structure:

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -113,6 +113,7 @@ class OpenSearchBM25Retriever:
         top_k: Optional[int] = None,
         fuzziness: Optional[str] = None,
         scale_score: Optional[bool] = None,
+        custom_query: Optional[str] = None,
     ):
         """
         Retrieve documents using BM25 retrieval.
@@ -124,6 +125,31 @@ class OpenSearchBM25Retriever:
         :param fuzziness: Fuzziness parameter for full-text queries.
         :param scale_score: Whether to scale the score of retrieved documents between 0 and 1.
             This is useful when comparing documents across different indexes.
+        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
+
+            **An example custom_query:**
+
+            ```python
+            {
+                "query": {
+                    "bool": {
+                        "should": [{"multi_match": {
+                            "query": ${query},                 // mandatory query placeholder
+                            "type": "most_fields",
+                            "fields": ["content", "title"]}}],
+                        "filter": ${filters}                  // optional filter placeholder
+                    }
+                }
+            }
+            ```
+
+        **For this custom_query, a sample `run()` could be:**
+
+        ```python
+        retriever.run(query="Why did the revenue increase?",
+                        filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
+        ```
+
 
         :returns:
             A dictionary containing the retrieved documents with the following structure:
@@ -140,6 +166,8 @@ class OpenSearchBM25Retriever:
             fuzziness = self._fuzziness
         if scale_score is None:
             scale_score = self._scale_score
+        if custom_query is None:
+            custom_query = self._custom_query
 
         docs = self._document_store._bm25_retrieval(
             query=query,
@@ -148,6 +176,6 @@ class OpenSearchBM25Retriever:
             top_k=top_k,
             scale_score=scale_score,
             all_terms_must_match=all_terms_must_match,
-            custom_query=self._custom_query,
+            custom_query=custom_query,
         )
         return {"documents": docs}

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -32,13 +32,12 @@ class OpenSearchBM25Retriever:
             This is useful when comparing documents across different indexes. Defaults to False.
         :param all_terms_must_match: If True, all terms in the query string must be present in the retrieved documents.
             This is useful when searching for short text where even one term can make a difference. Defaults to False.
-        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder.
+        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
 
             **An example custom_query:**
 
             ```python
             {
-                "size": 10,
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -19,7 +19,7 @@ class OpenSearchBM25Retriever:
         top_k: int = 10,
         scale_score: bool = False,
         all_terms_must_match: bool = False,
-        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
     ):
         """
         Create the OpenSearchBM25Retriever component.
@@ -41,10 +41,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": $query,                 // mandatory query placeholder
+                            "query": "$query",                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": $filters                  // optional filter placeholder
+                        "filter": "$filters"                  // optional filter placeholder
                     }
                 }
             }
@@ -113,7 +113,7 @@ class OpenSearchBM25Retriever:
         top_k: Optional[int] = None,
         fuzziness: Optional[str] = None,
         scale_score: Optional[bool] = None,
-        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
     ):
         """
         Retrieve documents using BM25 retrieval.
@@ -134,10 +134,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": $query,                 // mandatory query placeholder
+                            "query": "$query",                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": $filters                  // optional filter placeholder
+                        "filter": "$filters"                  // optional filter placeholder
                     }
                 }
             }

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -32,7 +32,8 @@ class OpenSearchBM25Retriever:
             This is useful when comparing documents across different indexes. Defaults to False.
         :param all_terms_must_match: If True, all terms in the query string must be present in the retrieved documents.
             This is useful when searching for short text where even one term can make a difference. Defaults to False.
-        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
+        :param custom_query: The query string containing a mandatory `{{ query }}` and an optional `{{ filters }}`
+            placeholder
 
             **An example custom_query:**
 
@@ -41,10 +42,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": ${query},                 // mandatory query placeholder
+                            "query": {{ query }},                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": ${filters}                  // optional filter placeholder
+                        "filter": {{ filters }}                  // optional filter placeholder
                     }
                 }
             }
@@ -125,7 +126,8 @@ class OpenSearchBM25Retriever:
         :param fuzziness: Fuzziness parameter for full-text queries.
         :param scale_score: Whether to scale the score of retrieved documents between 0 and 1.
             This is useful when comparing documents across different indexes.
-        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
+        :param custom_query: The query string containing a mandatory `{{ query }}` and an optional `{{ filters }}`
+            placeholder
 
             **An example custom_query:**
 
@@ -134,10 +136,10 @@ class OpenSearchBM25Retriever:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": ${query},                 // mandatory query placeholder
+                            "query": {{ query }},                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": ${filters}                  // optional filter placeholder
+                        "filter": {{ filters }}                  // optional filter placeholder
                     }
                 }
             }
@@ -149,7 +151,6 @@ class OpenSearchBM25Retriever:
         retriever.run(query="Why did the revenue increase?",
                         filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
         ```
-
 
         :returns:
             A dictionary containing the retrieved documents with the following structure:

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -31,8 +31,8 @@ class OpenSearchEmbeddingRetriever:
         :param filters: Filters applied to the retrieved Documents. Defaults to None.
             Filters are applied during the approximate kNN search to ensure that top_k matching documents are returned.
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
-            placeholder
+        :param custom_query: The query string containing a mandatory `{{ query_embedding }}` and an optional
+            `{{ filters }}` placeholder
 
             **An example custom_query:**
 
@@ -44,13 +44,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "vector": {{ query_embedding }},   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": ${filters}                            // optional filter placeholder
+                        "filter": {{ filters }}                            // optional filter placeholder
                     }
                 }
             }
@@ -118,8 +118,8 @@ class OpenSearchEmbeddingRetriever:
         :param query_embedding: Embedding of the query.
         :param filters: Optional filters to narrow down the search space.
         :param top_k: Maximum number of Documents to return.
-        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
-            placeholder
+        :param custom_query: The query string containing a mandatory `{{ query_embedding }}` and an optional
+            `{{ filters }}` placeholder
 
             **An example custom_query:**
 
@@ -131,13 +131,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "vector": {{ query_embedding }},   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": ${filters}                            // optional filter placeholder
+                        "filter": {{ filters }}                            // optional filter placeholder
                     }
                 }
             }

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -22,6 +22,7 @@ class OpenSearchEmbeddingRetriever:
         document_store: OpenSearchDocumentStore,
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 10,
+        custom_query: Optional[str] = None,
     ):
         """
         Create the OpenSearchEmbeddingRetriever component.
@@ -30,6 +31,33 @@ class OpenSearchEmbeddingRetriever:
         :param filters: Filters applied to the retrieved Documents. Defaults to None.
             Filters are applied during the approximate kNN search to ensure that top_k matching documents are returned.
         :param top_k: Maximum number of Documents to return, defaults to 10
+        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}` placeholder.
+
+            **An example custom_query:**
+
+            ```python
+            {
+                "size": 10,
+                "query": {
+                    "bool": {
+                        "must": [{"knn": {
+                            "embedding": {
+                                "vector": ${query_embedding},   // mandatory query placeholder
+                                "k": 10000,
+                            }}],
+                        "filter": ${filters}                  // optional filter placeholder
+                    }
+                }
+            }
+            ```
+
+        **For this custom_query, a sample `run()` could be:**
+
+        ```python
+        retriever.run(query_embedding=embedding,
+                        filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
+        ```
+
         :raises ValueError: If `document_store` is not an instance of OpenSearchDocumentStore.
         """
         if not isinstance(document_store, OpenSearchDocumentStore):
@@ -39,6 +67,7 @@ class OpenSearchEmbeddingRetriever:
         self._document_store = document_store
         self._filters = filters or {}
         self._top_k = top_k
+        self._custom_query = custom_query
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -91,5 +120,6 @@ class OpenSearchEmbeddingRetriever:
             query_embedding=query_embedding,
             filters=filters,
             top_k=top_k,
+            custom_query=self._custom_query,
         )
         return {"documents": docs}

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -105,7 +105,13 @@ class OpenSearchEmbeddingRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, query_embedding: List[float], filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = None, custom_query: Optional[str] = None,):
+    def run(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        custom_query: Optional[str] = None,
+    ):
         """
         Retrieve documents using a vector similarity metric.
 

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -31,21 +31,26 @@ class OpenSearchEmbeddingRetriever:
         :param filters: Filters applied to the retrieved Documents. Defaults to None.
             Filters are applied during the approximate kNN search to ensure that top_k matching documents are returned.
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}` placeholder.
+        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
+            placeholder
 
             **An example custom_query:**
 
             ```python
             {
-                "size": 10,
                 "query": {
                     "bool": {
-                        "must": [{"knn": {
-                            "embedding": {
-                                "vector": ${query_embedding},   // mandatory query placeholder
-                                "k": 10000,
-                            }}],
-                        "filter": ${filters}                  // optional filter placeholder
+                        "must": [
+                            {
+                                "knn": {
+                                    "embedding": {
+                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "k": 10000,
+                                    }
+                                }
+                            }
+                        ],
+                        "filter": ${filters}                            // optional filter placeholder
                     }
                 }
             }

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -105,13 +105,45 @@ class OpenSearchEmbeddingRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, query_embedding: List[float], filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = None):
+    def run(self, query_embedding: List[float], filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = None, custom_query: Optional[str] = None,):
         """
         Retrieve documents using a vector similarity metric.
 
         :param query_embedding: Embedding of the query.
         :param filters: Optional filters to narrow down the search space.
         :param top_k: Maximum number of Documents to return.
+        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
+            placeholder
+
+            **An example custom_query:**
+
+            ```python
+            {
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "knn": {
+                                    "embedding": {
+                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "k": 10000,
+                                    }
+                                }
+                            }
+                        ],
+                        "filter": ${filters}                            // optional filter placeholder
+                    }
+                }
+            }
+            ```
+
+        **For this custom_query, a sample `run()` could be:**
+
+        ```python
+        retriever.run(query_embedding=embedding,
+                        filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
+        ```
+
         :returns:
             Dictionary with key "documents" containing the retrieved Documents.
             - documents: List of Document similar to `query_embedding`.
@@ -120,11 +152,13 @@ class OpenSearchEmbeddingRetriever:
             filters = self._filters
         if top_k is None:
             top_k = self._top_k
+        if custom_query is None:
+            custom_query = self._custom_query
 
         docs = self._document_store._embedding_retrieval(
             query_embedding=query_embedding,
             filters=filters,
             top_k=top_k,
-            custom_query=self._custom_query,
+            custom_query=custom_query,
         )
         return {"documents": docs}

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -22,7 +22,7 @@ class OpenSearchEmbeddingRetriever:
         document_store: OpenSearchDocumentStore,
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 10,
-        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
     ):
         """
         Create the OpenSearchEmbeddingRetriever component.
@@ -43,13 +43,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": $query_embedding,   // mandatory query placeholder
+                                        "vector": "$query_embedding",   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": $filters                            // optional filter placeholder
+                        "filter": "$filters"                            // optional filter placeholder
                     }
                 }
             }
@@ -109,7 +109,7 @@ class OpenSearchEmbeddingRetriever:
         query_embedding: List[float],
         filters: Optional[Dict[str, Any]] = None,
         top_k: Optional[int] = None,
-        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
     ):
         """
         Retrieve documents using a vector similarity metric.
@@ -129,13 +129,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": $query_embedding,   // mandatory query placeholder
+                                        "vector": "$query_embedding",   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": $filters                            // optional filter placeholder
+                        "filter": "$filters"                            // optional filter placeholder
                     }
                 }
             }

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -22,7 +22,7 @@ class OpenSearchEmbeddingRetriever:
         document_store: OpenSearchDocumentStore,
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 10,
-        custom_query: Optional[str] = None,
+        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
     ):
         """
         Create the OpenSearchEmbeddingRetriever component.
@@ -31,8 +31,7 @@ class OpenSearchEmbeddingRetriever:
         :param filters: Filters applied to the retrieved Documents. Defaults to None.
             Filters are applied during the approximate kNN search to ensure that top_k matching documents are returned.
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
-            placeholder
+        :param custom_query: The query containing a mandatory `$query_embedding` and an optional `$filters` placeholder
 
             **An example custom_query:**
 
@@ -44,13 +43,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "vector": $query_embedding,   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": ${filters}                            // optional filter placeholder
+                        "filter": $filters                            // optional filter placeholder
                     }
                 }
             }
@@ -110,7 +109,7 @@ class OpenSearchEmbeddingRetriever:
         query_embedding: List[float],
         filters: Optional[Dict[str, Any]] = None,
         top_k: Optional[int] = None,
-        custom_query: Optional[str] = None,
+        custom_query: Optional[Union[str, Dict[str, Any]]] = None,
     ):
         """
         Retrieve documents using a vector similarity metric.
@@ -118,8 +117,7 @@ class OpenSearchEmbeddingRetriever:
         :param query_embedding: Embedding of the query.
         :param filters: Optional filters to narrow down the search space.
         :param top_k: Maximum number of Documents to return.
-        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
-            placeholder
+        :param custom_query: The query containing a mandatory `$query_embedding` and an optional `$filters` placeholder
 
             **An example custom_query:**
 
@@ -131,13 +129,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "vector": $query_embedding,   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": ${filters}                            // optional filter placeholder
+                        "filter": $filters                            // optional filter placeholder
                     }
                 }
             }

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -31,8 +31,8 @@ class OpenSearchEmbeddingRetriever:
         :param filters: Filters applied to the retrieved Documents. Defaults to None.
             Filters are applied during the approximate kNN search to ensure that top_k matching documents are returned.
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param custom_query: The query string containing a mandatory `{{ query_embedding }}` and an optional
-            `{{ filters }}` placeholder
+        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
+            placeholder
 
             **An example custom_query:**
 
@@ -44,13 +44,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": {{ query_embedding }},   // mandatory query placeholder
+                                        "vector": ${query_embedding},   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": {{ filters }}                            // optional filter placeholder
+                        "filter": ${filters}                            // optional filter placeholder
                     }
                 }
             }
@@ -118,8 +118,8 @@ class OpenSearchEmbeddingRetriever:
         :param query_embedding: Embedding of the query.
         :param filters: Optional filters to narrow down the search space.
         :param top_k: Maximum number of Documents to return.
-        :param custom_query: The query string containing a mandatory `{{ query_embedding }}` and an optional
-            `{{ filters }}` placeholder
+        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
+            placeholder
 
             **An example custom_query:**
 
@@ -131,13 +131,13 @@ class OpenSearchEmbeddingRetriever:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": {{ query_embedding }},   // mandatory query placeholder
+                                        "vector": ${query_embedding},   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": {{ filters }}                            // optional filter placeholder
+                        "filter": ${filters}                            // optional filter placeholder
                     }
                 }
             }

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import json
 import logging
-from string import Template
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import numpy as np

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -303,13 +303,12 @@ class OpenSearchDocumentStore:
         :param top_k: Maximum number of Documents to return, defaults to 10
         :param scale_score: If `True` scales the Document`s scores between 0 and 1, defaults to False
         :param all_terms_must_match: If `True` all terms in `query` must be present in the Document, defaults to False
-        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder.
+        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
 
             **An example custom_query:**
 
             ```python
             {
-                "size": 10,
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
@@ -330,7 +329,7 @@ class OpenSearchDocumentStore:
             body: Dict[str, Any] = {"query": {"bool": {"must": {"match_all": {}}}}}
             if filters:
                 body["query"]["bool"]["filter"] = normalize_filters(filters)
-        
+
         if custom_query:
             template = Template(custom_query)
             # substitute placeholder for query and filters for the custom_query template string
@@ -343,7 +342,7 @@ class OpenSearchDocumentStore:
 
         else:
             operator = "AND" if all_terms_must_match else "OR"
-            body: Dict[str, Any] = {
+            body = {
                 "query": {
                     "bool": {
                         "must": [
@@ -398,21 +397,25 @@ class OpenSearchDocumentStore:
         :param filters: Filters applied to the retrieved Documents. Defaults to None.
             Filters are applied during the approximate kNN search to ensure that top_k matching documents are returned.
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}` placeholder.
+        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
+            placeholder
 
             **An example custom_query:**
-
             ```python
             {
-                "size": 10,
                 "query": {
                     "bool": {
-                        "must": [{"knn": {
-                            "embedding": {
-                                "vector": ${query_embedding},   // mandatory query placeholder
-                                "k": 10000,
-                            }}],
-                        "filter": ${filters}                  // optional filter placeholder
+                        "must": [
+                            {
+                                "knn": {
+                                    "embedding": {
+                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "k": 10000,
+                                    }
+                                }
+                            }
+                        ],
+                        "filter": ${filters}                            // optional filter placeholder
                     }
                 }
             }
@@ -437,7 +440,7 @@ class OpenSearchDocumentStore:
             body = json.loads(custom_query_json)
 
         else:
-            body: Dict[str, Any] = {
+            body = {
                 "query": {
                     "bool": {
                         "must": [

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import logging
-from string import Template
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import numpy as np
@@ -13,6 +12,7 @@ from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumen
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils.filters import convert
 from haystack_integrations.document_stores.opensearch.filters import normalize_filters
+from jinja2 import Template
 from opensearchpy import OpenSearch
 from opensearchpy.helpers import bulk
 
@@ -303,7 +303,8 @@ class OpenSearchDocumentStore:
         :param top_k: Maximum number of Documents to return, defaults to 10
         :param scale_score: If `True` scales the Document`s scores between 0 and 1, defaults to False
         :param all_terms_must_match: If `True` all terms in `query` must be present in the Document, defaults to False
-        :param custom_query: The query string containing a mandatory `${query}` and an optional `${filters}` placeholder
+        :param custom_query: The query string containing a mandatory `{{ query }}` and an optional `{{ filters }}`
+            placeholder
 
             **An example custom_query:**
 
@@ -312,10 +313,10 @@ class OpenSearchDocumentStore:
                 "query": {
                     "bool": {
                         "should": [{"multi_match": {
-                            "query": ${query},                 // mandatory query placeholder
+                            "query": {{ query }},                 // mandatory query placeholder
                             "type": "most_fields",
                             "fields": ["content", "title"]}}],
-                        "filter": ${filters}                  // optional filter placeholder
+                        "filter": {{ filters }}                  // optional filter placeholder
                     }
                 }
             }
@@ -337,7 +338,7 @@ class OpenSearchDocumentStore:
                 "query": json.dumps(query),
                 "filters": json.dumps(normalize_filters(filters)),
             }
-            custom_query_json = template.substitute(**substitutions)
+            custom_query_json = template.render(substitutions)
             body = json.loads(custom_query_json)
 
         else:
@@ -397,8 +398,8 @@ class OpenSearchDocumentStore:
         :param filters: Filters applied to the retrieved Documents. Defaults to None.
             Filters are applied during the approximate kNN search to ensure that top_k matching documents are returned.
         :param top_k: Maximum number of Documents to return, defaults to 10
-        :param custom_query: The query string containing a mandatory `${query_embedding}` and an optional `${filters}`
-            placeholder
+        :param custom_query: The query string containing a mandatory `{{ query_embedding }}` and an optional
+            `{{ filters }}` placeholder
 
             **An example custom_query:**
             ```python
@@ -409,13 +410,13 @@ class OpenSearchDocumentStore:
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": ${query_embedding},   // mandatory query placeholder
+                                        "vector": {{ query_embedding }},   // mandatory query placeholder
                                         "k": 10000,
                                     }
                                 }
                             }
                         ],
-                        "filter": ${filters}                            // optional filter placeholder
+                        "filter": {{ filters }}                            // optional filter placeholder
                     }
                 }
             }
@@ -436,7 +437,7 @@ class OpenSearchDocumentStore:
                 "query_embedding": json.dumps(query_embedding),
                 "filters": json.dumps(normalize_filters(filters)),
             }
-            custom_query_json = template.substitute(**substitutions)
+            custom_query_json = template.render(substitutions)
             body = json.loads(custom_query_json)
 
         else:

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -106,7 +106,7 @@ def test_run_init_params():
         scale_score=True,
         top_k=11,
         fuzziness="1",
-        custom_query="some custom query",
+        custom_query={"some": "custom query"},
     )
     res = retriever.run(query="some query")
     mock_store._bm25_retrieval.assert_called_once_with(
@@ -116,7 +116,7 @@ def test_run_init_params():
         top_k=11,
         scale_score=True,
         all_terms_must_match=True,
-        custom_query="some custom query",
+        custom_query={"some": "custom query"},
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -89,6 +89,7 @@ def test_run():
         top_k=10,
         scale_score=False,
         all_terms_must_match=False,
+        custom_query=None,
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1
@@ -105,6 +106,7 @@ def test_run_init_params():
         scale_score=True,
         top_k=11,
         fuzziness="1",
+        custom_query="some custom query",
     )
     res = retriever.run(query="some query")
     mock_store._bm25_retrieval.assert_called_once_with(
@@ -114,6 +116,7 @@ def test_run_init_params():
         top_k=11,
         scale_score=True,
         all_terms_must_match=True,
+        custom_query="some custom query",
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1
@@ -146,6 +149,7 @@ def test_run_time_params():
         top_k=9,
         scale_score=False,
         all_terms_must_match=False,
+        custom_query=None,
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -361,10 +361,10 @@ class TestDocumentStore(DocumentStoreBaseTests):
                             "bool": {
                                 "must": {
                                     "match": {
-                                        "content": {{ query }}
+                                        "content": $query
                                     }
                                 },
-                                "filter": {{ filters }}
+                                "filter": $filters
                             }
                         },
                         "field_value_factor": {
@@ -460,13 +460,13 @@ class TestDocumentStore(DocumentStoreBaseTests):
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": {{ query_embedding }},
+                                        "vector": $query_embedding,
                                         "k": 3
                                     }
                                 }
                             }
                         ],
-                        "filter": {{ filters }}
+                        "filter": $filters
                     }
                 }
             }

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -361,10 +361,10 @@ class TestDocumentStore(DocumentStoreBaseTests):
                             "bool": {
                                 "must": {
                                     "match": {
-                                        "content": $query
+                                        "content": {{ query }}
                                     }
                                 },
-                                "filter": $filters
+                                "filter": {{ filters }}
                             }
                         },
                         "field_value_factor": {
@@ -460,13 +460,13 @@ class TestDocumentStore(DocumentStoreBaseTests):
                             {
                                 "knn": {
                                     "embedding": {
-                                        "vector": $query_embedding,
+                                        "vector": {{ query_embedding }},
                                         "k": 3
                                     }
                                 }
                             }
                         ],
-                        "filter": $filters
+                        "filter": {{ filters }}
                     }
                 }
             }

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -292,7 +292,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         assert "functional" in res[1].content
         assert "functional" in res[2].content
 
-    def test_bm25_retrieval_with_custom_query_dict(self, document_store: OpenSearchDocumentStore):
+    def test_bm25_retrieval_with_custom_query(self, document_store: OpenSearchDocumentStore):
         document_store.write_documents(
             [
                 Document(
@@ -373,103 +373,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
         assert "2" == res[1].id
         assert "3" == res[2].id
 
-    def test_bm25_retrieval_with_custom_query_str(self, document_store: OpenSearchDocumentStore):
-        document_store.write_documents(
-            [
-                Document(
-                    content="Haskell is a functional programming language",
-                    meta={"likes": 100000, "language_type": "functional"},
-                    id="1",
-                ),
-                Document(
-                    content="Lisp is a functional programming language",
-                    meta={"likes": 10000, "language_type": "functional"},
-                    id="2",
-                ),
-                Document(
-                    content="Exilir is a functional programming language",
-                    meta={"likes": 1000, "language_type": "functional"},
-                    id="3",
-                ),
-                Document(
-                    content="F# is a functional programming language",
-                    meta={"likes": 100, "language_type": "functional"},
-                    id="4",
-                ),
-                Document(
-                    content="C# is a functional programming language",
-                    meta={"likes": 10, "language_type": "functional"},
-                    id="5",
-                ),
-                Document(
-                    content="C++ is an object oriented programming language",
-                    meta={"likes": 100000, "language_type": "object_oriented"},
-                    id="6",
-                ),
-                Document(
-                    content="Dart is an object oriented programming language",
-                    meta={"likes": 10000, "language_type": "object_oriented"},
-                    id="7",
-                ),
-                Document(
-                    content="Go is an object oriented programming language",
-                    meta={"likes": 1000, "language_type": "object_oriented"},
-                    id="8",
-                ),
-                Document(
-                    content="Python is a object oriented programming language",
-                    meta={"likes": 100, "language_type": "object_oriented"},
-                    id="9",
-                ),
-                Document(
-                    content="Ruby is a object oriented programming language",
-                    meta={"likes": 10, "language_type": "object_oriented"},
-                    id="10",
-                ),
-                Document(
-                    content="PHP is a object oriented programming language",
-                    meta={"likes": 1, "language_type": "object_oriented"},
-                    id="11",
-                ),
-            ]
-        )
-
-        custom_query = """
-            {
-                "query": {
-                    "function_score": {
-                        "query": {
-                            "bool": {
-                                "must": {
-                                    "match": {
-                                        "content": $query
-                                    }
-                                },
-                                "filter": $filters
-                            }
-                        },
-                        "field_value_factor": {
-                            "field": "likes",
-                            "factor": 0.1,
-                            "modifier": "log1p",
-                            "missing": 0
-                        }
-                    }
-                }
-            }
-        """
-
-        res = document_store._bm25_retrieval(
-            "functional",
-            top_k=3,
-            custom_query=custom_query,
-            filters={"field": "language_type", "operator": "==", "value": "functional"},
-        )
-        assert len(res) == 3
-        assert "1" == res[0].id
-        assert "2" == res[1].id
-        assert "3" == res[2].id
-
     def test_embedding_retrieval(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
         docs = [
             Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
@@ -521,7 +424,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         )
         assert len(results) == 11
 
-    def test_embedding_retrieval_with_custom_query_dict(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
+    def test_embedding_retrieval_with_custom_query(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
         docs = [
             Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
             Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
@@ -538,45 +441,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
                 "bool": {"must": [{"knn": {"embedding": {"vector": "$query_embedding", "k": 3}}}], "filter": "$filters"}
             }
         }
-
-        filters = {"field": "meta_field", "operator": "==", "value": "custom_value"}
-        results = document_store_embedding_dim_4._embedding_retrieval(
-            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, filters=filters, custom_query=custom_query
-        )
-        assert len(results) == 1
-        assert results[0].content == "Not very similar document with meta field"
-
-    def test_embedding_retrieval_with_custom_query_str(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
-        docs = [
-            Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
-            Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
-            Document(
-                content="Not very similar document with meta field",
-                embedding=[0.0, 0.8, 0.3, 0.9],
-                meta={"meta_field": "custom_value"},
-            ),
-        ]
-        document_store_embedding_dim_4.write_documents(docs)
-
-        custom_query = """
-            {
-                "query": {
-                    "bool": {
-                        "must": [
-                            {
-                                "knn": {
-                                    "embedding": {
-                                        "vector": $query_embedding,
-                                        "k": 3
-                                    }
-                                }
-                            }
-                        ],
-                        "filter": $filters
-                    }
-                }
-            }
-        """
 
         filters = {"field": "meta_field", "operator": "==", "value": "custom_value"}
         results = document_store_embedding_dim_4._embedding_retrieval(

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -292,6 +292,103 @@ class TestDocumentStore(DocumentStoreBaseTests):
         assert "functional" in res[1].content
         assert "functional" in res[2].content
 
+    def test_bm25_retrieval_with_custom_query(self, document_store: OpenSearchDocumentStore):
+        document_store.write_documents(
+            [
+                Document(
+                    content="Haskell is a functional programming language",
+                    meta={"likes": 100000, "language_type": "functional"},
+                    id="1",
+                ),
+                Document(
+                    content="Lisp is a functional programming language",
+                    meta={"likes": 10000, "language_type": "functional"},
+                    id="2",
+                ),
+                Document(
+                    content="Exilir is a functional programming language",
+                    meta={"likes": 1000, "language_type": "functional"},
+                    id="3",
+                ),
+                Document(
+                    content="F# is a functional programming language",
+                    meta={"likes": 100, "language_type": "functional"},
+                    id="4",
+                ),
+                Document(
+                    content="C# is a functional programming language",
+                    meta={"likes": 10, "language_type": "functional"},
+                    id="5",
+                ),
+                Document(
+                    content="C++ is an object oriented programming language",
+                    meta={"likes": 100000, "language_type": "object_oriented"},
+                    id="6",
+                ),
+                Document(
+                    content="Dart is an object oriented programming language",
+                    meta={"likes": 10000, "language_type": "object_oriented"},
+                    id="7",
+                ),
+                Document(
+                    content="Go is an object oriented programming language",
+                    meta={"likes": 1000, "language_type": "object_oriented"},
+                    id="8",
+                ),
+                Document(
+                    content="Python is a object oriented programming language",
+                    meta={"likes": 100, "language_type": "object_oriented"},
+                    id="9",
+                ),
+                Document(
+                    content="Ruby is a object oriented programming language",
+                    meta={"likes": 10, "language_type": "object_oriented"},
+                    id="10",
+                ),
+                Document(
+                    content="PHP is a object oriented programming language",
+                    meta={"likes": 1, "language_type": "object_oriented"},
+                    id="11",
+                ),
+            ]
+        )
+
+        custom_query = """
+            {
+                "query": {
+                    "function_score": {
+                        "query": {
+                            "bool": {
+                                "must": {
+                                    "match": {
+                                        "content": $query
+                                    }
+                                },
+                                "filter": $filters
+                            }
+                        },
+                        "field_value_factor": {
+                            "field": "likes",
+                            "factor": 0.1,
+                            "modifier": "log1p",
+                            "missing": 0
+                        }
+                    }
+                }
+            }
+        """
+
+        res = document_store._bm25_retrieval(
+            "functional",
+            top_k=3,
+            custom_query=custom_query,
+            filters={"field": "language_type", "operator": "==", "value": "functional"},
+        )
+        assert len(res) == 3
+        assert "1" == res[0].id
+        assert "2" == res[1].id
+        assert "3" == res[2].id
+
     def test_embedding_retrieval(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
         docs = [
             Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
@@ -342,6 +439,47 @@ class TestDocumentStore(DocumentStoreBaseTests):
             query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=11, filters={}
         )
         assert len(results) == 11
+
+    def test_embedding_retrieval_with_custom_query(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
+        docs = [
+            Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
+            Document(
+                content="Not very similar document with meta field",
+                embedding=[0.0, 0.8, 0.3, 0.9],
+                meta={"meta_field": "custom_value"},
+            ),
+        ]
+        document_store_embedding_dim_4.write_documents(docs)
+
+        custom_query = """
+            {
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "knn": {
+                                    "embedding": {
+                                        "vector": $query_embedding,
+                                        "k": 3
+                                    }
+                                }
+                            }
+                        ],
+                        "filter": $filters
+                    }
+                }
+            }
+        """
+
+        filters = {"field": "meta_field", "operator": "==", "value": "custom_value"}
+        # we set top_k=3, to make the test pass as we are not sure whether efficient filtering is supported for nmslib
+        # TODO: remove top_k=3, when efficient filtering is supported for nmslib
+        results = document_store_embedding_dim_4._embedding_retrieval(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, filters=filters, custom_query=custom_query
+        )
+        assert len(results) == 1
+        assert results[0].content == "Not very similar document with meta field"
 
     def test_embedding_retrieval_query_documents_different_embedding_sizes(
         self, document_store_embedding_dim_4: OpenSearchDocumentStore

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -540,8 +540,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
         }
 
         filters = {"field": "meta_field", "operator": "==", "value": "custom_value"}
-        # we set top_k=3, to make the test pass as we are not sure whether efficient filtering is supported for nmslib
-        # TODO: remove top_k=3, when efficient filtering is supported for nmslib
         results = document_store_embedding_dim_4._embedding_retrieval(
             query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, filters=filters, custom_query=custom_query
         )
@@ -581,8 +579,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
         """
 
         filters = {"field": "meta_field", "operator": "==", "value": "custom_value"}
-        # we set top_k=3, to make the test pass as we are not sure whether efficient filtering is supported for nmslib
-        # TODO: remove top_k=3, when efficient filtering is supported for nmslib
         results = document_store_embedding_dim_4._embedding_retrieval(
             query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, filters=filters, custom_query=custom_query
         )

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -96,6 +96,7 @@ def test_run():
         query_embedding=[0.5, 0.7],
         filters={},
         top_k=10,
+        custom_query=None,
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1
@@ -106,12 +107,15 @@ def test_run():
 def test_run_init_params():
     mock_store = Mock(spec=OpenSearchDocumentStore)
     mock_store._embedding_retrieval.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]
-    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store, filters={"from": "init"}, top_k=11)
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store, filters={"from": "init"}, top_k=11, custom_query="custom_query"
+    )
     res = retriever.run(query_embedding=[0.5, 0.7])
     mock_store._embedding_retrieval.assert_called_once_with(
         query_embedding=[0.5, 0.7],
         filters={"from": "init"},
         top_k=11,
+        custom_query="custom_query",
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1
@@ -128,6 +132,7 @@ def test_run_time_params():
         query_embedding=[0.5, 0.7],
         filters={"from": "run"},
         top_k=9,
+        custom_query=None,
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1


### PR DESCRIPTION
### Related Issues

- fixes support for custom OpenSearch queries

### Proposed Changes:
- add `custom_query` param
- we support ~`str`~ and `dict` as custom_query: the former is easier to use with YAML, the latter is easier to use with ~python~JSON

### How did you test it?
- added tests

### Notes for the reviewer
- What do I mean with easier with YAML? See how a already properly formated OpenSearch query in JSON can be simply copied into yaml under https://docs.cloud.deepset.ai/docs/opensearch-queries-for-boosting-retrieval#used-in-a-pipeline 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
