### PR TITLE
fix: Ollama Chat Generator - add missing `to_dict` and `from_dict` methods

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -96,7 +96,6 @@ class OllamaChatGenerator:
         if serialized_callback_handler:
             data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
         return default_from_dict(cls, data)
-            
 
     def _message_to_dict(self, message: ChatMessage) -> Dict[str, str]:
         return {"role": message.role.value, "content": message.content}

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -2,10 +2,9 @@ from typing import List
 from unittest.mock import Mock
 
 import pytest
+from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, ChatRole
 from ollama._types import ResponseError
-
-from haystack.components.generators.utils import print_streaming_chunk
 
 from haystack_integrations.components.generators.ollama import OllamaChatGenerator
 
@@ -75,7 +74,7 @@ class TestOllamaChatGenerator:
         assert component.model == "llama2"
         assert component.streaming_callback is print_streaming_chunk
         assert component.url == "custom_url"
-        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}        
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
     def test_build_message_from_ollama_response(self):
         model = "some_model"

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -5,6 +5,8 @@ import pytest
 from haystack.dataclasses import ChatMessage, ChatRole
 from ollama._types import ResponseError
 
+from haystack.components.generators.utils import print_streaming_chunk
+
 from haystack_integrations.components.generators.ollama import OllamaChatGenerator
 
 
@@ -38,6 +40,42 @@ class TestOllamaChatGenerator:
         assert component.url == "http://my-custom-endpoint:11434"
         assert component.generation_kwargs == {"temperature": 0.5}
         assert component.timeout == 5
+
+    def test_to_dict(self):
+        component = OllamaChatGenerator(
+            model="llama2",
+            streaming_callback=print_streaming_chunk,
+            url="custom_url",
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack_integrations.components.generators.ollama.chat.chat_generator.OllamaChatGenerator",
+            "init_parameters": {
+                "timeout": 120,
+                "model": "llama2",
+                "url": "custom_url",
+                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+            },
+        }
+
+    def test_from_dict(self):
+        data = {
+            "type": "haystack_integrations.components.generators.ollama.chat.chat_generator.OllamaChatGenerator",
+            "init_parameters": {
+                "timeout": 120,
+                "model": "llama2",
+                "url": "custom_url",
+                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+            },
+        }
+        component = OllamaChatGenerator.from_dict(data)
+        assert component.model == "llama2"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.url == "custom_url"
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}        
 
     def test_build_message_from_ollama_response(self):
         model = "some_model"


### PR DESCRIPTION
### Related Issues
While working on https://github.com/deepset-ai/haystack/issues/8190, I discovered that these methods are missing.
Some parameters ('streaming_callback`) need a specific serialization.

### Proposed Changes:
Add the missing methods.

### How did you test it?
CI, new tests.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
