### PR TITLE
fix!: fix type errors in `QdrantDocumentStore`; rename `ids` (parameter of `delete_documents`) to `document_ids`

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -334,7 +334,7 @@ class QdrantDocumentStore:
         self,
         documents: List[Document],
         policy: DuplicatePolicy = DuplicatePolicy.FAIL,
-    ):
+    ) -> int:
         """
         Writes documents to Qdrant using the specified policy.
         The QdrantDocumentStore can handle duplicate documents based on the given policy.
@@ -358,7 +358,7 @@ class QdrantDocumentStore:
 
         if len(documents) == 0:
             logger.warning("Calling QdrantDocumentStore.write_documents() with empty list")
-            return
+            return 0
 
         document_objects = self._handle_duplicate_documents(
             documents=documents,
@@ -383,13 +383,13 @@ class QdrantDocumentStore:
                 progress_bar.update(self.write_batch_size)
         return len(document_objects)
 
-    def delete_documents(self, ids: List[str]):
+    def delete_documents(self, document_ids: List[str]) -> None:
         """
         Deletes documents that match the provided `document_ids` from the document store.
 
         :param document_ids: the document ids to delete
         """
-        ids = [convert_id(_id) for _id in ids]
+        ids = [convert_id(_id) for _id in document_ids]
         try:
             self.client.delete(
                 collection_name=self.index,


### PR DESCRIPTION
The `QdrantDocumentStore` did not properly implement the `DocumentStore` protocol.

### Related Issues

- fixes #1039

### Proposed Changes:

Ensure that the `write_documents` and `delete_documents` methods match the type expectations of the `DocumentStore` protocol.

### How did you test it?

Manual verification. Can't test via hatch, as it's currently trashed on my system.

### Notes for the reviewer

This is technically a breaking change, because it changes the name of the `ids` argument in `delete_documents` to `document_ids`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
