### PR TITLE
fix: skip unsupported meta fields in PineconeDB

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import io
 import logging
-import warnings
 from copy import copy
 from typing import Any, Dict, List, Literal, Optional
 
@@ -27,7 +26,7 @@ TOP_K_LIMIT = 1_000
 
 
 DEFAULT_STARTER_PLAN_SPEC = {"serverless": {"region": "us-east-1", "cloud": "aws"}}
-METADATA_SUPPORTED_PRIMITIVE_TYPES = str, int, bool  # List[str] is supported and checked separately
+METADATA_SUPPORTED_TYPES = str, int, bool  # List[str] is supported and checked separately
 
 
 class PineconeDocumentStore:
@@ -300,7 +299,7 @@ class PineconeDocumentStore:
     @staticmethod
     def check_metadata(document: Document):
         def valid_type(value: Any):
-            return isinstance(value, METADATA_SUPPORTED_PRIMITIVE_TYPES) or (
+            return isinstance(value, METADATA_SUPPORTED_TYPES) or (
                 isinstance(value, list) and all(isinstance(i, str) for i in value)
             )
 
@@ -315,7 +314,6 @@ class PineconeDocumentStore:
                 msg = (f"Document {document.id} has metadata fields with unsupported types: {discarded_keys}. "
                        f"Only str, int, bool, and List[str] are supported. The values of these fields will be ignored.")
                 logger.warning(msg)
-                warnings.warn(msg, UserWarning)
 
         return document
 

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -319,7 +319,7 @@ class PineconeDocumentStore:
             if discarded_keys:
                 msg = (
                     f"Document {document.id} has metadata fields with unsupported types: {discarded_keys}. "
-                    f"Only str, int, bool, and List[str] are supported. The values of these fields will be ignored."
+                    f"Only str, int, bool, and List[str] are supported. The values of these fields will be discarded."
                 )
                 logger.warning(msg)
 

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -311,8 +311,10 @@ class PineconeDocumentStore:
                     document.meta[key] = "IGNORED"
 
             if discarded_keys:
-                msg = (f"Document {document.id} has metadata fields with unsupported types: {discarded_keys}. "
-                       f"Only str, int, bool, and List[str] are supported. The values of these fields will be ignored.")
+                msg = (
+                    f"Document {document.id} has metadata fields with unsupported types: {discarded_keys}. "
+                    f"Only str, int, bool, and List[str] are supported. The values of these fields will be ignored."
+                )
                 logger.warning(msg)
 
         return document
@@ -329,7 +331,7 @@ class PineconeDocumentStore:
                 embedding = self._dummy_vector
 
             if document.meta:
-                document = self.check_metadata(document)
+                self.check_metadata(document)
 
             doc_for_pinecone = {"id": document.id, "values": embedding, "metadata": dict(document.meta)}
 

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -142,6 +142,42 @@ def test_convert_dict_spec_to_pinecone_object_fail():
         PineconeDocumentStore._convert_dict_spec_to_pinecone_object(dict_spec)
 
 
+def test_check_metadata_invalid():
+    invalid_metadata_doc = Document(
+        content="The moonlight shimmered ",
+        meta={
+            "source_id": "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0",
+            "page_number": 1,
+            "split_id": 0,
+            "split_idx_start": 0,
+            "_split_overlap": [
+                {"doc_id": "68ed48ba830048c5d7815874ed2de794722e6d10866b6c55349a914fd9a0df65", "range": (0, 20)}
+            ],
+        },
+    )
+    pinecone_doc = PineconeDocumentStore.check_metadata(invalid_metadata_doc)
+
+    assert pinecone_doc.meta["source_id"] == "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0"
+    assert pinecone_doc.meta["page_number"] == 1
+    assert pinecone_doc.meta["split_id"] == 0
+    assert pinecone_doc.meta["split_idx_start"] == 0
+    assert pinecone_doc.meta["_split_overlap"] == "IGNORED"
+
+
+def test_check_metadata_valid():
+    valid_metadata_doc = Document(
+        content="The moonlight shimmered ",
+        meta={
+            "source_id": "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0",
+            "page_number": 1,
+        },
+    )
+    pinecone_doc = PineconeDocumentStore.check_metadata(valid_metadata_doc)
+
+    assert pinecone_doc.meta["source_id"] == "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0"
+    assert pinecone_doc.meta["page_number"] == 1
+
+
 @pytest.mark.integration
 @pytest.mark.skipif("PINECONE_API_KEY" not in os.environ, reason="PINECONE_API_KEY not set")
 def test_serverless_index_creation_from_scratch(sleep_time):

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -142,7 +142,7 @@ def test_convert_dict_spec_to_pinecone_object_fail():
         PineconeDocumentStore._convert_dict_spec_to_pinecone_object(dict_spec)
 
 
-def test_check_metadata_invalid():
+def test_validate_metadata_invalid():
     invalid_metadata_doc = Document(
         content="The moonlight shimmered ",
         meta={
@@ -155,16 +155,16 @@ def test_check_metadata_invalid():
             ],
         },
     )
-    pinecone_doc = PineconeDocumentStore.check_metadata(invalid_metadata_doc)
+    pinecone_doc = PineconeDocumentStore._discard_invalid_meta(invalid_metadata_doc)
 
     assert pinecone_doc.meta["source_id"] == "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0"
     assert pinecone_doc.meta["page_number"] == 1
     assert pinecone_doc.meta["split_id"] == 0
     assert pinecone_doc.meta["split_idx_start"] == 0
-    assert pinecone_doc.meta["_split_overlap"] == "IGNORED"
+    assert "_split_overlap" not in pinecone_doc.meta
 
 
-def test_check_metadata_valid():
+def test_validate_metadata_valid():
     valid_metadata_doc = Document(
         content="The moonlight shimmered ",
         meta={
@@ -172,7 +172,7 @@ def test_check_metadata_valid():
             "page_number": 1,
         },
     )
-    pinecone_doc = PineconeDocumentStore.check_metadata(valid_metadata_doc)
+    pinecone_doc = PineconeDocumentStore._discard_invalid_meta(valid_metadata_doc)
 
     assert pinecone_doc.meta["source_id"] == "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0"
     assert pinecone_doc.meta["page_number"] == 1

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -142,7 +142,7 @@ def test_convert_dict_spec_to_pinecone_object_fail():
         PineconeDocumentStore._convert_dict_spec_to_pinecone_object(dict_spec)
 
 
-def test_validate_metadata_invalid():
+def test_discard_invalid_meta_invalid():
     invalid_metadata_doc = Document(
         content="The moonlight shimmered ",
         meta={
@@ -164,7 +164,7 @@ def test_validate_metadata_invalid():
     assert "_split_overlap" not in pinecone_doc.meta
 
 
-def test_validate_metadata_valid():
+def test_discard_invalid_meta_valid():
     valid_metadata_doc = Document(
         content="The moonlight shimmered ",
         meta={


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8181
- fixes #919

### How did you test it?

- unit tests, integration tests and manual verification

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
