### PR TITLE
fix: `ChromaDocumentStore` - discard `meta` items when the type of their value is not supported in Chroma

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -228,18 +228,22 @@ class ChromaDocumentStore:
 
             if doc.meta:
                 valid_meta = {}
+                discarded_keys = []
 
                 for k, v in doc.meta.items():
                     if isinstance(v, SUPPORTED_TYPES_FOR_METADATA_VALUES):
                         valid_meta[k] = v
                     else:
-                        logger.warning(
-                            "Document %s contains a `meta` value of type %s for the key %s. "
-                            "This type is not supported by Chroma. The item will be discarded.",
-                            doc.id,
-                            type(v).__name__,
-                            k,
-                        )
+                        discarded_keys.append(k)
+
+                if discarded_keys:
+                    logger.warning(
+                        "Document %s contains `meta` values of unsupported types for the keys: %s. "
+                        "These items will be discarded. Supported types are: %s.",
+                        doc.id,
+                        ", ".join(discarded_keys),
+                        ", ".join([t.__name__ for t in SUPPORTED_TYPES_FOR_METADATA_VALUES]),
+                    )
 
                 if valid_meta:
                     data["metadatas"] = [valid_meta]


### PR DESCRIPTION
### Related Issues

- fixes #904
- It is important because starting from 2.3.0 we are automatically populating `meta` with `_split_overlap` when using the `DocumentSplitter` (https://github.com/deepset-ai/haystack/pull/7933). `_split_overlap` is a list, unsupported by Chroma.

### Proposed Changes:
- Check if the value of each item in `meta` has a type supported in Chroma. If not, discard it and emit a warning.

### How did you test it?
CI, new test.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
