### PR TITLE
chore: Weaviate - remove legacy filter support

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -387,8 +387,7 @@ class WeaviateDocumentStore:
         :returns: A list of Documents that match the given filters.
         """
         if filters and "operator" not in filters and "conditions" not in filters:
-            msg = ("Invalid filter syntax. "
-                   "See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details.")
+            msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
             raise ValueError(msg)
 
         result = []

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -12,7 +12,6 @@ from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses.document import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types.policy import DuplicatePolicy
-from haystack.utils.filters import convert
 
 import weaviate
 from weaviate.collections.classes.data import DataObject
@@ -388,7 +387,7 @@ class WeaviateDocumentStore:
         :returns: A list of Documents that match the given filters.
         """
         if filters and "operator" not in filters and "conditions" not in filters:
-            filters = convert(filters)
+            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
 
         result = []
         if filters:

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -387,7 +387,8 @@ class WeaviateDocumentStore:
         :returns: A list of Documents that match the given filters.
         """
         if filters and "operator" not in filters and "conditions" not in filters:
-            msg = "Legacy filters support has been removed. Please see documentation for new filter syntax."
+            msg = ("Invalid filter syntax. "
+                   "See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details.")
             raise ValueError(msg)
 
         result = []

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -387,7 +387,8 @@ class WeaviateDocumentStore:
         :returns: A list of Documents that match the given filters.
         """
         if filters and "operator" not in filters and "conditions" not in filters:
-            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
+            msg = "Legacy filters support has been removed. Please see documentation for new filter syntax."
+            raise ValueError(msg)
 
         result = []
         if filters:

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -660,15 +660,6 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         with pytest.raises(ValueError):
             document_store._embedding_retrieval(query_embedding=[], distance=0.1, certainty=0.1)
 
-    def test_filter_documents_with_legacy_filters(self, document_store):
-        docs = []
-        for index in range(10):
-            docs.append(Document(content="This is some content", meta={"index": index}))
-        document_store.write_documents(docs)
-        result = document_store.filter_documents({"content": {"$eq": "This is some content"}})
-
-        assert len(result) == 10
-
     def test_filter_documents_below_default_limit(self, document_store):
         docs = []
         for index in range(9998):


### PR DESCRIPTION
- Removes legacy filter support in Weaviate (i.e. use of `convert` from from `haystack-ai`)
- See https://github.com/deepset-ai/haystack/pull/8342 for more details
- Removes outdated test