### PR TITLE
chore: Jina - ruff update, don't ruff tests

### DIFF
--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -62,8 +62,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/}", "style"]
 all = ["style", "typing"]
 
 [tool.black]

--- a/integrations/jina/tests/test_document_embedder.py
+++ b/integrations/jina/tests/test_document_embedder.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from haystack import Document
 from haystack.utils import Secret
+
 from haystack_integrations.components.embedders.jina import JinaDocumentEmbedder
 
 

--- a/integrations/jina/tests/test_ranker.py
+++ b/integrations/jina/tests/test_ranker.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from haystack import Document
 from haystack.utils import Secret
+
 from haystack_integrations.components.rankers.jina import JinaRanker
 
 

--- a/integrations/jina/tests/test_text_embedder.py
+++ b/integrations/jina/tests/test_text_embedder.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 import requests
 from haystack.utils import Secret
+
 from haystack_integrations.components.embedders.jina import JinaTextEmbedder
 
 


### PR DESCRIPTION
- fix ruffing  after ruff 0.6.0 has been released
- exclude tests from ruffing