### PR TITLE
Chroma: empty filters should behave as no filters

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -312,7 +312,7 @@ class ChromaDocumentStore:
         self._ensure_initialized()
         assert self._collection is not None
 
-        if filters is None:
+        if not filters:
             results = self._collection.query(
                 query_texts=queries,
                 n_results=top_k,
@@ -346,7 +346,7 @@ class ChromaDocumentStore:
         self._ensure_initialized()
         assert self._collection is not None
 
-        if filters is None:
+        if not filters:
             results = self._collection.query(
                 query_embeddings=query_embeddings,
                 n_results=top_k,

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -137,6 +137,10 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, FilterDocuments
         assert isinstance(doc.embedding, list)
         assert all(isinstance(el, float) for el in doc.embedding)
 
+        # check that empty filters behave as no filters
+        result_empty_filters = document_store.search(["Third"], filters={}, top_k=1)
+        assert result == result_empty_filters
+
     def test_write_documents_unsupported_meta_values(self, document_store: ChromaDocumentStore):
         """
         Unsupported meta values should be removed from the documents before writing them to the database


### PR DESCRIPTION
### Related Issues

- fixes #1116 

### Proposed Changes:

In `search` and `search_embeddings` methods, skip filtering in case `filters=={}`.

### How did you test it?
CI, new assertion in existing test.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
