### PR TITLE
refactor: fix chroma linting; do not use numpy

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import chromadb
-import numpy as np
 from chromadb.api.types import GetResult, QueryResult, validate_where, validate_where_document
 from haystack import default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -453,7 +452,7 @@ class ChromaDocumentStore:
             for j in range(len(answers)):
                 document_dict: Dict[str, Any] = {
                     "id": result["ids"][i][j],
-                    "content": documents[i][j],
+                    "content": answers[j],
                 }
 
                 # prepare metadata
@@ -465,7 +464,7 @@ class ChromaDocumentStore:
                     pass
 
                 if embeddings := result.get("embeddings"):
-                    document_dict["embedding"] = np.array(embeddings[i][j])
+                    document_dict["embedding"] = embeddings[i][j]
 
                 if distances := result.get("distances"):
                     document_dict["score"] = distances[i][j]

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -106,7 +106,12 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, LegacyFilterDoc
 
         # Assertions to verify correctness
         assert len(result) == 1
-        assert result[0][0].content == "Third document"
+        doc = result[0][0]
+        assert doc.content == "Third document"
+        assert doc.meta == {"author": "Author2"}
+        assert doc.embedding
+        assert isinstance(doc.embedding, list)
+        assert all(isinstance(el, float) for el in doc.embedding)
 
     def test_write_documents_unsupported_meta_values(self, document_store: ChromaDocumentStore):
         """


### PR DESCRIPTION
### Related Issues

- fixes CI linting errors: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/10755366118

### Proposed Changes:
- fix the linting error
- remove the usage of `np.array` to handle embeddings: our `embedding` is a `list` of `float`

### How did you test it?
CI, added new assertions to an existing test to verify that the returned `embedding` is a `list` of `float`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
