### PR TITLE
chore: pin `google-cloud-aiplatform>=1.61` and fix tests

### DIFF
--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "google-cloud-aiplatform>=1.38", "pyarrow>3"]
+dependencies = ["haystack-ai", "google-cloud-aiplatform>=1.61", "pyarrow>3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_vertex#readme"

--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -22,11 +22,11 @@ GET_CURRENT_WEATHER_FUNC = FunctionDeclaration(
     name="get_current_weather",
     description="Get the current weather in a given location",
     parameters={
-        "type_": "OBJECT",
+        "type": "object",
         "properties": {
-            "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
+            "location": {"type": "string", "description": "The city and state, e.g. San Francisco, CA"},
             "unit": {
-                "type_": "STRING",
+                "type": "string",
                 "enum": [
                     "celsius",
                     "fahrenheit",
@@ -238,13 +238,19 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
                                 "name": "get_current_weather",
                                 "description": "Get the current weather in a given location",
                                 "parameters": {
-                                    "type_": "OBJECT",
+                                    "type": "object",
                                     "properties": {
                                         "location": {
-                                            "type_": "STRING",
+                                            "type": "string",
                                             "description": "The city and state, e.g. San Francisco, CA",
                                         },
-                                        "unit": {"type_": "STRING", "enum": ["celsius", "fahrenheit"]},
+                                        "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                                "celsius",
+                                                "fahrenheit",
+                                            ],
+                                        },
                                     },
                                     "required": ["location"],
                                 },

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -18,11 +18,11 @@ GET_CURRENT_WEATHER_FUNC = FunctionDeclaration(
     name="get_current_weather",
     description="Get the current weather in a given location",
     parameters={
-        "type_": "OBJECT",
+        "type": "object",
         "properties": {
-            "location": {"type_": "STRING", "description": "The city and state, e.g. San Francisco, CA"},
+            "location": {"type": "string", "description": "The city and state, e.g. San Francisco, CA"},
             "unit": {
-                "type_": "STRING",
+                "type": "string",
                 "enum": [
                     "celsius",
                     "fahrenheit",
@@ -226,12 +226,18 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
                             {
                                 "name": "get_current_weather",
                                 "parameters": {
-                                    "type_": "OBJECT",
+                                    "type": "object",
                                     "properties": {
-                                        "unit": {"type_": "STRING", "enum": ["celsius", "fahrenheit"]},
                                         "location": {
-                                            "type_": "STRING",
+                                            "type": "string",
                                             "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                                "celsius",
+                                                "fahrenheit",
+                                            ],
                                         },
                                     },
                                     "required": ["location"],


### PR DESCRIPTION
### Related Issues

- Tests failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11171554730/job/31056492960

### Proposed Changes:

- to fix the tests, adopt the correct format for `FunctionDeclaration`, copied from [docs](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/python/latest#function-calling).

- I also verified that our integration only works with `google-cloud-aiplatform>=1.61`, so I updated the pin

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
