### PR TITLE
Enable streaming in GoogleAIGemini

### DIFF
--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -345,7 +345,7 @@ class GoogleAIGeminiChatGenerator:
         """
         responses = []
         for chunk in stream:
-            content = chunk.text if "text" in chunk.parts else ""
+            content = chunk.text if len(chunk.parts) > 0 and "text" in chunk.parts[0] else ""
             streaming_callback(StreamingChunk(content=content, meta=chunk.to_dict()))
             responses.append(content)
 

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -5,7 +5,7 @@ import google.generativeai as genai
 from google.ai.generativelanguage import Content, Part
 from google.ai.generativelanguage import Tool as ToolProto
 from google.generativeai import GenerationConfig, GenerativeModel
-from google.generativeai.types import HarmBlockThreshold, HarmCategory, Tool
+from google.generativeai.types import GenerateContentResponse, HarmBlockThreshold, HarmCategory, Tool
 from haystack.core.component import component
 from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream, StreamingChunk
@@ -293,6 +293,8 @@ class GoogleAIGeminiChatGenerator:
 
         :param messages:
             A list of `ChatMessage` instances, representing the input messages.
+        :param streaming_callback:
+            A callback function that is called when a new token is received from the stream.
         :returns:
             A dictionary containing the following key:
             - `replies`:  A list containing the generated responses as `ChatMessage` instances.
@@ -309,11 +311,11 @@ class GoogleAIGeminiChatGenerator:
             stream=streaming_callback is not None,
         )
 
-        replies = self.get_stream_response(res, streaming_callback) if streaming_callback else self.get_response(res)
+        replies = self._get_stream_response(res, streaming_callback) if streaming_callback else self._get_response(res)
 
         return {"replies": replies}
 
-    def get_response(self, response_body) -> List[ChatMessage]:
+    def _get_response(self, response_body: GenerateContentResponse) -> List[ChatMessage]:
         """
         Extracts the responses from the Google AI response.
 
@@ -335,7 +337,9 @@ class GoogleAIGeminiChatGenerator:
                     )
         return replies
 
-    def get_stream_response(self, stream, streaming_callback: Callable[[StreamingChunk], None]) -> List[ChatMessage]:
+    def _get_stream_response(
+        self, stream: GenerateContentResponse, streaming_callback: Callable[[StreamingChunk], None]
+    ) -> List[ChatMessage]:
         """
         Extracts the responses from the Google AI streaming response.
 

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import google.generativeai as genai
 from google.ai.generativelanguage import Content, Part, Tool
 from google.generativeai import GenerationConfig, GenerativeModel
-from google.generativeai.types import HarmBlockThreshold, HarmCategory
+from google.generativeai.types import GenerateContentResponse, HarmBlockThreshold, HarmCategory
 from haystack.core.component import component
 from haystack.core.component.types import Variadic
 from haystack.core.serialization import default_from_dict, default_to_dict
@@ -211,11 +211,11 @@ class GoogleAIGeminiGenerator:
             stream=streaming_callback is not None,
         )
         self._model.start_chat()
-        replies = self.get_stream_response(res, streaming_callback) if streaming_callback else self.get_response(res)
+        replies = self._get_stream_response(res, streaming_callback) if streaming_callback else self._get_response(res)
 
         return {"replies": replies}
 
-    def get_response(self, response_body) -> List[str]:
+    def _get_response(self, response_body: GenerateContentResponse) -> List[str]:
         """
         Extracts the responses from the Google AI request.
         :param response_body: The response body from the Google AI request.
@@ -234,7 +234,9 @@ class GoogleAIGeminiGenerator:
                     replies.append(function_call)
         return replies
 
-    def get_stream_response(self, stream, streaming_callback: Callable[[StreamingChunk], None]) -> List[str]:
+    def _get_stream_response(
+        self, stream: GenerateContentResponse, streaming_callback: Callable[[StreamingChunk], None]
+    ) -> List[str]:
         """
         Extracts the responses from the Google AI streaming response.
         :param stream: The streaming response from the Google AI request.

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -92,6 +92,8 @@ class GoogleAIGeminiGenerator:
             A dictionary with `HarmCategory` as keys and `HarmBlockThreshold` as values.
             For more information, see [the API reference](https://ai.google.dev/api)
         :param tools: A list of Tool objects that can be used for [Function calling](https://ai.google.dev/docs/function_calling).
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+            The callback function accepts StreamingChunk as an argument.
         """
         genai.configure(api_key=api_key.resolve_value())
 
@@ -192,6 +194,7 @@ class GoogleAIGeminiGenerator:
 
         :param parts:
             A heterogeneous list of strings, `ByteStream` or `Part` objects.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
         :returns:
             A dictionary containing the following key:
             - `replies`: A list of strings or dictionaries with function calls.
@@ -215,8 +218,8 @@ class GoogleAIGeminiGenerator:
 
     def get_response(self, response_body) -> List[str]:
         """
-        Extracts the responses from the Vertex AI response.
-        :param response_body: The response body from the Vertex AI request.
+        Extracts the responses from the Google AI request.
+        :param response_body: The response body from the Google AI request.
         :returns: A list of string responses.
         """
         replies = []

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -244,10 +244,7 @@ class GoogleAIGeminiGenerator:
 
         responses = []
         for chunk in stream:
-            if len(chunk.parts) > 0 and "text" in chunk.parts[0]:
-                content = chunk.text
-            else:
-                content = ""
+            content = chunk.text if len(chunk.parts) > 0 and "text" in chunk.parts[0] else ""
             streaming_callback(StreamingChunk(content=content, meta=chunk.to_dict()))
             responses.append(content)
 

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -245,7 +245,7 @@ class GoogleAIGeminiGenerator:
         streaming_chunks: List[StreamingChunk] = []
 
         for chunk in stream:
-            streaming_chunk = StreamingChunk(content=chunk.text, meta=chunk.usage_metadata)
+            streaming_chunk = StreamingChunk(content=chunk.text, meta=chunk)
             streaming_chunks.append(streaming_chunk)
             streaming_callback(streaming_chunk)
 

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -5,9 +5,28 @@ import pytest
 from google.generativeai import GenerationConfig, GenerativeModel
 from google.generativeai.types import FunctionDeclaration, HarmBlockThreshold, HarmCategory, Tool
 from haystack.dataclasses.chat_message import ChatMessage
+from haystack.dataclasses import StreamingChunk
 
 from haystack_integrations.components.generators.google_ai import GoogleAIGeminiChatGenerator
 
+GET_CURRENT_WEATHER_FUNC = FunctionDeclaration(
+    name="get_current_weather",
+    description="Get the current weather in a given location",
+    parameters={
+        "type_": "OBJECT",
+        "properties": {
+            "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
+            "unit": {
+                "type_": "STRING",
+                "enum": [
+                    "celsius",
+                    "fahrenheit",
+                ],
+            },
+        },
+        "required": ["location"],
+    },
+)
 
 def test_init(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "test")
@@ -21,25 +40,7 @@ def test_init(monkeypatch):
         top_k=0.5,
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    get_current_weather_func = FunctionDeclaration(
-        name="get_current_weather",
-        description="Get the current weather in a given location",
-        parameters={
-            "type_": "OBJECT",
-            "properties": {
-                "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
-                "unit": {
-                    "type_": "STRING",
-                    "enum": [
-                        "celsius",
-                        "fahrenheit",
-                    ],
-                },
-            },
-            "required": ["location"],
-        },
-    )
-
+    get_current_weather_func = GET_CURRENT_WEATHER_FUNC
     tool = Tool(function_declarations=[get_current_weather_func])
     with patch(
         "haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"
@@ -69,25 +70,7 @@ def test_to_dict(monkeypatch):
         top_k=2,
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    get_current_weather_func = FunctionDeclaration(
-        name="get_current_weather",
-        description="Get the current weather in a given location",
-        parameters={
-            "type_": "OBJECT",
-            "properties": {
-                "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
-                "unit": {
-                    "type_": "STRING",
-                    "enum": [
-                        "celsius",
-                        "fahrenheit",
-                    ],
-                },
-            },
-            "required": ["location"],
-        },
-    )
-
+    get_current_weather_func = GET_CURRENT_WEATHER_FUNC
     tool = Tool(function_declarations=[get_current_weather_func])
 
     with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
@@ -110,6 +93,7 @@ def test_to_dict(monkeypatch):
                 "stop_sequences": ["stop"],
             },
             "safety_settings": {10: 3},
+            "streaming_callback": None,
             "tools": [
                 b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
                 b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
@@ -118,8 +102,49 @@ def test_to_dict(monkeypatch):
         },
     }
 
+def test_to_dict_with_param(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test")
+
+    with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
+        gemini = GoogleAIGeminiChatGenerator()
+    assert gemini.to_dict() == {
+        "type": "haystack_integrations.components.generators.google_ai.chat.gemini.GoogleAIGeminiChatGenerator",
+        "init_parameters": {
+            "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
+            "model": "gemini-pro-vision",
+            "generation_config": None,
+            "safety_settings": None,
+            "streaming_callback": None,
+            "tools": None,
+        },
+    }
+
 
 def test_from_dict(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test")
+
+    with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
+        gemini = GoogleAIGeminiChatGenerator.from_dict(
+            {
+                "type": "haystack_integrations.components.generators.google_ai.chat.gemini.GoogleAIGeminiChatGenerator",
+                "init_parameters": {
+                    "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
+                    "model": "gemini-pro-vision",
+                    "generation_config": None,
+                    "safety_settings": None,
+                    "streaming_callback": None,
+                    "tools": None,
+                },
+            }
+        )
+
+    assert gemini._model_name == "gemini-pro-vision"
+    assert gemini._generation_config is None
+    assert gemini._safety_settings is None
+    assert gemini._tools is None
+    assert isinstance(gemini._model, GenerativeModel)
+
+def test_from_dict_with_param(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "test")
 
     with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
@@ -138,6 +163,7 @@ def test_from_dict(monkeypatch):
                         "stop_sequences": ["stop"],
                     },
                     "safety_settings": {10: 3},
+                    "streaming_callback": None,
                     "tools": [
                         b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
                         b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
@@ -196,6 +222,19 @@ def test_run():
 
     res = gemini_chat.run(messages=messages)
     assert len(res["replies"]) > 0
+
+@pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")
+def test_run_with_streaming_callback():
+    streaming_callback_called = False
+
+    def streaming_callback(_chunk: StreamingChunk) -> None:
+        nonlocal streaming_callback_called
+        streaming_callback_called = True
+
+    gemini = GoogleAIGeminiChatGenerator(streaming_callback=streaming_callback)
+    res = gemini.run("Tell me something cool")
+    assert len(res["replies"]) > 0
+    assert streaming_callback_called
 
 
 @pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -41,8 +41,7 @@ def test_init(monkeypatch):
         top_k=0.5,
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    get_current_weather_func = GET_CURRENT_WEATHER_FUNC
-    tool = Tool(function_declarations=[get_current_weather_func])
+    tool = Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])
     with patch(
         "haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"
     ) as mock_genai_configure:
@@ -89,8 +88,7 @@ def test_to_dict_with_param(monkeypatch):
         top_k=2,
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    get_current_weather_func = GET_CURRENT_WEATHER_FUNC
-    tool = Tool(function_declarations=[get_current_weather_func])
+    tool = Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])
 
     with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
         gemini = GoogleAIGeminiChatGenerator(

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -249,12 +249,6 @@ def test_run_with_streaming_callback():
     messages = [ChatMessage.from_user(content="What is the temperature in celsius in Berlin?")]
     res = gemini_chat.run(messages=messages)
     assert len(res["replies"]) > 0
-
-    weather = get_current_weather(res["replies"][0].content)
-    messages += res["replies"] + [ChatMessage.from_function(content=weather, name="get_current_weather")]
-
-    res = gemini_chat.run(messages=messages)
-    assert len(res["replies"]) > 0
     assert streaming_callback_called
 
 

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -62,6 +62,24 @@ def test_init(monkeypatch):
 def test_to_dict(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "test")
 
+    with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
+        gemini = GoogleAIGeminiChatGenerator()
+    assert gemini.to_dict() == {
+        "type": "haystack_integrations.components.generators.google_ai.chat.gemini.GoogleAIGeminiChatGenerator",
+        "init_parameters": {
+            "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
+            "model": "gemini-pro-vision",
+            "generation_config": None,
+            "safety_settings": None,
+            "streaming_callback": None,
+            "tools": None,
+        },
+    }
+
+
+def test_to_dict_with_param(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test")
+
     generation_config = GenerationConfig(
         candidate_count=1,
         stop_sequences=["stop"],
@@ -100,24 +118,6 @@ def test_to_dict(monkeypatch):
                 b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
                 b"\x01\x1a*The city and state, e.g. San Francisco, CAB\x08location"
             ],
-        },
-    }
-
-
-def test_to_dict_with_param(monkeypatch):
-    monkeypatch.setenv("GOOGLE_API_KEY", "test")
-
-    with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
-        gemini = GoogleAIGeminiChatGenerator()
-    assert gemini.to_dict() == {
-        "type": "haystack_integrations.components.generators.google_ai.chat.gemini.GoogleAIGeminiChatGenerator",
-        "init_parameters": {
-            "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-            "model": "gemini-pro-vision",
-            "generation_config": None,
-            "safety_settings": None,
-            "streaming_callback": None,
-            "tools": None,
         },
     }
 

--- a/integrations/google_ai/tests/generators/test_gemini.py
+++ b/integrations/google_ai/tests/generators/test_gemini.py
@@ -108,6 +108,7 @@ def test_to_dict(monkeypatch):
                 "stop_sequences": ["stop"],
             },
             "safety_settings": {10: 3},
+            "streaming_callback": None,
             "tools": [
                 b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
                 b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
@@ -135,6 +136,7 @@ def test_from_dict(monkeypatch):
                         "stop_sequences": ["stop"],
                     },
                     "safety_settings": {10: 3},
+                    "streaming_callback": None,
                     "tools": [
                         b"\n\xad\x01\n\x13get_current_weather\x12+Get the current weather in a given location\x1ai"
                         b"\x08\x06:\x1f\n\x04unit\x12\x17\x08\x01*\x07celsius*\nfahrenheit::\n\x08location\x12.\x08"
@@ -189,3 +191,17 @@ def test_run():
     gemini = GoogleAIGeminiGenerator(model="gemini-pro")
     res = gemini.run("Tell me something cool")
     assert len(res["replies"]) > 0
+
+
+@pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")
+def test_run_with_streaming_callback():
+    streaming_callback_called = False
+
+    def streaming_callback(_chunk):
+        nonlocal streaming_callback_called
+        streaming_callback_called = True
+
+    gemini = GoogleAIGeminiGenerator(model="gemini-pro", streaming_callback=streaming_callback)
+    res = gemini.run("Tell me something cool")
+    assert len(res["replies"]) > 0
+    assert streaming_callback_called

--- a/integrations/google_ai/tests/generators/test_gemini.py
+++ b/integrations/google_ai/tests/generators/test_gemini.py
@@ -27,6 +27,7 @@ GET_CURRENT_WEATHER_FUNC = FunctionDeclaration(
     },
 )
 
+
 def test_init(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "test")
 
@@ -89,6 +90,7 @@ def test_to_dict(monkeypatch):
             "tools": None,
         },
     }
+
 
 def test_to_dict_with_param(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "test")
@@ -191,11 +193,7 @@ def test_from_dict(monkeypatch):
         top_k=0.5,
     )
     assert gemini._safety_settings == {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    assert gemini._tools == [
-        Tool(
-            function_declarations=[GET_CURRENT_WEATHER_FUNC]
-        )
-    ]
+    assert gemini._tools == [Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])]
     assert isinstance(gemini._model, GenerativeModel)
 
 


### PR DESCRIPTION
### Related Issues

- fixes #1002 

### Proposed Changes:

Add `streaming_callback` to `init` and `run` methods of `GoogleAIGeminiGenerator` and `GoogleAIGeminiChatGenerator`.

### How did you test it?

- Updated and ran existing unit tests
- Added a test for streaming
- Tested locally on my system

### Notes for the reviewer

Similar to the PR for VertexAI: [1014](https://github.com/deepset-ai/haystack-core-integrations/pull/1014) 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
