### PR TITLE
feat: Add metadata parameter to ChromaDocumentStore.

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -93,12 +93,8 @@ class ChromaDocumentStore:
         if collection_name in [c.name for c in self._chroma_client.list_collections()]:
             self._collection = self._chroma_client.get_collection(collection_name, embedding_function=embedding_func)
 
-            if distance_function != self._collection.metadata["hnsw:space"]:
-                logger.warning("Collection already exists. The `distance_function` parameter will be ignored.")
-
-            for key in metadata:
-                if metadata[key] != self._collection.metadata[key]:
-                    logger.warning(f"Collection already exists. The `metadata[{key}]` parameter will be ignored.")
+            if metadata != self._collection.metadata:
+                logger.warning("Collection already exists. The `distance_function` and `metadata` parameters will be ignored.")
         else:
             self._collection = self._chroma_client.create_collection(
                 name=collection_name,

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -59,8 +59,8 @@ class ChromaDocumentStore:
             **Note**: `distance_function` can only be set during the creation of a collection.
             To change the distance metric of an existing collection, consider cloning the collection.
         :param metadata: a dictionary of chromadb collection parameters passed directly to chromadb's client
-        method `create_collection`. If it contains the key `"hnsw:space"`, the value will take precedence over the
-        `distance_function` parameter above.
+            method `create_collection`. If it contains the key `"hnsw:space"`, the value will take precedence over the
+            `distance_function` parameter above.
 
         :param embedding_function_params: additional parameters to pass to the embedding function.
         """

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -94,7 +94,9 @@ class ChromaDocumentStore:
             self._collection = self._chroma_client.get_collection(collection_name, embedding_function=embedding_func)
 
             if metadata != self._collection.metadata:
-                logger.warning("Collection already exists. The `distance_function` and `metadata` parameters will be ignored.")
+                logger.warning(
+                    "Collection already exists. The `distance_function` and `metadata` parameters will be ignored."
+                )
         else:
             self._collection = self._chroma_client.create_collection(
                 name=collection_name,

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -35,6 +35,7 @@ class ChromaDocumentStore:
         embedding_function: str = "default",
         persist_path: Optional[str] = None,
         distance_function: Literal["l2", "cosine", "ip"] = "l2",
+        metadata: Optional[dict] = None,
         **embedding_function_params,
     ):
         """
@@ -57,6 +58,9 @@ class ChromaDocumentStore:
             - `"ip"` stands for inner product, where higher scores indicate greater similarity between vectors.
             **Note**: `distance_function` can only be set during the creation of a collection.
             To change the distance metric of an existing collection, consider cloning the collection.
+        :param metadata: a dictionary of chromadb collection parameters passed directly to chromadb's client
+        method `create_collection`. If it contains the key `"hnsw:space"`, the value will take precedence over the
+        `distance_function` parameter above.
 
         :param embedding_function_params: additional parameters to pass to the embedding function.
         """
@@ -81,13 +85,21 @@ class ChromaDocumentStore:
             self._chroma_client = chromadb.PersistentClient(path=persist_path)
 
         embedding_func = get_embedding_function(embedding_function, **embedding_function_params)
-        metadata = {"hnsw:space": distance_function}
+
+        if metadata is None:
+            metadata = {}
+        if "hnsw:space" not in metadata:
+            metadata["hnsw:space"] = distance_function
 
         if collection_name in [c.name for c in self._chroma_client.list_collections()]:
             self._collection = self._chroma_client.get_collection(collection_name, embedding_function=embedding_func)
 
             if distance_function != self._collection.metadata["hnsw:space"]:
                 logger.warning("Collection already exists. The `distance_function` parameter will be ignored.")
+
+            for key in metadata:
+                if metadata[key] != self._collection.metadata[key]:
+                    logger.warning(f"Collection already exists. The `metadata[{key}]` parameter will be ignored.")
         else:
             self._collection = self._chroma_client.create_collection(
                 name=collection_name,

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -86,8 +86,7 @@ class ChromaDocumentStore:
 
         embedding_func = get_embedding_function(embedding_function, **embedding_function_params)
 
-        if metadata is None:
-            metadata = {}
+        metadata = metadata or {}
         if "hnsw:space" not in metadata:
             metadata["hnsw:space"] = distance_function
 

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -164,7 +164,10 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
         with caplog.at_level(logging.WARNING):
             new_store = ChromaDocumentStore("test_4", distance_function="ip")
 
-        assert "Collection already exists. The `distance_function` and `metadata` parameter will be ignored." in caplog.text
+        assert (
+            "Collection already exists. The `distance_function` and `metadata` parameter will be ignored."
+            in caplog.text
+        )
         assert store._collection.metadata["hnsw:space"] == "cosine"
         assert new_store._collection.metadata["hnsw:space"] == "cosine"
 

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -164,7 +164,7 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
         with caplog.at_level(logging.WARNING):
             new_store = ChromaDocumentStore("test_4", distance_function="ip")
 
-        assert "Collection already exists. The `distance_function` parameter will be ignored." in caplog.text
+        assert "Collection already exists. The `distance_function` and `metadata` parameter will be ignored." in caplog.text
         assert store._collection.metadata["hnsw:space"] == "cosine"
         assert new_store._collection.metadata["hnsw:space"] == "cosine"
 

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -165,7 +165,7 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
             new_store = ChromaDocumentStore("test_4", distance_function="ip")
 
         assert (
-            "Collection already exists. The `distance_function` and `metadata` parameter will be ignored."
+            "Collection already exists. The `distance_function` and `metadata` parameters will be ignored."
             in caplog.text
         )
         assert store._collection.metadata["hnsw:space"] == "cosine"
@@ -200,7 +200,7 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
             )
 
         assert (
-            "Collection already exists. The `distance_function` and `metadata` parameter will be ignored."
+            "Collection already exists. The `distance_function` and `metadata` parameters will be ignored."
             in caplog.text
         )
         assert store._collection.metadata["hnsw:space"] == "ip"

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -168,6 +168,23 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
         assert store._collection.metadata["hnsw:space"] == "cosine"
         assert new_store._collection.metadata["hnsw:space"] == "cosine"
 
+    @pytest.mark.integration
+    def test_metadata_initialization(self):
+        store = ChromaDocumentStore(
+            "test_5",
+            distance_function="cosine",
+            metadata={
+                "hnsw:space": "ip",
+                "hnsw:search_ef": 101,
+                "hnsw:construction_ef": 102,
+                "hnsw:M": 103,
+            },
+        )
+        assert store._collection.metadata["hnsw:space"] == "ip"
+        assert store._collection.metadata["hnsw:search_ef"] == 101
+        assert store._collection.metadata["hnsw:construction_ef"] == 102
+        assert store._collection.metadata["hnsw:M"] == 103
+
     @pytest.mark.skip(reason="Filter on dataframe contents is not supported.")
     def test_filter_document_dataframe(self, document_store: ChromaDocumentStore, filterable_docs: List[Document]):
         pass


### PR DESCRIPTION
### Related Issues

- fixes #891

### Proposed Changes:

 <!--- In case of a feature: Describe what did you add and how it works -->
Adds a `metadata` parameter do ChromaDocumentStore to be passed directly to chroma client’s `create_collection` method.

### How did you test it?

integration tests

### Notes for the reviewer


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
