### PR TITLE
fix: remove dependency constraints for instructor-embedders

### DIFF
--- a/integrations/instructor_embedders/pyproject.toml
+++ b/integrations/instructor_embedders/pyproject.toml
@@ -30,18 +30,17 @@ dependencies = [
   # Commenting some of them to not interfere with the dependencies of Haystack.
   #"transformers==4.20.0",
   "datasets>=2.2.0",
-  "huggingface_hub<0.26.0",
+  "huggingface_hub",
   #"pyarrow==8.0.0",
   "jsonlines",
   "numpy",
   "requests>=2.26.0",
   "scikit_learn>=1.0.2",
   "scipy",
-  "sentence_transformers>=2.2.0,<2.3.0",
+  "sentence_transformers>=2.2.0",
   "torch",
   "tqdm",
   "rich",
-
   "InstructorEmbedding",
 ]
 


### PR DESCRIPTION
### Related Issues

- fixes dependency constraints for instructor-embedders being too restrictive. They have been taken from the [repo](https://github.com/xlang-ai/instructor-embedding/blob/main/requirements.txt) as the package itself doesn't have proper dependencies. Even in the repo they made them less restrictive

### Proposed Changes:
- remove version constraint for sentence-transformers and huggingface-hub

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
