### PR TITLE
feat: Raise error when attempting to embed empty documents/strings with Nvidia embedders

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -2,7 +2,6 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from haystack import Document, component, default_from_dict, default_to_dict
-from haystack.document_stores import in_memory
 from haystack.utils import Secret, deserialize_secrets_inplace
 from tqdm import tqdm
 

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -2,6 +2,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from haystack import Document, component, default_from_dict, default_to_dict
+from haystack.document_stores import in_memory
 from haystack.utils import Secret, deserialize_secrets_inplace
 from tqdm import tqdm
 
@@ -230,6 +231,11 @@ class NvidiaDocumentEmbedder:
                 "In case you want to embed a string, please use the NvidiaTextEmbedder."
             )
             raise TypeError(msg)
+
+        for doc in documents:
+            if not doc.content:
+                msg = f"Document '{doc.id}' has no content to embed."
+                raise ValueError(msg)
 
         texts_to_embed = self._prepare_texts_to_embed(documents)
         embeddings, metadata = self._embed_batch(texts_to_embed, self.batch_size)

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -176,7 +176,7 @@ class NvidiaTextEmbedder:
             )
             raise TypeError(msg)
         elif not text:
-            msg = f"Cannot embed an empty string."
+            msg = "Cannot embed an empty string."
             raise ValueError(msg)
 
         assert self.backend is not None

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -175,6 +175,9 @@ class NvidiaTextEmbedder:
                 "In case you want to embed a list of Documents, please use the NvidiaDocumentEmbedder."
             )
             raise TypeError(msg)
+        elif not text:
+            msg = f"Cannot embed an empty string."
+            raise ValueError(msg)
 
         assert self.backend is not None
         text_to_embed = self.prefix + text + self.suffix

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
@@ -50,16 +50,20 @@ class NimBackend:
     def embed(self, texts: List[str]) -> Tuple[List[List[float]], Dict[str, Any]]:
         url = f"{self.api_url}/embeddings"
 
-        res = self.session.post(
-            url,
-            json={
-                "model": self.model,
-                "input": texts,
-                **self.model_kwargs,
-            },
-            timeout=REQUEST_TIMEOUT,
-        )
-        res.raise_for_status()
+        try:
+            res = self.session.post(
+                url,
+                json={
+                    "model": self.model,
+                    "input": texts,
+                    **self.model_kwargs,
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+            res.raise_for_status()
+        except requests.HTTPError as e:
+            msg = f"Failed to query embedding endpoint: Error - {e.response.text}"
+            raise ValueError(msg) from e
 
         data = res.json()
         # Sort the embeddings by index, we don't know whether they're out of order or not
@@ -73,21 +77,25 @@ class NimBackend:
         # This is the same for local containers and the cloud API.
         url = f"{self.api_url}/chat/completions"
 
-        res = self.session.post(
-            url,
-            json={
-                "model": self.model,
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": prompt,
-                    },
-                ],
-                **self.model_kwargs,
-            },
-            timeout=REQUEST_TIMEOUT,
-        )
-        res.raise_for_status()
+        try:
+            res = self.session.post(
+                url,
+                json={
+                    "model": self.model,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": prompt,
+                        },
+                    ],
+                    **self.model_kwargs,
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+            res.raise_for_status()
+        except requests.HTTPError as e:
+            msg = f"Failed to query chat completion endpoint: Error - {e.response.text}"
+            raise ValueError(msg) from e
 
         completions = res.json()
         choices = completions["choices"]
@@ -139,17 +147,21 @@ class NimBackend:
     ) -> List[Dict[str, Any]]:
         url = endpoint or f"{self.api_url}/ranking"
 
-        res = self.session.post(
-            url,
-            json={
-                "model": self.model,
-                "query": {"text": query},
-                "passages": [{"text": doc.content} for doc in documents],
-                **self.model_kwargs,
-            },
-            timeout=REQUEST_TIMEOUT,
-        )
-        res.raise_for_status()
+        try:
+            res = self.session.post(
+                url,
+                json={
+                    "model": self.model,
+                    "query": {"text": query},
+                    "passages": [{"text": doc.content} for doc in documents],
+                    **self.model_kwargs,
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+            res.raise_for_status()
+        except requests.HTTPError as e:
+            msg = f"Failed to rank endpoint: Error - {e.response.text}"
+            raise ValueError(msg) from e
 
         data = res.json()
         assert "rankings" in data, f"Expected 'rankings' in response, got {data}"

--- a/integrations/nvidia/tests/test_document_embedder.py
+++ b/integrations/nvidia/tests/test_document_embedder.py
@@ -326,6 +326,17 @@ class TestNvidiaDocumentEmbedder:
         with pytest.raises(TypeError, match="NvidiaDocumentEmbedder expects a list of Documents as input"):
             embedder.run(documents=list_integers_input)
 
+    def test_run_empty_document(self):
+        model = "playground_nvolveqa_40k"
+        api_key = Secret.from_token("fake-api-key")
+        embedder = NvidiaDocumentEmbedder(model, api_key=api_key)
+
+        embedder.warm_up()
+        embedder.backend = MockBackend(model=model, api_key=api_key)
+
+        with pytest.raises(ValueError, match="no content to embed"):
+            embedder.run(documents=[Document(content="")])
+
     def test_run_on_empty_list(self):
         model = "playground_nvolveqa_40k"
         api_key = Secret.from_token("fake-api-key")

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -147,6 +147,17 @@ class TestNvidiaTextEmbedder:
         with pytest.raises(TypeError, match="NvidiaTextEmbedder expects a string as an input"):
             embedder.run(text=list_integers_input)
 
+    def test_run_empty_string(self):
+        model = "playground_nvolveqa_40k"
+        api_key = Secret.from_token("fake-api-key")
+        embedder = NvidiaTextEmbedder(model, api_key=api_key)
+
+        embedder.warm_up()
+        embedder.backend = MockBackend(model=model, api_key=api_key)
+
+        with pytest.raises(ValueError, match="empty string"):
+            embedder.run(text="")
+
     @pytest.mark.skipif(
         not os.environ.get("NVIDIA_NIM_EMBEDDER_MODEL", None) or not os.environ.get("NVIDIA_NIM_ENDPOINT_URL", None),
         reason="Export an env var called NVIDIA_NIM_EMBEDDER_MODEL containing the hosted model name and "


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Nvidia (Nim) embedding endpoints will raise an error if empty strings are passed to them. This PR adds checks to the document and text embedder components to prevent that.

Additionally improves error handling in the Nim backend by displaying the remote response in the error message.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
