### PR TITLE
refactor: Use Qdrant's Query API

### DIFF
--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -114,19 +114,7 @@ class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocu
         sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
         embedding = [0.1] * 768
 
-        with patch.object(document_store.client, "search_batch", side_effect=Exception("search_batch error")):
+        with patch.object(document_store.client, "query_points", side_effect=Exception("query_points")):
 
             with pytest.raises(QdrantStoreError):
                 document_store._query_hybrid(query_sparse_embedding=sparse_embedding, query_embedding=embedding)
-
-    @patch("haystack_integrations.document_stores.qdrant.document_store.reciprocal_rank_fusion")
-    def test_query_hybrid_reciprocal_rank_fusion_failure(self, mocked_fusion):
-        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True)
-
-        sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
-        embedding = [0.1] * 768
-
-        mocked_fusion.side_effect = Exception("reciprocal_rank_fusion error")
-
-        with pytest.raises(QdrantStoreError):
-            document_store._query_hybrid(query_sparse_embedding=sparse_embedding, query_embedding=embedding)


### PR DESCRIPTION
## Description

This PR updates the Qdrant integration to use the new [Query API](https://qdrant.tech/blog/qdrant-1.10.x/) that supersedes the search API.
It also support server-side fusion of the hybrid results.