### PR TITLE
chore: Chroma - ruff update, don't ruff tests

### DIFF
--- a/integrations/chroma/example/example.py
+++ b/integrations/chroma/example/example.py
@@ -1,4 +1,5 @@
 # Colab: https://colab.research.google.com/drive/1YpDetI8BRbObPDEVdfqUcwhEX9UUXP-m?usp=sharing
+
 import os
 from pathlib import Path
 
@@ -6,14 +7,15 @@ from haystack import Pipeline
 from haystack.components.converters import TextFileToDocument
 from haystack.components.writers import DocumentWriter
 
-from haystack_integrations.document_stores.chroma import ChromaDocumentStore
 from haystack_integrations.components.retrievers.chroma import ChromaQueryTextRetriever
+from haystack_integrations.document_stores.chroma import ChromaDocumentStore
+
+# Chroma is used in-memory so we use the same instances in the two pipelines below
+document_store = ChromaDocumentStore()
 
 HERE = Path(__file__).resolve().parent
 file_paths = [HERE / "data" / Path(name) for name in os.listdir("data")]
 
-# Chroma is used in-memory so we use the same instances in the two pipelines below
-document_store = ChromaDocumentStore()
 
 indexing = Pipeline()
 indexing.add_component("converter", TextFileToDocument())

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -70,8 +70,8 @@ dependencies = [
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests}", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -70,8 +70,8 @@ dependencies = [
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:. --exclude tests}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests}", "style"]
+style = ["ruff check {args:. --exclude tests/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/}", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]
@@ -85,7 +85,7 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py38"
 line-length = 120
-select = [
+lint.select = [
   "A",
   "ARG",
   "B",
@@ -112,7 +112,7 @@ select = [
   "W",
   "YTT",
 ]
-ignore = [
+lint.ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
   # Allow boolean positional values in function calls, like `dict.get(... True)`
@@ -130,14 +130,14 @@ ignore = [
   # Ignore unused params
   "ARG002",
 ]
-unfixable = [
+lint.unfixable = [
   # Don't touch unused imports
   "F401",
 ]
 exclude = ["example"]
 
 [tool.ruff.isort]
-known-first-party = ["src"]
+known-first-party = ["src", "example", "tests"]
 
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "parents"
@@ -145,6 +145,7 @@ ban-relative-imports = "parents"
 [tool.ruff.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+"example/**/*" = ["T201"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
+
 from haystack_integrations.document_stores.chroma import ChromaDocumentStore
 
 

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -16,6 +16,7 @@ from haystack.testing.document_store import (
     DeleteDocumentsTest,
     LegacyFilterDocumentsTest,
 )
+
 from haystack_integrations.document_stores.chroma import ChromaDocumentStore
 
 

--- a/integrations/chroma/tests/test_retriever.py
+++ b/integrations/chroma/tests/test_retriever.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 from haystack.document_stores.types import FilterPolicy
+
 from haystack_integrations.components.retrievers.chroma import ChromaQueryTextRetriever
 from haystack_integrations.document_stores.chroma import ChromaDocumentStore
 


### PR DESCRIPTION
- fix ruffing after ruff 0.6.0 has been released
- exclude tests from ruff 