### PR TITLE
fix: Weaviate: Use collections.list_all instead of collections._get_all

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -203,7 +203,7 @@ class WeaviateDocumentStore:
         self._client.connect()
 
         # Test connection, it will raise an exception if it fails.
-        self._client.collections._get_all(simple=True)
+        self._client.collections.list_all(simple=True)
         if not self._client.collections.exists(self._collection_settings["class"]):
             self._client.collections.create_from_dict(self._collection_settings)
 


### PR DESCRIPTION
- Weaviate released weaviate-client 4.7.0 library on 23.7.24 - this version started failing our CI tests.
- Seems like weaviate client removed internal method _get_all and introduced list_all. 
- This fix uses list_all
