### PR TITLE
fix: errors in convert_filters_to_qdrant

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/filters.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/filters.py
@@ -100,6 +100,8 @@ def convert_filters_to_qdrant(
             return qdrant_filter[0]
         else:
             must_clauses.extend(conditions)
+            payload = build_payload(must_clauses, should_clauses, must_not_clauses)
+            print (payload)
             return build_payload(must_clauses, should_clauses, must_not_clauses)
 
     # Store conditions of each level in output of the loop

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/filters.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/filters.py
@@ -100,8 +100,6 @@ def convert_filters_to_qdrant(
             return qdrant_filter[0]
         else:
             must_clauses.extend(conditions)
-            payload = build_payload(must_clauses, should_clauses, must_not_clauses)
-            print (payload)
             return build_payload(must_clauses, should_clauses, must_not_clauses)
 
     # Store conditions of each level in output of the loop

--- a/integrations/qdrant/tests/test_filters.py
+++ b/integrations/qdrant/tests/test_filters.py
@@ -61,6 +61,50 @@ class TestQdrantStoreBaseTests(FilterDocumentsTest):
             [d for d in filterable_docs if (d.meta.get("number") != 100 and d.meta.get("name") != "name_0")],
         )
 
+    def test_filter_criteria(self, document_store):
+        documents = [
+            Document(
+                content="This is a test document 1.",
+                meta={"file_name": "file1", "classification": {"details": {"category1": 0.9, "category2": 0.3}}},
+            ),
+            Document(
+                content="This is a test document 2.",
+                meta={"file_name": "file2", "classification": {"details": {"category1": 0.1, "category2": 0.7}}},
+            ),
+            Document(
+                content="This is a test document 3.",
+                meta={"file_name": "file3", "classification": {"details": {"category1": 0.7, "category2": 0.9}}},
+            ),
+        ]
+
+        document_store.write_documents(documents)
+        filter_criteria = {
+            "operator": "AND",
+            "conditions": [
+                {"field": "meta.file_name", "operator": "in", "value": ["file1", "file2"]},
+                {
+                    "operator": "OR",
+                    "conditions": [
+                        {"field": "meta.classification.details.category1", "operator": ">=", "value": 0.85},
+                        {"field": "meta.classification.details.category2", "operator": ">=", "value": 0.85},
+                    ],
+                },
+            ],
+        }
+        result = document_store.filter_documents(filter_criteria)
+        self.assert_documents_are_equal(
+            result,
+            [
+                d
+                for d in documents
+                if (d.meta.get("file_name") in ["file1", "file2"])
+                and (
+                    (d.meta.get("classification").get("details").get("category1") >= 0.85)
+                    or (d.meta.get("classification").get("details").get("category2") >= 0.85)
+                )
+            ],
+        )
+
     # ======== OVERRIDES FOR NONE VALUED FILTERS ========
 
     def test_comparison_equal_with_none(self, document_store, filterable_docs):

--- a/integrations/qdrant/tests/test_filters.py
+++ b/integrations/qdrant/tests/test_filters.py
@@ -64,15 +64,15 @@ class TestQdrantStoreBaseTests(FilterDocumentsTest):
     def test_filter_criteria(self, document_store):
         documents = [
             Document(
-                content="This is a test document 1.",
+                content="This is test document 1.",
                 meta={"file_name": "file1", "classification": {"details": {"category1": 0.9, "category2": 0.3}}},
             ),
             Document(
-                content="This is a test document 2.",
+                content="This is test document 2.",
                 meta={"file_name": "file2", "classification": {"details": {"category1": 0.1, "category2": 0.7}}},
             ),
             Document(
-                content="This is a test document 3.",
+                content="This is test document 3.",
                 meta={"file_name": "file3", "classification": {"details": {"category1": 0.7, "category2": 0.9}}},
             ),
         ]
@@ -105,87 +105,24 @@ class TestQdrantStoreBaseTests(FilterDocumentsTest):
             ],
         )
 
-    def test_advanced_filter_criteria(self, document_store):
+    def test_complex_filter_criteria(self, document_store):
         documents = [
             Document(
-                content="This is a test document 1.",
-                meta={"file_name": "file1", "classification": {"details": {"category1": 0.8, "category3": 0.2}}},
-            ),
-            Document(
-                content="This is a test document 2.",
-                meta={"file_name": "file2", "classification": {"details": {"category1": 0.3, "category3": 0.95}}},
-            ),
-            Document(
-                content="This is a test document 3.",
-                meta={"file_name": "file3", "classification": {"details": {"category2": 0.6, "category3": 0.85}}},
-            ),
-            Document(
-                content="This is a test document 4.",
-                meta={"file_name": "file4", "classification": {"details": {"category2": 0.88, "category3": 0.4}}},
-            ),
-        ]
-
-        document_store.write_documents(documents)
-        filter_criteria = {
-            "operator": "AND",
-            "conditions": [
-                {
-                    "operator": "OR",
-                    "conditions": [
-                        {"field": "meta.file_name", "operator": "in", "value": ["file1", "file3"]},
-                        {"field": "meta.file_name", "operator": "in", "value": ["file4"]},
-                    ],
-                },
-                {
-                    "operator": "AND",
-                    "conditions": [
-                        {
-                            "operator": "OR",
-                            "conditions": [
-                                {"field": "meta.classification.details.category1", "operator": ">=", "value": 0.75},
-                                {"field": "meta.classification.details.category2", "operator": ">=", "value": 0.85},
-                            ],
-                        },
-                        {"field": "meta.classification.details.category3", "operator": "<", "value": 0.9},
-                    ],
-                },
-            ],
-        }
-        result = document_store.filter_documents(filter_criteria)
-        self.assert_documents_are_equal(
-            result,
-            [
-                d
-                for d in documents
-                if (
-                    (d.meta.get("file_name") in ["file1", "file3"] or d.meta.get("file_name") == "file4")
-                    and (
-                        (d.meta.get("classification").get("details").get("category1", 0) >= 0.75)
-                        or (d.meta.get("classification").get("details").get("category2", 0) >= 0.85)
-                    )
-                    and (d.meta.get("classification").get("details").get("category3") < 0.9)
-                )
-            ],
-        )
-
-    def test_filter_criteria_complex(self, document_store):
-        documents = [
-            Document(
-                content="Complex document 1.",
+                content="This is test document 1.",
                 meta={
                     "file_name": "file1",
                     "classification": {"details": {"category1": 0.45, "category2": 0.5, "category3": 0.2}},
                 },
             ),
             Document(
-                content="Complex document 2.",
+                content="This is test document 2.",
                 meta={
                     "file_name": "file2",
                     "classification": {"details": {"category1": 0.95, "category2": 0.85, "category3": 0.4}},
                 },
             ),
             Document(
-                content="Complex document 3.",
+                content="This is test document 3.",
                 meta={
                     "file_name": "file3",
                     "classification": {"details": {"category1": 0.85, "category2": 0.7, "category3": 0.95}},

--- a/integrations/qdrant/tests/test_filters.py
+++ b/integrations/qdrant/tests/test_filters.py
@@ -105,6 +105,69 @@ class TestQdrantStoreBaseTests(FilterDocumentsTest):
             ],
         )
 
+    def test_advanced_filter_criteria(self, document_store):
+        documents = [
+            Document(
+                content="This is a test document 1.",
+                meta={"file_name": "file1", "classification": {"details": {"category1": 0.8, "category3": 0.2}}},
+            ),
+            Document(
+                content="This is a test document 2.",
+                meta={"file_name": "file2", "classification": {"details": {"category1": 0.3, "category3": 0.95}}},
+            ),
+            Document(
+                content="This is a test document 3.",
+                meta={"file_name": "file3", "classification": {"details": {"category2": 0.6, "category3": 0.85}}},
+            ),
+            Document(
+                content="This is a test document 4.",
+                meta={"file_name": "file4", "classification": {"details": {"category2": 0.88, "category3": 0.4}}},
+            ),
+        ]
+
+        document_store.write_documents(documents)
+        filter_criteria = {
+            "operator": "AND",
+            "conditions": [
+                {
+                    "operator": "OR",
+                    "conditions": [
+                        {"field": "meta.file_name", "operator": "in", "value": ["file1", "file3"]},
+                        {"field": "meta.file_name", "operator": "in", "value": ["file4"]},
+                    ],
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {
+                            "operator": "OR",
+                            "conditions": [
+                                {"field": "meta.classification.details.category1", "operator": ">=", "value": 0.75},
+                                {"field": "meta.classification.details.category2", "operator": ">=", "value": 0.85},
+                            ],
+                        },
+                        {"field": "meta.classification.details.category3", "operator": "<", "value": 0.9},
+                    ],
+                },
+            ],
+        }
+        result = document_store.filter_documents(filter_criteria)
+        self.assert_documents_are_equal(
+            result,
+            [
+                d
+                for d in documents
+                if (
+                    (d.meta.get("file_name") in ["file1", "file3"] or d.meta.get("file_name") == "file4")
+                    and (
+                        (d.meta.get("classification").get("details").get("category1", 0) >= 0.75)
+                        or (d.meta.get("classification").get("details").get("category2", 0) >= 0.85)
+                    )
+                    and (d.meta.get("classification").get("details").get("category3") < 0.9)
+                )
+            ],
+        )
+
     def test_filter_criteria_complex(self, document_store):
         documents = [
             Document(
@@ -118,14 +181,14 @@ class TestQdrantStoreBaseTests(FilterDocumentsTest):
                 content="Complex document 2.",
                 meta={
                     "file_name": "file2",
-                    "classification": {"details": {"category1": 0.95, "category2": 0.1, "category3": 0.4}},
+                    "classification": {"details": {"category1": 0.95, "category2": 0.85, "category3": 0.4}},
                 },
             ),
             Document(
                 content="Complex document 3.",
                 meta={
                     "file_name": "file3",
-                    "classification": {"details": {"category1": 0.85, "category2": 0.85, "category3": 0.95}},
+                    "classification": {"details": {"category1": 0.85, "category2": 0.7, "category3": 0.95}},
                 },
             ),
         ]


### PR DESCRIPTION
### Related Issues

- fixes #846 

### Proposed Changes:

Previous function creates a unnecessary nested structure of Filters causing logic errors. Then uses the `squeeze_filter` to simplify the structure which wrongly deletes some parts of filters.
I tried implementing a solution which handles different cases of filters while creating thus no need to squeeze it afterwards.

### How did you test it?

Created four examples for manual testing of converted filters and their results
Existing unit and integration tests

**Example comparison**

Haystack filter
```
filter_criteria = {
        "operator": "AND",
        "conditions": [
            {"field": "meta.file_name", "operator": "in", "value": ["file1", "file2"]},
            {
                "operator": "OR",
                "conditions": [
                    {"field": "meta.classification.details.category1", "operator": ">=", "value": 0.85},
                    {"field": "meta.classification.details.category2", "operator": ">=", "value": 0.85},
                ],
            },
        ],
    }
```

Qdrant filter from old function
`should=None min_should=None must=[Filter(should=[FieldCondition(key='meta.file_name', match=MatchText(text='file1'), range=None, geo_bounding_box=None, geo_radius=None, geo_polygon=None, values_count=None), FieldCondition(key='meta.file_name', match=MatchText(text='file2'), range=None, geo_bounding_box=None, geo_radius=None, geo_polygon=None, values_count=None)], min_should=None, must=None, must_not=None)] must_not=None`


Qdrant filter from updated function
`should=None min_should=None must=[Filter(should=[FieldCondition(key='meta.file_name', match=MatchText(text='file1'), range=None, geo_bounding_box=None, geo_radius=None, geo_polygon=None, values_count=None), FieldCondition(key='meta.file_name', match=MatchText(text='file2'), range=None, geo_bounding_box=None, geo_radius=None, geo_polygon=None, values_count=None)], min_should=None, must=None, must_not=None), Filter(should=[FieldCondition(key='meta.classification.details.category1', match=None, range=Range(lt=None, gt=None, gte=0.85, lte=None), geo_bounding_box=None, geo_radius=None, geo_polygon=None, values_count=None), FieldCondition(key='meta.classification.details.category2', match=None, range=Range(lt=None, gt=None, gte=0.85, lte=None), geo_bounding_box=None, geo_radius=None, geo_polygon=None, values_count=None)], min_should=None, must=None, must_not=None)] must_not=None`

### Notes for the reviewer

Results are correct but I am sure the code can be improvised.
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
