### PR TITLE
chore: Migrate from Preview to Stable Package for Vertex AI Integration

### DIFF
--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -8,7 +8,7 @@ from haystack.dataclasses.byte_stream import ByteStream
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole
 from haystack.utils import deserialize_callable, serialize_callable
 from vertexai import init as vertexai_init
-from vertexai.preview.generative_models import (
+from vertexai.generative_models import (
     Content,
     GenerationConfig,
     GenerationResponse,

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -135,10 +135,6 @@ class VertexAIGeminiGenerator:
             streaming_callback=callback_name,
         )
 
-        for t in self._tools:
-            print(Tool.to_dict(t))
-            print ("FUNCTION DECLARATION")
-            print (t._callable_functions)
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [Tool.to_dict(t) for t in tools]
         if (generation_config := data["init_parameters"].get("generation_config")) is not None:

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -7,7 +7,7 @@ from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream, StreamingChunk
 from haystack.utils import deserialize_callable, serialize_callable
 from vertexai import init as vertexai_init
-from vertexai.preview.generative_models import (
+from vertexai.generative_models import (
     Content,
     GenerationConfig,
     GenerationResponse,
@@ -134,6 +134,11 @@ class VertexAIGeminiGenerator:
             tools=self._tools,
             streaming_callback=callback_name,
         )
+
+        for t in self._tools:
+            print(Tool.to_dict(t))
+            print ("FUNCTION DECLARATION")
+            print (t._callable_functions)
         if (tools := data["init_parameters"].get("tools")) is not None:
             data["init_parameters"]["tools"] = [Tool.to_dict(t) for t in tools]
         if (generation_config := data["init_parameters"].get("generation_config")) is not None:

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -7,7 +7,7 @@ from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream, StreamingChunk
 from haystack.utils import deserialize_callable, serialize_callable
 from vertexai import init as vertexai_init
-from vertexai.generative_models import (
+from vertexai.preview.generative_models import (
     Content,
     GenerationConfig,
     GenerationResponse,

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 from haystack.dataclasses import StreamingChunk
-from vertexai.preview.generative_models import (
+from vertexai.generative_models import (
     FunctionDeclaration,
     GenerationConfig,
     HarmBlockThreshold,
@@ -103,6 +103,8 @@ def test_to_dict_with_params(_mock_vertexai_init, _mock_generative_model):
         safety_settings=safety_settings,
         tools=[tool],
     )
+
+    print (gemini.to_dict())
     assert gemini.to_dict() == {
         "type": "haystack_integrations.components.generators.google_vertex.gemini.VertexAIGeminiGenerator",
         "init_parameters": {

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 from haystack.dataclasses import StreamingChunk
-from vertexai.preview.generative_models import (
+from vertexai.generative_models import (
     FunctionDeclaration,
     GenerationConfig,
     HarmBlockThreshold,

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -104,7 +104,6 @@ def test_to_dict_with_params(_mock_vertexai_init, _mock_generative_model):
         tools=[tool],
     )
 
-    print (gemini.to_dict())
     assert gemini.to_dict() == {
         "type": "haystack_integrations.components.generators.google_vertex.gemini.VertexAIGeminiGenerator",
         "init_parameters": {

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 from haystack.dataclasses import StreamingChunk
-from vertexai.generative_models import (
+from vertexai.preview.generative_models import (
     FunctionDeclaration,
     GenerationConfig,
     HarmBlockThreshold,


### PR DESCRIPTION
### Related Issues

- partial fix for #1018 

### Proposed Changes:

Migrate from `vertex.preview.generative_model` and `vertex.generative_model`.

### How did you test it?

- Ran the unit tests
- Manual testing with examples

### Notes for the reviewer

NA
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
