### PR TITLE
fix: Weaviate - fix connection issues with some WCS URLs

### DIFF
--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -44,6 +44,7 @@ jobs:
         run: pip install --upgrade hatch
 
       - name: Lint
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run lint:all
 
       - name: Run Weaviate container

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -172,11 +172,7 @@ class WeaviateDocumentStore:
         if self._client:
             return self._client
 
-        if (
-            self._url
-            and self._url.startswith("http")
-            and (self._url.endswith(".weaviate.network") or self._url.endswith(".weaviate.cloud"))
-        ):
+        if self._url and (self._url.endswith(".weaviate.network") or self._url.endswith(".weaviate.cloud")):
             # We use this utility function instead of using WeaviateClient directly like in other cases
             # otherwise we'd have to parse the URL to get some information about the connection.
             # This utility function does all that for us.

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -172,10 +172,10 @@ class WeaviateDocumentStore:
         if self._client:
             return self._client
 
-        if self._url and (self._url.endswith(".weaviate.network") or self._url.endswith(".weaviate.cloud")):
-            # We use this utility function instead of using WeaviateClient directly like in other cases
-            # otherwise we'd have to parse the URL to get some information about the connection.
-            # This utility function does all that for us.
+        if self._url and self._url.endswith((".weaviate.network", ".weaviate.cloud")):
+            # If we detect that the URL is a Weaviate Cloud URL, we use the utility function to connect
+            # instead of using WeaviateClient directly like in other cases.
+            # Among other things, the utility function takes care of parsing the URL.
             self._client = weaviate.connect_to_weaviate_cloud(
                 self._url,
                 auth_credentials=self._auth_client_secret.resolve_value() if self._auth_client_secret else None,

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -172,11 +172,15 @@ class WeaviateDocumentStore:
         if self._client:
             return self._client
 
-        if self._url and self._url.startswith("http") and self._url.endswith(".weaviate.network"):
+        if (
+            self._url
+            and self._url.startswith("http")
+            and (self._url.endswith(".weaviate.network") or self._url.endswith(".weaviate.cloud"))
+        ):
             # We use this utility function instead of using WeaviateClient directly like in other cases
             # otherwise we'd have to parse the URL to get some information about the connection.
             # This utility function does all that for us.
-            self._client = weaviate.connect_to_wcs(
+            self._client = weaviate.connect_to_weaviate_cloud(
                 self._url,
                 auth_credentials=self._auth_client_secret.resolve_value() if self._auth_client_secret else None,
                 headers=self._additional_headers,

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -183,6 +183,7 @@ class WeaviateDocumentStore:
                 additional_config=self._additional_config,
             )
         else:
+            # Embedded, local Docker deployment or custom connection.
             # proxies, timeout_config, trust_env are part of additional_config now
             # startup_period has been removed
             self._client = weaviate.WeaviateClient(

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -68,7 +68,7 @@ class WeaviateDocumentStore:
     from haystack_integrations.document_stores.weaviate.auth import AuthApiKey
     from haystack_integrations.document_stores.weaviate.document_store import WeaviateDocumentStore
 
-    os.environ["WEAVIATE_API_KEY"] = "MY_API_KEY
+    os.environ["WEAVIATE_API_KEY"] = "MY_API_KEY"
 
     document_store = WeaviateDocumentStore(
         url="rAnD0mD1g1t5.something.weaviate.cloud",


### PR DESCRIPTION
### Related Issues

- fixes #1057
 
### Proposed Changes:

- extend the existing condition to take into account also URLs ending with ".weaviate.cloud"
- replace `connect_to_wcs` (deprecated) with `connect_to_weaviate_cloud`

### How did you test it?
CI, manual test on Weaviate Cloud (before the fix, I could not connect)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
