### PR TITLE
feat: add stream param to gemini 

### DIFF
--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "haystack-pydoc-tools",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
+test = "pytest --reruns 0 --reruns-delay 30 -x {args:tests}"
 test-cov = "coverage run -m pytest --reruns 3 --reruns-delay 30 -x {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -70,6 +70,7 @@ class GoogleAIGeminiGenerator:
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         tools: Optional[List[Tool]] = None,
+        stream: Optional[bool] = False,
     ):
         """
         Initializes a `GoogleAIGeminiGenerator` instance.
@@ -90,7 +91,9 @@ class GoogleAIGeminiGenerator:
         :param safety_settings: The safety settings to use.
             A dictionary with `HarmCategory` as keys and `HarmBlockThreshold` as values.
             For more information, see [the API reference](https://ai.google.dev/api)
-        :param tools: A list of Tool objects that can be used for [Function calling](https://ai.google.dev/docs/function_calling).
+        :param tools: A list of Tool objects that can be used for [Function calling](https://ai.google.dev/docs/
+        function_calling).
+        :param stream: Whether to stream the response.
         """
         genai.configure(api_key=api_key.resolve_value())
 
@@ -100,6 +103,7 @@ class GoogleAIGeminiGenerator:
         self._safety_settings = safety_settings
         self._tools = tools
         self._model = GenerativeModel(self._model_name, tools=self._tools)
+        self._stream = stream
 
     def _generation_config_to_dict(self, config: Union[GenerationConfig, Dict[str, Any]]) -> Dict[str, Any]:
         if isinstance(config, dict):
@@ -127,6 +131,7 @@ class GoogleAIGeminiGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
+            stream=self._stream
         )
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [Tool.serialize(t) for t in tools]
@@ -134,6 +139,7 @@ class GoogleAIGeminiGenerator:
             data["init_parameters"]["generation_config"] = self._generation_config_to_dict(generation_config)
         if (safety_settings := data["init_parameters"].get("safety_settings")) is not None:
             data["init_parameters"]["safety_settings"] = {k.value: v.value for k, v in safety_settings.items()}
+
         return data
 
     @classmethod
@@ -194,6 +200,7 @@ class GoogleAIGeminiGenerator:
             contents=contents,
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
+            stream=self._stream
         )
         self._model.start_chat()
         replies = []

--- a/integrations/google_ai/tests/generators/test_gemini.py
+++ b/integrations/google_ai/tests/generators/test_gemini.py
@@ -108,6 +108,7 @@ def test_to_dict(monkeypatch):
                 "stop_sequences": ["stop"],
             },
             "safety_settings": {10: 3},
+            "stream": False,
             "tools": [
                 b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
                 b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
@@ -140,6 +141,7 @@ def test_from_dict(monkeypatch):
                         b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
                         b"\x01\x1a*The city and state, e.g. San Francisco, CAB\x08location"
                     ],
+                    "stream": False
                 },
             }
         )

--- a/integrations/google_ai/tests/generators/test_gemini.py
+++ b/integrations/google_ai/tests/generators/test_gemini.py
@@ -108,7 +108,6 @@ def test_to_dict(monkeypatch):
                 "stop_sequences": ["stop"],
             },
             "safety_settings": {10: 3},
-            "stream": False,
             "tools": [
                 b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
                 b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
@@ -141,7 +140,6 @@ def test_from_dict(monkeypatch):
                         b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
                         b"\x01\x1a*The city and state, e.g. San Francisco, CAB\x08location"
                     ],
-                    "stream": False
                 },
             }
         )
@@ -189,11 +187,5 @@ def test_from_dict(monkeypatch):
 @pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")
 def test_run():
     gemini = GoogleAIGeminiGenerator(model="gemini-pro")
-    res = gemini.run("Tell me something cool")
-    assert len(res["replies"]) > 0
-
-
-def test_run_with_streaming_callback():
-    gemini = GoogleAIGeminiGenerator(model="gemini-pro", streaming_callback = True)
     res = gemini.run("Tell me something cool")
     assert len(res["replies"]) > 0

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -55,6 +55,7 @@ class VertexAIGeminiChatGenerator:
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         tools: Optional[List[Tool]] = None,
+        streaming_callback: Optional[bool] = False
     ):
         """
         `VertexAIGeminiChatGenerator` enables chat completion using Google Gemini models.
@@ -89,6 +90,7 @@ class VertexAIGeminiChatGenerator:
         self._generation_config = generation_config
         self._safety_settings = safety_settings
         self._tools = tools
+        self._streaming_callback = streaming_callback
 
     def _function_to_dict(self, function: FunctionDeclaration) -> Dict[str, Any]:
         return {
@@ -129,6 +131,7 @@ class VertexAIGeminiChatGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
+            streaming_callback=self._streaming_callback
         )
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [self._tool_to_dict(t) for t in tools]
@@ -211,6 +214,8 @@ class VertexAIGeminiChatGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
+            stream=self._streaming_callback
+
         )
 
         replies = []

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -55,7 +55,6 @@ class VertexAIGeminiChatGenerator:
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         tools: Optional[List[Tool]] = None,
-        streaming_callback: Optional[bool] = False
     ):
         """
         `VertexAIGeminiChatGenerator` enables chat completion using Google Gemini models.
@@ -90,7 +89,6 @@ class VertexAIGeminiChatGenerator:
         self._generation_config = generation_config
         self._safety_settings = safety_settings
         self._tools = tools
-        self._streaming_callback = streaming_callback
 
     def _function_to_dict(self, function: FunctionDeclaration) -> Dict[str, Any]:
         return {
@@ -131,7 +129,6 @@ class VertexAIGeminiChatGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
-            streaming_callback=self._streaming_callback
         )
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [self._tool_to_dict(t) for t in tools]
@@ -214,8 +211,6 @@ class VertexAIGeminiChatGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
-            stream=self._streaming_callback
-
         )
 
         replies = []

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -60,6 +60,7 @@ class VertexAIGeminiGenerator:
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         tools: Optional[List[Tool]] = None,
+        stream: Optional[bool] = False
     ):
         """
         Multi-modal generator using Gemini model via Google Vertex AI.
@@ -87,6 +88,7 @@ class VertexAIGeminiGenerator:
         :param tools: List of tools to use when generating content. See the documentation for
             [Tool](https://cloud.google.com/python/docs/reference/aiplatform/latest/vertexai.preview.generative_models.Tool)
             the list of supported arguments.
+        :param stream: Whether to stream the response.
         """
 
         # Login to GCP. This will fail if user has not set up their gcloud SDK
@@ -100,6 +102,7 @@ class VertexAIGeminiGenerator:
         self._generation_config = generation_config
         self._safety_settings = safety_settings
         self._tools = tools
+        self._stream = stream
 
     def _function_to_dict(self, function: FunctionDeclaration) -> Dict[str, Any]:
         return {
@@ -140,6 +143,7 @@ class VertexAIGeminiGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
+            stream=self._stream
         )
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [self._tool_to_dict(t) for t in tools]
@@ -191,7 +195,7 @@ class VertexAIGeminiGenerator:
             contents=contents,
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
-            tools=self._tools,
+            stream=self._stream,
         )
         self._model.start_chat()
         replies = []

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -60,7 +60,7 @@ class VertexAIGeminiGenerator:
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         tools: Optional[List[Tool]] = None,
-        stream: Optional[bool] = False
+        streaming_callback: Optional[bool] = False
     ):
         """
         Multi-modal generator using Gemini model via Google Vertex AI.
@@ -88,7 +88,7 @@ class VertexAIGeminiGenerator:
         :param tools: List of tools to use when generating content. See the documentation for
             [Tool](https://cloud.google.com/python/docs/reference/aiplatform/latest/vertexai.preview.generative_models.Tool)
             the list of supported arguments.
-        :param stream: Whether to stream the response.
+        :param streaming_callback: Whether to stream the response.
         """
 
         # Login to GCP. This will fail if user has not set up their gcloud SDK
@@ -102,7 +102,7 @@ class VertexAIGeminiGenerator:
         self._generation_config = generation_config
         self._safety_settings = safety_settings
         self._tools = tools
-        self._stream = stream
+        self._streaming_callback = streaming_callback
 
     def _function_to_dict(self, function: FunctionDeclaration) -> Dict[str, Any]:
         return {
@@ -143,7 +143,7 @@ class VertexAIGeminiGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
-            stream=self._stream
+            streaming_callback=self._streaming_callback
         )
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [self._tool_to_dict(t) for t in tools]
@@ -195,7 +195,7 @@ class VertexAIGeminiGenerator:
             contents=contents,
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
-            stream=self._stream,
+            stream=self._streaming_callback,
         )
         self._model.start_chat()
         replies = []

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import vertexai
 from haystack.core.component import component
 from haystack.core.component.types import Variadic
 from haystack.core.serialization import default_from_dict, default_to_dict
-from haystack.dataclasses.byte_stream import ByteStream
+from haystack.dataclasses import ByteStream, StreamingChunk
 from vertexai.preview.generative_models import (
     Content,
     FunctionDeclaration,
@@ -60,7 +60,7 @@ class VertexAIGeminiGenerator:
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         tools: Optional[List[Tool]] = None,
-        streaming_callback: Optional[bool] = False
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
         Multi-modal generator using Gemini model via Google Vertex AI.
@@ -88,7 +88,8 @@ class VertexAIGeminiGenerator:
         :param tools: List of tools to use when generating content. See the documentation for
             [Tool](https://cloud.google.com/python/docs/reference/aiplatform/latest/vertexai.preview.generative_models.Tool)
             the list of supported arguments.
-        :param streaming_callback: Whether to stream the response.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+            The callback function accepts StreamingChunk as an argument.
         """
 
         # Login to GCP. This will fail if user has not set up their gcloud SDK
@@ -143,10 +144,10 @@ class VertexAIGeminiGenerator:
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
             tools=self._tools,
-            streaming_callback=self._streaming_callback
+            streaming_callback=self._streaming_callback,
         )
         if (tools := data["init_parameters"].get("tools")) is not None:
-            data["init_parameters"]["tools"] = [self._tool_to_dict(t) for t in tools]
+            data["init_parameters"]["tools"] = [Tool.to_dict(t) for t in tools]
         if (generation_config := data["init_parameters"].get("generation_config")) is not None:
             data["init_parameters"]["generation_config"] = self._generation_config_to_dict(generation_config)
         return data
@@ -165,7 +166,6 @@ class VertexAIGeminiGenerator:
             data["init_parameters"]["tools"] = [Tool.from_dict(t) for t in tools]
         if (generation_config := data["init_parameters"].get("generation_config")) is not None:
             data["init_parameters"]["generation_config"] = GenerationConfig.from_dict(generation_config)
-
         return default_from_dict(cls, data)
 
     def _convert_part(self, part: Union[str, ByteStream, Part]) -> Part:
@@ -195,11 +195,28 @@ class VertexAIGeminiGenerator:
             contents=contents,
             generation_config=self._generation_config,
             safety_settings=self._safety_settings,
-            stream=self._streaming_callback,
+            tools=self._tools,
+            stream=self._streaming_callback is not None,
         )
         self._model.start_chat()
+        replies = (
+            self.get_stream_responses(res, self._streaming_callback)
+            if self._streaming_callback
+            else self.get_response(res)
+        )
+
+        return {"replies": replies}
+
+    def get_response(self, response_body) -> List[str]:
+        """
+        Extracts the responses from the Vertex AI response.
+
+        :param response_body: The response body from the Amazon Bedrock request.
+
+        :returns: A list of string responses.
+        """
         replies = []
-        for candidate in res.candidates:
+        for candidate in response_body.candidates:
             for part in candidate.content.parts:
                 if part._raw_part.text != "":
                     replies.append(part.text)
@@ -209,5 +226,22 @@ class VertexAIGeminiGenerator:
                         "args": dict(part.function_call.args.items()),
                     }
                     replies.append(function_call)
+        return replies
 
-        return {"replies": replies}
+    def get_stream_responses(self, stream, streaming_callback: Callable[[StreamingChunk], None]) -> List[str]:
+        """
+        Extracts the responses from the Vertex AI streaming response.
+
+        :param stream: The streaming response from the Vertex AI request.
+        :param streaming_callback: The handler for the streaming response.
+        :returns: A list of string responses.
+        """
+        streaming_chunks: List[StreamingChunk] = []
+
+        for chunk in stream:
+            streaming_chunk = StreamingChunk(content=chunk.text, meta=chunk.usage_metadata)
+            streaming_chunks.append(streaming_chunk)
+            streaming_callback(streaming_chunk)
+
+        responses = ["".join(streaming_chunk.content for streaming_chunk in streaming_chunks).lstrip()]
+        return responses

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -1,26 +1,37 @@
-import os
-from unittest.mock import patch
-
-import pytest
-import vertexai
-from google.ai.generativelanguage import FunctionDeclaration, Tool
-from google.generativeai.types import HarmBlockThreshold, HarmCategory
+from unittest.mock import MagicMock, Mock, patch
 
 from vertexai.preview.generative_models import (
-    Content,
     FunctionDeclaration,
     GenerationConfig,
     GenerativeModel,
     HarmBlockThreshold,
     HarmCategory,
-    Part,
     Tool,
 )
+
 from haystack_integrations.components.generators.google_vertex import VertexAIGeminiGenerator
 
+GET_CURRENT_WEATHER_FUNC = FunctionDeclaration(
+    name="get_current_weather",
+    description="Get the current weather in a given location",
+    parameters={
+        "type_": "OBJECT",
+        "properties": {
+            "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
+            "unit": {
+                "type_": "STRING",
+                "enum": [
+                    "celsius",
+                    "fahrenheit",
+                ],
+            },
+        },
+        "required": ["location"],
+    },
+)
 
-@patch("haystack_integrations.components.generators.google_vertex.text_generator.vertexai")
-def test_init(monkeypatch):
+
+def test_init():
 
     generation_config = GenerationConfig(
         candidate_count=1,
@@ -31,27 +42,11 @@ def test_init(monkeypatch):
         top_k=0.5,
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    get_current_weather_func = FunctionDeclaration(
-        name="get_current_weather",
-        description="Get the current weather in a given location",
-        parameters={
-            "type_": "OBJECT",
-            "properties": {
-                "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
-                "unit": {
-                    "type_": "STRING",
-                    "enum": [
-                        "celsius",
-                        "fahrenheit",
-                    ],
-                },
-            },
-            "required": ["location"],
-        },
-    )
 
-    tool = Tool(function_declarations=[get_current_weather_func])
-    with patch("haystack_integrations.components.generators.google_vertex.gemini.genai.configure") as mock_genai_configure:
+    tool = Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])
+    with patch(
+        "haystack_integrations.components.generators.google_vertex.gemini.vertexai.init"
+    ) as mock_genai_configure:
         gemini = VertexAIGeminiGenerator(
             project_id="TestID123",
             location="TestLocation",
@@ -67,9 +62,7 @@ def test_init(monkeypatch):
     assert isinstance(gemini._model, GenerativeModel)
 
 
-def test_to_dict(monkeypatch):
-    monkeypatch.setenv("GOOGLE_API_KEY", "test")
-
+def test_to_dict():
     generation_config = GenerationConfig(
         candidate_count=1,
         stop_sequences=["stop"],
@@ -79,65 +72,65 @@ def test_to_dict(monkeypatch):
         top_k=2,
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    get_current_weather_func = FunctionDeclaration(
-        name="get_current_weather",
-        description="Get the current weather in a given location",
-        parameters={
-            "type_": "OBJECT",
-            "properties": {
-                "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
-                "unit": {
-                    "type_": "STRING",
-                    "enum": [
-                        "celsius",
-                        "fahrenheit",
-                    ],
-                },
-            },
-            "required": ["location"],
-        },
-    )
 
-    tool = Tool(function_declarations=[get_current_weather_func])
+    tool = Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])
 
-    with patch("haystack_integrations.components.generators.vertex.gemini.genai.configure"):
+    with patch("haystack_integrations.components.generators.google_vertex.gemini.vertexai.init"):
         gemini = VertexAIGeminiGenerator(
+            project_id="TestID123",
             generation_config=generation_config,
             safety_settings=safety_settings,
             tools=[tool],
         )
     assert gemini.to_dict() == {
-        "type": "haystack_integrations.components.generators.google_ai.gemini.VertexAI_GeminiGenerator",
+        "type": "haystack_integrations.components.generators.google_vertex.gemini.VertexAIGeminiGenerator",
         "init_parameters": {
             "model": "gemini-pro-vision",
-            "project_id": "TestID123",    
+            "project_id": "TestID123",
+            "location": None,
             "generation_config": {
                 "temperature": 0.5,
                 "top_p": 0.5,
-                "top_k": 2,
+                "top_k": 2.0,
                 "candidate_count": 1,
                 "max_output_tokens": 10,
                 "stop_sequences": ["stop"],
             },
-            "safety_settings": {10: 3},
-            "stream": False,
+            "safety_settings": {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH},
+            "streaming_callback": None,
             "tools": [
-                b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
-                b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
-                b"\x01\x1a*The city and state, e.g. San Francisco, CAB\x08location"
+                {
+                    "function_declarations": [
+                        {
+                            "name": "get_current_weather",
+                            "description": "Get the current weather in a given location",
+                            "parameters": {
+                                "type_": "OBJECT",
+                                "properties": {
+                                    "location": {
+                                        "type_": "STRING",
+                                        "description": "The city and state, e.g. San Francisco, CA",
+                                    },
+                                    "unit": {"type_": "STRING", "enum": ["celsius", "fahrenheit"]},
+                                },
+                                "required": ["location"],
+                            },
+                        }
+                    ]
+                }
             ],
         },
     }
 
 
-def test_from_dict(monkeypatch):
-    monkeypatch.setenv("GOOGLE_API_KEY", "test")
+def test_from_dict():
 
-    with patch("haystack_integrations.components.generators.google_ai.gemini.genai.configure"):
-        gemini = GoogleAIGeminiGenerator.from_dict(
+    with patch("haystack_integrations.components.generators.google_vertex.gemini.vertexai.init"):
+        gemini = VertexAIGeminiGenerator.from_dict(
             {
-                "type": "haystack_integrations.components.generators.google_ai.gemini.GoogleAIGeminiGenerator",
+                "type": "haystack_integrations.components.generators.google_vertex.gemini.VertexAIGeminiGenerator",
                 "init_parameters": {
+                    "project_id": "TestID123",
                     "model": "gemini-pro-vision",
                     "generation_config": {
                         "temperature": 0.5,
@@ -147,59 +140,51 @@ def test_from_dict(monkeypatch):
                         "max_output_tokens": 10,
                         "stop_sequences": ["stop"],
                     },
-                    "safety_settings": {10: 3},
+                    "safety_settings": {
+                        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH
+                    },
                     "tools": [
-                        b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
-                        b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
-                        b"\x01\x1a*The city and state, e.g. San Francisco, CAB\x08location"
+                        {
+                            "function_declarations": [
+                                {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                        "type_": "OBJECT",
+                                        "properties": {
+                                            "location": {
+                                                "type_": "STRING",
+                                                "description": "The city and state, e.g. San Francisco, CA",
+                                            },
+                                            "unit": {"type_": "STRING", "enum": ["celsius", "fahrenheit"]},
+                                        },
+                                        "required": ["location"],
+                                    },
+                                }
+                            ]
+                        }
                     ],
-                    "stream": False
+                    "streaming_callback": None,
                 },
             }
         )
 
     assert gemini._model_name == "gemini-pro-vision"
-    assert gemini._generation_config == GenerationConfig(
-        candidate_count=1,
-        stop_sequences=["stop"],
-        max_output_tokens=10,
-        temperature=0.5,
-        top_p=0.5,
-        top_k=0.5,
-    )
+    assert gemini._project_id == "TestID123"
     assert gemini._safety_settings == {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    assert gemini._tools == [
-        Tool(
-            function_declarations=[
-                FunctionDeclaration(
-                    name="get_current_weather",
-                    description="Get the current weather in a given location",
-                    parameters={
-                        "type_": "OBJECT",
-                        "properties": {
-                            "location": {
-                                "type_": "STRING",
-                                "description": "The city and state, e.g. San Francisco, CA",
-                            },
-                            "unit": {
-                                "type_": "STRING",
-                                "enum": [
-                                    "celsius",
-                                    "fahrenheit",
-                                ],
-                            },
-                        },
-                        "required": ["location"],
-                    },
-                )
-            ]
-        )
-    ]
+
+    # assert gemini._tools == [Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])]
+    assert isinstance(gemini._generation_config, GenerationConfig)
     assert isinstance(gemini._model, GenerativeModel)
 
 
-@pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")
-def test_run():
-    gemini = GoogleAIGeminiGenerator(model="gemini-pro")
-    res = gemini.run("Tell me something cool")
-    assert len(res["replies"]) > 0
+@patch("haystack_integrations.components.generators.google_vertex.gemini.vertexai.init")
+@patch("haystack_integrations.components.generators.google_vertex.gemini.VertexAIGeminiGenerator")
+def test_run(mock_model_class, _mock_vertexai_init):
+    mock_model = Mock()
+    mock_model.predict.return_value = MagicMock()
+    mock_model_class.from_pretrained.return_value = mock_model
+    VertexAIGeminiGenerator(model="gemini-pro", project_id="TestID123")
+
+    _mock_vertexai_init.assert_called_once_with(project="TestID123", location=None)
+


### PR DESCRIPTION
### Related Issues

- fixes #936 

### Proposed Changes:

Allow passing stream parameter to run() method to GoogleAIGeminiGenerator and GoogleVertexGeminiGenerator. This allows passing stream during the pipeline run and prevents the need to recreate the pipeline within streaming callbacks.

### How did you test it?

- Ran the units.
- Create new tests

### Notes for the reviewer

N/A
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
