### PR TITLE
fix(Bedrock): allow tools kwargs for AWS Bedrock Claude model

### DIFF
--- a/integrations/amazon_bedrock/CHANGELOG.md
+++ b/integrations/amazon_bedrock/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [integrations/amazon_bedrock-v1.0.0] - 2024-08-12
+
+### 🚜 Refactor
+
+- Change meta data fields (#911)
+
+### 🧪 Testing
+
+- Do not retry tests in `hatch run test` command (#954)
+
 ## [integrations/amazon_bedrock-v0.10.0] - 2024-08-12
 
 ### 🐛 Bug Fixes

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -166,6 +166,7 @@ class AnthropicClaudeChatAdapter(BedrockModelChatAdapter):
         "top_k",
         "system",
         "tools",
+        "tool_choice",
     ]
 
     def __init__(self, truncate: Optional[bool], generation_kwargs: Dict[str, Any]):

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -164,6 +164,7 @@ class AnthropicClaudeChatAdapter(BedrockModelChatAdapter):
         "top_p",
         "top_k",
         "system",
+        "tools",
     ]
 
     def __init__(self, generation_kwargs: Dict[str, Any]):

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -250,6 +250,10 @@ class AnthropicClaudeChatAdapter(BedrockModelChatAdapter):
                 if content.get("type") == "text":
                     meta = {k: v for k, v in response_body.items() if k not in ["type", "content", "role"]}
                     messages.append(ChatMessage.from_assistant(content["text"], meta=meta))
+                if content.get("type") == "tool_use":
+                    meta = {k: v for k, v in response_body.items() if k not in ["type", "content", "role"]}
+                    json_answer = json.dumps(content)
+                    messages.append(ChatMessage.from_assistant(json_answer, meta=meta))
         return messages
 
     def _build_streaming_chunk(self, chunk: Dict[str, Any]) -> StreamingChunk:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -253,14 +253,18 @@ class AnthropicClaudeChatAdapter(BedrockModelChatAdapter):
         """
         messages: List[ChatMessage] = []
         if response_body.get("type") == "message":
-            for content in response_body["content"]:
-                if content.get("type") == "text":
-                    meta = {k: v for k, v in response_body.items() if k not in ["type", "content", "role"]}
-                    messages.append(ChatMessage.from_assistant(content["text"], meta=meta))
-                if content.get("type") == "tool_use":
-                    meta = {k: v for k, v in response_body.items() if k not in ["type", "content", "role"]}
-                    json_answer = json.dumps(content)
-                    messages.append(ChatMessage.from_assistant(json_answer, meta=meta))
+            if response_body.get("stop_reason") == "tool_use":  # If `tool_use` we only keep the tool_use content
+                for content in response_body["content"]:
+                    if content.get("type") == "tool_use":
+                        meta = {k: v for k, v in response_body.items() if k not in ["type", "content", "role"]}
+                        json_answer = json.dumps(content)
+                        messages.append(ChatMessage.from_assistant(json_answer, meta=meta))
+            else:  # For other stop_reason, return all text content
+                for content in response_body["content"]:
+                    if content.get("type") == "text":
+                        meta = {k: v for k, v in response_body.items() if k not in ["type", "content", "role"]}
+                        messages.append(ChatMessage.from_assistant(content["text"], meta=meta))
+
         return messages
 
     def _build_streaming_chunk(self, chunk: Dict[str, Any]) -> StreamingChunk:

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import json
 from typing import Optional, Type
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from haystack_integrations.components.generators.amazon_bedrock.chat.adapters im
 
 KLASS = "haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator.AmazonBedrockChatGenerator"
 MODELS_TO_TEST = ["anthropic.claude-3-sonnet-20240229-v1:0", "anthropic.claude-v2:1", "meta.llama2-13b-chat-v1"]
+MODELS_TO_TEST_WITH_TOOLS = ["anthropic.claude-3-haiku-20240307-v1:0"]
 MISTRAL_MODELS = [
     "mistral.mistral-7b-instruct-v0:2",
     "mistral.mixtral-8x7b-instruct-v0:1",
@@ -175,6 +177,46 @@ class TestAnthropicClaudeAdapter:
 
         assert body == expected_body
 
+    @pytest.mark.parametrize("model_name", MODELS_TO_TEST_WITH_TOOLS)
+    @pytest.mark.integration
+    def test_tools_use(self, model_name):
+        # See https://docs.anthropic.com/en/docs/tool-use for more information
+        tools = [
+            {
+                "name": "top_song",
+                "description": "Get the most popular song played on a radio station.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "sign": {
+                            "type": "string",
+                            "description": "The call sign for the radio station for which you want the most popular song. Example calls signs are WZPZ and WKRP."
+                        }
+                    },
+                    "required": [
+                        "sign"
+                    ]
+                }
+            }
+        ]
+        messages = []
+        messages.append(ChatMessage.from_user("What is the most popular song on WZPZ?"))
+        client = AmazonBedrockChatGenerator(model=model_name)
+        response = client.run(messages=messages, generation_kwargs={"tools": tools})
+        replies = response["replies"]
+        assert isinstance(replies, list), "Replies is not a list"
+        assert len(replies) > 0, "No replies received"
+
+        first_reply = replies[0]
+        assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
+        assert first_reply.content, "First reply has no content"
+        assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
+        assert "top_song" in first_reply.content.lower(), "First reply does not contain top_song"
+        assert first_reply.meta, "First reply has no metadata"
+        fc_response = json.loads(first_reply.content)
+        assert "name" in fc_response, "First reply does not contain name of the tool"
+        assert "input" in fc_response, "First reply does not contain input of the tool"
+
 
 class TestMistralAdapter:
     def test_prepare_body_with_default_params(self) -> None:
@@ -254,8 +296,8 @@ class TestMistralAdapter:
     @pytest.mark.skipif(
         not os.environ.get("HF_API_TOKEN", None),
         reason=(
-            "To run this test, you need to set the HF_API_TOKEN environment variable. The associated account must also "
-            "have requested access to the gated model `mistralai/Mistral-7B-Instruct-v0.1`"
+                "To run this test, you need to set the HF_API_TOKEN environment variable. The associated account must also "
+                "have requested access to the gated model `mistralai/Mistral-7B-Instruct-v0.1`"
         ),
     )
     @pytest.mark.parametrize("model_name", MISTRAL_MODELS)

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -334,7 +334,7 @@ class TestAnthropicClaudeAdapter:
         messages = []
         messages.append(ChatMessage.from_user("What is the most popular song on WZPZ?"))
         client = AmazonBedrockChatGenerator(model=model_name)
-        response = client.run(messages=messages, generation_kwargs={"tools": tools})
+        response = client.run(messages=messages, generation_kwargs={"tools": tools, "tool_choice": {"type": "any"}})
         replies = response["replies"]
         assert isinstance(replies, list), "Replies is not a list"
         assert len(replies) > 0, "No replies received"

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -426,8 +426,8 @@ class TestMistralAdapter:
     @pytest.mark.skipif(
         not os.environ.get("HF_API_TOKEN", None),
         reason=(
-                "To run this test, you need to set the HF_API_TOKEN environment variable. The associated account must also "
-                "have requested access to the gated model `mistralai/Mistral-7B-Instruct-v0.1`"
+            "To run this test, you need to set the HF_API_TOKEN environment variable. The associated account must also "
+            "have requested access to the gated model `mistralai/Mistral-7B-Instruct-v0.1`"
         ),
     )
     @pytest.mark.parametrize("model_name", MISTRAL_MODELS)

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -1,6 +1,6 @@
+import json
 import logging
 import os
-import json
 from typing import Optional, Type
 from unittest.mock import MagicMock, patch
 
@@ -310,6 +310,9 @@ class TestAnthropicClaudeAdapter:
     @pytest.mark.parametrize("model_name", MODELS_TO_TEST_WITH_TOOLS)
     @pytest.mark.integration
     def test_tools_use(self, model_name):
+        """
+        Test function calling with AWS Bedrock Anthropic adapter
+        """
         # See https://docs.anthropic.com/en/docs/tool-use for more information
         tools = [
             {
@@ -320,13 +323,12 @@ class TestAnthropicClaudeAdapter:
                     "properties": {
                         "sign": {
                             "type": "string",
-                            "description": "The call sign for the radio station for which you want the most popular song. Example calls signs are WZPZ and WKRP."
+                            "description": "The call sign for the radio station for which you want the most popular"
+                            " song. Example calls signs are WZPZ and WKRP.",
                         }
                     },
-                    "required": [
-                        "sign"
-                    ]
-                }
+                    "required": ["sign"],
+                },
             }
         ]
         messages = []


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/975

### Proposed Changes:
Allow the tools kwargs for AWS Bedrock Anthropic models because it is listed as valid here: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html

### How did you test it?

I did not, as it's a tiny fix and I didn't really have time to setup the whole testing process.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
