### PR TITLE
fix: compatibility with Weaviate 4.9.0

### DIFF
--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -7,7 +7,7 @@ name = "weaviate-haystack"
 dynamic = ["version"]
 description = "An integration of Weaviate vector database with Haystack"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "weaviate-client>=4.0",
+  "weaviate-client>=4.9",
   "haystack-pydoc-tools",
   "python-dateutil",
 ]

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -265,6 +265,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                         "session_pool_connections": 20,
                         "session_pool_maxsize": 100,
                         "session_pool_max_retries": 3,
+                        "session_pool_timeout": 5,
                     },
                     "proxies": {"http": "http://proxy:1234", "https": None, "grpc": None},
                     "timeout": [30, 90],

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -303,6 +303,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
                         "connection": {
                             "session_pool_connections": 20,
                             "session_pool_maxsize": 20,
+                            "session_pool_timeout": 5,
                         },
                         "proxies": {"http": "http://proxy:1234"},
                         "timeout": [10, 60],
@@ -339,6 +340,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         assert document_store._embedded_options.grpc_port == DEFAULT_GRPC_PORT
         assert document_store._additional_config.connection.session_pool_connections == 20
         assert document_store._additional_config.connection.session_pool_maxsize == 20
+        assert document_store._additional_config.connection.session_pool_timeout == 5
 
     def test_to_data_object(self, document_store, test_files_path):
         doc = Document(content="test doc")


### PR DESCRIPTION
### Related Issues
Weaviate tests started failing (https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11382891630/job/31667385516?pr=1142) due to a new release: https://github.com/weaviate/weaviate-python-client/releases/tag/v4.9.0

### Proposed Changes:
- pin the new version of the client
- drop python 3.8, as they did
- adjust the test

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
