### PR TITLE
fix: `pinecone` - Fallback to default filter policy when deserializing retrievers without the init parameter

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -104,6 +104,8 @@ class PineconeEmbeddingRetriever:
         data["init_parameters"]["document_store"] = PineconeDocumentStore.from_dict(
             data["init_parameters"]["document_store"]
         )
+        # Pipelines serialized with old versions of the component might not
+        # have the filter_policy field.
         if filter_policy := data["init_parameters"].get("filter_policy"):
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)

--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -104,7 +104,8 @@ class PineconeEmbeddingRetriever:
         data["init_parameters"]["document_store"] = PineconeDocumentStore.from_dict(
             data["init_parameters"]["document_store"]
         )
-        data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
+        if filter_policy := data["init_parameters"].get("filter_policy"):
+            data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/integrations/pinecone/tests/test_embedding_retriever.py
+++ b/integrations/pinecone/tests/test_embedding_retriever.py
@@ -114,6 +114,52 @@ def test_from_dict(mock_pinecone, monkeypatch):
     assert retriever.filter_policy == FilterPolicy.REPLACE
 
 
+@patch("haystack_integrations.document_stores.pinecone.document_store.Pinecone")
+def test_from_dict_no_filter_policy(mock_pinecone, monkeypatch):
+    data = {
+        "type": "haystack_integrations.components.retrievers.pinecone.embedding_retriever.PineconeEmbeddingRetriever",
+        "init_parameters": {
+            "document_store": {
+                "init_parameters": {
+                    "api_key": {
+                        "env_vars": [
+                            "PINECONE_API_KEY",
+                        ],
+                        "strict": True,
+                        "type": "env_var",
+                    },
+                    "index": "default",
+                    "namespace": "test-namespace",
+                    "batch_size": 50,
+                    "dimension": 512,
+                    "spec": {"serverless": {"region": "us-east-1", "cloud": "aws"}},
+                    "metric": "cosine",
+                },
+                "type": "haystack_integrations.document_stores.pinecone.document_store.PineconeDocumentStore",
+            },
+            "filters": {},
+            "top_k": 10,
+        },
+    }
+
+    mock_pinecone.return_value.Index.return_value.describe_index_stats.return_value = {"dimension": 512}
+    monkeypatch.setenv("PINECONE_API_KEY", "test-key")
+    retriever = PineconeEmbeddingRetriever.from_dict(data)
+
+    document_store = retriever.document_store
+    assert document_store.api_key == Secret.from_env_var("PINECONE_API_KEY", strict=True)
+    assert document_store.index_name == "default"
+    assert document_store.namespace == "test-namespace"
+    assert document_store.batch_size == 50
+    assert document_store.dimension == 512
+    assert document_store.metric == "cosine"
+    assert document_store.spec == {"serverless": {"region": "us-east-1", "cloud": "aws"}}
+
+    assert retriever.filters == {}
+    assert retriever.top_k == 10
+    assert retriever.filter_policy == FilterPolicy.REPLACE  # defaults to REPLACE
+
+
 def test_run():
     mock_store = Mock(spec=PineconeDocumentStore)
     mock_store._embedding_retrieval.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]


### PR DESCRIPTION
- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/894