### PR TITLE
chore: PgVector - remove legacy filter support

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -388,7 +388,8 @@ class PgvectorDocumentStore:
                 msg = "Filters must be a dictionary"
                 raise TypeError(msg)
             if "operator" not in filters and "conditions" not in filters:
-                raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
+                msg = "Legacy filters support has been removed. Please see documentation for new filter syntax."
+                raise ValueError(msg)
 
         sql_filter = SQL("SELECT * FROM {table_name}").format(table_name=Identifier(self.table_name))
 

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -388,7 +388,7 @@ class PgvectorDocumentStore:
                 msg = "Filters must be a dictionary"
                 raise TypeError(msg)
             if "operator" not in filters and "conditions" not in filters:
-                msg = "Legacy filters support has been removed. Please see documentation for new filter syntax."
+                msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
                 raise ValueError(msg)
 
         sql_filter = SQL("SELECT * FROM {table_name}").format(table_name=Identifier(self.table_name))

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -9,7 +9,6 @@ from haystack.dataclasses.document import ByteStream, Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils.auth import Secret, deserialize_secrets_inplace
-from haystack.utils.filters import convert
 from psycopg import Error, IntegrityError, connect
 from psycopg.abc import Query
 from psycopg.cursor import Cursor
@@ -389,7 +388,7 @@ class PgvectorDocumentStore:
                 msg = "Filters must be a dictionary"
                 raise TypeError(msg)
             if "operator" not in filters and "conditions" not in filters:
-                filters = convert(filters)
+                raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
 
         sql_filter = SQL("SELECT * FROM {table_name}").format(table_name=Identifier(self.table_name))
 


### PR DESCRIPTION
- Removes legacy filter support in PgVector (i.e. use of `convert` from from `haystack-ai`)
- See https://github.com/deepset-ai/haystack/pull/8342 for more details