### PR TITLE
fix: remove exposure of connection_string

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -82,7 +82,6 @@ class MongoDBAtlasDocumentStore:
             msg = f'Invalid collection name: "{collection_name}". It can only contain letters, numbers, -, or _.'
             raise ValueError(msg)
 
-        self.resolved_connection_string = mongo_connection_string.resolve_value()
         self.mongo_connection_string = mongo_connection_string
 
         self.database_name = database_name
@@ -95,7 +94,7 @@ class MongoDBAtlasDocumentStore:
     def connection(self) -> MongoClient:
         if self._connection is None:
             self._connection = MongoClient(
-                self.resolved_connection_string, driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
+                self.mongo_connection_string.resolve_value(), driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
             )
 
         return self._connection


### PR DESCRIPTION
### Related Issues

Unnecessary exposure of resolved Mongodb connection string, making it prone to leaks.

### Proposed Changes:

Avoid storing the connection string value.

### How did you test it?

Ran the existing tests
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
