### PR TITLE
chore: Pinecone - fix import in conftest

### DIFF
--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -2,7 +2,13 @@ import time
 
 import pytest
 from haystack.document_stores.types import DuplicatePolicy
-from pinecone.core.client.exceptions import NotFoundException
+
+try:
+    # pinecone-client < 5.0.0
+    from pinecone.core.client.exceptions import NotFoundException
+except ModuleNotFoundError:
+    # pinecone-client >= 5.0.0
+    from pinecone.exceptions import NotFoundException
 
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/actions/runs/10032414872/job/27724082100
- the imported `NotFoundException` is available in different modules depending on the `pinecone-client` version

### Proposed Changes:
In case the exception import fails, try another import

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
