### PR TITLE
chore: Update changelog after removing legacy filters

### DIFF
--- a/integrations/elasticsearch/CHANGELOG.md
+++ b/integrations/elasticsearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [integrations/elasticsearch-v1.0.0] - 2024-09-12
 
 ### 🚀 Features
 
@@ -11,10 +11,15 @@
 
 - `ElasticSearch` - Fallback to default filter policy when deserializing retrievers without the init parameter (#898)
 
+### 🧪 Testing
+
+- Do not retry tests in `hatch run test` command (#954)
+
 ### ⚙️ Miscellaneous Tasks
 
 - Retry tests to reduce flakyness (#836)
 - Update ruff invocation to include check parameter (#853)
+- ElasticSearch - remove legacy filters elasticsearch (#1078)
 
 ## [integrations/elasticsearch-v0.5.0] - 2024-05-24
 

--- a/integrations/opensearch/CHANGELOG.md
+++ b/integrations/opensearch/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [unreleased]
+
+### 📚 Documentation
+
+- Update opensearch retriever docstrings (#1035)
+
+### 🧪 Testing
+
+- Do not retry tests in `hatch run test` command (#954)
+
+### ⚙️ Miscellaneous Tasks
+
+- OpenSearch - remove legacy filter support (#1067)
+
+### Docs
+
+- Update BM25 docstrings (#945)
+
 ## [integrations/opensearch-v0.9.0] - 2024-08-01
 
 ### 🚀 Features

--- a/integrations/opensearch/CHANGELOG.md
+++ b/integrations/opensearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [integrations/opensearch-v1.0.0] - 2024-09-12
 
 ### 📚 Documentation
 

--- a/integrations/pgvector/CHANGELOG.md
+++ b/integrations/pgvector/CHANGELOG.md
@@ -10,10 +10,15 @@
 
 - `PgVector` - Fallback to default filter policy when deserializing retrievers without the init parameter (#900)
 
+### 🧪 Testing
+
+- Do not retry tests in `hatch run test` command (#954)
+
 ### ⚙️ Miscellaneous Tasks
 
 - Retry tests to reduce flakyness (#836)
 - Update ruff invocation to include check parameter (#853)
+- PgVector - remove legacy filter support (#1068)
 
 ## [integrations/pgvector-v0.4.0] - 2024-06-20
 

--- a/integrations/pgvector/CHANGELOG.md
+++ b/integrations/pgvector/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [integrations/pgvector-v1.0.0] - 2024-09-12
 
 ### 🚀 Features
 

--- a/integrations/pinecone/CHANGELOG.md
+++ b/integrations/pinecone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [integrations/pinecone-v2.0.0] - 2024-09-12
 
 ### ⚙️ Miscellaneous Tasks
 

--- a/integrations/pinecone/CHANGELOG.md
+++ b/integrations/pinecone/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+
+### ⚙️ Miscellaneous Tasks
+
+- Pinecone - remove legacy filter support (#1069)
+
 ## [integrations/pinecone-v1.2.3] - 2024-08-29
 
 ### 🚀 Features

--- a/integrations/weaviate/CHANGELOG.md
+++ b/integrations/weaviate/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+
+### ⚙️ Miscellaneous Tasks
+
+- Weaviate - remove legacy filter support (#1070)
+
 ## [integrations/weaviate-v2.2.1] - 2024-09-07
 
 ### 🚀 Features

--- a/integrations/weaviate/CHANGELOG.md
+++ b/integrations/weaviate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [integrations/weaviate-v3.0.0] - 2024-09-12
 
 ### ⚙️ Miscellaneous Tasks
 


### PR DESCRIPTION
I ran git-cliff with parameters from github CI runs that failed. Note that most changelogs have this unreleased section while elastic has the actual tag. I wasn't sure what's right here, perhaps you know - I'd guess the actual tag?