### PR TITLE
chore: fastembed - pin `onnxruntime<1.20.0`

### DIFF
--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.0.1", "fastembed>=0.2.5"]
+dependencies = ["haystack-ai>=2.0.1", "fastembed>=0.2.5", "onnxruntime<1.20.0"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"


### PR DESCRIPTION
### Related Issues

- tests are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11655952323/job/32451370656
- related fastembed issue: https://github.com/qdrant/fastembed/issues/385

### Proposed Changes:
Temporarily pin `onnxruntime<1.20.0`.

We should remove this pin in the future: I would expect that fastembed will support `onnxruntime<1.20.0` or they will pin the library themselves.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
