### PR TITLE
docs: add link to langfuse in LangfuseConnector

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -7,8 +7,8 @@ from langfuse import Langfuse
 @component
 class LangfuseConnector:
     """
-    LangfuseConnector connects Haystack LLM framework with Langfuse in order to enable the tracing of operations
-    and data flow within various components of a pipeline.
+    LangfuseConnector connects Haystack LLM framework with [Langfuse](https://langfuse.com) in order to enable the
+    tracing of operations and data flow within various components of a pipeline.
 
     Simply add this component to your pipeline, but *do not* connect it to any other component. The LangfuseConnector
     will automatically trace the operations and data flow within the pipeline.


### PR DESCRIPTION
### Related Issues

None

### Proposed Changes:

I propose to add a link to Langfuse to help people figure out what Langfuse actually is when browsing the api reference.

### How did you test it?

I did not test it

### Notes for the reviewer

None

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
