### PR TITLE
chore: qdrant - ruff update, don't ruff tests

### DIFF
--- a/integrations/qdrant/examples/embedding_retrieval.py
+++ b/integrations/qdrant/examples/embedding_retrieval.py
@@ -12,6 +12,7 @@ from haystack.components.converters import MarkdownToDocument
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
+
 from haystack_integrations.components.retrievers.qdrant import QdrantEmbeddingRetriever
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -62,8 +62,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/, examples/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/, examples/}", "style"]
 all = ["style", "typing"]
 
 [tool.black]

--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -4,8 +4,9 @@ from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
-from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 from qdrant_client.http import models
+
+from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 
 
 @component

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/migrate_to_sparse.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/migrate_to_sparse.py
@@ -1,8 +1,9 @@
 import logging
 import time
 
-from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 from qdrant_client.http import models
+
+from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())

--- a/integrations/qdrant/tests/test_converters.py
+++ b/integrations/qdrant/tests/test_converters.py
@@ -1,9 +1,10 @@
 import numpy as np
+from qdrant_client.http import models as rest
+
 from haystack_integrations.document_stores.qdrant.converters import (
     convert_id,
     convert_qdrant_point_to_haystack_document,
 )
-from qdrant_client.http import models as rest
 
 
 def test_convert_id_is_deterministic():

--- a/integrations/qdrant/tests/test_dict_converters.py
+++ b/integrations/qdrant/tests/test_dict_converters.py
@@ -1,4 +1,5 @@
 from haystack.utils import Secret
+
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 
 

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -12,12 +12,13 @@ from haystack.testing.document_store import (
     WriteDocumentsTest,
     _random_embeddings,
 )
+from qdrant_client.http import models as rest
+
 from haystack_integrations.document_stores.qdrant.document_store import (
     SPARSE_VECTORS_NAME,
     QdrantDocumentStore,
     QdrantStoreError,
 )
-from qdrant_client.http import models as rest
 
 
 class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsTest):

--- a/integrations/qdrant/tests/test_filters.py
+++ b/integrations/qdrant/tests/test_filters.py
@@ -4,8 +4,9 @@ import pytest
 from haystack import Document
 from haystack.testing.document_store import FilterDocumentsTest
 from haystack.utils.filters import FilterError
-from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 from qdrant_client.http import models
+
+from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 
 
 class TestQdrantStoreBaseTests(FilterDocumentsTest):

--- a/integrations/qdrant/tests/test_legacy_filters.py
+++ b/integrations/qdrant/tests/test_legacy_filters.py
@@ -5,6 +5,7 @@ from haystack import Document
 from haystack.document_stores.types import DocumentStore
 from haystack.testing.document_store import LegacyFilterDocumentsTest
 from haystack.utils.filters import FilterError
+
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 
 # The tests below are from haystack.testing.document_store.LegacyFilterDocumentsTest

--- a/integrations/qdrant/tests/test_retriever.py
+++ b/integrations/qdrant/tests/test_retriever.py
@@ -8,6 +8,7 @@ from haystack.testing.document_store import (
     FilterableDocsFixtureMixin,
     _random_embeddings,
 )
+
 from haystack_integrations.components.retrievers.qdrant import (
     QdrantEmbeddingRetriever,
     QdrantHybridRetriever,


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests and examples from ruff