### PR TITLE
fix: chat roles for model responses in chat generators

### DIFF
--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -200,7 +200,7 @@ def test_long_prompt_is_not_truncated_when_truncate_false(mock_boto3_session):
     """
     Test that a long prompt is not truncated and _ensure_token_limit is not called when truncate is set to False
     """
-    messages = [ChatMessage.from_system("What is the biggest city in United States?")]
+    messages = [ChatMessage.from_user("What is the biggest city in United States?")]
 
     # Our mock prompt is 8 tokens long, so it exceeds the total limit (8 prompt tokens + 3 generated tokens > 10 tokens)
     max_length_generated_text = 3

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -326,7 +326,7 @@ class GoogleAIGeminiChatGenerator:
         for candidate in response_body.candidates:
             for part in candidate.content.parts:
                 if part.text != "":
-                    replies.append(ChatMessage.from_system(part.text))
+                    replies.append(ChatMessage.from_assistant(part.text))
                 elif part.function_call is not None:
                     replies.append(
                         ChatMessage(
@@ -354,4 +354,4 @@ class GoogleAIGeminiChatGenerator:
             responses.append(content)
 
         combined_response = "".join(responses).lstrip()
-        return [ChatMessage.from_system(content=combined_response)]
+        return [ChatMessage.from_assistant(content=combined_response)]

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -241,14 +241,14 @@ class GoogleAIGeminiChatGenerator:
             raise ValueError(msg)
 
     def _message_to_part(self, message: ChatMessage) -> Part:
-        if message.role == ChatRole.SYSTEM and message.name:
+        if message.role == ChatRole.ASSISTANT and message.name:
             p = Part()
             p.function_call.name = message.name
             p.function_call.args = {}
             for k, v in message.content.items():
                 p.function_call.args[k] = v
             return p
-        elif message.role == ChatRole.SYSTEM:
+        elif message.role in {ChatRole.SYSTEM, ChatRole.ASSISTANT}:
             p = Part()
             p.text = message.content
             return p
@@ -261,13 +261,13 @@ class GoogleAIGeminiChatGenerator:
             return self._convert_part(message.content)
 
     def _message_to_content(self, message: ChatMessage) -> Content:
-        if message.role == ChatRole.SYSTEM and message.name:
+        if message.role == ChatRole.ASSISTANT and message.name:
             part = Part()
             part.function_call.name = message.name
             part.function_call.args = {}
             for k, v in message.content.items():
                 part.function_call.args[k] = v
-        elif message.role == ChatRole.SYSTEM:
+        elif message.role in {ChatRole.SYSTEM, ChatRole.ASSISTANT}:
             part = Part()
             part.text = message.content
         elif message.role == ChatRole.FUNCTION:

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -331,7 +331,7 @@ class GoogleAIGeminiChatGenerator:
                     replies.append(
                         ChatMessage(
                             content=dict(part.function_call.args.items()),
-                            role=ChatRole.SYSTEM,
+                            role=ChatRole.ASSISTANT,
                             name=part.function_call.name,
                         )
                     )

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -256,8 +256,9 @@ def test_run_with_streaming_callback():
 def test_past_conversation():
     gemini_chat = GoogleAIGeminiChatGenerator(model="gemini-pro")
     messages = [
+        ChatMessage.from_system(content="You are a knowledageable mathematician."),
         ChatMessage.from_user(content="What is 2+2?"),
-        ChatMessage.from_system(content="It's an arithmetic operation."),
+        ChatMessage.from_assistant(content="It's an arithmetic operation."),
         ChatMessage.from_user(content="Yeah, but what's the result?"),
     ]
     res = gemini_chat.run(messages=messages)

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -164,12 +164,12 @@ class VertexAIGeminiChatGenerator:
             raise ValueError(msg)
 
     def _message_to_part(self, message: ChatMessage) -> Part:
-        if message.role == ChatRole.SYSTEM and message.name:
+        if message.role == ChatRole.ASSISTANT and message.name:
             p = Part.from_dict({"function_call": {"name": message.name, "args": {}}})
             for k, v in message.content.items():
                 p.function_call.args[k] = v
             return p
-        elif message.role == ChatRole.SYSTEM:
+        elif message.role in {ChatRole.SYSTEM, ChatRole.ASSISTANT}:
             return Part.from_text(message.content)
         elif message.role == ChatRole.FUNCTION:
             return Part.from_function_response(name=message.name, response=message.content)
@@ -177,11 +177,11 @@ class VertexAIGeminiChatGenerator:
             return self._convert_part(message.content)
 
     def _message_to_content(self, message: ChatMessage) -> Content:
-        if message.role == ChatRole.SYSTEM and message.name:
+        if message.role == ChatRole.ASSISTANT and message.name:
             part = Part.from_dict({"function_call": {"name": message.name, "args": {}}})
             for k, v in message.content.items():
                 part.function_call.args[k] = v
-        elif message.role == ChatRole.SYSTEM:
+        elif message.role in {ChatRole.SYSTEM, ChatRole.ASSISTANT}:
             part = Part.from_text(message.content)
         elif message.role == ChatRole.FUNCTION:
             part = Part.from_function_response(name=message.name, response=message.content)
@@ -241,7 +241,7 @@ class VertexAIGeminiChatGenerator:
                     replies.append(
                         ChatMessage(
                             content=dict(part.function_call.args.items()),
-                            role=ChatRole.SYSTEM,
+                            role=ChatRole.ASSISTANT,
                             name=part.function_call.name,
                         )
                     )

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -236,7 +236,7 @@ class VertexAIGeminiChatGenerator:
         for candidate in response_body.candidates:
             for part in candidate.content.parts:
                 if part._raw_part.text != "":
-                    replies.append(ChatMessage.from_system(part.text))
+                    replies.append(ChatMessage.from_assistant(part.text))
                 elif part.function_call is not None:
                     replies.append(
                         ChatMessage(
@@ -264,4 +264,4 @@ class VertexAIGeminiChatGenerator:
             responses.append(streaming_chunk.content)
 
         combined_response = "".join(responses).lstrip()
-        return [ChatMessage.from_system(content=combined_response)]
+        return [ChatMessage.from_assistant(content=combined_response)]

--- a/integrations/ollama/examples/chat_generator_example.py
+++ b/integrations/ollama/examples/chat_generator_example.py
@@ -11,7 +11,7 @@ from haystack_integrations.components.generators.ollama import OllamaChatGenerat
 
 messages = [
     ChatMessage.from_user("What's Natural Language Processing?"),
-    ChatMessage.from_system(
+    ChatMessage.from_assistant(
         "Natural Language Processing (NLP) is a field of computer science and artificial "
         "intelligence concerned with the interaction between computers and human language"
     ),


### PR DESCRIPTION
### Related Issues

- fixes #1026 

### Proposed Changes:

- Updated the role assigned to model responses from `system` to `assistant` for both `GoogleGeminiChatGenerator` and `VertexAIGeminiChatGenerator`.
- Reviewed and verified consistency across other generators to ensure correct role assignment.

### How did you test it?

Ran existing tests
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
