### PR TITLE
fix: Elasticsearch - allow passing headers

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -105,9 +105,12 @@ class ElasticsearchDocumentStore:
     @property
     def client(self) -> Elasticsearch:
         if self._client is None:
+            headers = self._kwargs.pop("headers", {})
+            headers["user-agent"] = f"haystack-py-ds/{haystack_version}"
+
             client = Elasticsearch(
                 self._hosts,
-                headers={"user-agent": f"haystack-py-ds/{haystack_version}"},
+                headers=headers,
                 **self._kwargs,
             )
             # Check client connection, this will raise if not connected

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -23,6 +23,20 @@ def test_init_is_lazy(_mock_es_client):
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_headers_are_supported(_mock_es_client):
+    _ = ElasticsearchDocumentStore(hosts="testhost", headers={"header1": "value1", "header2": "value2"}).client
+
+    assert _mock_es_client.call_count == 1
+    _, kwargs = _mock_es_client.call_args
+
+    headers_found = kwargs["headers"]
+    assert headers_found["header1"] == "value1"
+    assert headers_found["header2"] == "value2"
+
+    assert headers_found["user-agent"].startswith("haystack-py-ds/")
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
 def test_to_dict(_mock_elasticsearch_client):
     document_store = ElasticsearchDocumentStore(hosts="some hosts")
     res = document_store.to_dict()


### PR DESCRIPTION
### Related Issues

- fixes #1149

The problem is related to the fact that we allow passing `headers` in `**kwargs`, but then we also pass a custom `headers` field containing the `user-agent`.

### Proposed Changes:
Extract `headers` from `**kwargs` and integrate the `user-agent` into the existing headers.

### How did you test it?
CI, new unit test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
