### PR TITLE
feat: introduce `model_kwargs` in Sparse Embedders (can be used for BM25 parameters)

### DIFF
--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -104,12 +104,14 @@ class _FastembedSparseEmbeddingBackend:
         local_files_only: bool = False,
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
+        model_kwargs = model_kwargs or {}
+
         self.model = SparseTextEmbedding(
             model_name=model_name,
             cache_dir=cache_dir,
             threads=threads,
             local_files_only=local_files_only,
-            **(model_kwargs if model_kwargs else {}),
+            **model_kwargs,
         )
 
     def embed(self, data: List[List[str]], progress_bar=True, **kwargs) -> List[SparseEmbedding]:

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -73,15 +73,19 @@ class _FastembedSparseEmbeddingBackendFactory:
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
         local_files_only: bool = False,
-        bm25: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
-        embedding_backend_id = f"{model_name}{cache_dir}{threads}{bm25}"
+        embedding_backend_id = f"{model_name}{cache_dir}{threads}{model_kwargs}"
 
         if embedding_backend_id in _FastembedSparseEmbeddingBackendFactory._instances:
             return _FastembedSparseEmbeddingBackendFactory._instances[embedding_backend_id]
 
         embedding_backend = _FastembedSparseEmbeddingBackend(
-            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only, bm25=bm25
+            model_name=model_name,
+            cache_dir=cache_dir,
+            threads=threads,
+            local_files_only=local_files_only,
+            model_kwargs=model_kwargs,
         )
         _FastembedSparseEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
@@ -98,14 +102,14 @@ class _FastembedSparseEmbeddingBackend:
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
         local_files_only: bool = False,
-        bm25: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         self.model = SparseTextEmbedding(
             model_name=model_name,
             cache_dir=cache_dir,
             threads=threads,
             local_files_only=local_files_only,
-            **(bm25 if bm25 else {}),
+            **(model_kwargs if model_kwargs else {}),
         )
 
     def embed(self, data: List[List[str]], progress_bar=True, **kwargs) -> List[SparseEmbedding]:

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from tqdm import tqdm
@@ -73,14 +73,15 @@ class _FastembedSparseEmbeddingBackendFactory:
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
         local_files_only: bool = False,
+        bm25: Optional[Dict[str, Any]] = None,
     ):
-        embedding_backend_id = f"{model_name}{cache_dir}{threads}"
+        embedding_backend_id = f"{model_name}{cache_dir}{threads}{bm25}"
 
         if embedding_backend_id in _FastembedSparseEmbeddingBackendFactory._instances:
             return _FastembedSparseEmbeddingBackendFactory._instances[embedding_backend_id]
 
         embedding_backend = _FastembedSparseEmbeddingBackend(
-            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only
+            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only, bm25=bm25
         )
         _FastembedSparseEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
@@ -97,9 +98,14 @@ class _FastembedSparseEmbeddingBackend:
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
         local_files_only: bool = False,
+        bm25: Optional[Dict[str, Any]] = None,
     ):
         self.model = SparseTextEmbedding(
-            model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only
+            model_name=model_name,
+            cache_dir=cache_dir,
+            threads=threads,
+            local_files_only=local_files_only,
+            **(bm25 if bm25 else {}),
         )
 
     def embed(self, data: List[List[str]], progress_bar=True, **kwargs) -> List[SparseEmbedding]:

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -75,7 +75,7 @@ class _FastembedSparseEmbeddingBackendFactory:
         local_files_only: bool = False,
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
-        embedding_backend_id = f"{model_name}{cache_dir}{threads}{model_kwargs}"
+        embedding_backend_id = f"{model_name}{cache_dir}{threads}{local_files_only}{model_kwargs}"
 
         if embedding_backend_id in _FastembedSparseEmbeddingBackendFactory._instances:
             return _FastembedSparseEmbeddingBackendFactory._instances[embedding_backend_id]

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -62,7 +62,7 @@ class FastembedSparseDocumentEmbedder:
         local_files_only: bool = False,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
-        bm25: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Create an FastembedDocumentEmbedder component.
@@ -82,7 +82,7 @@ class FastembedSparseDocumentEmbedder:
         :param local_files_only: If `True`, only use the model files in the `cache_dir`.
         :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
-        :param bm25: Dictionary containing BM25 parameters (`k`, `b`, `avg_len`, `language`, `token_max_length`).
+        :param model_kwargs: Dictionary containing model parameters such as (`k`, `b`, `avg_len`, `language`).
         """
 
         self.model_name = model
@@ -94,7 +94,7 @@ class FastembedSparseDocumentEmbedder:
         self.local_files_only = local_files_only
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
-        self.bm25 = bm25 if model == "Qdrant/bm25" else None
+        self.model_kwargs = model_kwargs
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -113,7 +113,7 @@ class FastembedSparseDocumentEmbedder:
             local_files_only=self.local_files_only,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
-            bm25=self.bm25,
+            model_kwargs=self.model_kwargs,
         )
 
     def warm_up(self):
@@ -126,7 +126,7 @@ class FastembedSparseDocumentEmbedder:
                 cache_dir=self.cache_dir,
                 threads=self.threads,
                 local_files_only=self.local_files_only,
-                bm25=self.bm25,
+                model_kwargs=self.model_kwargs,
             )
 
     def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -82,7 +82,7 @@ class FastembedSparseDocumentEmbedder:
         :param local_files_only: If `True`, only use the model files in the `cache_dir`.
         :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
-        :param model_kwargs: Dictionary containing model parameters such as (`k`, `b`, `avg_len`, `language`).
+        :param model_kwargs: Dictionary containing model parameters such as `k`, `b`, `avg_len`, `language`.
         """
 
         self.model_name = model

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -62,6 +62,7 @@ class FastembedSparseDocumentEmbedder:
         local_files_only: bool = False,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
+        bm25: Optional[Dict[str, Any]] = None,
     ):
         """
         Create an FastembedDocumentEmbedder component.
@@ -81,6 +82,7 @@ class FastembedSparseDocumentEmbedder:
         :param local_files_only: If `True`, only use the model files in the `cache_dir`.
         :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
+        :param bm25: Dictionary containing BM25 parameters (`k`, `b`, `avg_len`, `language`, `token_max_length`).
         """
 
         self.model_name = model
@@ -92,6 +94,7 @@ class FastembedSparseDocumentEmbedder:
         self.local_files_only = local_files_only
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
+        self.bm25 = bm25 if model == "Qdrant/bm25" else None
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -110,6 +113,7 @@ class FastembedSparseDocumentEmbedder:
             local_files_only=self.local_files_only,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
+            bm25=self.bm25,
         )
 
     def warm_up(self):
@@ -122,6 +126,7 @@ class FastembedSparseDocumentEmbedder:
                 cache_dir=self.cache_dir,
                 threads=self.threads,
                 local_files_only=self.local_files_only,
+                bm25=self.bm25,
             )
 
     def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -51,7 +51,7 @@ class FastembedSparseTextEmbedder:
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
         :param local_files_only: If `True`, only use the model files in the `cache_dir`.
-        :param model_kwargs: Dictionary containing model parameters such as (`k`, `b`, `avg_len`, `language`).
+        :param model_kwargs: Dictionary containing model parameters such as `k`, `b`, `avg_len`, `language`.
         """
 
         self.model_name = model

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -35,6 +35,7 @@ class FastembedSparseTextEmbedder:
         progress_bar: bool = True,
         parallel: Optional[int] = None,
         local_files_only: bool = False,
+        bm25: Optional[Dict[str, Any]] = None,
     ):
         """
         Create a FastembedSparseTextEmbedder component.
@@ -50,6 +51,7 @@ class FastembedSparseTextEmbedder:
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
         :param local_files_only: If `True`, only use the model files in the `cache_dir`.
+        :param bm25: Dictionary containing BM25 parameters (`k`, `b`, `avg_len`, `language`, `token_max_length`).
         """
 
         self.model_name = model
@@ -58,6 +60,7 @@ class FastembedSparseTextEmbedder:
         self.progress_bar = progress_bar
         self.parallel = parallel
         self.local_files_only = local_files_only
+        self.bm25 = bm25 if model == "Qdrant/bm25" else None
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -74,6 +77,7 @@ class FastembedSparseTextEmbedder:
             progress_bar=self.progress_bar,
             parallel=self.parallel,
             local_files_only=self.local_files_only,
+            bm25=self.bm25,
         )
 
     def warm_up(self):
@@ -86,6 +90,7 @@ class FastembedSparseTextEmbedder:
                 cache_dir=self.cache_dir,
                 threads=self.threads,
                 local_files_only=self.local_files_only,
+                bm25=self.bm25,
             )
 
     @component.output_types(sparse_embedding=SparseEmbedding)

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -35,7 +35,7 @@ class FastembedSparseTextEmbedder:
         progress_bar: bool = True,
         parallel: Optional[int] = None,
         local_files_only: bool = False,
-        bm25: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Create a FastembedSparseTextEmbedder component.
@@ -51,7 +51,7 @@ class FastembedSparseTextEmbedder:
                 If 0, use all available cores.
                 If None, don't use data-parallel processing, use default onnxruntime threading instead.
         :param local_files_only: If `True`, only use the model files in the `cache_dir`.
-        :param bm25: Dictionary containing BM25 parameters (`k`, `b`, `avg_len`, `language`, `token_max_length`).
+        :param model_kwargs: Dictionary containing model parameters such as (`k`, `b`, `avg_len`, `language`).
         """
 
         self.model_name = model
@@ -60,7 +60,7 @@ class FastembedSparseTextEmbedder:
         self.progress_bar = progress_bar
         self.parallel = parallel
         self.local_files_only = local_files_only
-        self.bm25 = bm25 if model == "Qdrant/bm25" else None
+        self.model_kwargs = model_kwargs
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -77,7 +77,7 @@ class FastembedSparseTextEmbedder:
             progress_bar=self.progress_bar,
             parallel=self.parallel,
             local_files_only=self.local_files_only,
-            bm25=self.bm25,
+            model_kwargs=self.model_kwargs,
         )
 
     def warm_up(self):
@@ -90,7 +90,7 @@ class FastembedSparseTextEmbedder:
                 cache_dir=self.cache_dir,
                 threads=self.threads,
                 local_files_only=self.local_files_only,
-                bm25=self.bm25,
+                model_kwargs=self.model_kwargs,
             )
 
     @component.output_types(sparse_embedding=SparseEmbedding)

--- a/integrations/fastembed/tests/test_fastembed_backend.py
+++ b/integrations/fastembed/tests/test_fastembed_backend.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from haystack_integrations.components.embedders.fastembed.embedding_backend.fastembed_backend import (
     _FastembedEmbeddingBackendFactory,
+    _FastembedSparseEmbeddingBackendFactory,
 )
 
 
@@ -44,3 +45,28 @@ def test_embedding_function_with_kwargs(mock_instructor):  # noqa: ARG001
     embedding_backend.model.embed.assert_called_once_with(data)
     # restore the factory stateTrue
     _FastembedEmbeddingBackendFactory._instances = {}
+
+
+@patch("haystack_integrations.components.embedders.fastembed.embedding_backend.fastembed_backend.SparseTextEmbedding")
+def test_bm25_model_initialization(mock_instructor):
+    bm25_config = {
+        "k": 1.2,
+        "b": 0.75,
+        "avg_len": 300.0,
+        "language": "english",
+        "token_max_length": 40,
+    }
+
+    # Invoke the backend factory with the BM25 configuration
+    _FastembedSparseEmbeddingBackendFactory.get_embedding_backend(
+        model_name="Qdrant/bm25",
+        bm25=bm25_config,
+    )
+
+    # Check if SparseTextEmbedding was called with the correct arguments
+    mock_instructor.assert_called_once_with(
+        model_name="Qdrant/bm25", cache_dir=None, threads=None, local_files_only=False, **bm25_config
+    )
+
+    # Restore factory state after the test
+    _FastembedSparseEmbeddingBackendFactory._instances = {}

--- a/integrations/fastembed/tests/test_fastembed_backend.py
+++ b/integrations/fastembed/tests/test_fastembed_backend.py
@@ -48,7 +48,7 @@ def test_embedding_function_with_kwargs(mock_instructor):  # noqa: ARG001
 
 
 @patch("haystack_integrations.components.embedders.fastembed.embedding_backend.fastembed_backend.SparseTextEmbedding")
-def test_bm25_model_initialization(mock_instructor):
+def test_model_kwargs_initialization(mock_instructor):
     bm25_config = {
         "k": 1.2,
         "b": 0.75,
@@ -60,7 +60,7 @@ def test_bm25_model_initialization(mock_instructor):
     # Invoke the backend factory with the BM25 configuration
     _FastembedSparseEmbeddingBackendFactory.get_embedding_backend(
         model_name="Qdrant/bm25",
-        bm25=bm25_config,
+        model_kwargs=bm25_config,
     )
 
     # Check if SparseTextEmbedding was called with the correct arguments

--- a/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
@@ -69,7 +69,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
                 "local_files_only": False,
                 "embedding_separator": "\n",
                 "meta_fields_to_embed": [],
-                "bm25": None,
+                "model_kwargs": None,
             },
         }
 
@@ -101,7 +101,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
                 "local_files_only": True,
                 "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
-                "bm25": None,
+                "model_kwargs": None,
             },
         }
 
@@ -176,7 +176,11 @@ class TestFastembedSparseDocumentEmbedderDoc:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="prithvida/Splade_PP_en_v1", cache_dir=None, threads=None, local_files_only=False, bm25=None
+            model_name="prithvida/Splade_PP_en_v1",
+            cache_dir=None,
+            threads=None,
+            local_files_only=False,
+            model_kwargs=None,
         )
 
     @patch(
@@ -277,9 +281,9 @@ class TestFastembedSparseDocumentEmbedderDoc:
             parallel=None,
         )
 
-    def test_init_with_bm25_parameters(self):
+    def test_init_with_model_kwargs_parameters(self):
         """
-        Test initialization of FastembedSparseDocumentEmbedder with BM25 parameters.
+        Test initialization of FastembedSparseDocumentEmbedder with model_kwargs parameters.
         """
         bm25_config = {
             "k": 1.2,
@@ -291,45 +295,27 @@ class TestFastembedSparseDocumentEmbedderDoc:
 
         embedder = FastembedSparseDocumentEmbedder(
             model="Qdrant/bm25",
-            bm25=bm25_config,
+            model_kwargs=bm25_config,
         )
 
-        assert embedder.bm25 == bm25_config
-
-    def test_bm25_not_passed_for_non_bm25_model(self):
-        """
-        Test that BM25 parameters are not used if model is not "Qdrant/bm25".
-        """
-        bm25_config = {
-            "k": 1.5,
-            "b": 0.9,
-            "avg_len": 250.0,
-        }
-
-        embedder = FastembedSparseDocumentEmbedder(
-            model="prithvida/Splade_PP_en_v1",
-            bm25=bm25_config,
-        )
-        assert embedder.bm25 is None
+        assert embedder.model_kwargs == bm25_config
 
     @pytest.mark.integration
-    def test_run_with_bm25(self):
+    def test_run_with_model_kwargs(self):
         """
-        Integration test to check the embedding with bm25 parameters.
+        Integration test to check the embedding with model_kwargs parameters.
         """
-        bm25_config = {
-            "k": 1.2,
-            "b": 0.75,
-            "avg_len": 256.0,
+        bm42_config = {
+            "alpha": 0.2,
         }
 
         embedder = FastembedSparseDocumentEmbedder(
-            model="Qdrant/bm25",
-            bm25=bm25_config,
+            model="Qdrant/bm42-all-minilm-l6-v2-attentions",
+            model_kwargs=bm42_config,
         )
         embedder.warm_up()
 
-        doc = Document(content="Example content using BM25")
+        doc = Document(content="Example content using BM42")
 
         result = embedder.run(documents=[doc])
         embedding = result["documents"][0].sparse_embedding

--- a/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
@@ -54,7 +54,7 @@ class TestFastembedSparseTextEmbedder:
                 "progress_bar": True,
                 "parallel": None,
                 "local_files_only": False,
-                "bm25": None,
+                "model_kwargs": None,
             },
         }
 
@@ -80,7 +80,7 @@ class TestFastembedSparseTextEmbedder:
                 "progress_bar": False,
                 "parallel": 1,
                 "local_files_only": True,
-                "bm25": None,
+                "model_kwargs": None,
             },
         }
 
@@ -137,7 +137,11 @@ class TestFastembedSparseTextEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="prithvida/Splade_PP_en_v1", cache_dir=None, threads=None, local_files_only=False, bm25=None
+            model_name="prithvida/Splade_PP_en_v1",
+            cache_dir=None,
+            threads=None,
+            local_files_only=False,
+            model_kwargs=None,
         )
 
     @patch(
@@ -197,9 +201,9 @@ class TestFastembedSparseTextEmbedder:
         with pytest.raises(TypeError, match="FastembedSparseTextEmbedder expects a string as input"):
             embedder.run(text=list_integers_input)
 
-    def test_init_with_bm25_parameters(self):
+    def test_init_with_model_kwargs_parameters(self):
         """
-        Test initialization of FastembedSparseTextEmbedder with BM25 parameters.
+        Test initialization of FastembedSparseTextEmbedder with model_kwargs parameters.
         """
         bm25_config = {
             "k": 1.2,
@@ -211,31 +215,15 @@ class TestFastembedSparseTextEmbedder:
 
         embedder = FastembedSparseTextEmbedder(
             model="Qdrant/bm25",
-            bm25=bm25_config,
+            model_kwargs=bm25_config,
         )
 
-        assert embedder.bm25 == bm25_config
-
-    def test_bm25_not_passed_for_non_bm25_model(self):
-        """
-        Test that BM25 parameters are not used if model is not "Qdrant/bm25".
-        """
-        bm25_config = {
-            "k": 1.5,
-            "b": 0.9,
-            "avg_len": 250.0,
-        }
-
-        embedder = FastembedSparseTextEmbedder(
-            model="prithvida/Splade_PP_en_v1",
-            bm25=bm25_config,
-        )
-        assert embedder.bm25 is None
+        assert embedder.model_kwargs == bm25_config
 
     @pytest.mark.integration
-    def test_run_with_bm25(self):
+    def test_run_with_model_kwargs(self):
         """
-        Integration test to check the embedding with bm25 parameters.
+        Integration test to check the embedding with model_kwargs parameters.
         """
         bm25_config = {
             "k": 1.2,
@@ -245,7 +233,7 @@ class TestFastembedSparseTextEmbedder:
 
         embedder = FastembedSparseTextEmbedder(
             model="Qdrant/bm25",
-            bm25=bm25_config,
+            model_kwargs=bm25_config,
         )
         embedder.warm_up()
 


### PR DESCRIPTION
### Related Issues

- fixes #1096

### Proposed Changes:

 <!--- In case of a feature: Describe what did you add and how it works -->
if qdrant/bm25 model is chosen, there is a new config available to do fine tuning

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI, added new unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
