### PR TITLE
fix: make sure that streaming works with function calls - (drop python3.8)

### DIFF
--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -7,7 +7,7 @@ name = "google-ai-haystack"
 dynamic = ["version"]
 description = 'Use models like Gemini via Makersuite'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -348,14 +348,12 @@ class GoogleAIGeminiChatGenerator:
         for chunk in stream:
             content: Union[str, Dict[str, Any]] = ""
             dict_chunk = chunk.to_dict()
-            metadata = dict(dict_chunk) # we copy and store the whole chunk as metadata in streaming calls
+            metadata = dict(dict_chunk)  # we copy and store the whole chunk as metadata in streaming calls
             for candidate in dict_chunk["candidates"]:
                 for part in candidate["content"]["parts"]:
                     if "text" in part and part["text"] != "":
                         content = part["text"]
-                        replies.append(
-                            ChatMessage(content=content, role=ChatRole.ASSISTANT, meta=metadata, name=None)
-                        )
+                        replies.append(ChatMessage(content=content, role=ChatRole.ASSISTANT, meta=metadata, name=None))
                     elif "function_call" in part and len(part["function_call"]) > 0:
                         metadata["function_call"] = part["function_call"]
                         content = part["function_call"]["args"]

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -347,16 +347,16 @@ class GoogleAIGeminiChatGenerator:
         replies: List[ChatMessage] = []
         for chunk in stream:
             content: Union[str, Dict[str, Any]] = ""
-            dict_chunk = chunk.to_dict()  # we store whole chunk as metadata in streaming calls
+            dict_chunk = chunk.to_dict()
+            metadata = dict(dict_chunk) # we copy and store the whole chunk as metadata in streaming calls
             for candidate in dict_chunk["candidates"]:
                 for part in candidate["content"]["parts"]:
                     if "text" in part and part["text"] != "":
                         content = part["text"]
                         replies.append(
-                            ChatMessage(content=content, role=ChatRole.ASSISTANT, meta=dict_chunk, name=None)
+                            ChatMessage(content=content, role=ChatRole.ASSISTANT, meta=metadata, name=None)
                         )
                     elif "function_call" in part and len(part["function_call"]) > 0:
-                        metadata = dict(dict_chunk)
                         metadata["function_call"] = part["function_call"]
                         content = part["function_call"]["args"]
                         replies.append(
@@ -368,5 +368,5 @@ class GoogleAIGeminiChatGenerator:
                             )
                         )
 
-                    streaming_callback(StreamingChunk(content=content, meta=dict_chunk))
+                    streaming_callback(StreamingChunk(content=content, meta=metadata))
         return replies


### PR DESCRIPTION
### Related Issues

Tests are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11337043949
The conversion of function calls into dictionaries is not working properly.

### Proposed Changes:
- Use the chunk dictionaries to access all required attributes (instead of Google Proto objects).
- Officially drop Python 3.8 in this package (`google-generativeai` never supported it)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
