### PR TITLE
fix: Weaviate - skip `_split_overlap` meta field

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -286,6 +286,14 @@ class WeaviateDocumentStore:
         # The embedding vector is stored separately from the rest of the data
         del data["embedding"]
 
+        # _split_overlap meta field is unsupported because of a bug
+        # https://github.com/deepset-ai/haystack-core-integrations/issues/1172
+        if "_split_overlap" in data:
+            data.pop("_split_overlap")
+            logger.warning(
+                "Document %s has the unsupported `_split_overlap` meta field. It will be ignored.", data["_original_id"]
+            )
+
         if "sparse_embedding" in data:
             sparse_embedding = data.pop("sparse_embedding", None)
             if sparse_embedding:

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -508,6 +508,30 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
     def test_comparison_not_equal_with_dataframe(self, document_store, filterable_docs):
         return super().test_comparison_not_equal_with_dataframe(document_store, filterable_docs)
 
+    def test_meta_split_overlap_is_skipped(self, document_store):
+        doc = Document(
+            content="The moonlight shimmered ",
+            meta={
+                "source_id": "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0",
+                "page_number": 1,
+                "split_id": 0,
+                "split_idx_start": 0,
+                "_split_overlap": [
+                    {"doc_id": "68ed48ba830048c5d7815874ed2de794722e6d10866b6c55349a914fd9a0df65", "range": (0, 20)}
+                ],
+            },
+        )
+        document_store.write_documents([doc])
+
+        written_doc = document_store.filter_documents()[0]
+
+        assert written_doc.content == "The moonlight shimmered "
+        assert written_doc.meta["source_id"] == "62049ba1d1e1d5ebb1f6230b0b00c5356b8706c56e0b9c36b1dfc86084cd75f0"
+        assert written_doc.meta["page_number"] == 1.0
+        assert written_doc.meta["split_id"] == 0.0
+        assert written_doc.meta["split_idx_start"] == 0.0
+        assert "_split_overlap" not in written_doc.meta
+
     def test_bm25_retrieval(self, document_store):
         document_store.write_documents(
             [


### PR DESCRIPTION
### Related Issues

- temporary fix for #1172 

### Proposed Changes:
In case `_split_overlap` meta field is present, do not write it.

### How did you test it?
CI, new test.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
