### PR TITLE
refactor: Remove usage of deprecated `ChatMessage.to_openai_format`

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, ClassVar, Dict, List, Optional
 
 from botocore.eventstream import EventStream
+from haystack.components.generators.openai_utils import _convert_message_to_openai_format
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
@@ -389,26 +390,13 @@ class MistralChatAdapter(BedrockModelChatAdapter):
         # default is https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1/blob/main/tokenizer_config.json
         # but we'll use our custom chat template
         prepared_prompt: str = self.prompt_handler.tokenizer.apply_chat_template(
-            conversation=[self.to_openai_format(m) for m in messages], tokenize=False, chat_template=self.chat_template
+            conversation=[_convert_message_to_openai_format(m) for m in messages],
+            tokenize=False,
+            chat_template=self.chat_template,
         )
         if self.truncate:
             prepared_prompt = self._ensure_token_limit(prepared_prompt)
         return prepared_prompt
-
-    def to_openai_format(self, m: ChatMessage) -> Dict[str, Any]:
-        """
-        Convert the message to the format expected by OpenAI's Chat API.
-        See the [API reference](https://platform.openai.com/docs/api-reference/chat/create) for details.
-
-        :returns: A dictionary with the following key:
-            - `role`
-            - `content`
-            - `name` (optional)
-        """
-        msg = {"role": m.role.value, "content": m.content}
-        if m.name:
-            msg["name"] = m.name
-        return msg
 
     def check_prompt(self, prompt: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8239

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
