### PR TITLE
refactor: avoid downloading tokenizer if `truncate` is `False`

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -153,7 +153,7 @@ class AmazonBedrockGenerator:
         model_max_length = kwargs.get("model_max_length", 4096)
 
         # we initialize the prompt handler only if truncate is True: we avoid unnecessarily downloading the tokenizer
-        if truncate:
+        if self.truncate:
             # Truncate prompt if prompt tokens > model_max_length-max_length
             # (max_length is the length of the generated text)
             # we use GPT2 tokenizer which will likely provide good token count approximation

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -152,15 +152,16 @@ class AmazonBedrockGenerator:
         # We pop the model_max_length as it is not sent to the model but used to truncate the prompt if needed
         model_max_length = kwargs.get("model_max_length", 4096)
 
-        # Truncate prompt if prompt tokens > model_max_length-max_length
-        # (max_length is the length of the generated text)
-        # we use GPT2 tokenizer which will likely provide good token count approximation
-
-        self.prompt_handler = DefaultPromptHandler(
-            tokenizer="gpt2",
-            model_max_length=model_max_length,
-            max_length=self.max_length or 100,
-        )
+        # we initialize the prompt handler only if truncate is True: we avoid unnecessarily downloading the tokenizer
+        if truncate:
+            # Truncate prompt if prompt tokens > model_max_length-max_length
+            # (max_length is the length of the generated text)
+            # we use GPT2 tokenizer which will likely provide good token count approximation
+            self.prompt_handler = DefaultPromptHandler(
+                tokenizer="gpt2",
+                model_max_length=model_max_length,
+                max_length=self.max_length or 100,
+            )
 
         model_adapter_cls = self.get_model_adapter(model=model)
         if not model_adapter_cls:

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -108,6 +108,14 @@ def test_constructor_prompt_handler_initialized(mock_boto3_session, mock_prompt_
     assert layer.prompt_handler.model_max_length == 4096
 
 
+def test_prompt_handler_absent_when_truncate_false(mock_boto3_session):
+    """
+    Test that the prompt_handler is not initialized when truncate is set to False.
+    """
+    generator = AmazonBedrockGenerator(model="anthropic.claude-v2", truncate=False)
+    assert not hasattr(generator, "prompt_handler")
+
+
 def test_constructor_with_model_kwargs(mock_boto3_session):
     """
     Test that model_kwargs are correctly set in the constructor


### PR DESCRIPTION
### Related Issues

- fixes #1125

### Proposed Changes:
If `truncate` is `False`, do not initialize the `PromptHandler` (which internally downloads the tokenizer).
In the Generator, the `PromptHandler` is only used to truncate the text if needed.

### How did you test it?
CI + a new unit test.

### Notes for the reviewer
This change only applies to `AmazonBedrockGenerator`.

I would have liked to do the same for the corresponding Chat Generator.
Unfortunately, in the Chat Generator, the `PromptHandler` (and its internal tokenizer) have 2 different purposes:
- transform messages into text with special tokens (via `tokenizer.apply_chat_template`)
- truncate the text, like in the Generator

Therefore, we cannot easily get rid of the tokenizer.

(I hope we can prioritize #977 soon: this would greatly simplify the Chat Generator.)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
