### PR TITLE
feat: Use non-gated tokenizer as fallback for mistral in AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -338,10 +338,12 @@ class MistralChatAdapter(BedrockModelChatAdapter):
             tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
         else:
             tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained("NousResearch/Llama-2-7b-chat-hf")
-            logger.warning(f"Gated mistralai/Mistral-7B-Instruct-v0.1 model cannot be used as a tokenizer for "
-                           f"estimating the prompt length because no HF_TOKEN was found. Using "
-                           f"NousResearch/Llama-2-7b-chat-hf instead. To use a mistral tokenizer export an env var "
-                           f"HF_TOKEN containing a Hugging Face token and make sure you have access to the model.")
+            logger.warning(
+                "Gated mistralai/Mistral-7B-Instruct-v0.1 model cannot be used as a tokenizer for "
+                "estimating the prompt length because no HF_TOKEN was found. Using "
+                "NousResearch/Llama-2-7b-chat-hf instead. To use a mistral tokenizer export an env var "
+                "HF_TOKEN containing a Hugging Face token and make sure you have access to the model."
+            )
 
         self.prompt_handler = DefaultPromptHandler(
             tokenizer=tokenizer,

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -334,10 +334,11 @@ class MistralChatAdapter(BedrockModelChatAdapter):
         # a) we should get good estimates for the prompt length
         # b) we can use apply_chat_template with the template above to delineate ChatMessages
         # Mistral models are gated on HF Hub. If no HF_TOKEN is found we use a non-gated alternative tokenizer model.
+        tokenizer: PreTrainedTokenizer
         if os.environ.get("HF_TOKEN"):
-            tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
+            tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
         else:
-            tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained("NousResearch/Llama-2-7b-chat-hf")
+            tokenizer = AutoTokenizer.from_pretrained("NousResearch/Llama-2-7b-chat-hf")
             logger.warning(
                 "Gated mistralai/Mistral-7B-Instruct-v0.1 model cannot be used as a tokenizer for "
                 "estimating the prompt length because no HF_TOKEN was found. Using "

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -246,7 +246,7 @@ class TestMistralAdapter:
         with (
             patch("transformers.AutoTokenizer.from_pretrained") as mock_pretrained,
             patch("haystack_integrations.components.generators.amazon_bedrock.chat.adapters.DefaultPromptHandler"),
-            caplog.at_level(logging.WARNING)
+            caplog.at_level(logging.WARNING),
         ):
             MistralChatAdapter(generation_kwargs={})
             mock_pretrained.assert_called_with("NousResearch/Llama-2-7b-chat-hf")
@@ -256,7 +256,7 @@ class TestMistralAdapter:
         monkeypatch.setenv("HF_TOKEN", "test")
         with (
             patch("transformers.AutoTokenizer.from_pretrained") as mock_pretrained,
-            patch("haystack_integrations.components.generators.amazon_bedrock.chat.adapters.DefaultPromptHandler")
+            patch("haystack_integrations.components.generators.amazon_bedrock.chat.adapters.DefaultPromptHandler"),
         ):
             MistralChatAdapter(generation_kwargs={})
             mock_pretrained.assert_called_with("mistralai/Mistral-7B-Instruct-v0.1")
@@ -264,8 +264,8 @@ class TestMistralAdapter:
     @pytest.mark.skipif(
         not os.environ.get("HF_API_TOKEN", None),
         reason=(
-                "To run this test, you need to set the HF_API_TOKEN environment variable. The associated account must also "
-                "have requested access to the gated model `mistralai/Mistral-7B-Instruct-v0.1`"
+            "To run this test, you need to set the HF_API_TOKEN environment variable. The associated account must also "
+            "have requested access to the gated model `mistralai/Mistral-7B-Instruct-v0.1`"
         ),
     )
     @pytest.mark.parametrize("model_name", MISTRAL_MODELS)

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -4,7 +4,6 @@ from typing import Optional, Type
 from unittest.mock import patch
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
 
@@ -241,7 +240,7 @@ class TestMistralAdapter:
         except Exception as e:
             assert "Conversation roles must alternate user/assistant/" in str(e)
 
-    def test_use_mistral_adapter_without_hf_token(self, monkeypatch: MonkeyPatch, caplog) -> None:
+    def test_use_mistral_adapter_without_hf_token(self, monkeypatch, caplog) -> None:
         monkeypatch.delenv("HF_TOKEN", raising=False)
         with (
             patch("transformers.AutoTokenizer.from_pretrained") as mock_pretrained,
@@ -252,7 +251,7 @@ class TestMistralAdapter:
             mock_pretrained.assert_called_with("NousResearch/Llama-2-7b-chat-hf")
             assert "no HF_TOKEN was found" in caplog.text
 
-    def test_use_mistral_adapter_with_hf_token(self, monkeypatch: MonkeyPatch) -> None:
+    def test_use_mistral_adapter_with_hf_token(self, monkeypatch) -> None:
         monkeypatch.setenv("HF_TOKEN", "test")
         with (
             patch("transformers.AutoTokenizer.from_pretrained") as mock_pretrained,


### PR DESCRIPTION
### Related Issues

- fixes #732

### Proposed Changes:

If AmazonBedrockChatGenerator is used with a mistral model while there is no env var HF_TOKEN, we now use a fallback tokenizer model that is not gated and has similar tokenization behavior: "NousResearch/Llama-2-7b-chat-hf". We log a warning if the fallback tokenizer is used.

This PR doesn't change the behavior if AmazonBedrockChatGenerator is used with a mistral model while an env var HF_TOKEN is set and the user has access to "mistralai/Mistral-7B-Instruct-v0.1". The user might have access to the model either because it's cached or because it can be downloaded from the hub.

### How did you test it?

* Added two new unit tests.
* I checked that tokenization with "NousResearch/Llama-2-7b-chat-hf" and "mistralai/Mistral-7B-Instruct-v0.1" yields a similar number of tokens on 20 SQuAD example documents. Mean difference was less than 2%.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
