### PR TITLE
fix: `ElasticSearch` - Fallback to default filter policy when deserializing retrievers without the init parameter

### DIFF
--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -100,7 +100,8 @@ class ChromaQueryTextRetriever:
         """
         document_store = ChromaDocumentStore.from_dict(data["init_parameters"]["document_store"])
         data["init_parameters"]["document_store"] = document_store
-        data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
+        if filter_policy := data["init_parameters"].get("filter_policy"):
+            data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
 
         return default_from_dict(cls, data)
 

--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -100,8 +100,7 @@ class ChromaQueryTextRetriever:
         """
         document_store = ChromaDocumentStore.from_dict(data["init_parameters"]["document_store"])
         data["init_parameters"]["document_store"] = document_store
-        if filter_policy := data["init_parameters"].get("filter_policy"):
-            data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
+        data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
 
         return default_from_dict(cls, data)
 

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -108,6 +108,8 @@ class ElasticsearchBM25Retriever:
         data["init_parameters"]["document_store"] = ElasticsearchDocumentStore.from_dict(
             data["init_parameters"]["document_store"]
         )
+        # Pipelines serialized with old versions of the component might not
+        # have the filter_policy field.
         if filter_policy := data["init_parameters"].get("filter_policy"):
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -108,7 +108,8 @@ class ElasticsearchBM25Retriever:
         data["init_parameters"]["document_store"] = ElasticsearchDocumentStore.from_dict(
             data["init_parameters"]["document_store"]
         )
-        data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
+        if filter_policy := data["init_parameters"].get("filter_policy"):
+            data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
@@ -106,7 +106,10 @@ class ElasticsearchEmbeddingRetriever:
         data["init_parameters"]["document_store"] = ElasticsearchDocumentStore.from_dict(
             data["init_parameters"]["document_store"]
         )
-        data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
+        # Pipelines serialized with old versions of the component might not
+        # have the filter_policy field.
+        if filter_policy := data["init_parameters"].get("filter_policy"):
+            data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/integrations/elasticsearch/tests/test_bm25_retriever.py
+++ b/integrations/elasticsearch/tests/test_bm25_retriever.py
@@ -77,6 +77,30 @@ def test_from_dict(_mock_elasticsearch_client):
     assert retriever._filter_policy == FilterPolicy.REPLACE
 
 
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_from_dict_no_filter_policy(_mock_elasticsearch_client):
+    data = {
+        "type": "haystack_integrations.components.retrievers.elasticsearch.bm25_retriever.ElasticsearchBM25Retriever",
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {"hosts": "some fake host", "index": "default"},
+                "type": "haystack_integrations.document_stores.elasticsearch.document_store.ElasticsearchDocumentStore",
+            },
+            "filters": {},
+            "fuzziness": "AUTO",
+            "top_k": 10,
+            "scale_score": True,
+        },
+    }
+    retriever = ElasticsearchBM25Retriever.from_dict(data)
+    assert retriever._document_store
+    assert retriever._filters == {}
+    assert retriever._fuzziness == "AUTO"
+    assert retriever._top_k == 10
+    assert retriever._scale_score
+    assert retriever._filter_policy == FilterPolicy.REPLACE  # defaults to REPLACE
+
+
 def test_run():
     mock_store = Mock(spec=ElasticsearchDocumentStore)
     mock_store._bm25_retrieval.return_value = [Document(content="Test doc")]

--- a/integrations/elasticsearch/tests/test_embedding_retriever.py
+++ b/integrations/elasticsearch/tests/test_embedding_retriever.py
@@ -74,6 +74,29 @@ def test_from_dict(_mock_elasticsearch_client):
     assert retriever._num_candidates is None
 
 
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_from_dict_no_filter_policy(_mock_elasticsearch_client):
+    t = "haystack_integrations.components.retrievers.elasticsearch.embedding_retriever.ElasticsearchEmbeddingRetriever"
+    data = {
+        "type": t,
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {"hosts": "some fake host", "index": "default"},
+                "type": "haystack_integrations.document_stores.elasticsearch.document_store.ElasticsearchDocumentStore",
+            },
+            "filters": {},
+            "top_k": 10,
+            "num_candidates": None,
+        },
+    }
+    retriever = ElasticsearchEmbeddingRetriever.from_dict(data)
+    assert retriever._document_store
+    assert retriever._filters == {}
+    assert retriever._top_k == 10
+    assert retriever._num_candidates is None
+    assert retriever._filter_policy == FilterPolicy.REPLACE  # defaults to REPLACE
+    
+
 def test_run():
     mock_store = Mock(spec=ElasticsearchDocumentStore)
     mock_store._embedding_retrieval.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]

--- a/integrations/elasticsearch/tests/test_embedding_retriever.py
+++ b/integrations/elasticsearch/tests/test_embedding_retriever.py
@@ -95,7 +95,7 @@ def test_from_dict_no_filter_policy(_mock_elasticsearch_client):
     assert retriever._top_k == 10
     assert retriever._num_candidates is None
     assert retriever._filter_policy == FilterPolicy.REPLACE  # defaults to REPLACE
-    
+
 
 def test_run():
     mock_store = Mock(spec=ElasticsearchDocumentStore)


### PR DESCRIPTION
- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/894