### PR TITLE
chore: pgvector ruff update, don't ruff tests

### DIFF
--- a/integrations/pgvector/examples/embedding_retrieval.py
+++ b/integrations/pgvector/examples/embedding_retrieval.py
@@ -17,6 +17,7 @@ from haystack.components.converters import MarkdownToDocument
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
+
 from haystack_integrations.components.retrievers.pgvector import PgvectorEmbeddingRetriever
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 

--- a/integrations/pgvector/examples/hybrid_retrieval.py
+++ b/integrations/pgvector/examples/hybrid_retrieval.py
@@ -18,6 +18,7 @@ from haystack.components.embedders import SentenceTransformersDocumentEmbedder, 
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
+
 from haystack_integrations.components.retrievers.pgvector import PgvectorEmbeddingRetriever, PgvectorKeywordRetriever
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 

--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -66,8 +66,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/, examples/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/, examples/}", "style"]
 all = ["style", "typing"]
 
 [tool.black]

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
@@ -7,6 +7,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
+
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 from haystack_integrations.document_stores.pgvector.document_store import VALID_VECTOR_FUNCTIONS
 

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
@@ -7,6 +7,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
+
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 
 

--- a/integrations/pgvector/tests/conftest.py
+++ b/integrations/pgvector/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 
 

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -11,8 +11,9 @@ from haystack.document_stores.errors import DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import CountDocumentsTest, DeleteDocumentsTest, WriteDocumentsTest
 from haystack.utils import Secret
-from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 from pandas import DataFrame
+
+from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 
 
 @pytest.mark.integration

--- a/integrations/pgvector/tests/test_embedding_retrieval.py
+++ b/integrations/pgvector/tests/test_embedding_retrieval.py
@@ -6,8 +6,9 @@ from typing import List
 
 import pytest
 from haystack.dataclasses.document import Document
-from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 from numpy.random import rand
+
+from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 
 
 @pytest.mark.integration

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -3,6 +3,10 @@ from typing import List
 import pytest
 from haystack.dataclasses.document import Document
 from haystack.testing.document_store import FilterDocumentsTest
+from pandas import DataFrame
+from psycopg.sql import SQL
+from psycopg.types.json import Jsonb
+
 from haystack_integrations.document_stores.pgvector.filters import (
     FilterError,
     _convert_filters_to_where_clause_and_params,
@@ -10,9 +14,6 @@ from haystack_integrations.document_stores.pgvector.filters import (
     _parse_logical_condition,
     _treat_meta_field,
 )
-from pandas import DataFrame
-from psycopg.sql import SQL
-from psycopg.types.json import Jsonb
 
 
 @pytest.mark.integration

--- a/integrations/pgvector/tests/test_keyword_retrieval.py
+++ b/integrations/pgvector/tests/test_keyword_retrieval.py
@@ -1,5 +1,6 @@
 import pytest
 from haystack.dataclasses.document import Document
+
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 
 

--- a/integrations/pgvector/tests/test_retrievers.py
+++ b/integrations/pgvector/tests/test_retrievers.py
@@ -7,6 +7,7 @@ import pytest
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
 from haystack.utils.auth import EnvVarSecret
+
 from haystack_integrations.components.retrievers.pgvector import PgvectorEmbeddingRetriever, PgvectorKeywordRetriever
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 


### PR DESCRIPTION
- fix ruffing after ruff 0.6.0 has been released
- exclude tests examples from ruff

**Note:** 
We first need to merge https://github.com/deepset-ai/haystack-core-integrations/pull/970