### PR TITLE
ci: add retry config to Pinecone test

### DIFF
--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -54,8 +54,8 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 # Pinecone tests are slow (require HTTP requests), so we run them in parallel
 # with pytest-xdist (https://pytest-xdist.readthedocs.io/en/stable/distribution.html)
-test = "pytest -n auto --maxprocesses=2 {args:tests}"
-test-cov = "coverage run -m pytest -n auto --maxprocesses=2 {args:tests}"
+test = "pytest -n auto --maxprocesses=2 --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest -n auto --maxprocesses=2 --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]


### PR DESCRIPTION
### Related Issues

Pinecone tests have been overlooked in recent work on automatically retrying failing tests (#836 and #845).

(tests failed and not retried: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/9654201625)

### Proposed Changes:
Add retry configurations to existing ones in Pinecone test scripts

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
