### PR TITLE
chore: Ragas - remove context relevancy metric

### DIFF
--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -41,10 +41,10 @@ root = "../.."
 git_describe_command = 'git describe --tags --match="integrations/ragas-v[0-9]*"'
 
 [tool.hatch.envs.default]
-dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
+dependencies = ["coverage[toml]>=6.5", "pytest", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest -x {args:tests}"
+test-cov = "coverage run -m pytest -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "ragas"]
+dependencies = ["haystack-ai", "ragas>=0.1.11"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ragas"

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -41,10 +41,10 @@ root = "../.."
 git_describe_command = 'git describe --tags --match="integrations/ragas-v[0-9]*"'
 
 [tool.hatch.envs.default]
-dependencies = ["coverage[toml]>=6.5", "pytest", "haystack-pydoc-tools"]
+dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools", "pytest-asyncio"]
 [tool.hatch.envs.default.scripts]
-test = "pytest -x {args:tests}"
-test-cov = "coverage run -m pytest -x {args:tests}"
+test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/metrics.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/metrics.py
@@ -12,7 +12,6 @@ from ragas.metrics import (  # type: ignore
     AspectCritique,  # type: ignore
     ContextPrecision,  # type: ignore
     ContextRecall,  # type: ignore
-    ContextRelevancy,  # type: ignore
     ContextUtilization,  # type: ignore
     Faithfulness,  # type: ignore
 )
@@ -80,10 +79,6 @@ class RagasMetric(RagasBaseEnum):
     #: Inputs - `questions: List[str], contexts: List[List[str]], responses: List[str]`\
     #: Parameters - `name: str, definition: str, strictness: int`
     ASPECT_CRITIQUE = "aspect_critique"
-
-    #: Context relevancy.\
-    #: Inputs - `questions: List[str], contexts: List[List[str]]`
-    CONTEXT_RELEVANCY = "context_relevancy"
 
     #: Answer relevancy.\
     #: Inputs - `questions: List[str], contexts: List[List[str]], responses: List[str]`\
@@ -328,11 +323,6 @@ METRIC_DESCRIPTORS = {
         InputConverters.question_context_response,  # type: ignore
         OutputConverters.aspect_critique,
         init_parameters=["name", "definition", "strictness"],
-    ),
-    RagasMetric.CONTEXT_RELEVANCY: MetricDescriptor.new(
-        RagasMetric.CONTEXT_RELEVANCY,
-        ContextRelevancy,
-        InputConverters.question_context,  # type: ignore
     ),
     RagasMetric.ANSWER_RELEVANCY: MetricDescriptor.new(
         RagasMetric.ANSWER_RELEVANCY,

--- a/integrations/ragas/tests/test_evaluator.py
+++ b/integrations/ragas/tests/test_evaluator.py
@@ -283,6 +283,7 @@ def test_evaluator_outputs(current_metric, inputs, expected_outputs, metric_para
 # This integration test validates the evaluator by running it against the
 # OpenAI API. It is parameterized by the metric, the inputs to the evaluator
 # and the metric parameters.
+@pytest.mark.asyncio
 @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
 @pytest.mark.parametrize(
     "metric, inputs, metric_params",

--- a/integrations/ragas/tests/test_evaluator.py
+++ b/integrations/ragas/tests/test_evaluator.py
@@ -51,7 +51,6 @@ class MockBackend:
             RagasMetric.CONTEXT_UTILIZATION: Result(scores=Dataset.from_list([{"context_utilization": 1.0}])),
             RagasMetric.CONTEXT_RECALL: Result(scores=Dataset.from_list([{"context_recall": 0.9}])),
             RagasMetric.ASPECT_CRITIQUE: Result(scores=Dataset.from_list([{"harmfulness": 1.0}])),
-            RagasMetric.CONTEXT_RELEVANCY: Result(scores=Dataset.from_list([{"context_relevancy": 1.0}])),
             RagasMetric.ANSWER_RELEVANCY: Result(scores=Dataset.from_list([{"answer_relevancy": 0.4}])),
         }
         assert isinstance(metric, Metric)
@@ -76,7 +75,6 @@ class MockBackend:
                 "large?",
             },
         ),
-        (RagasMetric.CONTEXT_RELEVANCY, None),
         (RagasMetric.ANSWER_RELEVANCY, {"strictness": 2}),
     ],
 )
@@ -160,7 +158,6 @@ def test_evaluator_serde():
                 "large?",
             },
         ),
-        (RagasMetric.CONTEXT_RELEVANCY, {"questions": [], "contexts": []}, None),
         (RagasMetric.ANSWER_RELEVANCY, {"questions": [], "contexts": [], "responses": []}, {"strictness": 2}),
     ],
 )
@@ -177,7 +174,6 @@ def test_evaluator_valid_inputs(current_metric, inputs, params):
 @pytest.mark.parametrize(
     "current_metric, inputs, error_string, params",
     [
-        (RagasMetric.CONTEXT_RELEVANCY, {"questions": {}, "contexts": []}, "to be a collection of type 'list'", None),
         (
             RagasMetric.FAITHFULNESS,
             {"questions": [1], "contexts": [2], "responses": [3]},
@@ -257,12 +253,6 @@ def test_evaluator_invalid_inputs(current_metric, inputs, error_string, params):
             },
         ),
         (
-            RagasMetric.CONTEXT_RELEVANCY,
-            {"questions": ["q8"], "contexts": [["c8"]]},
-            [[(None, 1.0)]],
-            None,
-        ),
-        (
             RagasMetric.ANSWER_RELEVANCY,
             {"questions": ["q9"], "contexts": [["c9"]], "responses": ["r9"]},
             [[(None, 0.4)]],
@@ -337,7 +327,6 @@ def test_evaluator_outputs(current_metric, inputs, expected_outputs, metric_para
                 "large?",
             },
         ),
-        (RagasMetric.CONTEXT_RELEVANCY, {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS}, None),
         (
             RagasMetric.ANSWER_RELEVANCY,
             {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS, "responses": DEFAULT_RESPONSES},


### PR DESCRIPTION
### Related Issues

- this metric was removed in ragas [0.1.11](https://github.com/explodinggradients/ragas/releases/tag/v0.1.11). (I cannot find much explanation about this removal.)
- CI failures: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/10050341672

### Proposed Changes:
- remove the metric from the Haystack integration

### How did you test it?
CI

### Notes for the reviewer
I don't know if it is preferable to handle it differently. Let me know your thoughts...

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
