### PR TITLE
chore: Update test for the new `apply_filter_policy` usage

### DIFF
--- a/integrations/pgvector/tests/test_retrievers.py
+++ b/integrations/pgvector/tests/test_retrievers.py
@@ -311,7 +311,7 @@ class TestKeywordRetriever:
         )
         res = retriever.run(query="test query", filters={"field2": "value2"})
 
-        mock_store._keyword_retrieval.assert_called_once_with(
+        mock_store.mock_calls[0].assert_called_once_with(
             query="test query", filters={"field": "value", "field2": "value2"}, top_k=10
         )
 


### PR DESCRIPTION
- Update pgvector `test_run_with_filters` test to match the results of the common `apply_filter_policy` algorithm applied across all db stores
- update mock

**NOTE:**

- We need to wait for new haystack-ai to be released and then open this PR