### PR TITLE
chore: weaviate - ruff update, don't ruff tests

### DIFF
--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -65,8 +65,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/}", "style"]
 all = ["style", "typing"]
 
 [tool.black]

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
+
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
+
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 

--- a/integrations/weaviate/tests/test_auth.py
+++ b/integrations/weaviate/tests/test_auth.py
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from weaviate.auth import AuthApiKey as WeaviateAuthApiKey
+from weaviate.auth import AuthBearerToken as WeaviateAuthBearerToken
+from weaviate.auth import AuthClientCredentials as WeaviateAuthClientCredentials
+from weaviate.auth import AuthClientPassword as WeaviateAuthClientPassword
+
 from haystack_integrations.document_stores.weaviate.auth import (
     AuthApiKey,
     AuthBearerToken,
@@ -9,10 +14,6 @@ from haystack_integrations.document_stores.weaviate.auth import (
     AuthClientPassword,
     AuthCredentials,
 )
-from weaviate.auth import AuthApiKey as WeaviateAuthApiKey
-from weaviate.auth import AuthBearerToken as WeaviateAuthBearerToken
-from weaviate.auth import AuthClientCredentials as WeaviateAuthClientCredentials
-from weaviate.auth import AuthClientPassword as WeaviateAuthClientPassword
 
 
 class TestAuthApiKey:

--- a/integrations/weaviate/tests/test_bm25_retriever.py
+++ b/integrations/weaviate/tests/test_bm25_retriever.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from haystack.document_stores.types import FilterPolicy
+
 from haystack_integrations.components.retrievers.weaviate import WeaviateBM25Retriever
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -22,11 +22,6 @@ from haystack.testing.document_store import (
     WriteDocumentsTest,
 )
 from haystack.utils.auth import Secret
-from haystack_integrations.document_stores.weaviate.auth import AuthApiKey
-from haystack_integrations.document_stores.weaviate.document_store import (
-    DOCUMENT_COLLECTION_PROPERTIES,
-    WeaviateDocumentStore,
-)
 from numpy import array as np_array
 from numpy import array_equal as np_array_equal
 from numpy import float32 as np_float32
@@ -39,6 +34,12 @@ from weaviate.embedded import (
     DEFAULT_PERSISTENCE_DATA_PATH,
     DEFAULT_PORT,
     EmbeddedOptions,
+)
+
+from haystack_integrations.document_stores.weaviate.auth import AuthApiKey
+from haystack_integrations.document_stores.weaviate.document_store import (
+    DOCUMENT_COLLECTION_PROPERTIES,
+    WeaviateDocumentStore,
 )
 
 

--- a/integrations/weaviate/tests/test_embedding_retriever.py
+++ b/integrations/weaviate/tests/test_embedding_retriever.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from haystack.document_stores.types import FilterPolicy
+
 from haystack_integrations.components.retrievers.weaviate import WeaviateEmbeddingRetriever
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests  from ruff