### PR TITLE
chore: fastembed - ruff update, don't ruff tests

### DIFF
--- a/integrations/fastembed/examples/example.py
+++ b/integrations/fastembed/examples/example.py
@@ -1,6 +1,7 @@
 from haystack import Document, Pipeline
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+
 from haystack_integrations.components.embedders.fastembed import FastembedDocumentEmbedder, FastembedTextEmbedder
 
 document_store = InMemoryDocumentStore(embedding_similarity_function="cosine")

--- a/integrations/fastembed/examples/sparse_example.py
+++ b/integrations/fastembed/examples/sparse_example.py
@@ -4,6 +4,7 @@
 # involving indexing and retrieval of documents.
 
 from haystack import Document
+
 from haystack_integrations.components.embedders.fastembed import FastembedSparseDocumentEmbedder
 
 document_list = [

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -66,8 +66,8 @@ detached = true
 dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243", "numpy"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/, examples/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/, examples/}", "style"]
 all = ["style", "typing"]
 
 [tool.black]

--- a/integrations/fastembed/tests/test_fastembed_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_document_embedder.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 from haystack import Document, default_from_dict
+
 from haystack_integrations.components.embedders.fastembed.fastembed_document_embedder import (
     FastembedDocumentEmbedder,
 )

--- a/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from haystack import Document, default_from_dict
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
+
 from haystack_integrations.components.embedders.fastembed.fastembed_sparse_document_embedder import (
     FastembedSparseDocumentEmbedder,
 )

--- a/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from haystack import default_from_dict
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
+
 from haystack_integrations.components.embedders.fastembed.fastembed_sparse_text_embedder import (
     FastembedSparseTextEmbedder,
 )

--- a/integrations/fastembed/tests/test_fastembed_text_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_text_embedder.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 from haystack import default_from_dict
+
 from haystack_integrations.components.embedders.fastembed.fastembed_text_embedder import (
     FastembedTextEmbedder,
 )


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests and examples from ruff