### PR TITLE
test: do not retry tests in `hatch run test` command

### DIFF
--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -82,7 +82,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -63,7 +63,7 @@ jobs:
         run: hatch run docs
 
       - name: Run unit tests
-        run: hatch run cov -m "not integration"
+        run: hatch run cov-retry -m "not integration"
 
       # Do not authenticate on pull requests from forks
       - name: AWS authentication
@@ -76,13 +76,13 @@ jobs:
       # Do not run integration tests on pull requests from forks
       - name: Run integration tests
         if: github.event.pull_request.head.repo.full_name == github.repository
-        run: hatch run cov -m "integration"
+        run: hatch run cov-retry -m "integration"
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -57,13 +57,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -60,7 +60,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -54,13 +54,13 @@ jobs:
         run: hatch run lint:all
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -67,7 +67,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -61,13 +61,13 @@ jobs:
         env:
           ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
           ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -57,13 +57,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -58,13 +58,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -58,13 +58,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -55,13 +55,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -61,7 +61,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -42,13 +42,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -48,7 +48,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -58,13 +58,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/google_vertex.yml
+++ b/.github/workflows/google_vertex.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/google_vertex.yml
+++ b/.github/workflows/google_vertex.yml
@@ -57,13 +57,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -41,7 +41,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -35,13 +35,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -57,13 +57,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -60,13 +60,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -57,13 +57,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -58,13 +58,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -54,13 +54,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -60,7 +60,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -65,7 +65,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -55,7 +55,7 @@ jobs:
         run: hatch run lint:all
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
@@ -65,7 +65,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -81,7 +81,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -75,13 +75,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -55,13 +55,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -61,7 +61,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -57,13 +57,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -67,7 +67,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -61,13 +61,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -63,13 +63,13 @@ jobs:
       - name: Run tests
         env:
           INDEX_NAME: ${{ matrix.INDEX_NAME }}
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -69,7 +69,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -57,13 +57,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -58,13 +58,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -75,7 +75,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -69,13 +69,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -54,13 +54,13 @@ jobs:
         run: hatch run docs
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch run cov-retry
 
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run cov -m "not integration"
+          hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -60,7 +60,7 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           hatch run pip install git+https://github.com/deepset-ai/haystack.git
-          hatch run test -m "not integration"
+          hatch run cov -m "not integration"
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -50,9 +50,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/integrations/amazon_sagemaker/pyproject.toml
+++ b/integrations/amazon_sagemaker/pyproject.toml
@@ -52,8 +52,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 

--- a/integrations/amazon_sagemaker/pyproject.toml
+++ b/integrations/amazon_sagemaker/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 

--- a/integrations/amazon_sagemaker/pyproject.toml
+++ b/integrations/amazon_sagemaker/pyproject.toml
@@ -53,9 +53,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 
 docs = ["pydoc-markdown pydoc/config.yml"]
 

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -50,9 +50,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/integrations/astra/pyproject.toml
+++ b/integrations/astra/pyproject.toml
@@ -48,8 +48,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/astra/pyproject.toml
+++ b/integrations/astra/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/astra/pyproject.toml
+++ b/integrations/astra/pyproject.toml
@@ -49,9 +49,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -50,9 +50,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
   "databind-core<4.5.0",  # FIXME: the latest 4.5.0 causes loops in pip resolver
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -44,9 +44,11 @@ git_describe_command = 'git describe --tags --match="integrations/cohere-v[0-9]*
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -44,7 +44,7 @@ git_describe_command = 'git describe --tags --match="integrations/cohere-v[0-9]*
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -43,8 +43,8 @@ git_describe_command = 'git describe --tags --match="integrations/cohere-v[0-9]*
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -44,7 +44,7 @@ git_describe_command = 'git describe --tags --match="integrations/deepeval-v[0-9
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -43,8 +43,8 @@ git_describe_command = 'git describe --tags --match="integrations/deepeval-v[0-9
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -44,9 +44,11 @@ git_describe_command = 'git describe --tags --match="integrations/deepeval-v[0-9
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -50,9 +50,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -51,9 +51,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -50,8 +50,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -48,8 +48,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -49,9 +49,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]

--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -48,8 +48,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -49,9 +49,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]

--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -72,9 +72,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.test.matrix]]

--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -71,8 +71,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -46,7 +46,7 @@ git_describe_command = 'git describe --tags --match="integrations/jina-v[0-9]*"'
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -46,9 +46,11 @@ git_describe_command = 'git describe --tags --match="integrations/jina-v[0-9]*"'
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -45,8 +45,8 @@ git_describe_command = 'git describe --tags --match="integrations/jina-v[0-9]*"'
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -50,9 +50,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -53,8 +53,8 @@ dependencies = [
     "transformers[sentencepiece]",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -54,9 +54,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -44,7 +44,7 @@ git_describe_command = 'git describe --tags --match="integrations/mistral-v[0-9]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -43,8 +43,8 @@ git_describe_command = 'git describe --tags --match="integrations/mistral-v[0-9]
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -44,9 +44,11 @@ git_describe_command = 'git describe --tags --match="integrations/mistral-v[0-9]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -51,9 +51,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -50,8 +50,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -45,7 +45,7 @@ git_describe_command = 'git describe --tags --match="integrations/nvidia-v[0-9]*
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -44,8 +44,8 @@ git_describe_command = 'git describe --tags --match="integrations/nvidia-v[0-9]*
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -45,9 +45,11 @@ git_describe_command = 'git describe --tags --match="integrations/nvidia-v[0-9]*
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -54,9 +54,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -53,8 +53,8 @@ dependencies = [
     "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -51,9 +51,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 
 docs = ["pydoc-markdown pydoc/config.yml"]
 

--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 

--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -50,8 +50,8 @@ dependencies = [
   "boto3",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 

--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -64,9 +64,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -63,8 +63,8 @@ dependencies = [
   "setuptools",           # FIXME: the latest 4.5.0 causes loops in pip resolver
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -51,9 +51,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -50,8 +50,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -55,9 +55,11 @@ dependencies = [
 # Pinecone tests are slow (require HTTP requests), so we run them in parallel
 # with pytest-xdist (https://pytest-xdist.readthedocs.io/en/stable/distribution.html)
 test = "pytest -n auto --maxprocesses=2 -x {args:tests}"
-test-cov = "coverage run -m pytest -n auto --maxprocesses=2 --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest -n auto --maxprocesses=2 {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
 # Pinecone tests are slow (require HTTP requests), so we run them in parallel
 # with pytest-xdist (https://pytest-xdist.readthedocs.io/en/stable/distribution.html)
 test = "pytest -n auto --maxprocesses=2 -x {args:tests}"
-test-cov = "coverage run -m pytest -n auto --maxprocesses=2 -x {args:tests}"
+test-cov = "coverage run -m pytest -n auto --maxprocesses=2 --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -54,8 +54,8 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 # Pinecone tests are slow (require HTTP requests), so we run them in parallel
 # with pytest-xdist (https://pytest-xdist.readthedocs.io/en/stable/distribution.html)
-test = "pytest -n auto --maxprocesses=2 --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest -n auto --maxprocesses=2 --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest -n auto --maxprocesses=2 -x {args:tests}"
+test-cov = "coverage run -m pytest -n auto --maxprocesses=2 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -46,8 +46,8 @@ git_describe_command = 'git describe --tags --match="integrations/qdrant-v[0-9]*
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -47,7 +47,7 @@ git_describe_command = 'git describe --tags --match="integrations/qdrant-v[0-9]*
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -47,9 +47,11 @@ git_describe_command = 'git describe --tags --match="integrations/qdrant-v[0-9]*
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -44,9 +44,11 @@ git_describe_command = 'git describe --tags --match="integrations/ragas-v[0-9]*"
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools", "pytest-asyncio"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -44,7 +44,7 @@ git_describe_command = 'git describe --tags --match="integrations/ragas-v[0-9]*"
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools", "pytest-asyncio"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -43,8 +43,8 @@ git_describe_command = 'git describe --tags --match="integrations/ragas-v[0-9]*"
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "haystack-pydoc-tools", "pytest-asyncio"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -48,8 +48,8 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -49,9 +49,11 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -50,7 +50,7 @@ git_describe_command = 'git describe --tags --match="integrations/weaviate-v[0-9
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -50,9 +50,11 @@ git_describe_command = 'git describe --tags --match="integrations/weaviate-v[0-9
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -49,8 +49,8 @@ git_describe_command = 'git describe --tags --match="integrations/weaviate-v[0-9
 [tool.hatch.envs.default]
 dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython"]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
-test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]


### PR DESCRIPTION
### Related Issues
In #836 and #845, `pytest-rerunfailures` was introduced and it is currently used in `hatch run test` and `hatch run cov`.

When running tests locally with `hatch run test`, this makes the tests rerun 3 times with a delay of 30 seconds and stop at the first failing test.
This is a frustrating experience. :smile: 

### Proposed Changes:
- change the `hatch run test` command to simply do `pytest {args:tests}`
- make sure to always use `cov` in CI runs.

### How did you test it?
Manual tests, CI.

### Notes for the reviewer
There could be better ways to fix this, but they would probably involve duplicating some configs and/or restructuring the workflow.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
