### PR TITLE
chore: instructor-embedders - ruff update, don't ruff tests

### DIFF
--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -88,8 +88,8 @@ dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/}", "style"]
 all = ["style", "typing"]
 
 [tool.coverage.run]

--- a/integrations/instructor_embedders/tests/test_instructor_backend.py
+++ b/integrations/instructor_embedders/tests/test_instructor_backend.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from haystack.utils.auth import Secret
+
 from haystack_integrations.components.embedders.instructor_embedders.embedding_backend.instructor_backend import (
     _InstructorEmbeddingBackendFactory,
 )

--- a/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_document_embedder.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from haystack import Document
 from haystack.utils import ComponentDevice, Secret
+
 from haystack_integrations.components.embedders.instructor_embedders import InstructorDocumentEmbedder
 
 

--- a/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
+++ b/integrations/instructor_embedders/tests/test_instructor_text_embedder.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 from haystack.utils import ComponentDevice, Secret
+
 from haystack_integrations.components.embedders.instructor_embedders import InstructorTextEmbedder
 
 


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests from ruff