### PR TITLE
chore: introduce Stalebot

### DIFF
--- a/.github/workflows/CI_stale.yml
+++ b/.github/workflows/CI_stale.yml
@@ -1,0 +1,15 @@
+name: 'Stalebot'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  makestale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          any-of-labels: 'community-triage'
+          stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          days-before-stale: 30
+          days-before-close: 10


### PR DESCRIPTION
In Haystack repo, we have a [similar Stalebot](https://github.com/deepset-ai/haystack/blob/c7b898994e371e376dd3b7236620eeca05f3f463/.github/workflows/stale.yml):
if an issue is tagged with `community-triage`, it is tagged as stale after 30 days with no activity, then closed after 10 additional days.


### Proposed Changes:
Introduce a Stalebot workflow for core-integrations

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
