### PR TITLE
fix: `VertexAIGeminiGenerator` - remove support for tools and change output type

### DIFF
--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -1,37 +1,16 @@
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
 from haystack import Pipeline
 from haystack.components.builders import PromptBuilder
 from haystack.dataclasses import StreamingChunk
 from vertexai.generative_models import (
-    FunctionDeclaration,
     GenerationConfig,
     HarmBlockThreshold,
     HarmCategory,
-    Tool,
-    ToolConfig,
 )
 
 from haystack_integrations.components.generators.google_vertex import VertexAIGeminiGenerator
-
-GET_CURRENT_WEATHER_FUNC = FunctionDeclaration(
-    name="get_current_weather",
-    description="Get the current weather in a given location",
-    parameters={
-        "type": "object",
-        "properties": {
-            "location": {"type": "string", "description": "The city and state, e.g. San Francisco, CA"},
-            "unit": {
-                "type": "string",
-                "enum": [
-                    "celsius",
-                    "fahrenheit",
-                ],
-            },
-        },
-        "required": ["location"],
-    },
-)
 
 
 @patch("haystack_integrations.components.generators.google_vertex.gemini.vertexai_init")
@@ -48,30 +27,26 @@ def test_init(mock_vertexai_init, _mock_generative_model):
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
 
-    tool = Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])
-    tool_config = ToolConfig(
-        function_calling_config=ToolConfig.FunctionCallingConfig(
-            mode=ToolConfig.FunctionCallingConfig.Mode.ANY,
-            allowed_function_names=["get_current_weather_func"],
-        )
-    )
-
     gemini = VertexAIGeminiGenerator(
         project_id="TestID123",
         location="TestLocation",
         generation_config=generation_config,
         safety_settings=safety_settings,
-        tools=[tool],
-        tool_config=tool_config,
         system_instruction="Please provide brief answers.",
     )
     mock_vertexai_init.assert_called()
     assert gemini._model_name == "gemini-1.5-flash"
     assert gemini._generation_config == generation_config
     assert gemini._safety_settings == safety_settings
-    assert gemini._tools == [tool]
-    assert gemini._tool_config == tool_config
     assert gemini._system_instruction == "Please provide brief answers."
+
+
+def test_init_fails_with_tools_or_tool_config():
+    with pytest.raises(TypeError, match="VertexAIGeminiGenerator does not support `tools`"):
+        VertexAIGeminiGenerator(tools=["tool1", "tool2"])
+
+    with pytest.raises(TypeError, match="VertexAIGeminiGenerator does not support `tools`"):
+        VertexAIGeminiGenerator(tool_config={"custom": "config"})
 
 
 @patch("haystack_integrations.components.generators.google_vertex.gemini.vertexai_init")
@@ -88,8 +63,6 @@ def test_to_dict(_mock_vertexai_init, _mock_generative_model):
             "generation_config": None,
             "safety_settings": None,
             "streaming_callback": None,
-            "tools": None,
-            "tool_config": None,
             "system_instruction": None,
         },
     }
@@ -108,21 +81,11 @@ def test_to_dict_with_params(_mock_vertexai_init, _mock_generative_model):
     )
     safety_settings = {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
 
-    tool = Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])
-    tool_config = ToolConfig(
-        function_calling_config=ToolConfig.FunctionCallingConfig(
-            mode=ToolConfig.FunctionCallingConfig.Mode.ANY,
-            allowed_function_names=["get_current_weather_func"],
-        )
-    )
-
     gemini = VertexAIGeminiGenerator(
         project_id="TestID123",
         location="TestLocation",
         generation_config=generation_config,
         safety_settings=safety_settings,
-        tools=[tool],
-        tool_config=tool_config,
         system_instruction="Please provide brief answers.",
     )
     assert gemini.to_dict() == {
@@ -141,34 +104,6 @@ def test_to_dict_with_params(_mock_vertexai_init, _mock_generative_model):
             },
             "safety_settings": {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH},
             "streaming_callback": None,
-            "tools": [
-                {
-                    "function_declarations": [
-                        {
-                            "name": "get_current_weather",
-                            "description": "Get the current weather in a given location",
-                            "parameters": {
-                                "type_": "OBJECT",
-                                "properties": {
-                                    "location": {
-                                        "type_": "STRING",
-                                        "description": "The city and state, e.g. San Francisco, CA",
-                                    },
-                                    "unit": {"type_": "STRING", "enum": ["celsius", "fahrenheit"]},
-                                },
-                                "required": ["location"],
-                                "property_ordering": ["location", "unit"],
-                            },
-                        }
-                    ]
-                }
-            ],
-            "tool_config": {
-                "function_calling_config": {
-                    "mode": ToolConfig.FunctionCallingConfig.Mode.ANY,
-                    "allowed_function_names": ["get_current_weather_func"],
-                }
-            },
             "system_instruction": "Please provide brief answers.",
         },
     }
@@ -186,9 +121,7 @@ def test_from_dict(_mock_vertexai_init, _mock_generative_model):
                 "model": "gemini-1.5-flash",
                 "generation_config": None,
                 "safety_settings": None,
-                "tools": None,
                 "streaming_callback": None,
-                "tool_config": None,
                 "system_instruction": None,
             },
         }
@@ -198,8 +131,6 @@ def test_from_dict(_mock_vertexai_init, _mock_generative_model):
     assert gemini._project_id is None
     assert gemini._location is None
     assert gemini._safety_settings is None
-    assert gemini._tools is None
-    assert gemini._tool_config is None
     assert gemini._system_instruction is None
     assert gemini._generation_config is None
 
@@ -223,40 +154,7 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
                     "stop_sequences": ["stop"],
                 },
                 "safety_settings": {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH},
-                "tools": [
-                    {
-                        "function_declarations": [
-                            {
-                                "name": "get_current_weather",
-                                "parameters": {
-                                    "type": "object",
-                                    "properties": {
-                                        "location": {
-                                            "type": "string",
-                                            "description": "The city and state, e.g. San Francisco, CA",
-                                        },
-                                        "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                                "celsius",
-                                                "fahrenheit",
-                                            ],
-                                        },
-                                    },
-                                    "required": ["location"],
-                                },
-                                "description": "Get the current weather in a given location",
-                            }
-                        ]
-                    }
-                ],
                 "streaming_callback": None,
-                "tool_config": {
-                    "function_calling_config": {
-                        "mode": ToolConfig.FunctionCallingConfig.Mode.ANY,
-                        "allowed_function_names": ["get_current_weather_func"],
-                    }
-                },
                 "system_instruction": "Please provide brief answers.",
             },
         }
@@ -266,13 +164,8 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
     assert gemini._project_id == "TestID123"
     assert gemini._location == "TestLocation"
     assert gemini._safety_settings == {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
-    assert repr(gemini._tools) == repr([Tool(function_declarations=[GET_CURRENT_WEATHER_FUNC])])
     assert isinstance(gemini._generation_config, GenerationConfig)
-    assert isinstance(gemini._tool_config, ToolConfig)
     assert gemini._system_instruction == "Please provide brief answers."
-    assert (
-        gemini._tool_config._gapic_tool_config.function_calling_config.mode == ToolConfig.FunctionCallingConfig.Mode.ANY
-    )
 
 
 @patch("haystack_integrations.components.generators.google_vertex.gemini.GenerativeModel")


### PR DESCRIPTION
### Related Issues

- twin PR of #1177

We are removing support for tools in order to produce a `List[str]` output type, for consistency with other generators.
Users interested in tool calling should use the corresponding Chat Generator.

### Proposed Changes:
- remove support for tools
- change output type to `List[str]`

### How did you test it?
CI

### Notes for the reviewer
This is a breaking change and I will release a major version.
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
