### PR TITLE
chore: Pinecone - remove legacy filter support

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -11,7 +11,6 @@ from haystack import default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.filters import convert
 
 from pinecone import Pinecone, PodSpec, ServerlessSpec
 
@@ -201,6 +200,9 @@ class PineconeDocumentStore:
         :returns: A list of Documents that match the given filters.
         """
 
+        if filters and "operator" not in filters and "conditions" not in filters:
+            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
+
         # Pinecone only performs vector similarity search
         # here we are querying with a dummy vector and the max compatible top_k
         documents = self._embedding_retrieval(query_embedding=self._dummy_vector, filters=filters, top_k=TOP_K_LIMIT)
@@ -253,7 +255,7 @@ class PineconeDocumentStore:
             raise ValueError(msg)
 
         if filters and "operator" not in filters and "conditions" not in filters:
-            filters = convert(filters)
+            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
         filters = _normalize_filters(filters) if filters else None
 
         result = self.index.query(

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -201,8 +201,7 @@ class PineconeDocumentStore:
         """
 
         if filters and "operator" not in filters and "conditions" not in filters:
-            msg = ("Invalid filter syntax. "
-                   "See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details.")
+            msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
             raise ValueError(msg)
 
         # Pinecone only performs vector similarity search

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -201,7 +201,7 @@ class PineconeDocumentStore:
         """
 
         if filters and "operator" not in filters and "conditions" not in filters:
-            msg = ("Legacy filters support has been removed. "
+            msg = ("Invalid filter syntax. "
                    "See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details.")
             raise ValueError(msg)
 

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -201,7 +201,8 @@ class PineconeDocumentStore:
         """
 
         if filters and "operator" not in filters and "conditions" not in filters:
-            msg = "Legacy filters support has been removed. See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details."
+            msg = ("Legacy filters support has been removed. "
+                   "See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details.")
             raise ValueError(msg)
 
         # Pinecone only performs vector similarity search

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -201,7 +201,8 @@ class PineconeDocumentStore:
         """
 
         if filters and "operator" not in filters and "conditions" not in filters:
-            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
+            msg = "Legacy filters support has been removed. Please see documentation for new filter syntax."
+            raise ValueError(msg)
 
         # Pinecone only performs vector similarity search
         # here we are querying with a dummy vector and the max compatible top_k
@@ -255,7 +256,8 @@ class PineconeDocumentStore:
             raise ValueError(msg)
 
         if filters and "operator" not in filters and "conditions" not in filters:
-            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
+            msg = "Legacy filters support has been removed. Please see documentation for new filter syntax."
+            raise ValueError(msg)
         filters = _normalize_filters(filters) if filters else None
 
         result = self.index.query(

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -201,7 +201,7 @@ class PineconeDocumentStore:
         """
 
         if filters and "operator" not in filters and "conditions" not in filters:
-            msg = "Legacy filters support has been removed. Please see documentation for new filter syntax."
+            msg = "Legacy filters support has been removed. See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details."
             raise ValueError(msg)
 
         # Pinecone only performs vector similarity search


### PR DESCRIPTION
- Removes legacy filter support in Pinecone (i.e. use of `convert` from from `haystack-ai`)
- See https://github.com/deepset-ai/haystack/pull/8342 for more details