### PR TITLE
modify regex to allow cross-region inference in bedrock 

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -58,7 +58,7 @@ class AmazonBedrockChatGenerator:
     """
 
     SUPPORTED_MODEL_PATTERNS: ClassVar[Dict[str, Type[BedrockModelChatAdapter]]] = {
-        r"anthropic.claude.*": AnthropicClaudeChatAdapter,
+        r"(.+\.)?anthropic.claude.*": AnthropicClaudeChatAdapter,
         r"meta.llama2.*": MetaLlama2ChatAdapter,
         r"mistral.*": MistralChatAdapter,
     }

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -69,7 +69,7 @@ class AmazonBedrockGenerator:
         r"ai21.j2.*": AI21LabsJurassic2Adapter,
         r"cohere.command-[^r].*": CohereCommandAdapter,
         r"cohere.command-r.*": CohereCommandRAdapter,
-        r"anthropic.claude.*": AnthropicClaudeAdapter,
+        r"(.+\.)?anthropic.claude.*": AnthropicClaudeAdapter,
         r"meta.llama.*": MetaLlamaAdapter,
         r"mistral.*": MistralAdapter,
     }

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -254,6 +254,8 @@ def test_long_prompt_is_not_truncated_when_truncate_false(mock_boto3_session):
     [
         ("anthropic.claude-v1", AnthropicClaudeChatAdapter),
         ("anthropic.claude-v2", AnthropicClaudeChatAdapter),
+        ("eu.anthropic.claude-v1", AnthropicClaudeChatAdapter),  # cross-region inference
+        ("us.anthropic.claude-v2", AnthropicClaudeChatAdapter),  # cross-region inference
         ("anthropic.claude-instant-v1", AnthropicClaudeChatAdapter),
         ("anthropic.claude-super-v5", AnthropicClaudeChatAdapter),  # artificial
         ("meta.llama2-13b-chat-v1", MetaLlama2ChatAdapter),

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -231,6 +231,8 @@ def test_long_prompt_is_not_truncated_when_truncate_false(mock_boto3_session):
     [
         ("anthropic.claude-v1", AnthropicClaudeAdapter),
         ("anthropic.claude-v2", AnthropicClaudeAdapter),
+        ("eu.anthropic.claude-v1", AnthropicClaudeAdapter),  # cross-region inference
+        ("us.anthropic.claude-v2", AnthropicClaudeAdapter),  # cross-region inference
         ("anthropic.claude-instant-v1", AnthropicClaudeAdapter),
         ("anthropic.claude-super-v5", AnthropicClaudeAdapter),  # artificial
         ("cohere.command-text-v14", CohereCommandAdapter),


### PR DESCRIPTION
more info here: https://aws.amazon.com/de/blogs/machine-learning/getting-started-with-cross-region-inference-in-amazon-bedrock/

for now this feature is only available for anthropic claude models

### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
