### PR TITLE
fix: `OpenSearch` - Fallback to default filter policy when deserializing retrievers without the init parameter

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -119,7 +119,11 @@ class OpenSearchBM25Retriever:
         data["init_parameters"]["document_store"] = OpenSearchDocumentStore.from_dict(
             data["init_parameters"]["document_store"]
         )
-        data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
+
+        # Pipelines serialized with old versions of the component might not
+        # have the filter_policy field.
+        if "filter_policy" in data["init_parameters"]:
+            data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -118,7 +118,11 @@ class OpenSearchEmbeddingRetriever:
         data["init_parameters"]["document_store"] = OpenSearchDocumentStore.from_dict(
             data["init_parameters"]["document_store"]
         )
-        data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
+
+        # Pipelines serialized with old versions of the component might not
+        # have the filter_policy field.
+        if "filter_policy" in data["init_parameters"]:
+            data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -96,6 +96,25 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever._custom_query == {"some": "custom query"}
     assert retriever._raise_on_failure is False
 
+    # For backwards compatibility with older versions of the retriever without a filter policy
+    data = {
+        "type": "haystack_integrations.components.retrievers.opensearch.bm25_retriever.OpenSearchBM25Retriever",
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {"hosts": "some fake host", "index": "default"},
+                "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
+            },
+            "filters": {},
+            "fuzziness": "AUTO",
+            "top_k": 10,
+            "scale_score": True,
+            "custom_query": {"some": "custom query"},
+            "raise_on_failure": False,
+        },
+    }
+    retriever = OpenSearchBM25Retriever.from_dict(data)
+    assert retriever._filter_policy == FilterPolicy.REPLACE
+
 
 def test_run():
     mock_store = Mock(spec=OpenSearchDocumentStore)

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -106,6 +106,23 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever._raise_on_failure is False
     assert retriever._filter_policy == FilterPolicy.REPLACE
 
+    # For backwards compatibility with older versions of the retriever without a filter policy
+    data = {
+        "type": type_s,
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {"hosts": "some fake host", "index": "default"},
+                "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
+            },
+            "filters": {},
+            "top_k": 10,
+            "custom_query": {"some": "custom query"},
+            "raise_on_failure": False,
+        },
+    }
+    retriever = OpenSearchEmbeddingRetriever.from_dict(data)
+    assert retriever._filter_policy == FilterPolicy.REPLACE
+
 
 def test_run():
     mock_store = Mock(spec=OpenSearchDocumentStore)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/894

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Fixes an oversight introduced in #822 that broke the deserialization of pipelines with older versions of the OpenSearch retriever components.


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit test


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
