### PR TITLE
fix: Missing Nvidia embedding truncate mode

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -6,7 +6,7 @@ class EmbeddingTruncateMode(Enum):
     Specifies how inputs to the NVIDIA embedding components are truncated.
     If START, the input will be truncated from the start.
     If END, the input will be truncated from the end.
-    If NONE, an error will be returned.
+    If NONE, an error will be returned (if the input is too long).
     """
 
     START = "START"

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -17,6 +17,11 @@ class EmbeddingTruncateMode(Enum):
         return self.value
 
     @classmethod
+    def _missing_(cls, value: object):
+        msg = f"Unknown truncate mode '{value}'. Supported modes are: {list(cls.__members__.keys())}"
+        raise ValueError(msg)
+
+    @classmethod
     def from_str(cls, string: str) -> "EmbeddingTruncateMode":
         """
         Create an truncate mode from a string.
@@ -26,9 +31,4 @@ class EmbeddingTruncateMode(Enum):
         :returns:
             Truncate mode.
         """
-        enum_map = {e.value: e for e in EmbeddingTruncateMode}
-        opt_mode = enum_map.get(string)
-        if opt_mode is None:
-            msg = f"Unknown truncate mode '{string}'. Supported modes are: {list(enum_map.keys())}"
-            raise ValueError(msg)
-        return opt_mode
+        return cls(string)

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -6,10 +6,12 @@ class EmbeddingTruncateMode(Enum):
     Specifies how inputs to the NVIDIA embedding components are truncated.
     If START, the input will be truncated from the start.
     If END, the input will be truncated from the end.
+    If NONE, an error will be returned.
     """
 
     START = "START"
     END = "END"
+    NONE = "NONE"
 
     def __str__(self):
         return self.value

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -17,11 +17,6 @@ class EmbeddingTruncateMode(Enum):
         return self.value
 
     @classmethod
-    def _missing_(cls, value: object):
-        msg = f"Unknown truncate mode '{value}'. Supported modes are: {list(cls.__members__.keys())}"
-        raise ValueError(msg)
-
-    @classmethod
     def from_str(cls, string: str) -> "EmbeddingTruncateMode":
         """
         Create an truncate mode from a string.
@@ -31,4 +26,9 @@ class EmbeddingTruncateMode(Enum):
         :returns:
             Truncate mode.
         """
-        return cls(string)
+        enum_map = {e.value: e for e in EmbeddingTruncateMode}
+        opt_mode = enum_map.get(string)
+        if opt_mode is None:
+            msg = f"Unknown truncate mode '{string}'. Supported modes are: {list(enum_map.keys())}"
+            raise ValueError(msg)
+        return opt_mode

--- a/integrations/nvidia/tests/test_embedding_truncate_mode.py
+++ b/integrations/nvidia/tests/test_embedding_truncate_mode.py
@@ -1,0 +1,40 @@
+import pytest
+
+from haystack_integrations.components.embedders.nvidia import EmbeddingTruncateMode
+
+
+class TestEmbeddingTruncateMode:
+    @pytest.mark.parametrize(
+        "mode, expected",
+        [
+            ("START", EmbeddingTruncateMode.START),
+            ("END", EmbeddingTruncateMode.END),
+            ("NONE", EmbeddingTruncateMode.NONE),
+            (EmbeddingTruncateMode.START, EmbeddingTruncateMode.START),
+            (EmbeddingTruncateMode.END, EmbeddingTruncateMode.END),
+            (EmbeddingTruncateMode.NONE, EmbeddingTruncateMode.NONE),
+        ],
+    )
+    def test_init_with_valid_mode(self, mode, expected):
+        assert EmbeddingTruncateMode(mode) == expected
+
+    def test_init_with_invalid_mode_raises_value_error(self):
+        with pytest.raises(ValueError):
+            invalid_mode = "INVALID"
+            EmbeddingTruncateMode(invalid_mode)
+
+    @pytest.mark.parametrize(
+        "mode, expected",
+        [
+            ("START", EmbeddingTruncateMode.START),
+            ("END", EmbeddingTruncateMode.END),
+            ("NONE", EmbeddingTruncateMode.NONE),
+        ],
+    )
+    def test_from_str_with_valid_mode(self, mode, expected):
+        assert EmbeddingTruncateMode.from_str(mode) == expected
+
+    def test_from_str_with_invalid_mode_raises_value_error(self):
+        with pytest.raises(ValueError):
+            invalid_mode = "INVALID"
+            EmbeddingTruncateMode.from_str(invalid_mode)


### PR DESCRIPTION
### Related Issues

- fixes #1027 
### Proposed Changes:
Add missing `NONE` member to `EmbeddingTruncateMode`

### How did you test it?
Ran existing test.
Ran test locally.
Add unit test for `EmbeddingTruncateMode`
### Notes for the reviewer

Implemented [`_missing_`](https://docs.python.org/3/library/enum.html#enum.Enum._missing_) for `EmbeddingTruncateMode`. Reasoning is to ensure that a ValueError with message is raised consistently, whether a user instantiates the enum directly or through the `from_str()` method. I tested instantiation both ways in the unit test.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
