### PR TITLE
chore: opensearch - ruff update, don't ruff tests

### DIFF
--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -67,8 +67,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243", "boto3"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff check --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff check --fix {args:. --exclude tests/}", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -8,6 +8,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
+
 from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 
 logger = logging.getLogger(__name__)

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -8,6 +8,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
+
 from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 
 logger = logging.getLogger(__name__)

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -10,10 +10,11 @@ from haystack.dataclasses import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils.filters import convert
-from haystack_integrations.document_stores.opensearch.auth import AWSAuth
-from haystack_integrations.document_stores.opensearch.filters import normalize_filters
 from opensearchpy import OpenSearch
 from opensearchpy.helpers import bulk
+
+from haystack_integrations.document_stores.opensearch.auth import AWSAuth
+from haystack_integrations.document_stores.opensearch.filters import normalize_filters
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/opensearch/tests/test_auth.py
+++ b/integrations/opensearch/tests/test_auth.py
@@ -1,8 +1,9 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from haystack_integrations.document_stores.opensearch.auth import AWSAuth
 from opensearchpy import Urllib3AWSV4SignerAuth
+
+from haystack_integrations.document_stores.opensearch.auth import AWSAuth
 
 
 class TestAWSAuth:

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
+
 from haystack_integrations.components.retrievers.opensearch import OpenSearchBM25Retriever
 from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 from haystack_integrations.document_stores.opensearch.document_store import DEFAULT_MAX_CHUNK_BYTES

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -11,10 +11,11 @@ from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumen
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
 from haystack.utils.auth import Secret
+from opensearchpy.exceptions import RequestError
+
 from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 from haystack_integrations.document_stores.opensearch.auth import AWSAuth
 from haystack_integrations.document_stores.opensearch.document_store import DEFAULT_MAX_CHUNK_BYTES
-from opensearchpy.exceptions import RequestError
 
 
 @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
+
 from haystack_integrations.components.retrievers.opensearch import OpenSearchEmbeddingRetriever
 from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 from haystack_integrations.document_stores.opensearch.document_store import DEFAULT_MAX_CHUNK_BYTES

--- a/integrations/opensearch/tests/test_filters.py
+++ b/integrations/opensearch/tests/test_filters.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 from haystack.errors import FilterError
+
 from haystack_integrations.document_stores.opensearch.filters import _normalize_ranges, normalize_filters
 
 filters_data = [


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests  from ruff