### PR TITLE
fix: normalising ChatGenerators output

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -334,7 +334,7 @@ class MistralChatAdapter(BedrockModelChatAdapter):
         # b) we can use apply_chat_template with the template above to delineate ChatMessages
         # Mistral models are gated on HF Hub. If no HF_TOKEN is found we use a non-gated alternative tokenizer model.
         tokenizer: PreTrainedTokenizer
-        if os.environ.get("HF_TOKEN"):
+        if os.environ.get("HF_TOKEN") or os.environ.get("HF_API_TOKEN"):
             tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
         else:
             tokenizer = AutoTokenizer.from_pretrained("NousResearch/Llama-2-7b-chat-hf")

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -215,8 +215,8 @@ class AmazonBedrockChatGenerator:
                     if "output_tokens" in response.meta["usage"]:
                         response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_tokens")
                 else:
-                    response.meta["usage"] = {}
                     if "prompt_token_count" in response.meta:
+                        response.meta["usage"] = {}
                         response.meta["usage"]["prompt_tokens"] = response.meta.pop("prompt_token_count")
                     if "generation_token_count" in response.meta:
                         response.meta["usage"]["completion_tokens"] = response.meta.pop("generation_token_count")

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -217,7 +217,8 @@ class AmazonBedrockChatGenerator:
                     if "output_token" in response.meta["usage"]:
                         response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_token")
                 else:
-                    raise ValueError("The meta key is not in the expected format.")
+                    msg = "The meta key is not in the expected format."
+                    raise ValueError(msg)
 
         return {"replies": replies}
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -205,17 +205,17 @@ class AmazonBedrockChatGenerator:
 
         # rename the meta key to be inline with OpenAI meta output keys
         for response in replies:
-            if response.meta is not None:
-                if "usage" not in response.meta:
+            if response.meta:
+                if "usage" in response.meta:
+                    if "input_tokens" in response.meta["usage"]:
+                        response.meta["usage"]["prompt_tokens"] = response.meta["usage"].pop("input_tokens")
+                    if "output_tokens" in response.meta["usage"]:
+                        response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_tokens")
+                elif "usage" not in response.meta:
                     if "prompt_token_count" in response.meta:
                         response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
                     if "generation_token_count" in response.meta:
                         response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
-                elif "usage" in response.meta:
-                    if "input_tokens" in response.meta["usage"]:
-                        response.meta["usage"]["prompt_tokens"] = response.meta["usage"].pop("input_tokens")
-                    if "output_token" in response.meta["usage"]:
-                        response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_token")
                 else:
                     msg = "The meta key is not in the expected format."
                     raise ValueError(msg)

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -215,8 +215,8 @@ class AmazonBedrockChatGenerator:
                     if "output_tokens" in response.meta["usage"]:
                         response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_tokens")
                 else:
+                    response.meta["usage"] = {}
                     if "prompt_token_count" in response.meta:
-                        response.meta["usage"] = {}
                         response.meta["usage"]["prompt_tokens"] = response.meta.pop("prompt_token_count")
                     if "generation_token_count" in response.meta:
                         response.meta["usage"]["completion_tokens"] = response.meta.pop("generation_token_count")

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -213,9 +213,10 @@ class AmazonBedrockChatGenerator:
                         response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_tokens")
                 elif "usage" not in response.meta:
                     if "prompt_token_count" in response.meta:
-                        response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
+                        response.meta["usage"] = {}
+                        response.meta["usage"]["prompt_tokens"] = response.meta.pop("prompt_token_count")
                     if "generation_token_count" in response.meta:
-                        response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
+                        response.meta["usage"]["completion_tokens"] = response.meta.pop("generation_token_count")
                 else:
                     msg = "The meta key is not in the expected format."
                     raise ValueError(msg)

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -211,15 +211,12 @@ class AmazonBedrockChatGenerator:
                         response.meta["usage"]["prompt_tokens"] = response.meta["usage"].pop("input_tokens")
                     if "output_tokens" in response.meta["usage"]:
                         response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_tokens")
-                elif "usage" not in response.meta:
+                else:
                     if "prompt_token_count" in response.meta:
                         response.meta["usage"] = {}
                         response.meta["usage"]["prompt_tokens"] = response.meta.pop("prompt_token_count")
                     if "generation_token_count" in response.meta:
                         response.meta["usage"]["completion_tokens"] = response.meta.pop("generation_token_count")
-                else:
-                    msg = "The meta key is not in the expected format."
-                    raise ValueError(msg)
 
         return {"replies": replies}
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -206,16 +206,16 @@ class AmazonBedrockChatGenerator:
         # rename the meta key to be inline with OpenAI meta output keys
         for response in replies:
             if response.meta is not None:
-                if 'usage' not in response.meta:
+                if "usage" not in response.meta:
                     if "prompt_token_count" in response.meta:
                         response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
-                    if 'generation_token_count' in response.meta:
+                    if "generation_token_count" in response.meta:
                         response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
                 elif "usage" in response.meta:
-                    if "input_tokens" in response.meta['usage']:
-                        response.meta["usage"]['prompt_tokens'] = response.meta['usage'].pop("input_tokens")
-                    if "output_token" in response.meta['usage']:
-                        response.meta["usage"]['completion_tokens'] = response.meta['usage'].pop("output_token")
+                    if "input_tokens" in response.meta["usage"]:
+                        response.meta["usage"]["prompt_tokens"] = response.meta["usage"].pop("input_tokens")
+                    if "output_token" in response.meta["usage"]:
+                        response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_token")
                 else:
                     print("DEBUG", response.meta)
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -205,9 +205,9 @@ class AmazonBedrockChatGenerator:
 
         # rename the meta key to be inline with OpenAI meta output keys
         for response in replies:
-            if response.meta is not None and "usage" in response.meta:
-                response.meta["usage"]["prompt_tokens"] = response.meta["usage"].pop("input_tokens")
-                response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_tokens")
+            if response.meta is not None:
+                response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
+                response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
 
         return {"replies": replies}
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -206,8 +206,10 @@ class AmazonBedrockChatGenerator:
         # rename the meta key to be inline with OpenAI meta output keys
         for response in replies:
             if response.meta is not None:
-                response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
-                response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
+                if "prompt_token_count" in response.meta:
+                    response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
+                if "generation_token_count" in response.meta:
+                    response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
 
         return {"replies": replies}
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -206,10 +206,18 @@ class AmazonBedrockChatGenerator:
         # rename the meta key to be inline with OpenAI meta output keys
         for response in replies:
             if response.meta is not None:
-                if "prompt_token_count" in response.meta:
-                    response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
-                if "generation_token_count" in response.meta:
-                    response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
+                if 'usage' not in response.meta:
+                    if "prompt_token_count" in response.meta:
+                        response.meta["prompt_tokens"] = response.meta.pop("prompt_token_count")
+                    if 'generation_token_count' in response.meta:
+                        response.meta["completion_tokens"] = response.meta.pop("generation_token_count")
+                elif "usage" in response.meta:
+                    if "input_tokens" in response.meta['usage']:
+                        response.meta["usage"]['prompt_tokens'] = response.meta['usage'].pop("input_tokens")
+                    if "output_token" in response.meta['usage']:
+                        response.meta["usage"]['completion_tokens'] = response.meta['usage'].pop("output_token")
+                else:
+                    print("DEBUG", response.meta)
 
         return {"replies": replies}
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -217,7 +217,7 @@ class AmazonBedrockChatGenerator:
                     if "output_token" in response.meta["usage"]:
                         response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_token")
                 else:
-                    print("DEBUG", response.meta)
+                    raise ValueError("The meta key is not in the expected format.")
 
         return {"replies": replies}
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -362,10 +362,6 @@ class TestMetaLlama2ChatAdapter:
             assert "prompt_tokens" in first_reply.meta["usage"]
             assert "completion_tokens" in first_reply.meta["usage"]
 
-        if first_reply.meta and "usage" not in first_reply.meta:
-            assert "prompt_tokens" in first_reply.meta
-            assert "completion_tokens" in first_reply.meta
-
     @pytest.mark.parametrize("model_name", MODELS_TO_TEST)
     @pytest.mark.integration
     def test_default_inference_with_streaming(self, model_name, chat_messages):

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -228,14 +228,12 @@ def test_long_prompt_is_not_truncated_when_truncate_false(mock_boto3_session):
                         content="Some text",
                         role=ChatRole.ASSISTANT,
                         name=None,
-                        meta=[
-                            {
+                        meta={
                                 "model": "claude-3-sonnet-20240229",
                                 "index": 0,
                                 "finish_reason": "end_turn",
                                 "usage": {"prompt_tokens": 16, "completion_tokens": 55},
-                            }
-                        ],
+                        }
                     )
                 ]
             )

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -358,6 +358,14 @@ class TestMetaLlama2ChatAdapter:
         assert "paris" in first_reply.content.lower(), "First reply does not contain 'paris'"
         assert first_reply.meta, "First reply has no metadata"
 
+        if first_reply.meta and 'usage' in first_reply.meta:
+            assert 'prompt_tokens' in first_reply.meta['usage']
+            assert 'completion_tokens' in first_reply.meta['usage']
+
+        if first_reply.meta and 'usage' not in first_reply.meta:
+            assert 'prompt_tokens' in first_reply.meta
+            assert 'completion_tokens' in first_reply.meta
+
     @pytest.mark.parametrize("model_name", MODELS_TO_TEST)
     @pytest.mark.integration
     def test_default_inference_with_streaming(self, model_name, chat_messages):

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -229,11 +229,11 @@ def test_long_prompt_is_not_truncated_when_truncate_false(mock_boto3_session):
                         role=ChatRole.ASSISTANT,
                         name=None,
                         meta={
-                                "model": "claude-3-sonnet-20240229",
-                                "index": 0,
-                                "finish_reason": "end_turn",
-                                "usage": {"prompt_tokens": 16, "completion_tokens": 55},
-                        }
+                            "model": "claude-3-sonnet-20240229",
+                            "index": 0,
+                            "finish_reason": "end_turn",
+                            "usage": {"prompt_tokens": 16, "completion_tokens": 55},
+                        },
                     )
                 ]
             )

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -358,13 +358,13 @@ class TestMetaLlama2ChatAdapter:
         assert "paris" in first_reply.content.lower(), "First reply does not contain 'paris'"
         assert first_reply.meta, "First reply has no metadata"
 
-        if first_reply.meta and 'usage' in first_reply.meta:
-            assert 'prompt_tokens' in first_reply.meta['usage']
-            assert 'completion_tokens' in first_reply.meta['usage']
+        if first_reply.meta and "usage" in first_reply.meta:
+            assert "prompt_tokens" in first_reply.meta["usage"]
+            assert "completion_tokens" in first_reply.meta["usage"]
 
-        if first_reply.meta and 'usage' not in first_reply.meta:
-            assert 'prompt_tokens' in first_reply.meta
-            assert 'completion_tokens' in first_reply.meta
+        if first_reply.meta and "usage" not in first_reply.meta:
+            assert "prompt_tokens" in first_reply.meta
+            assert "completion_tokens" in first_reply.meta
 
     @pytest.mark.parametrize("model_name", MODELS_TO_TEST)
     @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes #7687

### Proposed Changes:

- Something change in AmazonBedrock and the PR I merged had no effect

### How did you test it?

unit tests, integration tests, manual verification, instructions for manual tests

### A few things I noticed when testing the ChatGenarators

#### Test coverage

- `generators/amazon_bedrock/chat/adapters.py`is at 59%
- `generators/amazon_bedrock/chat/chat_generator.py` is at 51%

#### Some integrations tests are still being skipped, see the CI logs for details

```
cmd [1] | coverage run -m pytest -m integration --reruns 3 --reruns-delay 30 -x
============================= test session starts ==============================
platform linux -- Python 3.9.19, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/runner/work/haystack-core-integrations/haystack-core-integrations/integrations/amazon_bedrock
configfile: pyproject.toml
plugins: rerunfailures-14.0, anyio-4.4.0
collected 152 items / 140 deselected / 12 selected
tests/test_chat_generator.py::TestMistralAdapter::test_default_inference_params[mistral.mistral-7b-instruct-v0:2] SKIPPED [  8%]
tests/test_chat_generator.py::TestMistralAdapter::test_default_inference_params[mistral.mixtral-8x7b-instruct-v0:1] SKIPPED [ 16%]
tests/test_chat_generator.py::TestMistralAdapter::test_default_inference_params[mistral.mistral-large-2402-v1:0] SKIPPED [ 25%]
```

#### Several warnings about parameters being ignored

```
WARNING  haystack_integrations.components.generators.amazon_bedrock.chat.adapters:adapters.py:76 Parameter 'top_k' is not allowed and will be ignored.
WARNING  haystack_integrations.components.generators.amazon_bedrock.chat.adapters:adapters.py:76 Parameter 'stop_sequences' is not allowed and will be ignored.
WARNING  haystack_integrations.components.generators.amazon_bedrock.chat.adapters:adapters.py:76 Parameter 'stream' is not allowed and will be ignored.

```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
