### PR TITLE
chore: fix Vertex tests

### DIFF
--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -170,6 +170,7 @@ def test_to_dict_with_params(_mock_vertexai_init, _mock_generative_model):
                                     "unit": {"type_": "STRING", "enum": ["celsius", "fahrenheit"]},
                                 },
                                 "required": ["location"],
+                                "property_ordering": ["location", "unit"],
                             },
                         }
                     ]
@@ -252,7 +253,6 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
                                             ],
                                         },
                                     },
-                                    "property_ordering": ["unit", "location"],
                                     "required": ["location"],
                                 },
                             }

--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -252,6 +252,7 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
                                             ],
                                         },
                                     },
+                                    "property_ordering": ["unit", "location"],
                                     "required": ["location"],
                                 },
                             }

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -157,6 +157,7 @@ def test_to_dict_with_params(_mock_vertexai_init, _mock_generative_model):
                                     "unit": {"type_": "STRING", "enum": ["celsius", "fahrenheit"]},
                                 },
                                 "required": ["location"],
+                                "property_ordering": ["location", "unit"],
                             },
                         }
                     ]


### PR DESCRIPTION
### Related Issues

- Nightly tests are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11603564730/job/32310766803
- probably a new version was released, that introduced a new field (`property_ordering`)

### Proposed Changes:
- Fix the failing test, introducing the new field 

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
