### PR TITLE
feat: Langfuse - support generation span for more LLMs

### DIFF
--- a/integrations/langfuse/example/chat.py
+++ b/integrations/langfuse/example/chat.py
@@ -12,25 +12,28 @@ from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator, HuggingFaceAPIChatGenerator
 from haystack.utils.hf import HFGenerationAPIType
 from haystack.dataclasses import ChatMessage
+from haystack.utils.auth import Secret
 
 from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
 from haystack_integrations.components.generators.cohere import CohereChatGenerator
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
-from haystack.utils.auth import Secret
 
-# create a dict with all supported chat generators
-supported_chat_generators = {
-    "openai": OpenAIChatGenerator(),
-    "anthropic": AnthropicChatGenerator(),
-    "hf_api": HuggingFaceAPIChatGenerator(
+os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
+
+selected_chat_generator = "openai"
+
+generators = {
+    "openai": OpenAIChatGenerator,
+    "anthropic": AnthropicChatGenerator,
+    "hf_api": lambda: HuggingFaceAPIChatGenerator(
         api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
         api_params={"model": "mistralai/Mixtral-8x7B-Instruct-v0.1"},
-        token=Secret.from_token(os.environ["HF_API_KEY"]),
+        token=Secret.from_token(os.environ["HF_API_KEY"])
     ),
-    "cohere": CohereChatGenerator(),
+    "cohere": CohereChatGenerator
 }
 
-selected_chat_generator = supported_chat_generators["openai"]
+selected_chat_generator = generators[selected_chat_generator]()
 
 if __name__ == "__main__":
 

--- a/integrations/langfuse/example/chat.py
+++ b/integrations/langfuse/example/chat.py
@@ -28,9 +28,9 @@ generators = {
     "hf_api": lambda: HuggingFaceAPIChatGenerator(
         api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
         api_params={"model": "mistralai/Mixtral-8x7B-Instruct-v0.1"},
-        token=Secret.from_token(os.environ["HF_API_KEY"])
+        token=Secret.from_token(os.environ["HF_API_KEY"]),
     ),
-    "cohere": CohereChatGenerator
+    "cohere": CohereChatGenerator,
 }
 
 selected_chat_generator = generators[selected_chat_generator]()

--- a/integrations/langfuse/example/chat.py
+++ b/integrations/langfuse/example/chat.py
@@ -2,6 +2,9 @@ import os
 
 # See README.md for more information on how to set up the environment variables
 # before running this script
+
+# In addition to setting the environment variables, you need to install the following packages:
+# pip install cohere-haystack anthropic-haystack
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
 from haystack import Pipeline
@@ -27,7 +30,7 @@ supported_chat_generators = {
     "cohere": CohereChatGenerator(),
 }
 
-selected_chat_generator = supported_chat_generators["cohere"]
+selected_chat_generator = supported_chat_generators["openai"]
 
 if __name__ == "__main__":
 

--- a/integrations/langfuse/example/chat.py
+++ b/integrations/langfuse/example/chat.py
@@ -9,14 +9,14 @@ os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
 from haystack import Pipeline
 from haystack.components.builders import ChatPromptBuilder
-from haystack.components.generators.chat import OpenAIChatGenerator, HuggingFaceAPIChatGenerator
-from haystack.utils.hf import HFGenerationAPIType
+from haystack.components.generators.chat import HuggingFaceAPIChatGenerator, OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack.utils.auth import Secret
+from haystack.utils.hf import HFGenerationAPIType
 
+from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
 from haystack_integrations.components.generators.cohere import CohereChatGenerator
-from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.1.0", "langfuse"]
+dependencies = ["haystack-ai>=2.1.0", "langfuse", "anthropic-haystack"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.1.0", "langfuse", "anthropic-haystack", "cohere-haystack"]
+dependencies = ["haystack-ai>=2.1.0", "langfuse"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"
@@ -47,6 +47,8 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
+  "anthropic-haystack",
+  "cohere-haystack"
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.1.0", "langfuse", "anthropic-haystack"]
+dependencies = ["haystack-ai>=2.1.0", "langfuse", "anthropic-haystack", "cohere-haystack"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -10,8 +10,22 @@ from haystack.tracing import utils as tracing_utils
 import langfuse
 
 HAYSTACK_LANGFUSE_ENFORCE_FLUSH_ENV_VAR = "HAYSTACK_LANGFUSE_ENFORCE_FLUSH"
-_SUPPORTED_GENERATORS = ["AzureOpenAIGenerator", "OpenAIGenerator"]
-_SUPPORTED_CHAT_GENERATORS = ["AzureOpenAIChatGenerator", "OpenAIChatGenerator"]
+_SUPPORTED_GENERATORS = [
+    "AzureOpenAIGenerator",
+    "OpenAIGenerator",
+    "AnthropicGenerator",
+    "HuggingFaceAPIGenerator",
+    "HuggingFaceLocalGenerator",
+    "CohereGenerator",
+]
+_SUPPORTED_CHAT_GENERATORS = [
+    "AzureOpenAIChatGenerator",
+    "OpenAIChatGenerator",
+    "AnthropicChatGenerator",
+    "HuggingFaceAPIChatGenerator",
+    "HuggingFaceLocalChatGenerator",
+    "CohereChatGenerator",
+]
 _ALL_SUPPORTED_GENERATORS = _SUPPORTED_GENERATORS + _SUPPORTED_CHAT_GENERATORS
 
 

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -32,7 +32,7 @@ def test_tracing_integration(llm_name, llm_class, env_var, expected_trace):
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector(name=f"Chat example - {llm_name}", public=True))
     pipe.add_component("prompt_builder", ChatPromptBuilder())
-    pipe.add_component("llm",llm_class())
+    pipe.add_component("llm", llm_class())
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
     messages = [

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -16,6 +16,7 @@ from requests.auth import HTTPBasicAuth
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
+from haystack_integrations.components.generators.cohere import CohereChatGenerator
 
 
 @pytest.mark.integration
@@ -98,6 +99,49 @@ def test_tracing_integration_anthropic():
 
         # ensure Anthropic is in the trace and GENERATION span is present
         assert "Anthropic" in str(response.content)
+        assert "GENERATION" in str(response.content)
+    except requests.exceptions.RequestException as e:
+        assert False, f"Failed to retrieve data from Langfuse API: {e}"
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("LANGFUSE_SECRET_KEY", None)
+    and not os.environ.get("LANGFUSE_PUBLIC_KEY", None)
+    and not os.environ.get("COHERE_API_KEY", None),
+    reason="Export an env var called LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY containing Langfuse credentials and COHERE_API_KEY containing an Cohere API key.",
+)
+def test_tracing_integration_cohere():
+
+    pipe = Pipeline()
+    pipe.add_component("tracer", LangfuseConnector(name="Chat example", public=True))  # public so anyone can verify run
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", CohereChatGenerator())
+
+    pipe.connect("prompt_builder.prompt", "llm.messages")
+
+    messages = [
+        ChatMessage.from_system("Always respond in German even if some input data is in other languages."),
+        ChatMessage.from_user("Tell me about {{location}}"),
+    ]
+
+    response = pipe.run(data={"prompt_builder": {"template_variables": {"location": "Berlin"}, "template": messages}})
+    assert "Berlin" in response["llm"]["replies"][0].content
+    assert response["tracer"]["trace_url"]
+    url = "https://cloud.langfuse.com/api/public/traces/"
+    trace_url = response["tracer"]["trace_url"]
+    parsed_url = urlparse(trace_url)
+    # trace id is the last part of the path (after the last '/')
+    uuid = os.path.basename(parsed_url.path)
+    try:
+        # GET request with Basic Authentication on the Langfuse API
+        response = requests.get(
+            url + uuid, auth=HTTPBasicAuth(os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get("LANGFUSE_SECRET_KEY"))
+        )
+
+        assert response.status_code == 200, f"Failed to retrieve data from Langfuse API: {response.status_code}"
+
+        # ensure Cohere is in the trace and GENERATION span is present
+        assert "Cohere" in str(response.content)
         assert "GENERATION" in str(response.content)
     except requests.exceptions.RequestException as e:
         assert False, f"Failed to retrieve data from Langfuse API: {e}"

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -103,6 +103,7 @@ def test_tracing_integration_anthropic():
     except requests.exceptions.RequestException as e:
         assert False, f"Failed to retrieve data from Langfuse API: {e}"
 
+
 @pytest.mark.integration
 @pytest.mark.skipif(
     not os.environ.get("LANGFUSE_SECRET_KEY", None)

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -1,36 +1,38 @@
 import os
+import pytest
+from urllib.parse import urlparse
+import requests
+from requests.auth import HTTPBasicAuth
+from haystack import Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.components.connectors.langfuse import LangfuseConnector
+from haystack.components.generators.chat import OpenAIChatGenerator
+
+from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
+from haystack_integrations.components.generators.cohere import CohereChatGenerator
 
 # don't remove (or move) this env var setting from here, it's needed to turn tracing on
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from urllib.parse import urlparse
-
-import pytest
-import requests
-
-from haystack import Pipeline
-from haystack.components.builders import ChatPromptBuilder
-from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.dataclasses import ChatMessage
-from requests.auth import HTTPBasicAuth
-
-from haystack_integrations.components.connectors.langfuse import LangfuseConnector
-from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
-from haystack_integrations.components.generators.cohere import CohereChatGenerator
-
 
 @pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("LANGFUSE_SECRET_KEY", None) and not os.environ.get("LANGFUSE_PUBLIC_KEY", None),
-    reason="Export an env var called LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY containing Langfuse credentials.",
+@pytest.mark.parametrize(
+    "llm_name, llm_class, env_var, expected_trace",
+    [
+        ("OpenAI", OpenAIChatGenerator, "OPENAI_API_KEY", "OpenAI"),
+        ("Anthropic", AnthropicChatGenerator, "ANTHROPIC_API_KEY", "Anthropic"),
+        ("Cohere", CohereChatGenerator, "COHERE_API_KEY", "Cohere"),
+    ],
 )
-def test_tracing_integration():
+def test_tracing_integration(llm_name, llm_class, env_var, expected_trace):
+    if not all([os.environ.get("LANGFUSE_SECRET_KEY"), os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get(env_var)]):
+        pytest.skip(f"Missing required environment variables: LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, or {env_var}")
 
     pipe = Pipeline()
-    pipe.add_component("tracer", LangfuseConnector(name="Chat example", public=True))  # public so anyone can verify run
+    pipe.add_component("tracer", LangfuseConnector(name=f"Chat example - {llm_name}", public=True))
     pipe.add_component("prompt_builder", ChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
-
+    pipe.add_component("llm",llm_class())
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
     messages = [
@@ -41,108 +43,20 @@ def test_tracing_integration():
     response = pipe.run(data={"prompt_builder": {"template_variables": {"location": "Berlin"}, "template": messages}})
     assert "Berlin" in response["llm"]["replies"][0].content
     assert response["tracer"]["trace_url"]
+
     url = "https://cloud.langfuse.com/api/public/traces/"
     trace_url = response["tracer"]["trace_url"]
-    parsed_url = urlparse(trace_url)
-    # trace id is the last part of the path (after the last '/')
-    uuid = os.path.basename(parsed_url.path)
+    uuid = os.path.basename(urlparse(trace_url).path)
+
     try:
-        # GET request with Basic Authentication on the Langfuse API
         response = requests.get(
-            url + uuid, auth=HTTPBasicAuth(os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get("LANGFUSE_SECRET_KEY"))
+            url + uuid, auth=HTTPBasicAuth(os.environ["LANGFUSE_PUBLIC_KEY"], os.environ["LANGFUSE_SECRET_KEY"])
         )
-
-        assert response.status_code == 200, f"Failed to retrieve data from Langfuse API: {response.status_code}"
-        # ensure OpenAI is in the trace and GENERATION span is present
-        assert "OpenAI" in str(response.content)
-        assert "GENERATION" in str(response.content)
-    except requests.exceptions.RequestException as e:
-        assert False, f"Failed to retrieve data from Langfuse API: {e}"
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("LANGFUSE_SECRET_KEY", None)
-    and not os.environ.get("LANGFUSE_PUBLIC_KEY", None)
-    and not os.environ.get("ANTHROPIC_API_KEY", None),
-    reason="Export an env var called LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY containing Langfuse credentials and ANTHROPIC_API_KEY containing an Anthropic API key.",
-)
-def test_tracing_integration_anthropic():
-
-    pipe = Pipeline()
-    pipe.add_component("tracer", LangfuseConnector(name="Chat example", public=True))  # public so anyone can verify run
-    pipe.add_component("prompt_builder", ChatPromptBuilder())
-    pipe.add_component("llm", AnthropicChatGenerator())
-
-    pipe.connect("prompt_builder.prompt", "llm.messages")
-
-    messages = [
-        ChatMessage.from_system("Always respond in German even if some input data is in other languages."),
-        ChatMessage.from_user("Tell me about {{location}}"),
-    ]
-
-    response = pipe.run(data={"prompt_builder": {"template_variables": {"location": "Berlin"}, "template": messages}})
-    assert "Berlin" in response["llm"]["replies"][0].content
-    assert response["tracer"]["trace_url"]
-    url = "https://cloud.langfuse.com/api/public/traces/"
-    trace_url = response["tracer"]["trace_url"]
-    parsed_url = urlparse(trace_url)
-    # trace id is the last part of the path (after the last '/')
-    uuid = os.path.basename(parsed_url.path)
-    try:
-        # GET request with Basic Authentication on the Langfuse API
-        response = requests.get(
-            url + uuid, auth=HTTPBasicAuth(os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get("LANGFUSE_SECRET_KEY"))
-        )
-
         assert response.status_code == 200, f"Failed to retrieve data from Langfuse API: {response.status_code}"
 
-        # ensure Anthropic is in the trace and GENERATION span is present
-        assert "Anthropic" in str(response.content)
+        # check if the trace contains the expected LLM name
+        assert expected_trace in str(response.content)
+        # check if the trace contains the expected generation span
         assert "GENERATION" in str(response.content)
     except requests.exceptions.RequestException as e:
-        assert False, f"Failed to retrieve data from Langfuse API: {e}"
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("LANGFUSE_SECRET_KEY", None)
-    and not os.environ.get("LANGFUSE_PUBLIC_KEY", None)
-    and not os.environ.get("COHERE_API_KEY", None),
-    reason="Export an env var called LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY containing Langfuse credentials and COHERE_API_KEY containing an Cohere API key.",
-)
-def test_tracing_integration_cohere():
-
-    pipe = Pipeline()
-    pipe.add_component("tracer", LangfuseConnector(name="Chat example", public=True))  # public so anyone can verify run
-    pipe.add_component("prompt_builder", ChatPromptBuilder())
-    pipe.add_component("llm", CohereChatGenerator())
-
-    pipe.connect("prompt_builder.prompt", "llm.messages")
-
-    messages = [
-        ChatMessage.from_system("Always respond in German even if some input data is in other languages."),
-        ChatMessage.from_user("Tell me about {{location}}"),
-    ]
-
-    response = pipe.run(data={"prompt_builder": {"template_variables": {"location": "Berlin"}, "template": messages}})
-    assert "Berlin" in response["llm"]["replies"][0].content
-    assert response["tracer"]["trace_url"]
-    url = "https://cloud.langfuse.com/api/public/traces/"
-    trace_url = response["tracer"]["trace_url"]
-    parsed_url = urlparse(trace_url)
-    # trace id is the last part of the path (after the last '/')
-    uuid = os.path.basename(parsed_url.path)
-    try:
-        # GET request with Basic Authentication on the Langfuse API
-        response = requests.get(
-            url + uuid, auth=HTTPBasicAuth(os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get("LANGFUSE_SECRET_KEY"))
-        )
-
-        assert response.status_code == 200, f"Failed to retrieve data from Langfuse API: {response.status_code}"
-
-        # ensure Cohere is in the trace and GENERATION span is present
-        assert "Cohere" in str(response.content)
-        assert "GENERATION" in str(response.content)
-    except requests.exceptions.RequestException as e:
-        assert False, f"Failed to retrieve data from Langfuse API: {e}"
+        pytest.fail(f"Failed to retrieve data from Langfuse API: {e}")

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -18,19 +18,19 @@ os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "llm_name, llm_class, env_var, expected_trace",
+    "llm_class, env_var, expected_trace",
     [
-        ("OpenAI", OpenAIChatGenerator, "OPENAI_API_KEY", "OpenAI"),
-        ("Anthropic", AnthropicChatGenerator, "ANTHROPIC_API_KEY", "Anthropic"),
-        ("Cohere", CohereChatGenerator, "COHERE_API_KEY", "Cohere"),
+        (OpenAIChatGenerator, "OPENAI_API_KEY", "OpenAI"),
+        (AnthropicChatGenerator, "ANTHROPIC_API_KEY", "Anthropic"),
+        (CohereChatGenerator, "COHERE_API_KEY", "Cohere"),
     ],
 )
-def test_tracing_integration(llm_name, llm_class, env_var, expected_trace):
+def test_tracing_integration(llm_class, env_var, expected_trace):
     if not all([os.environ.get("LANGFUSE_SECRET_KEY"), os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get(env_var)]):
         pytest.skip(f"Missing required environment variables: LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, or {env_var}")
 
     pipe = Pipeline()
-    pipe.add_component("tracer", LangfuseConnector(name=f"Chat example - {llm_name}", public=True))
+    pipe.add_component("tracer", LangfuseConnector(name=f"Chat example - {expected_trace}", public=True))
     pipe.add_component("prompt_builder", ChatPromptBuilder())
     pipe.add_component("llm", llm_class())
     pipe.connect("prompt_builder.prompt", "llm.messages")

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -15,6 +15,7 @@ from haystack.dataclasses import ChatMessage
 from requests.auth import HTTPBasicAuth
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
+from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
 
 
 @pytest.mark.integration
@@ -51,5 +52,52 @@ def test_tracing_integration():
         )
 
         assert response.status_code == 200, f"Failed to retrieve data from Langfuse API: {response.status_code}"
+        # ensure OpenAI is in the trace and GENERATION span is present
+        assert "OpenAI" in str(response.content)
+        assert "GENERATION" in str(response.content)
+    except requests.exceptions.RequestException as e:
+        assert False, f"Failed to retrieve data from Langfuse API: {e}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("LANGFUSE_SECRET_KEY", None)
+    and not os.environ.get("LANGFUSE_PUBLIC_KEY", None)
+    and not os.environ.get("ANTHROPIC_API_KEY", None),
+    reason="Export an env var called LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY containing Langfuse credentials and ANTHROPIC_API_KEY containing an Anthropic API key.",
+)
+def test_tracing_integration_anthropic():
+
+    pipe = Pipeline()
+    pipe.add_component("tracer", LangfuseConnector(name="Chat example", public=True))  # public so anyone can verify run
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", AnthropicChatGenerator())
+
+    pipe.connect("prompt_builder.prompt", "llm.messages")
+
+    messages = [
+        ChatMessage.from_system("Always respond in German even if some input data is in other languages."),
+        ChatMessage.from_user("Tell me about {{location}}"),
+    ]
+
+    response = pipe.run(data={"prompt_builder": {"template_variables": {"location": "Berlin"}, "template": messages}})
+    assert "Berlin" in response["llm"]["replies"][0].content
+    assert response["tracer"]["trace_url"]
+    url = "https://cloud.langfuse.com/api/public/traces/"
+    trace_url = response["tracer"]["trace_url"]
+    parsed_url = urlparse(trace_url)
+    # trace id is the last part of the path (after the last '/')
+    uuid = os.path.basename(parsed_url.path)
+    try:
+        # GET request with Basic Authentication on the Langfuse API
+        response = requests.get(
+            url + uuid, auth=HTTPBasicAuth(os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get("LANGFUSE_SECRET_KEY"))
+        )
+
+        assert response.status_code == 200, f"Failed to retrieve data from Langfuse API: {response.status_code}"
+
+        # ensure Anthropic is in the trace and GENERATION span is present
+        assert "Anthropic" in str(response.content)
+        assert "GENERATION" in str(response.content)
     except requests.exceptions.RequestException as e:
         assert False, f"Failed to retrieve data from Langfuse API: {e}"


### PR DESCRIPTION
- Adds GENERATION span (tag) Langfuse support for HuggingFace, Anthropic and Cohere LLMs
- Adds token counting (except HuggingFaceAPIChatGenerator and HuggingFaceAPIGenerator)
- Cohere support  is contingent to https://github.com/deepset-ai/haystack-core-integrations/pull/1086
- All tests were done manually in addition to updated automated integration tests.

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/887


- Screenshot below show Anthropic sonnet, other LLMs look similar
<img width="1150" alt="Screenshot 2024-09-16 at 15 19 01" src="https://github.com/user-attachments/assets/58f37368-eddc-4832-a104-4093daad5d8b">
