### PR TITLE
feat: Cohere LLM - adjust token counting meta to match OpenAI format

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -178,8 +178,7 @@ class CohereChatGenerator:
                 if finish_response.meta.billed_units:
                     tokens_in = finish_response.meta.billed_units.input_tokens or -1
                     tokens_out = finish_response.meta.billed_units.output_tokens or -1
-                    chat_message.meta["usage"] = {"prompt_tokens": tokens_in,
-                                                  "completion_tokens": tokens_out}
+                    chat_message.meta["usage"] = {"prompt_tokens": tokens_in, "completion_tokens": tokens_out}
                 chat_message.meta.update(
                     {
                         "model": self.model,
@@ -221,12 +220,13 @@ class CohereChatGenerator:
             message = ChatMessage.from_assistant(cohere_response.tool_calls[0].json())
         elif cohere_response.text:
             message = ChatMessage.from_assistant(content=cohere_response.text)
-        total_tokens = cohere_response.meta.billed_units.input_tokens + cohere_response.meta.billed_units.output_tokens
         message.meta.update(
             {
                 "model": self.model,
-                "usage": {"prompt_tokens": cohere_response.meta.billed_units.input_tokens,
-                          "completion_tokens": cohere_response.meta.billed_units.output_tokens},
+                "usage": {
+                    "prompt_tokens": cohere_response.meta.billed_units.input_tokens,
+                    "completion_tokens": cohere_response.meta.billed_units.output_tokens,
+                },
                 "index": 0,
                 "finish_reason": cohere_response.finish_reason,
                 "documents": cohere_response.documents,

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -224,7 +224,8 @@ class CohereChatGenerator:
         message.meta.update(
             {
                 "model": self.model,
-                "usage": total_tokens,
+                "usage": {"prompt_tokens": cohere_response.meta.billed_units.input_tokens,
+                          "completion_tokens": cohere_response.meta.billed_units.output_tokens},
                 "index": 0,
                 "finish_reason": cohere_response.finish_reason,
                 "documents": cohere_response.documents,

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -178,7 +178,8 @@ class CohereChatGenerator:
                 if finish_response.meta.billed_units:
                     tokens_in = finish_response.meta.billed_units.input_tokens or -1
                     tokens_out = finish_response.meta.billed_units.output_tokens or -1
-                    chat_message.meta["usage"] = tokens_in + tokens_out
+                    chat_message.meta["usage"] = {"prompt_tokens": tokens_in,
+                                                  "completion_tokens": tokens_out}
                 chat_message.meta.update(
                     {
                         "model": self.model,

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -169,6 +169,9 @@ class TestCohereChatGenerator:
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.content
+        assert "usage" in message.meta
+        assert "prompt_tokens" in message.meta["usage"]
+        assert "completion_tokens" in message.meta["usage"]
 
     @pytest.mark.skipif(
         not os.environ.get("COHERE_API_KEY", None) and not os.environ.get("CO_API_KEY", None),
@@ -209,6 +212,10 @@ class TestCohereChatGenerator:
 
         assert callback.counter > 1
         assert "Paris" in callback.responses
+
+        assert "usage" in message.meta
+        assert "prompt_tokens" in message.meta["usage"]
+        assert "completion_tokens" in message.meta["usage"]
 
     @pytest.mark.skipif(
         not os.environ.get("COHERE_API_KEY", None) and not os.environ.get("CO_API_KEY", None),


### PR DESCRIPTION
- we forgot to update Cohere LLM so that the meta token counting format matches OpenAI
- we need this format to match for general portability of generators
- we need this to turn on token counting and generation span in Langfuse integration
