### PR TITLE
fix: Allow search in ChromaDocumentStore without metadata

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -429,12 +429,12 @@ class ChromaDocumentStore:
 
                 # prepare metadata
                 metadatas = result.get("metadatas")
-                print (metadatas)
                 try:
                     if metadatas and metadatas[i][j] is not None:
                         document_dict["meta"] = metadatas[i][j]
-                except IndexError:
-                    raise IndexError("No metadata found for document: " + document_dict['id'])
+                except IndexError as e:
+                    msg = "No metadata found for document: " + document_dict["id"]
+                    raise IndexError(msg) from e
 
                 if embeddings := result.get("embeddings"):
                     document_dict["embedding"] = np.array(embeddings[i][j])

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -428,8 +428,9 @@ class ChromaDocumentStore:
                 }
 
                 # prepare metadata
-                if metadatas := result.get("metadatas"):
-                    document_dict["meta"] = dict(metadatas[i][j])
+                metadatas = result.get("metadatas")
+                if metadatas and metadatas[i][j] is not None:
+                    document_dict["meta"] = metadatas[i][j].copy()
 
                 if embeddings := result.get("embeddings"):
                     document_dict["embedding"] = np.array(embeddings[i][j])

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -429,8 +429,12 @@ class ChromaDocumentStore:
 
                 # prepare metadata
                 metadatas = result.get("metadatas")
-                if metadatas and metadatas[i][j] is not None:
-                    document_dict["meta"] = metadatas[i][j]
+                print (metadatas)
+                try:
+                    if metadatas and metadatas[i][j] is not None:
+                        document_dict["meta"] = metadatas[i][j]
+                except IndexError:
+                    raise IndexError("No metadata found for document: " + document_dict['id'])
 
                 if embeddings := result.get("embeddings"):
                     document_dict["embedding"] = np.array(embeddings[i][j])

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -432,9 +432,8 @@ class ChromaDocumentStore:
                 try:
                     if metadatas and metadatas[i][j] is not None:
                         document_dict["meta"] = metadatas[i][j]
-                except IndexError as e:
-                    msg = "No metadata found for document: " + document_dict["id"]
-                    raise IndexError(msg) from e
+                except IndexError:
+                    pass
 
                 if embeddings := result.get("embeddings"):
                     document_dict["embedding"] = np.array(embeddings[i][j])

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -430,7 +430,7 @@ class ChromaDocumentStore:
                 # prepare metadata
                 metadatas = result.get("metadatas")
                 if metadatas and metadatas[i][j] is not None:
-                    document_dict["meta"] = metadatas[i][j].copy()
+                    document_dict["meta"] = metadatas[i][j]
 
                 if embeddings := result.get("embeddings"):
                     document_dict["embedding"] = np.array(embeddings[i][j])

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -101,6 +101,29 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
         assert len(result) == 1
         assert result[0][0].content == "First document"
 
+    def test_document_store_search_with_metadata(self):
+        document_store = ChromaDocumentStore()
+
+        # Writing documents to the document store
+        documents = [
+            Document(content="First document", meta={"author": "Author1"}),
+            Document(content="Second document"),  # No metadata
+            Document(content="Third document", meta={"author": "Author2"}),
+            Document(content="Fourth document")  # No metadata
+        ]
+
+        document_store.write_documents(documents)
+        # Search for a document with metadata
+        result_with_metadata = document_store.search(["Author1"], top_k=1)
+        print(result_with_metadata[0])
+        assert result_with_metadata[0][0].content == "First document"
+
+        # Search for a document without metadata
+        #result_without_metadata = document_store.search(["Author2"], top_k=1)
+        
+        #assert result_without_metadata[0][0].content ==  "Second document"
+
+
     @pytest.mark.integration
     def test_to_json(self, request):
         ds = ChromaDocumentStore(

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -67,7 +67,11 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
 
     def test_document_store_search_without_metadata(self, document_store: ChromaDocumentStore):
         document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]] )
-        document_store.search(["First document"], top_k=1)
+        results = document_store.search(["First document"], top_k=1)[0]
+
+        # Assertions to verify correctness
+        assert len(results) == 1
+        assert results[0].content == "First document"
 
     def test_ne_filter(self, document_store: ChromaDocumentStore, filterable_docs: List[Document]):
         """

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -67,11 +67,11 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
 
     def test_document_store_search_without_metadata(self, document_store: ChromaDocumentStore):
         document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]] )
-        results = document_store.search(["First document"], top_k=1)[0]
+        result = document_store.search(["First document"], top_k=1)
 
         # Assertions to verify correctness
-        assert len(results) == 1
-        assert results[0].content == "First document"
+        assert len(result) == 1
+        assert result[0][0].content == "First document"
 
     def test_ne_filter(self, document_store: ChromaDocumentStore, filterable_docs: List[Document]):
         """

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -65,6 +65,10 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
             assert doc_received.content == doc_expected.content
             assert doc_received.meta == doc_expected.meta
 
+    def test_document_store_search_without_metadata(self, document_store: ChromaDocumentStore):
+        document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]] )
+        document_store.search(["First document"], top_k=1)
+
     def test_ne_filter(self, document_store: ChromaDocumentStore, filterable_docs: List[Document]):
         """
         We customize this test because Chroma consider "not equal" true when

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -66,7 +66,7 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
             assert doc_received.meta == doc_expected.meta
 
     def test_document_store_search_without_metadata(self, document_store: ChromaDocumentStore):
-        document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]] )
+        document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]])
         result = document_store.search(["First document"], top_k=1)
 
         # Assertions to verify correctness

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -92,7 +92,7 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
 
         assert document_store.filter_documents(filters={"id": doc.id}) == [doc]
 
-    def test_document_store_search(self):
+    def test_search(self):
         document_store = ChromaDocumentStore()
         documents = [
             Document(content="First document", meta={"author": "Author1"}),

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -92,30 +92,20 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
 
         assert document_store.filter_documents(filters={"id": doc.id}) == [doc]
 
-    def test_document_store_search_without_metadata(self):
+    def test_document_store_search(self):
         document_store = ChromaDocumentStore()
-        document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]])
-        result = document_store.search(["First document"], top_k=1)
-
-        # Assertions to verify correctness
-        assert len(result) == 1
-        assert result[0][0].content == "First document"
-
-    def test_document_store_search_with_metadata(self):
-        document_store = ChromaDocumentStore()
-
-        # Writing documents to the document store
         documents = [
             Document(content="First document", meta={"author": "Author1"}),
             Document(content="Second document"),  # No metadata
             Document(content="Third document", meta={"author": "Author2"}),
             Document(content="Fourth document"),  # No metadata
         ]
-
         document_store.write_documents(documents)
-        # Search for a document with metadata
-        result_with_metadata = document_store.search(["Author1"], top_k=1)
-        assert result_with_metadata[0][0].content == "First document"
+        result = document_store.search(["Third"], top_k=1)
+
+        # Assertions to verify correctness
+        assert len(result) == 1
+        assert result[0][0].content == "Third document"
 
     @pytest.mark.integration
     def test_to_json(self, request):

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -109,20 +109,13 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
             Document(content="First document", meta={"author": "Author1"}),
             Document(content="Second document"),  # No metadata
             Document(content="Third document", meta={"author": "Author2"}),
-            Document(content="Fourth document")  # No metadata
+            Document(content="Fourth document"),  # No metadata
         ]
 
         document_store.write_documents(documents)
         # Search for a document with metadata
         result_with_metadata = document_store.search(["Author1"], top_k=1)
-        print(result_with_metadata[0])
         assert result_with_metadata[0][0].content == "First document"
-
-        # Search for a document without metadata
-        #result_without_metadata = document_store.search(["Author2"], top_k=1)
-        
-        #assert result_without_metadata[0][0].content ==  "Second document"
-
 
     @pytest.mark.integration
     def test_to_json(self, request):

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -65,14 +65,6 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
             assert doc_received.content == doc_expected.content
             assert doc_received.meta == doc_expected.meta
 
-    def test_document_store_search_without_metadata(self, document_store: ChromaDocumentStore):
-        document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]])
-        result = document_store.search(["First document"], top_k=1)
-
-        # Assertions to verify correctness
-        assert len(result) == 1
-        assert result[0][0].content == "First document"
-
     def test_ne_filter(self, document_store: ChromaDocumentStore, filterable_docs: List[Document]):
         """
         We customize this test because Chroma consider "not equal" true when
@@ -99,6 +91,15 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
         document_store.delete_documents(["non_existing"])
 
         assert document_store.filter_documents(filters={"id": doc.id}) == [doc]
+
+    def test_document_store_search_without_metadata(self):
+        document_store = ChromaDocumentStore()
+        document_store.write_documents([Document(content=e) for e in ["First document", "Second document"]])
+        result = document_store.search(["First document"], top_k=1)
+
+        # Assertions to verify correctness
+        assert len(result) == 1
+        assert result[0][0].content == "First document"
 
     @pytest.mark.integration
     def test_to_json(self, request):


### PR DESCRIPTION
### Related Issues

- fixes #462 

### Proposed Changes:

Update `_query_result_to_documents` to also run without metadata 

### How did you test it?

Added a unit test

### Notes for the reviewer
NA

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
