### PR TITLE
feat: add `keep_alive` parameter to Ollama Generators

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -56,7 +56,13 @@ class OllamaChatGenerator:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
-            The option that controls how long the model will stay loaded into memory following the request.
+            The option that controls how long the model will stay loaded into memory following the request (default: `5m`)
+            
+            The value can be set to:
+            - a duration string (such as "10m" or "24h")
+            - a number in seconds (such as 3600)
+            - any negative number which will keep the model loaded in memory (e.g. -1 or "-1m")
+            - '0' which will unload the model immediately after generating a response
         """
 
         self.timeout = timeout

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -56,14 +56,13 @@ class OllamaChatGenerator:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
-            The option that controls how long the model will stay loaded into memory following the request
-            (default: `5m`)
-
+            The option that controls how long the model will stay loaded into memory following the request.
+            If not set, it will use the default value from the Ollama (5 minutes).
             The value can be set to:
             - a duration string (such as "10m" or "24h")
             - a number in seconds (such as 3600)
             - any negative number which will keep the model loaded in memory (e.g. -1 or "-1m")
-            - '0' which will unload the model immediately after generating a response
+            - '0' which will unload the model immediately after generating a response.
         """
 
         self.timeout = timeout

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -169,7 +169,9 @@ class OllamaChatGenerator:
 
         stream = self.streaming_callback is not None
         messages = [self._message_to_dict(message) for message in messages]
-        response = self._client.chat(model=self.model, messages=messages, stream=stream, keep_alive=self.keep_alive, options=generation_kwargs)
+        response = self._client.chat(
+            model=self.model, messages=messages, stream=stream, keep_alive=self.keep_alive, options=generation_kwargs
+        )
 
         if stream:
             chunks: List[StreamingChunk] = self._handle_streaming_response(response)

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -57,7 +57,7 @@ class OllamaChatGenerator:
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
             The option that controls how long the model will stay loaded into memory following the request (default: `5m`)
-            
+
             The value can be set to:
             - a duration string (such as "10m" or "24h")
             - a number in seconds (such as 3600)

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -56,7 +56,8 @@ class OllamaChatGenerator:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
-            The option that controls how long the model will stay loaded into memory following the request (default: `5m`)
+            The option that controls how long the model will stay loaded into memory following the request
+            (default: `5m`)
 
             The value can be set to:
             - a duration string (such as "10m" or "24h")

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -80,6 +80,7 @@ class OllamaChatGenerator:
             self,
             model=self.model,
             url=self.url,
+            keep_alive=self.keep_alive,
             generation_kwargs=self.generation_kwargs,
             timeout=self.timeout,
             streaming_callback=callback_name,

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage, StreamingChunk
@@ -38,6 +38,7 @@ class OllamaChatGenerator:
         url: str = "http://localhost:11434",
         generation_kwargs: Optional[Dict[str, Any]] = None,
         timeout: int = 120,
+        keep_alive: Optional[Union[float, str]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
@@ -54,12 +55,15 @@ class OllamaChatGenerator:
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
+        :param keep_alive:
+            The option that controls how long the model will stay loaded into memory following the request.
         """
 
         self.timeout = timeout
         self.generation_kwargs = generation_kwargs or {}
         self.url = url
         self.model = model
+        self.keep_alive = keep_alive
         self.streaming_callback = streaming_callback
 
         self._client = Client(host=self.url, timeout=self.timeout)
@@ -165,7 +169,7 @@ class OllamaChatGenerator:
 
         stream = self.streaming_callback is not None
         messages = [self._message_to_dict(message) for message in messages]
-        response = self._client.chat(model=self.model, messages=messages, stream=stream, options=generation_kwargs)
+        response = self._client.chat(model=self.model, messages=messages, stream=stream, keep_alive=self.keep_alive, options=generation_kwargs)
 
         if stream:
             chunks: List[StreamingChunk] = self._handle_streaming_response(response)

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import StreamingChunk
@@ -36,6 +36,7 @@ class OllamaGenerator:
         template: Optional[str] = None,
         raw: bool = False,
         timeout: int = 120,
+        keep_alive: Optional[Union[float, str]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
@@ -59,6 +60,8 @@ class OllamaGenerator:
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
+        :param keep_alive:
+            The option that controls how long the model will stay loaded into memory following the request.
         """
         self.timeout = timeout
         self.raw = raw
@@ -66,6 +69,7 @@ class OllamaGenerator:
         self.system_prompt = system_prompt
         self.model = model
         self.url = url
+        self.keep_alive = keep_alive
         self.generation_kwargs = generation_kwargs or {}
         self.streaming_callback = streaming_callback
 
@@ -172,7 +176,7 @@ class OllamaGenerator:
 
         stream = self.streaming_callback is not None
 
-        response = self._client.generate(model=self.model, prompt=prompt, stream=stream, options=generation_kwargs)
+        response = self._client.generate(model=self.model, prompt=prompt, stream=stream, keep_alive=self.keep_alive, options=generation_kwargs)
 
         if stream:
             chunks: List[StreamingChunk] = self._handle_streaming_response(response)

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -61,14 +61,13 @@ class OllamaGenerator:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
-            The option that controls how long the model will stay loaded into memory following the request
-            (default: `5m`)
-
+            The option that controls how long the model will stay loaded into memory following the request.
+            If not set, it will use the default value from the Ollama (5 minutes).
             The value can be set to:
             - a duration string (such as "10m" or "24h")
             - a number in seconds (such as 3600)
             - any negative number which will keep the model loaded in memory (e.g. -1 or "-1m")
-            - '0' which will unload the model immediately after generating a response
+            - '0' which will unload the model immediately after generating a response.
         """
         self.timeout = timeout
         self.raw = raw

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -62,7 +62,7 @@ class OllamaGenerator:
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
             The option that controls how long the model will stay loaded into memory following the request (default: `5m`)
-            
+
             The value can be set to:
             - a duration string (such as "10m" or "24h")
             - a number in seconds (such as 3600)

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -61,7 +61,8 @@ class OllamaGenerator:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
-            The option that controls how long the model will stay loaded into memory following the request (default: `5m`)
+            The option that controls how long the model will stay loaded into memory following the request
+            (default: `5m`)
 
             The value can be set to:
             - a duration string (such as "10m" or "24h")

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -91,6 +91,7 @@ class OllamaGenerator:
             system_prompt=self.system_prompt,
             model=self.model,
             url=self.url,
+            keep_alive=self.keep_alive,
             generation_kwargs=self.generation_kwargs,
             streaming_callback=callback_name,
         )

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -61,7 +61,13 @@ class OllamaGenerator:
             A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param keep_alive:
-            The option that controls how long the model will stay loaded into memory following the request.
+            The option that controls how long the model will stay loaded into memory following the request (default: `5m`)
+            
+            The value can be set to:
+            - a duration string (such as "10m" or "24h")
+            - a number in seconds (such as 3600)
+            - any negative number which will keep the model loaded in memory (e.g. -1 or "-1m")
+            - '0' which will unload the model immediately after generating a response
         """
         self.timeout = timeout
         self.raw = raw

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -176,7 +176,9 @@ class OllamaGenerator:
 
         stream = self.streaming_callback is not None
 
-        response = self._client.generate(model=self.model, prompt=prompt, stream=stream, keep_alive=self.keep_alive, options=generation_kwargs)
+        response = self._client.generate(
+            model=self.model, prompt=prompt, stream=stream, keep_alive=self.keep_alive, options=generation_kwargs
+        )
 
         if stream:
             chunks: List[StreamingChunk] = self._handle_streaming_response(response)

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -49,7 +49,7 @@ class TestOllamaChatGenerator:
             streaming_callback=print_streaming_chunk,
             url="custom_url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-            keep_alive="5m"
+            keep_alive="5m",
         )
         data = component.to_dict()
         assert data == {

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -26,12 +26,14 @@ class TestOllamaChatGenerator:
         assert component.url == "http://localhost:11434"
         assert component.generation_kwargs == {}
         assert component.timeout == 120
+        assert component.keep_alive is None
 
     def test_init(self):
         component = OllamaChatGenerator(
             model="llama2",
             url="http://my-custom-endpoint:11434",
             generation_kwargs={"temperature": 0.5},
+            keep_alive="10m",
             timeout=5,
         )
 
@@ -39,6 +41,7 @@ class TestOllamaChatGenerator:
         assert component.url == "http://my-custom-endpoint:11434"
         assert component.generation_kwargs == {"temperature": 0.5}
         assert component.timeout == 5
+        assert component.keep_alive == "10m"
 
     def test_to_dict(self):
         component = OllamaChatGenerator(
@@ -46,6 +49,7 @@ class TestOllamaChatGenerator:
             streaming_callback=print_streaming_chunk,
             url="custom_url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+            keep_alive="5m"
         )
         data = component.to_dict()
         assert data == {
@@ -53,6 +57,7 @@ class TestOllamaChatGenerator:
             "init_parameters": {
                 "timeout": 120,
                 "model": "llama2",
+                "keep_alive": "5m",
                 "url": "custom_url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -66,6 +71,7 @@ class TestOllamaChatGenerator:
                 "timeout": 120,
                 "model": "llama2",
                 "url": "custom_url",
+                "keep_alive": "5m",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
@@ -75,6 +81,7 @@ class TestOllamaChatGenerator:
         assert component.streaming_callback is print_streaming_chunk
         assert component.url == "custom_url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.keep_alive == "5m"
 
     def test_build_message_from_ollama_response(self):
         model = "some_model"

--- a/integrations/ollama/tests/test_generator.py
+++ b/integrations/ollama/tests/test_generator.py
@@ -45,6 +45,7 @@ class TestOllamaGenerator:
         assert component.template is None
         assert component.raw is False
         assert component.timeout == 120
+        assert component.keep_alive is None
         assert component.streaming_callback is None
 
     def test_init(self):
@@ -57,6 +58,7 @@ class TestOllamaGenerator:
             generation_kwargs={"temperature": 0.5},
             system_prompt="You are Luigi from Super Mario Bros.",
             timeout=5,
+            keep_alive="10m",
             streaming_callback=callback,
         )
         assert component.model == "llama2"
@@ -66,6 +68,7 @@ class TestOllamaGenerator:
         assert component.template is None
         assert component.raw is False
         assert component.timeout == 5
+        assert component.keep_alive == "10m"
         assert component.streaming_callback == callback
 
         component = OllamaGenerator()
@@ -80,6 +83,7 @@ class TestOllamaGenerator:
                 "model": "orca-mini",
                 "url": "http://localhost:11434",
                 "streaming_callback": None,
+                "keep_alive": None,
                 "generation_kwargs": {},
             },
         }
@@ -89,6 +93,7 @@ class TestOllamaGenerator:
             model="llama2",
             streaming_callback=print_streaming_chunk,
             url="going_to_51_pegasi_b_for_weekend",
+            keep_alive="10m",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
         data = component.to_dict()
@@ -100,6 +105,7 @@ class TestOllamaGenerator:
                 "template": None,
                 "system_prompt": None,
                 "model": "llama2",
+                "keep_alive": "10m",
                 "url": "going_to_51_pegasi_b_for_weekend",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -115,6 +121,7 @@ class TestOllamaGenerator:
                 "template": None,
                 "system_prompt": None,
                 "model": "llama2",
+                "keep_alive": "5m",
                 "url": "going_to_51_pegasi_b_for_weekend",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -125,6 +132,7 @@ class TestOllamaGenerator:
         assert component.streaming_callback is print_streaming_chunk
         assert component.url == "going_to_51_pegasi_b_for_weekend"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.keep_alive == "5m"
 
     @pytest.mark.integration
     def test_ollama_generator_run_streaming(self):


### PR DESCRIPTION
### Related Issues

- Partially resolves #1129

### Proposed Changes:

Added keep_alive parameter to `OllamaGenerator` and `OllamaChatGenerator`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Ran unit tests:
```bash
hatch run test -m"not integration"
```
Manual tests:
Set keep alive to 0 and checked process consumptions.
```python
from haystack_integrations.components.generators.ollama import OllamaGenerator, OllamaChatGenerator
from haystack.dataclasses import ChatMessage, ChatRole

generator = OllamaGenerator(keep_alive=0)
replies = generator.run("Say hello").get("replies")
assert replies and replies[0].strip() != ''

generator = OllamaChatGenerator(keep_alive=0)
message = ChatMessage(content="Hello", role=ChatRole.USER, name=None)
replies = generator.run([message]).get("replies")
assert replies and replies[0].meta['done'] == True
```

#### Expected behavior:
The processes immediately getting unloaded from memory.

#### Actual behaviour:
The processes immediately getting unloaded from memory.

### Notes for the reviewer

### Checklist

- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [X] I have updated the related issue with new insights and changes
- [X] I added unit tests and updated the docstrings
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
