### PR TITLE
fix: Add delay to flush the Langfuse traces

### DIFF
--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -1,4 +1,6 @@
 import os
+import random
+import time
 import pytest
 from urllib.parse import urlparse
 import requests
@@ -43,6 +45,10 @@ def test_tracing_integration(llm_class, env_var, expected_trace):
     response = pipe.run(data={"prompt_builder": {"template_variables": {"location": "Berlin"}, "template": messages}})
     assert "Berlin" in response["llm"]["replies"][0].content
     assert response["tracer"]["trace_url"]
+
+    # add a random delay between 1 and 3 seconds to make sure the trace is flushed
+    # and that the trace is available in Langfuse when we fetch it below
+    time.sleep(random.uniform(1, 3))
 
     url = "https://cloud.langfuse.com/api/public/traces/"
     trace_url = response["tracer"]["trace_url"]


### PR DESCRIPTION
Attempts to resolve a nightly test [failure](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/10913148211) which seems to be stemming from Langfuse traces not being available right after the pipeline test run. Not sure if this delay will help put I don't see any other course of action at them moment. If you do please say so. 

If this test fails again tonight - I'll contact the Langfuse people for advice.   