### PR TITLE
fix: Fix typo in the `ORTModel.inputs_names` field to align with upstream

### DIFF
--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
@@ -173,7 +173,7 @@ class _EmbedderBackend:
         tokenizer_outputs = self.tokenizer(texts, padding=True, truncation=True, return_tensors="pt").to(
             self.model.device
         )
-        model_inputs = {k: v for k, v in tokenizer_outputs.items() if k in self.model.inputs_names}
+        model_inputs = {k: v for k, v in tokenizer_outputs.items() if k in self.model.input_names}
         model_outputs = self.model(**model_inputs)
         return tokenizer_outputs, model_outputs
 


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
HF fixed a typo in a minor release.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
