### PR TITLE
refactor: introduce `_convert_message_to_llamacpp_format` utility function

### DIFF
--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -9,6 +9,21 @@ from llama_cpp.llama_tokenizer import LlamaHFTokenizer
 logger = logging.getLogger(__name__)
 
 
+def _convert_message_to_llamacpp_format(message: ChatMessage) -> Dict[str, str]:
+    """
+    Convert a message to the format expected by Llama.cpp.
+    :returns: A dictionary with the following keys:
+        - `role`
+        - `content`
+        - `name` (optional)
+    """
+    formatted_msg = {"role": message.role.value, "content": message.content}
+    if message.name:
+        formatted_msg["name"] = message.name
+
+    return formatted_msg
+
+
 @component
 class LlamaCppChatGenerator:
     """
@@ -96,7 +111,7 @@ class LlamaCppChatGenerator:
             return {"replies": []}
 
         updated_generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
-        formatted_messages = [msg.to_openai_format() for msg in messages]
+        formatted_messages = [_convert_message_to_llamacpp_format(msg) for msg in messages]
 
         response = self.model.create_chat_completion(messages=formatted_messages, **updated_generation_kwargs)
         replies = [

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -10,7 +10,10 @@ from haystack.components.builders.dynamic_chat_prompt_builder import DynamicChat
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack_integrations.components.generators.llama_cpp import LlamaCppChatGenerator
+from haystack_integrations.components.generators.llama_cpp.chat.chat_generator import (
+    LlamaCppChatGenerator,
+    _convert_message_to_llamacpp_format,
+)
 
 
 @pytest.fixture
@@ -27,6 +30,21 @@ def download_file(file_link, filename, capsys):
     else:
         with capsys.disabled():
             print("\nModel file already exists.")
+
+
+def test_convert_message_to_llamacpp_format():
+    message = ChatMessage.from_system("You are good assistant")
+    assert _convert_message_to_llamacpp_format(message) == {"role": "system", "content": "You are good assistant"}
+
+    message = ChatMessage.from_user("I have a question")
+    assert _convert_message_to_llamacpp_format(message) == {"role": "user", "content": "I have a question"}
+
+    message = ChatMessage.from_function("Function call", "function_name")
+    assert _convert_message_to_llamacpp_format(message) == {
+        "role": "function",
+        "content": "Function call",
+        "name": "function_name",
+    }
 
 
 class TestLlamaCppChatGenerator:


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/8144

### Proposed Changes:
Create a utility function and use it instead of `to_openai_format`

### How did you test it?
CI, new test

### Notes for the reviewer
Tests will fail due to #938

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
