### PR TITLE
feat: Snowflake connection params & permissions check update

### DIFF
--- a/integrations/snowflake/src/haystack_integrations/components/retrievers/snowflake/snowflake_table_retriever.py
+++ b/integrations/snowflake/src/haystack_integrations/components/retrievers/snowflake/snowflake_table_retriever.py
@@ -221,7 +221,7 @@ class SnowflakeTableRetriever:
         :param privileges: List of privileges.
         :param table_name: Name of the table.
         """
-        print(privileges)
+
         for privilege in reversed(privileges):
             if table_name.lower() == privilege[3].lower() and re.match(
                 pattern="select",


### PR DESCRIPTION
### Related Issues

- fixes #1179/1181
https://github.com/deepset-ai/haystack-core-integrations/issues/1179
https://github.com/deepset-ai/haystack-core-integrations/issues/1181

### Proposed Changes:

Added PrivateKey and PrivateKeyPwd parameters to allow more secure connection methodologies.
Added an additional role parameter and altered the check permissions logic to ensure the role/user has SELECT access, rather than read-only select access.

### How did you test it?

Tested locally with dev branch using live Snowflake instance.

### Notes for the reviewer

I've added the parameters which are commonly used (at least within our org), there is scope to add further params or custom connections. Happy to make future feature branches for this or discuss these changes further.
