### PR TITLE
feat: add raise_on_failure param to OpenSearch retrievers

### DIFF
--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -64,8 +64,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:.}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff check --fix {args:.}", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -191,12 +191,12 @@ class OpenSearchBM25Retriever:
             )
         except Exception as e:
             if self._raise_on_failure:
+                raise e
+            else:
                 logger.warning(
                     "An error during BM25 retrieval occurred and will be ignored by returning empty results: %s",
                     str(e),
                     exc_info=True,
                 )
-            else:
-                raise e
 
         return {"documents": docs}

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -179,12 +179,12 @@ class OpenSearchEmbeddingRetriever:
             )
         except Exception as e:
             if self._raise_on_failure:
+                raise e
+            else:
                 logger.warning(
                     "An error during embedding retrieval occurred and will be ignored by returning empty results: %s",
                     str(e),
                     exc_info=True,
                 )
-            else:
-                raise e
 
         return {"documents": docs}

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+import logging
 from typing import Any, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
+
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -23,6 +26,7 @@ class OpenSearchEmbeddingRetriever:
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 10,
         custom_query: Optional[Dict[str, Any]] = None,
+        ignore_errors: bool = False,
     ):
         """
         Create the OpenSearchEmbeddingRetriever component.
@@ -61,6 +65,8 @@ class OpenSearchEmbeddingRetriever:
         retriever.run(query_embedding=embedding,
                         filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
         ```
+        :param ignore_errors: If True, the retriever will ignore any errors that occur during the retrieval process
+            and return an empty list.
 
         :raises ValueError: If `document_store` is not an instance of OpenSearchDocumentStore.
         """
@@ -72,6 +78,7 @@ class OpenSearchEmbeddingRetriever:
         self._filters = filters or {}
         self._top_k = top_k
         self._custom_query = custom_query
+        self._ignore_errors = ignore_errors
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -86,6 +93,7 @@ class OpenSearchEmbeddingRetriever:
             top_k=self._top_k,
             document_store=self._document_store.to_dict(),
             custom_query=self._custom_query,
+            ignore_errors=self._ignore_errors,
         )
 
     @classmethod
@@ -160,10 +168,20 @@ class OpenSearchEmbeddingRetriever:
         if custom_query is None:
             custom_query = self._custom_query
 
-        docs = self._document_store._embedding_retrieval(
-            query_embedding=query_embedding,
-            filters=filters,
-            top_k=top_k,
-            custom_query=custom_query,
-        )
-        return {"documents": docs}
+        try:
+            docs = self._document_store._embedding_retrieval(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                custom_query=custom_query,
+            )
+            return {"documents": docs}
+        except Exception as e:
+            if self._ignore_errors:
+                logger.warning(
+                    "An error during embedding retrieval occurred and will be ignored by returning empty results: %s",
+                    str(e),
+                    exc_info=True,
+                )
+                return {"documents": []}
+            raise e

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -53,7 +53,7 @@ def test_to_dict(_mock_opensearch_client):
             "top_k": 10,
             "scale_score": False,
             "custom_query": {"some": "custom query"},
-            "ignore_errors": False,
+            "raise_on_failure": True,
         },
     }
 
@@ -72,7 +72,7 @@ def test_from_dict(_mock_opensearch_client):
             "top_k": 10,
             "scale_score": True,
             "custom_query": {"some": "custom query"},
-            "ignore_errors": True,
+            "raise_on_failure": False,
         },
     }
     retriever = OpenSearchBM25Retriever.from_dict(data)
@@ -82,7 +82,7 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever._top_k == 10
     assert retriever._scale_score
     assert retriever._custom_query == {"some": "custom query"}
-    assert retriever._ignore_errors
+    assert retriever._raise_on_failure is False
 
 
 def test_run():
@@ -167,7 +167,7 @@ def test_run_time_params():
 def test_run_ignore_errors(caplog):
     mock_store = Mock(spec=OpenSearchDocumentStore)
     mock_store._bm25_retrieval.side_effect = Exception("Some error")
-    retriever = OpenSearchBM25Retriever(document_store=mock_store, ignore_errors=True)
+    retriever = OpenSearchBM25Retriever(document_store=mock_store, raise_on_failure=False)
     res = retriever.run(query="some query")
     assert len(res) == 1
     assert res["documents"] == []

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -66,7 +66,7 @@ def test_to_dict(_mock_opensearch_client):
             "filters": {},
             "top_k": 10,
             "custom_query": {"some": "custom query"},
-            "ignore_errors": False,
+            "raise_on_failure": True,
         },
     }
 
@@ -84,7 +84,7 @@ def test_from_dict(_mock_opensearch_client):
             "filters": {},
             "top_k": 10,
             "custom_query": {"some": "custom query"},
-            "ignore_errors": True,
+            "raise_on_failure": False,
         },
     }
     retriever = OpenSearchEmbeddingRetriever.from_dict(data)
@@ -92,7 +92,7 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever._filters == {}
     assert retriever._top_k == 10
     assert retriever._custom_query == {"some": "custom query"}
-    assert retriever._ignore_errors
+    assert retriever._raise_on_failure is False
 
 
 def test_run():
@@ -151,7 +151,7 @@ def test_run_time_params():
 def test_run_ignore_errors(caplog):
     mock_store = Mock(spec=OpenSearchDocumentStore)
     mock_store._embedding_retrieval.side_effect = Exception("Some error")
-    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store, ignore_errors=True)
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store, raise_on_failure=False)
     res = retriever.run(query_embedding=[0.5, 0.7])
     assert len(res) == 1
     assert res["documents"] == []

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -66,6 +66,7 @@ def test_to_dict(_mock_opensearch_client):
             "filters": {},
             "top_k": 10,
             "custom_query": {"some": "custom query"},
+            "ignore_errors": False,
         },
     }
 
@@ -83,6 +84,7 @@ def test_from_dict(_mock_opensearch_client):
             "filters": {},
             "top_k": 10,
             "custom_query": {"some": "custom query"},
+            "ignore_errors": True,
         },
     }
     retriever = OpenSearchEmbeddingRetriever.from_dict(data)
@@ -90,6 +92,7 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever._filters == {}
     assert retriever._top_k == 10
     assert retriever._custom_query == {"some": "custom query"}
+    assert retriever._ignore_errors
 
 
 def test_run():
@@ -143,3 +146,13 @@ def test_run_time_params():
     assert len(res["documents"]) == 1
     assert res["documents"][0].content == "Test doc"
     assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+def test_run_ignore_errors(caplog):
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval.side_effect = Exception("Some error")
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store, ignore_errors=True)
+    res = retriever.run(query_embedding=[0.5, 0.7])
+    assert len(res) == 1
+    assert res["documents"] == []
+    assert "Some error" in caplog.text


### PR DESCRIPTION
### Related Issues

In a hybrid retrieval setting, it can occurr that one retriever raises an error (e.g. due to a too long query for BM25), but the other is fine. In such cases it's better to return the results of the working retriever and ignore the failed ones instead of getting no results at all.

### Proposed Changes:
- add `raise_on_failure` param to OpenSearch retrievers

### How did you test it?
- added tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
