### PR TITLE
chore: ElasticSearch - remove legacy filters elasticsearch

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -12,7 +12,6 @@ from haystack import default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
-from haystack.utils.filters import convert
 from haystack.version import __version__ as haystack_version
 
 from elasticsearch import Elasticsearch, helpers  # type: ignore[import-not-found]
@@ -224,7 +223,7 @@ class ElasticsearchDocumentStore:
         :returns: List of `Document`s that match the filters.
         """
         if filters and "operator" not in filters and "conditions" not in filters:
-            filters = convert(filters)
+            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
 
         query = {"bool": {"filter": _normalize_filters(filters)}} if filters else None
         documents = self._search_documents(query=query)

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -223,7 +223,8 @@ class ElasticsearchDocumentStore:
         :returns: List of `Document`s that match the filters.
         """
         if filters and "operator" not in filters and "conditions" not in filters:
-            raise ValueError("Legacy filters support has been removed. Please see documentation for new filter syntax.")
+            msg = "Legacy filters support has been removed. See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details."
+            raise ValueError(msg)
 
         query = {"bool": {"filter": _normalize_filters(filters)}} if filters else None
         documents = self._search_documents(query=query)

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -223,7 +223,7 @@ class ElasticsearchDocumentStore:
         :returns: List of `Document`s that match the filters.
         """
         if filters and "operator" not in filters and "conditions" not in filters:
-            msg = "Legacy filters support has been removed. See https://docs.haystack.deepset.ai/docs/metadata-filtering for more details."
+            msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
             raise ValueError(msg)
 
         query = {"bool": {"filter": _normalize_filters(filters)}} if filters else None


### PR DESCRIPTION
- Removes legacy filter support in elasticsearch (i.e. use of `convert` from from `haystack-ai`)
- See https://github.com/deepset-ai/haystack/pull/8342 for more details
- Removes outdated test