### PR TITLE
fix: AstraDocumentStore filter by id

### DIFF
--- a/integrations/astra/src/haystack_integrations/document_stores/astra/filters.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/filters.py
@@ -30,8 +30,6 @@ def _convert_filters(filters: Optional[Dict[str, Any]] = None) -> Optional[Dict[
         if key in {"$and", "$or"}:
             filter_statements[key] = value
         else:
-            if key == "id":
-                filter_statements[key] = {"_id": value}
             if key != "$in" and isinstance(value, list):
                 filter_statements[key] = {"$in": value}
             elif isinstance(value, pd.DataFrame):
@@ -45,6 +43,8 @@ def _convert_filters(filters: Optional[Dict[str, Any]] = None) -> Optional[Dict[
                 filter_statements[key] = converted
             else:
                 filter_statements[key] = value
+            if key == "id":
+                filter_statements["_id"] = filter_statements.pop("id")
 
     return filter_statements
 

--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -200,6 +200,12 @@ class TestDocumentStore(DocumentStoreBaseTests):
             ],
         )
 
+    def test_filter_documents_by_id(self, document_store):
+        docs = [Document(id="1", content="test doc 1"), Document(id="2", content="test doc 2")]
+        document_store.write_documents(docs)
+        result = document_store.filter_documents(filters={"field": "id", "operator": "==", "value": "1"})
+        self.assert_documents_are_equal(result, [docs[0]])
+
     @pytest.mark.skip(reason="Unsupported filter operator not.")
     def test_not_operator(self, document_store, filterable_docs):
         pass


### PR DESCRIPTION
### Related Issues

- fixes #1037 
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Correctly map `id` to `_id`. 

### How did you test it?
Added integration test `TestDocumentStore.test_filter_documents_by_id`

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
