### PR TITLE
fix: Incorrect astra not equal operator

### DIFF
--- a/integrations/astra/src/haystack_integrations/document_stores/astra/filters.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/filters.py
@@ -52,7 +52,7 @@ def _convert_filters(filters: Optional[Dict[str, Any]] = None) -> Optional[Dict[
 # TODO consider other operators, or filters that are not with the same structure as field operator value
 OPERATORS = {
     "==": "$eq",
-    "!=": "$neq",
+    "!=": "$ne",
     ">": "$gt",
     ">=": "$gte",
     "<": "$lt",


### PR DESCRIPTION
### Related Issues

- fixes #867 
### Proposed Changes:

The issue is an incorrect mapping between the haystack not equal filter `!=` and the astra not equal operator `$ne`. Before this change the value used as is `$neq`.

### How did you test it?

Manual test.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
