### PR TITLE
chore: lamma_cpp - ruff update, don't ruff tests

### DIFF
--- a/integrations/llama_cpp/examples/rag_pipeline_example.py
+++ b/integrations/llama_cpp/examples/rag_pipeline_example.py
@@ -6,6 +6,7 @@ from haystack.components.embedders import SentenceTransformersDocumentEmbedder, 
 from haystack.components.retrievers import InMemoryEmbeddingRetriever
 from haystack.components.writers import DocumentWriter
 from haystack.document_stores import InMemoryDocumentStore
+
 from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
 
 # Load first 100 rows of the Simple Wikipedia Dataset from HuggingFace

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -70,8 +70,8 @@ dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
 
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-style = ["ruff check {args:.}", "black --check --diff {args:.}"]
-fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+style = ["ruff check {args:. --exclude tests/, examples/}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:. --exclude tests/, examples/}", "style"]
 all = ["style", "typing"]
 
 [tool.hatch.metadata]

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -10,6 +10,7 @@ from haystack.components.builders import ChatPromptBuilder
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+
 from haystack_integrations.components.generators.llama_cpp.chat.chat_generator import (
     LlamaCppChatGenerator,
     _convert_message_to_llamacpp_format,

--- a/integrations/llama_cpp/tests/test_generator.py
+++ b/integrations/llama_cpp/tests/test_generator.py
@@ -9,6 +9,7 @@ from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+
 from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
 
 


### PR DESCRIPTION
- fix ruffing after a new ruff - 0.6.0 has been released
- exclude tests and examples from ruff