### PR TITLE
Ping `protobuf` to `<5.28` to fix Google Vertex Components serialization

### DIFF
--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -22,7 +22,12 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "google-cloud-aiplatform>=1.38", "pyarrow>3"]
+dependencies = [
+  "haystack-ai",
+  "google-cloud-aiplatform>=1.38",
+  "pyarrow>3",
+  "protobuf<5.28",
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_vertex#readme"


### PR DESCRIPTION
### Proposed Changes:

There is a [reproducible bug](https://github.com/googleapis/proto-plus-python/issues/483) that causes serialization to fail on Windows for Gemini Components in Google Vertex integration.

Pinning the version of `protobuf` to `<5.28` seems to solve the issue

### How did you test it?

This usually fails in CI on Windows, I don't have a Windows machine at the ready so CI will do.

### Notes for the reviewer

I'll open a tracking issue to unpin this as soon as the [original bug 
](https://github.com/googleapis/proto-plus-python/issues/483) is fixed.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
