### PR TITLE
chore: Minor retriever pydoc fix

### DIFF
--- a/integrations/astra/src/haystack_integrations/components/retrievers/astra/retriever.py
+++ b/integrations/astra/src/haystack_integrations/components/retrievers/astra/retriever.py
@@ -63,7 +63,7 @@ class AstraEmbeddingRetriever:
 
         :param query_embedding: floats representing the query embedding
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: the maximum number of documents to retrieve.
         :returns: a dictionary with the following keys:

--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -75,7 +75,7 @@ class ChromaQueryTextRetriever:
 
         :param query: The input data for the retriever. In this case, a plain-text query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: The maximum number of documents to retrieve.
             If not specified, the default value from the constructor is used.
@@ -138,7 +138,7 @@ class ChromaEmbeddingRetriever(ChromaQueryTextRetriever):
 
         :param query_embedding: the query embeddings.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: the maximum number of documents to retrieve.
             If not specified, the default value from the constructor is used.

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -118,7 +118,7 @@ class ElasticsearchBM25Retriever:
 
         :param query: String to search in `Document`s' text.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: Maximum number of `Document` to return.
         :returns: A dictionary with the following keys:

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
@@ -116,7 +116,7 @@ class ElasticsearchEmbeddingRetriever:
 
         :param query_embedding: Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: Maximum number of `Document`s to return.
         :returns: A dictionary with the following keys:

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -113,7 +113,7 @@ class MongoDBAtlasEmbeddingRetriever:
 
         :param query_embedding: Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: Maximum number of Documents to return. Overrides the value specified at initialization.
         :returns: A dictionary with the following keys:

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -138,7 +138,7 @@ class OpenSearchBM25Retriever:
 
         :param query: The query string
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param all_terms_must_match: If True, all terms in the query string must be present in the retrieved documents.
         :param top_k: Maximum number of Documents to return.

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -134,7 +134,7 @@ class OpenSearchEmbeddingRetriever:
 
         :param query_embedding: Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: Maximum number of Documents to return.
         :param custom_query: The query containing a mandatory `$query_embedding` and an optional `$filters` placeholder

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
@@ -142,7 +142,7 @@ class PgvectorEmbeddingRetriever:
 
         :param query_embedding: Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: Maximum number of Documents to return.
         :param vector_function: The similarity function to use when searching for similar embeddings.

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
@@ -115,7 +115,7 @@ class PgvectorKeywordRetriever:
 
         :param query: String to search in `Document`s' content.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: Maximum number of Documents to return.
 

--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -119,7 +119,7 @@ class PineconeEmbeddingRetriever:
 
         :param query_embedding: Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: Maximum number of `Document`s to return.
 

--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -267,7 +267,7 @@ class QdrantSparseEmbeddingRetriever:
 
         :param query_sparse_embedding: Sparse Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: The maximum number of documents to return.
         :param scale_score: Whether to scale the scores of the retrieved documents or not.
@@ -413,7 +413,7 @@ class QdrantHybridRetriever:
         :param query_embedding: Dense embedding of the query.
         :param query_sparse_embedding: Sparse embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k: The maximum number of documents to return.
         :param return_embedding: Whether to return the embedding of the retrieved Documents.

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
@@ -91,7 +91,7 @@ class WeaviateBM25Retriever:
         :param query:
             The query text.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k:
             The maximum number of documents to return.

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
@@ -108,7 +108,7 @@ class WeaviateEmbeddingRetriever:
         :param query_embedding:
             Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
-                        the `filter_policy` chosen at document store initialization. See init method docstring for more
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
                         details.
         :param top_k:
             The maximum number of documents to return.


### PR DESCRIPTION
- Fixes pydoc text mistake for all retrievers
- Do a search for `chosen at document store initialization` - ensure it is replaced by `chosen at retriever initialization`