### PR TITLE
chore: langfuse - ruff update, don't ruff tests

### DIFF
--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -67,8 +67,8 @@ dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/}", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -1,6 +1,6 @@
 from haystack import component, tracing
-from haystack_integrations.tracing.langfuse import LangfuseTracer
 
+from haystack_integrations.tracing.langfuse import LangfuseTracer
 from langfuse import Langfuse
 
 


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests from ruff