### PR TITLE
feat: add NVIDIA NIM ranker support

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/__init__.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/__init__.py
@@ -1,0 +1,3 @@
+from .ranker import NvidiaRanker
+
+__all__ = ["NvidiaRanker"]

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -175,7 +175,7 @@ class NvidiaRanker:
         if not all(isinstance(doc, Document) for doc in documents):
             msg = "Ranker expects the `documents` parameter to be a list of Document objects."
             raise TypeError(msg)
-        if top_k is not None and (not isinstance(top_k, int) or isinstance(top_k, bool)):
+        if top_k is not None and not isinstance(top_k, int):
             msg = "Ranker expects the `top_k` parameter to be an integer."
             raise TypeError(msg)
 

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -48,7 +48,7 @@ class NvidiaRanker:
     def __init__(
         self,
         model: Optional[str] = None,
-        truncate: Optional[Union[RankerTruncateMode, Literal["NONE", "END"]]] = None,
+        truncate: Optional[Union[RankerTruncateMode, str]] = None,
         api_url: Optional[str] = None,
         api_key: Optional[Secret] = None,
         top_k: int = 5,
@@ -74,7 +74,7 @@ class NvidiaRanker:
             msg = "Ranker expects the `api_url` parameter to be a string."
             raise TypeError(msg)
         if truncate is not None and not isinstance(truncate, RankerTruncateMode):
-            truncate = RankerTruncateMode(truncate)
+            truncate = RankerTruncateMode.from_str(truncate)
         if not isinstance(top_k, int):
             msg = "Ranker expects the `top_k` parameter to be an integer."
             raise TypeError(msg)

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -174,14 +174,15 @@ class NvidiaRanker:
         if not isinstance(documents, list):
             msg = "Ranker expects the `documents` parameter to be a list."
             raise TypeError(msg)
-        if len(documents) == 0:
-            return {"documents": []}
         if not all(isinstance(doc, Document) for doc in documents):
             msg = "Ranker expects the `documents` parameter to be a list of Document objects."
             raise TypeError(msg)
         if top_k is not None and not isinstance(top_k, int):
             msg = "Ranker expects the `top_k` parameter to be an integer."
             raise TypeError(msg)
+
+        if len(documents) == 0:
+            return {"documents": []}
 
         top_k = top_k if top_k is not None else self._top_k
         if top_k < 1:

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -22,10 +22,12 @@ class NvidiaRanker:
     Usage example:
     ```python
     from haystack_integrations.components.rankers.nvidia import NvidiaRanker
+    from haystack import Document
+    from haystack.utils import Secret
 
     ranker = NvidiaRanker(
         model="nvidia/nv-rerankqa-mistral-4b-v3",
-        api_key="your-api-key",
+        api_key=Secret.from_env_var("NVIDIA_API_KEY"),
     )
     ranker.warm_up()
 

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -74,7 +74,7 @@ class NvidiaRanker:
         if truncate is not None and truncate not in ["NONE", "END"]:
             msg = "Invalid truncate value. Must be 'NONE' or 'END'."
             raise ValueError(msg)
-        if not isinstance(top_k, int) or isinstance(top_k, bool):
+        if not isinstance(top_k, int):
             msg = "Ranker expects the `top_k` parameter to be an integer."
             raise TypeError(msg)
 

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -132,18 +132,19 @@ class NvidiaRanker:
 
         :raises ValueError: If the API key is required for hosted NVIDIA NIMs.
         """
-        model_kwargs = {}
-        if self._truncate is not None:
-            model_kwargs.update(truncate=str(self._truncate))
-        self._backend = NimBackend(
-            self._model,
-            api_url=self._api_url,
-            api_key=self._api_key,
-            model_kwargs=model_kwargs,
-        )
-        if not self._model:
-            self._model = _DEFAULT_MODEL
-        self._initialized = True
+        if not self._initialized:
+            model_kwargs = {}
+            if self._truncate is not None:
+                model_kwargs.update(truncate=str(self._truncate))
+            self._backend = NimBackend(
+                self._model,
+                api_url=self._api_url,
+                api_key=self._api_key,
+                model_kwargs=model_kwargs,
+            )
+            if not self._model:
+                self._model = _DEFAULT_MODEL
+            self._initialized = True
 
     @component.output_types(documents=List[Document])
     def run(

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -92,7 +92,7 @@ class NvidiaRanker:
         model: Optional[str] = _DEFAULT_MODEL,
         truncate: Optional[Literal["NONE", "END"]] = None,
         api_url: Optional[str] = None,
-        api_key: Optional[Secret] = Secret.from_env_var("NVIDIA_API_KEY"),
+        api_key: Optional[Secret] = None,
         top_k: int = 5,
     ):
         """
@@ -124,6 +124,7 @@ class NvidiaRanker:
 
         self._model = model
         self._truncate = truncate
+        self._api_key = api_key
         # if no api_url is provided, we're using a hosted model and can
         #  - assume the default url will work, because there's only one model
         #  - assume we won't call backend.models()
@@ -136,7 +137,8 @@ class NvidiaRanker:
                 raise ValueError(msg)
             self._api_url = None  # we handle the endpoint
             self._endpoint = _MODEL_ENDPOINT_MAP[self._model]
-        self._api_key = api_key
+            if api_key is None:
+                self._api_key = Secret.from_env_var("NVIDIA_API_KEY")
         self._top_k = top_k
         self._initialized = False
 

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -1,0 +1,245 @@
+import warnings
+from typing import Any, Dict, List, Literal, Optional
+
+from haystack import Document, component, default_from_dict, default_to_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+from haystack_integrations.utils.nvidia import NimBackend, url_validation
+
+#
+# Ranker spec
+# -----------
+#
+# Ranker is a class that ranks a list of items (documents) based on a given text (query).
+#
+# The class should have the following methods:
+#
+# - `__init__(self,
+#             model: Optional[str],
+#             top_k: int = 5,
+#             truncate: Optional[int],
+#             api_url: Optional[str],
+#             api_key: Optional[str])`
+#   Constructor method that initializes the ranker.
+#
+# - `warm_up(self)`
+#   Initializes the ranker.
+#
+# - `to_dict(self) -> Dict[str, Any]`
+#   Serializes the ranker to a dictionary.
+#
+# - `from_dict(cls, data: Dict[str, Any]) -> "Ranker"`
+#   Deserializes the ranker from a dictionary.
+#
+# - `run(self,
+#        query: str,
+#        documents: List[Document],
+#        top_k: Optional[int]) -> List[Document]`
+#   Ranks a list of documents based on a given query.
+#
+# The class should have the following attributes:
+#
+# - `model: str`
+#   The model to use for ranking.
+#
+# - `api_url: str`
+#   The URL of the API.
+#
+# - `api_key: str`
+#   The API key.
+#
+# - `truncate: Optional[Literal["NONE", "END"]]`
+#   The truncation strategy to use.
+#
+
+_DEFAULT_MODEL = "nvidia/nv-rerankqa-mistral-4b-v3"
+
+_MODEL_ENDPOINT_MAP = {
+    "nvidia/nv-rerankqa-mistral-4b-v3": "https://ai.api.nvidia.com/v1/retrieval/nvidia/nv-rerankqa-mistral-4b-v3/reranking",
+}
+
+
+@component
+class NvidiaRanker:
+    """
+    A component for ranking documents using ranking models provided by
+    [NVIDIA NIMs](https://ai.nvidia.com).
+
+    Usage example:
+    ```python
+    from haystack_integrations.components.rankers.nvidia import NvidiaRanker
+
+    ranker = NvidiaRanker(
+        model="nvidia/nv-rerankqa-mistral-4b-v3",
+        api_key="your-api-key",
+    )
+    ranker.warm_up()
+
+    query = "What is the capital of Germany?"
+    documents = [
+        Document(content="Berlin is the capital of Germany."),
+        Document(content="The capital of Germany is Berlin."),
+        Document(content="Germany's capital is Berlin."),
+    ]
+
+    result = ranker.run(query, documents, top_k=2)
+    print(result["documents"])
+    ```
+    """
+
+    def __init__(
+        self,
+        model: Optional[str] = _DEFAULT_MODEL,
+        truncate: Optional[Literal["NONE", "END"]] = None,
+        api_url: Optional[str] = None,
+        api_key: Optional[Secret] = Secret.from_env_var("NVIDIA_API_KEY"),
+        top_k: int = 5,
+    ):
+        """
+        Create a NvidiaRanker component.
+
+        :param model:
+            Ranking model to use.
+        :param truncate:
+            Truncation strategy to use. Can be "NONE" or "END". Defaults to NIM's default.
+        :param api_key:
+            API key for the NVIDIA NIM.
+        :param api_url:
+            Custom API URL for the NVIDIA NIM.
+        :param top_k:
+            Number of documents to return.
+        """
+        if not isinstance(model, str):
+            msg = "Ranker expects the `model` parameter to be a string."
+            raise TypeError(msg)
+        if not isinstance(api_url, (str, type(None))):
+            msg = "Ranker expects the `api_url` parameter to be a string."
+            raise TypeError(msg)
+        if truncate is not None and truncate not in ["NONE", "END"]:
+            msg = "Invalid truncate value. Must be 'NONE' or 'END'."
+            raise ValueError(msg)
+        if not isinstance(top_k, int) or isinstance(top_k, bool):
+            msg = "Ranker expects the `top_k` parameter to be an integer."
+            raise TypeError(msg)
+
+        self._model = model
+        self._truncate = truncate
+        # if no api_url is provided, we're using a hosted model and can
+        #  - assume the default url will work, because there's only one model
+        #  - assume we won't call backend.models()
+        if api_url is not None:
+            self._api_url = url_validation(api_url, None, ["v1/ranking"])
+            self._endpoint = None  # we let backend.rank() handle the endpoint
+        else:
+            if model not in _MODEL_ENDPOINT_MAP:
+                msg = f"Model '{model}' is unknown. Please provide an api_url to access it."
+                raise ValueError(msg)
+            self._api_url = None  # we handle the endpoint
+            self._endpoint = _MODEL_ENDPOINT_MAP[self._model]
+        self._api_key = api_key
+        self._top_k = top_k
+        self._initialized = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the ranker to a dictionary.
+
+        :return: A dictionary containing the ranker's attributes.
+        """
+        return default_to_dict(
+            self,
+            model=self._model,
+            top_k=self._top_k,
+            truncate=self._truncate,
+            api_url=self._api_url,
+            api_key=self._api_key,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "NvidiaRanker":
+        """
+        Deserialize the ranker from a dictionary.
+
+        :param data: A dictionary containing the ranker's attributes.
+        :return: The deserialized ranker.
+        """
+        deserialize_secrets_inplace(data, keys=["api_key"])
+        return default_from_dict(cls, data)
+
+    def warm_up(self):
+        """
+        Initialize the ranker.
+
+        :raises ValueError: If the API key is required for hosted NVIDIA NIMs.
+        """
+        model_kwargs = {}
+        if self._truncate is not None:
+            model_kwargs.update(truncate=self._truncate)
+        self._backend = NimBackend(
+            self._model,
+            api_url=self._api_url,
+            api_key=self._api_key,
+            model_kwargs=model_kwargs,
+        )
+        if not self._model:
+            self._model = _DEFAULT_MODEL
+        self._initialized = True
+
+    @component.output_types(replies=List[Document])
+    def run(
+        self,
+        query: str,
+        documents: List[Document],
+        top_k: Optional[int] = None,
+    ) -> Dict[str, List[Document]]:
+        """
+        Rank a list of documents based on a given query.
+
+        :param query: The query to rank the documents against.
+        :param documents: The list of documents to rank.
+        :param top_k: The number of documents to return.
+        :return: A list of ranked documents
+
+        :raises RuntimeError: If the ranker has not been loaded.
+        :raises TypeError: If the arguments are of the wrong type.
+
+        :return: A dictionary containing the ranked documents.
+        """
+        if not self._initialized:
+            msg = "The ranker has not been loaded. Please call warm_up() before running."
+            raise RuntimeError(msg)
+        if not isinstance(query, str):
+            msg = "Ranker expects the `query` parameter to be a string."
+            raise TypeError(msg)
+        if not isinstance(documents, list):
+            msg = "Ranker expects the `documents` parameter to be a list."
+            raise TypeError(msg)
+        if len(documents) == 0:
+            return {"documents": []}
+        if not all(isinstance(doc, Document) for doc in documents):
+            msg = "Ranker expects the `documents` parameter to be a list of Document objects."
+            raise TypeError(msg)
+        if top_k is not None and (not isinstance(top_k, int) or isinstance(top_k, bool)):
+            msg = "Ranker expects the `top_k` parameter to be an integer."
+            raise TypeError(msg)
+
+        top_k = top_k if top_k is not None else self._top_k
+        if top_k < 1:
+            warnings.warn("top_k should be at least 1, returning nothing", stacklevel=2)
+            return {"documents": []}
+
+        assert self._backend is not None
+        # rank result is list[{index: int, logit: float}] sorted by logit
+        sorted_indexes_and_scores = self._backend.rank(
+            query,
+            documents,
+            endpoint=self._endpoint,
+        )[:top_k]
+        sorted_documents = []
+        for item in sorted_indexes_and_scores:
+            # todo: should we copy or mutate?
+            doc = documents[item["index"]]
+            doc.score = item["logit"]
+            sorted_documents.append(doc)
+
+        return {"documents": sorted_documents}

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -144,7 +144,7 @@ class NvidiaRanker:
             self._model = _DEFAULT_MODEL
         self._initialized = True
 
-    @component.output_types(replies=List[Document])
+    @component.output_types(documents=List[Document])
     def run(
         self,
         query: str,

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -236,9 +236,9 @@ class NvidiaRanker:
             query,
             documents,
             endpoint=self._endpoint,
-        )[:top_k]
+        )
         sorted_documents = []
-        for item in sorted_indexes_and_scores:
+        for item in sorted_indexes_and_scores[:top_k]:
             # todo: should we copy or mutate?
             doc = documents[item["index"]]
             doc.score = item["logit"]

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -45,7 +45,7 @@ class NvidiaRanker:
 
     def __init__(
         self,
-        model: Optional[str] = _DEFAULT_MODEL,
+        model: Optional[str] = None,
         truncate: Optional[Literal["NONE", "END"]] = None,
         api_url: Optional[str] = None,
         api_key: Optional[Secret] = None,
@@ -65,7 +65,7 @@ class NvidiaRanker:
         :param top_k:
             Number of documents to return.
         """
-        if not isinstance(model, str):
+        if model is not None and not isinstance(model, str):
             msg = "Ranker expects the `model` parameter to be a string."
             raise TypeError(msg)
         if not isinstance(api_url, (str, type(None))):
@@ -78,7 +78,8 @@ class NvidiaRanker:
             msg = "Ranker expects the `top_k` parameter to be an integer."
             raise TypeError(msg)
 
-        self._model = model
+        # todo: detect default in non-hosted case (when api_url is provided)
+        self._model = model or _DEFAULT_MODEL
         self._truncate = truncate
         self._api_key = api_key
         # if no api_url is provided, we're using a hosted model and can
@@ -88,7 +89,7 @@ class NvidiaRanker:
             self._api_url = url_validation(api_url, None, ["v1/ranking"])
             self._endpoint = None  # we let backend.rank() handle the endpoint
         else:
-            if model not in _MODEL_ENDPOINT_MAP:
+            if self._model not in _MODEL_ENDPOINT_MAP:
                 msg = f"Model '{model}' is unknown. Please provide an api_url to access it."
                 raise ValueError(msg)
             self._api_url = None  # we handle the endpoint

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -103,7 +103,7 @@ class NvidiaRanker:
         """
         Serialize the ranker to a dictionary.
 
-        :return: A dictionary containing the ranker's attributes.
+        :returns: A dictionary containing the ranker's attributes.
         """
         return default_to_dict(
             self,
@@ -120,7 +120,7 @@ class NvidiaRanker:
         Deserialize the ranker from a dictionary.
 
         :param data: A dictionary containing the ranker's attributes.
-        :return: The deserialized ranker.
+        :returns: The deserialized ranker.
         """
         deserialize_secrets_inplace(data, keys=["api_key"])
         return default_from_dict(cls, data)
@@ -157,12 +157,11 @@ class NvidiaRanker:
         :param query: The query to rank the documents against.
         :param documents: The list of documents to rank.
         :param top_k: The number of documents to return.
-        :return: A list of ranked documents
 
         :raises RuntimeError: If the ranker has not been loaded.
         :raises TypeError: If the arguments are of the wrong type.
 
-        :return: A dictionary containing the ranked documents.
+        :returns: A dictionary containing the ranked documents.
         """
         if not self._initialized:
             msg = "The ranker has not been loaded. Please call warm_up() before running."

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -239,7 +239,7 @@ class NvidiaRanker:
         )
         sorted_documents = []
         for item in sorted_indexes_and_scores[:top_k]:
-            # todo: should we copy or mutate?
+            # mutate (don't copy) the document because we're only updating the score
             doc = documents[item["index"]]
             doc.score = item["logit"]
             sorted_documents.append(doc)

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -6,52 +6,6 @@ from haystack.utils import Secret, deserialize_secrets_inplace
 
 from haystack_integrations.utils.nvidia import NimBackend, url_validation
 
-#
-# Ranker spec
-# -----------
-#
-# Ranker is a class that ranks a list of items (documents) based on a given text (query).
-#
-# The class should have the following methods:
-#
-# - `__init__(self,
-#             model: Optional[str],
-#             top_k: int = 5,
-#             truncate: Optional[int],
-#             api_url: Optional[str],
-#             api_key: Optional[str])`
-#   Constructor method that initializes the ranker.
-#
-# - `warm_up(self)`
-#   Initializes the ranker.
-#
-# - `to_dict(self) -> Dict[str, Any]`
-#   Serializes the ranker to a dictionary.
-#
-# - `from_dict(cls, data: Dict[str, Any]) -> "Ranker"`
-#   Deserializes the ranker from a dictionary.
-#
-# - `run(self,
-#        query: str,
-#        documents: List[Document],
-#        top_k: Optional[int]) -> List[Document]`
-#   Ranks a list of documents based on a given query.
-#
-# The class should have the following attributes:
-#
-# - `model: str`
-#   The model to use for ranking.
-#
-# - `api_url: str`
-#   The URL of the API.
-#
-# - `api_key: str`
-#   The API key.
-#
-# - `truncate: Optional[Literal["NONE", "END"]]`
-#   The truncation strategy to use.
-#
-
 _DEFAULT_MODEL = "nvidia/nv-rerankqa-mistral-4b-v3"
 
 _MODEL_ENDPOINT_MAP = {

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class RankerTruncateMode(str, Enum):
+    """
+    Specifies how inputs to the NVIDIA ranker components are truncated.
+    If NONE, the input will not be truncated and an error returned instead.
+    If END, the input will be truncated from the end.
+    """
+
+    NONE = "NONE"
+    END = "END"
+
+    def __str__(self):
+        return self.value

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
@@ -13,3 +13,15 @@ class RankerTruncateMode(str, Enum):
 
     def __str__(self):
         return self.value
+
+    @classmethod
+    def from_str(cls, string: str) -> "RankerTruncateMode":
+        """
+        Create an truncate mode from a string.
+
+        :param string:
+            String to convert.
+        :returns:
+            Truncate mode.
+        """
+        return cls(string)

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
@@ -137,7 +137,7 @@ class NimBackend:
         documents: List[Document],
         endpoint: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        url = endpoint if endpoint else f"{self.api_url}/ranking"
+        url = endpoint or f"{self.api_url}/ranking"
 
         res = self.session.post(
             url,

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+from haystack import Document
 from haystack.utils import Secret
 
 REQUEST_TIMEOUT = 60
@@ -129,3 +130,28 @@ class NimBackend:
             msg = f"No hosted model were found at URL '{url}'."
             raise ValueError(msg)
         return models
+
+    def rank(
+        self,
+        query: str,
+        documents: List[Document],
+        endpoint: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        url = endpoint if endpoint else f"{self.api_url}/ranking"
+
+        res = self.session.post(
+            url,
+            json={
+                "model": self.model,
+                "query": {"text": query},
+                "passages": [{"text": doc.content} for doc in documents],
+                **self.model_kwargs,
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        res.raise_for_status()
+
+        data = res.json()
+        assert "rankings" in data, f"Expected 'rankings' in response, got {data}"
+
+        return data["rankings"]

--- a/integrations/nvidia/tests/test_base_url.py
+++ b/integrations/nvidia/tests/test_base_url.py
@@ -2,6 +2,7 @@ import pytest
 
 from haystack_integrations.components.embedders.nvidia import NvidiaDocumentEmbedder, NvidiaTextEmbedder
 from haystack_integrations.components.generators.nvidia import NvidiaGenerator
+from haystack_integrations.components.rankers.nvidia import NvidiaRanker
 
 
 @pytest.mark.parametrize(
@@ -15,12 +16,12 @@ from haystack_integrations.components.generators.nvidia import NvidiaGenerator
     ],
 )
 @pytest.mark.parametrize(
-    "embedder",
-    [NvidiaDocumentEmbedder, NvidiaTextEmbedder],
+    "component",
+    [NvidiaDocumentEmbedder, NvidiaTextEmbedder, NvidiaRanker],
 )
-def test_base_url_invalid_not_hosted(base_url: str, embedder) -> None:
+def test_base_url_invalid_not_hosted(base_url: str, component) -> None:
     with pytest.raises(ValueError):
-        embedder(api_url=base_url, model="x")
+        component(api_url=base_url, model="x")
 
 
 @pytest.mark.parametrize(
@@ -60,6 +61,16 @@ def test_base_url_valid_generator(base_url: str) -> None:
         "http://localhost:8888/chat/completions",
     ],
 )
+# todo: add this to test_base_url_invalid_not_hosted
 def test_base_url_invalid_generator(base_url: str) -> None:
     with pytest.raises(ValueError):
         NvidiaGenerator(api_url=base_url, model="x")
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    ["http://localhost:8080/v1/ranking", "http://0.0.0.0:8888/v1/ranking"],
+)
+def test_base_url_valid_ranker(base_url: str) -> None:
+    with pytest.warns(UserWarning):
+        NvidiaRanker(api_url=base_url)

--- a/integrations/nvidia/tests/test_base_url.py
+++ b/integrations/nvidia/tests/test_base_url.py
@@ -61,7 +61,6 @@ def test_base_url_valid_generator(base_url: str) -> None:
         "http://localhost:8888/chat/completions",
     ],
 )
-# todo: add this to test_base_url_invalid_not_hosted
 def test_base_url_invalid_generator(base_url: str) -> None:
     with pytest.raises(ValueError):
         NvidiaGenerator(api_url=base_url, model="x")

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -1,10 +1,10 @@
 import os
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import pytest
-from haystack import Document, component, default_from_dict, default_to_dict, logging
-from haystack.utils import Secret, deserialize_secrets_inplace
+from haystack import Document
+from haystack.utils import Secret
 
 from haystack_integrations.components.rankers.nvidia import NvidiaRanker
 from haystack_integrations.components.rankers.nvidia.ranker import _DEFAULT_MODEL

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -183,28 +183,32 @@ class TestNvidiaRanker:
             NvidiaRanker(api_url=1)
         assert "parameter to be a string" in str(e.value)
 
-    def test_query_typeerror(self) -> None:
+    def test_query_typeerror(self, monkeypatch) -> None:
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
         client = NvidiaRanker()
         client.warm_up()
         with pytest.raises(TypeError) as e:
             client.run(1, [Document(content="doc")])
         assert "parameter to be a string" in str(e.value)
 
-    def test_documents_typeerror(self) -> None:
+    def test_documents_typeerror(self, monkeypatch) -> None:
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
         client = NvidiaRanker()
         client.warm_up()
         with pytest.raises(TypeError) as e:
             client.run("query", "doc")
         assert "parameter to be a list" in str(e.value)
 
-    def test_documents_typeerror2(self) -> None:
+    def test_documents_typeerror2(self, monkeypatch) -> None:
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
         client = NvidiaRanker()
         client.warm_up()
         with pytest.raises(TypeError) as e:
             client.run("query", [1])
         assert "list of Document objects" in str(e.value)
 
-    def test_top_k_typeerror(self) -> None:
+    def test_top_k_typeerror(self, monkeypatch) -> None:
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
         client = NvidiaRanker()
         client.warm_up()
         with pytest.raises(TypeError) as e:

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -41,7 +41,7 @@ class TestNvidiaRanker:
         client = NvidiaRanker(api_url=url)
         assert client._api_url == url
 
-    def test_warm_up_required(self, requests_mock):
+    def test_warm_up_required(self):
         client = NvidiaRanker()
         with pytest.raises(RuntimeError) as e:
             client.run("query", [Document(content="doc")])

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -122,7 +122,7 @@ class TestNvidiaRanker:
         with pytest.raises(ValueError):
             NvidiaRanker(truncate=truncate)
 
-    @pytest.mark.parametrize("top_k", [True, False, "BOGUS"])
+    @pytest.mark.parametrize("top_k", [1.0, "BOGUS"])
     def test_top_k_invalid(self, monkeypatch, top_k: Any) -> None:
         with pytest.raises(TypeError) as e:
             NvidiaRanker(top_k=top_k)

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -1,0 +1,217 @@
+import os
+import re
+from typing import Any, Dict, List, Literal, Optional
+
+import pytest
+from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+from haystack_integrations.components.rankers.nvidia import NvidiaRanker
+from haystack_integrations.components.rankers.nvidia.ranker import _DEFAULT_MODEL
+
+
+class TestNvidiaRanker:
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+        client = NvidiaRanker()
+        assert client._model == _DEFAULT_MODEL
+        assert client._api_key == Secret.from_env_var("NVIDIA_API_KEY")
+
+    def test_init_with_parameters(self):
+        client = NvidiaRanker(
+            api_key=Secret.from_token("fake-api-key"),
+            model=_DEFAULT_MODEL,
+            top_k=3,
+            truncate="END",
+        )
+        assert client._api_key == Secret.from_token("fake-api-key")
+        assert client._model == _DEFAULT_MODEL
+        assert client._top_k == 3
+        assert client._truncate == "END"
+
+    def test_init_fail_wo_api_key(self, monkeypatch):
+        monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+        client = NvidiaRanker()
+        with pytest.raises(ValueError):
+            client.warm_up()
+
+    def test_init_pass_wo_api_key_w_api_url(self):
+        url = "https://url.bogus/v1"
+        client = NvidiaRanker(api_url=url)
+        assert client._api_url == url
+
+    def test_warm_up_required(self, requests_mock):
+        client = NvidiaRanker()
+        with pytest.raises(RuntimeError) as e:
+            client.run("query", [Document(content="doc")])
+        assert "not been loaded" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "truncate",
+        [
+            None,
+            "END",
+            "NONE",
+        ],
+    )
+    def test_mocked(
+        self,
+        requests_mock,
+        monkeypatch,
+        truncate: Optional[Literal["END", "NONE"]],
+    ) -> None:
+        query = "What is it?"
+        documents = [
+            Document(content="Nothing really."),
+            Document(content="Maybe something."),
+            Document(content="Not this."),
+        ]
+
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+
+        requests_mock.post(
+            re.compile(r".*ranking"),
+            json={
+                "rankings": [
+                    {"index": 1, "logit": 4.2},
+                    {"index": 0, "logit": 2.4},
+                    {"index": 2, "logit": -4.2},
+                ]
+            },
+        )
+
+        truncate_param = {}
+        if truncate:
+            truncate_param = {"truncate": truncate}
+        client = NvidiaRanker(
+            top_k=2,
+            **truncate_param,
+        )
+        client.warm_up()
+
+        response = client.run(
+            query=query,
+            documents=documents,
+        )["documents"]
+
+        assert requests_mock.last_request is not None
+        request_payload = requests_mock.last_request.json()
+        if truncate is None:
+            assert "truncate" not in request_payload
+        else:
+            assert "truncate" in request_payload
+            assert request_payload["truncate"] == truncate
+
+        assert len(response) == 2
+        assert response[0].content == documents[1].content
+        assert response[0].score == 4.2
+        assert response[1].content == documents[0].content
+        assert response[1].score == 2.4
+
+        response = client.run(
+            query=query,
+            documents=documents,
+            top_k=1,
+        )["documents"]
+        assert len(response) == 1
+        assert response[0].content == documents[1].content
+        assert response[0].score == 4.2
+
+    @pytest.mark.parametrize("truncate", [True, False, 1, 0, 1.0, "START", "BOGUS"])
+    def test_truncate_invalid(self, truncate: Any) -> None:
+        with pytest.raises(ValueError):
+            NvidiaRanker(truncate=truncate)
+
+    @pytest.mark.parametrize("top_k", [True, False, "BOGUS"])
+    def test_top_k_invalid(self, monkeypatch, top_k: Any) -> None:
+        with pytest.raises(TypeError) as e:
+            NvidiaRanker(top_k=top_k)
+        assert "parameter to be an integer" in str(e.value)
+
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+        client = NvidiaRanker()
+        client.warm_up()
+        with pytest.raises(TypeError) as e:
+            client.run("query", [Document(content="doc")], top_k=top_k)
+        assert "parameter to be an integer" in str(e.value)
+
+    @pytest.mark.skipif(
+        not os.environ.get("NVIDIA_API_KEY", None),
+        reason="Export an env var called NVIDIA_API_KEY containing the Nvidia API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_integration(
+        self,
+    ) -> None:
+        query = "What is it?"
+        documents = [
+            Document(content="Nothing really."),
+            Document(content="Maybe something."),
+            Document(content="Not this."),
+        ]
+
+        client = NvidiaRanker(top_k=2)
+        client.warm_up()
+
+        response = client.run(query=query, documents=documents)["documents"]
+
+        assert len(response) == 2
+        assert {response[0].content, response[1].content} == {documents[0].content, documents[1].content}
+
+    def test_top_k_warn(self, monkeypatch) -> None:
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+
+        client = NvidiaRanker(top_k=0)
+        client.warm_up()
+        with pytest.warns(UserWarning) as record0:
+            client.run("query", [Document(content="doc")])
+        assert "top_k should be at least 1" in str(record0[0].message)
+
+        client = NvidiaRanker(top_k=1)
+        client.warm_up()
+        with pytest.warns(UserWarning) as record1:
+            client.run("query", [Document(content="doc")], top_k=0)
+        assert "top_k should be at least 1" in str(record1[0].message)
+
+    def test_model_typeerror(self) -> None:
+        with pytest.raises(TypeError) as e:
+            NvidiaRanker(model=1)
+        assert "parameter to be a string" in str(e.value)
+
+    def test_api_url_typeerror(self) -> None:
+        with pytest.raises(TypeError) as e:
+            NvidiaRanker(api_url=1)
+        assert "parameter to be a string" in str(e.value)
+
+    def test_query_typeerror(self) -> None:
+        client = NvidiaRanker()
+        client.warm_up()
+        with pytest.raises(TypeError) as e:
+            client.run(1, [Document(content="doc")])
+        assert "parameter to be a string" in str(e.value)
+
+    def test_documents_typeerror(self) -> None:
+        client = NvidiaRanker()
+        client.warm_up()
+        with pytest.raises(TypeError) as e:
+            client.run("query", "doc")
+        assert "parameter to be a list" in str(e.value)
+
+    def test_documents_typeerror2(self) -> None:
+        client = NvidiaRanker()
+        client.warm_up()
+        with pytest.raises(TypeError) as e:
+            client.run("query", [1])
+        assert "list of Document objects" in str(e.value)
+
+    def test_top_k_typeerror(self) -> None:
+        client = NvidiaRanker()
+        client.warm_up()
+        with pytest.raises(TypeError) as e:
+            client.run("query", [Document(content="doc")], top_k="1")
+        assert "parameter to be an integer" in str(e.value)
+
+    def test_model_unknown(self) -> None:
+        with pytest.raises(ValueError) as e:
+            NvidiaRanker(model="unknown-model")
+        assert "unknown" in str(e.value)

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -247,3 +247,10 @@ class TestNvidiaRanker:
         with pytest.raises(ValueError) as e:
             NvidiaRanker(model="unknown-model")
         assert "unknown" in str(e.value)
+
+    def test_warm_up_once(self) -> None:
+        client = NvidiaRanker()
+        client.warm_up()
+        backend = client._backend
+        client.warm_up()
+        assert backend == client._backend

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -158,6 +158,33 @@ class TestNvidiaRanker:
         assert len(response) == 2
         assert {response[0].content, response[1].content} == {documents[0].content, documents[1].content}
 
+    @pytest.mark.skipif(
+        not os.environ.get("NVIDIA_NIM_RANKER_MODEL", None)
+        or not os.environ.get("NVIDIA_NIM_RANKER_ENDPOINT_URL", None),
+        reason="Export an env var called NVIDIA_NIM_RANKER_MODEL containing the hosted model name and "
+        "NVIDIA_NIM_RANKER_ENDPOINT_URL containing the local URL to call.",
+    )
+    @pytest.mark.integration
+    def test_nim_integration(self):
+        query = "What is it?"
+        documents = [
+            Document(content="Nothing really."),
+            Document(content="Maybe something."),
+            Document(content="Not this."),
+        ]
+
+        client = NvidiaRanker(
+            model=os.environ["NVIDIA_NIM_RANKER_MODEL"],
+            api_url=os.environ["NVIDIA_NIM_RANKER_ENDPOINT_URL"],
+            top_k=2,
+        )
+        client.warm_up()
+
+        response = client.run(query=query, documents=documents)["documents"]
+
+        assert len(response) == 2
+        assert {response[0].content, response[1].content} == {documents[0].content, documents[1].content}
+
     def test_top_k_warn(self, monkeypatch) -> None:
         monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
 

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 from haystack import Document, component, default_from_dict, default_to_dict, logging
@@ -62,7 +62,7 @@ class TestNvidiaRanker:
         self,
         requests_mock,
         monkeypatch,
-        truncate: Optional[Union[RankerTruncateMode, Literal["NONE", "END"]]],
+        truncate: Optional[Union[RankerTruncateMode, str]],
     ) -> None:
         query = "What is it?"
         documents = [

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -248,7 +248,9 @@ class TestNvidiaRanker:
             NvidiaRanker(model="unknown-model")
         assert "unknown" in str(e.value)
 
-    def test_warm_up_once(self) -> None:
+    def test_warm_up_once(self, monkeypatch) -> None:
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+
         client = NvidiaRanker()
         client.warm_up()
         backend = client._backend

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -226,10 +226,6 @@ class TestNvidiaRanker:
             client.run("query", "doc")
         assert "parameter to be a list" in str(e.value)
 
-    def test_documents_typeerror2(self, monkeypatch) -> None:
-        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
-        client = NvidiaRanker()
-        client.warm_up()
         with pytest.raises(TypeError) as e:
             client.run("query", [1])
         assert "list of Document objects" in str(e.value)


### PR DESCRIPTION
### Proposed Changes:

NVIDIA NIMs (hosted on https://build.nvidia.com and downloadable) support reranking models. This adds an NvidiaRanker component to access those models.

### How did you test it?

- [x] unit tests
- [x] integration tests of hosted NIM
- [x] integration tests of downloaded NIM

### Notes for the reviewer

1. should the input documents be mutated to add a score?
2. the ranker endpoints are not standardized, so i introduced an endpoint arg to rank(). an alternative is to refactor all components to pass the full inference endpoint to the backend.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
