### PR TITLE
chore: ChromaDocumentStore lint fix

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -453,7 +453,7 @@ class ChromaDocumentStore:
             for j in range(len(answers)):
                 document_dict: Dict[str, Any] = {
                     "id": result["ids"][i][j],
-                    "content": documents[i][j],
+                    "content": answers[j],
                 }
 
                 # prepare metadata


### PR DESCRIPTION
Fixes failed nightly run most likely due to updates in linting rules and the fix makes sense as well. 