### PR TITLE
chore: ollama - ruff update, don't ruff tests

### DIFF
--- a/integrations/ollama/examples/chat_generator_example.py
+++ b/integrations/ollama/examples/chat_generator_example.py
@@ -6,6 +6,7 @@
 # docker exec ollama ollama pull orca-mini
 
 from haystack.dataclasses import ChatMessage
+
 from haystack_integrations.components.generators.ollama import OllamaChatGenerator
 
 messages = [

--- a/integrations/ollama/examples/embedders_example.py
+++ b/integrations/ollama/examples/embedders_example.py
@@ -7,6 +7,7 @@
 from haystack import Document, Pipeline
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+
 from haystack_integrations.components.embedders.ollama.document_embedder import OllamaDocumentEmbedder
 from haystack_integrations.components.embedders.ollama.text_embedder import OllamaTextEmbedder
 

--- a/integrations/ollama/examples/generator_example.py
+++ b/integrations/ollama/examples/generator_example.py
@@ -9,6 +9,7 @@ from haystack import Document, Pipeline
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.retrievers import InMemoryBM25Retriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+
 from haystack_integrations.components.generators.ollama import OllamaGenerator
 
 document_store = InMemoryDocumentStore()

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -71,8 +71,8 @@ dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/, examples/ }", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/, examples/ }", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -3,8 +3,9 @@ from unittest.mock import Mock
 
 import pytest
 from haystack.dataclasses import ChatMessage, ChatRole
-from haystack_integrations.components.generators.ollama import OllamaChatGenerator
 from requests import HTTPError, Response
+
+from haystack_integrations.components.generators.ollama import OllamaChatGenerator
 
 
 @pytest.fixture

--- a/integrations/ollama/tests/test_document_embedder.py
+++ b/integrations/ollama/tests/test_document_embedder.py
@@ -1,7 +1,8 @@
 import pytest
 from haystack import Document
-from haystack_integrations.components.embedders.ollama import OllamaDocumentEmbedder
 from requests import HTTPError
+
+from haystack_integrations.components.embedders.ollama import OllamaDocumentEmbedder
 
 
 class TestOllamaDocumentEmbedder:

--- a/integrations/ollama/tests/test_generator.py
+++ b/integrations/ollama/tests/test_generator.py
@@ -7,8 +7,9 @@ from typing import Any
 import pytest
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import StreamingChunk
-from haystack_integrations.components.generators.ollama import OllamaGenerator
 from requests import HTTPError
+
+from haystack_integrations.components.generators.ollama import OllamaGenerator
 
 
 class TestOllamaGenerator:

--- a/integrations/ollama/tests/test_text_embedder.py
+++ b/integrations/ollama/tests/test_text_embedder.py
@@ -1,6 +1,7 @@
 import pytest
-from haystack_integrations.components.embedders.ollama import OllamaTextEmbedder
 from requests import HTTPError
+
+from haystack_integrations.components.embedders.ollama import OllamaTextEmbedder
 
 
 class TestOllamaTextEmbedder:


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests and examples from ruff