### PR TITLE
fix: dependency for weaviate document store

### DIFF
--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
   "haystack-ai",
   "weaviate-client>=4.9",
-  "haystack-pydoc-tools",
   "python-dateutil",
 ]
 

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -47,7 +47,7 @@ git_describe_command = 'git describe --tags --match="integrations/weaviate-v[0-9
 
 [tool.hatch.envs.default]
 installer = "uv"
-dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython"]
+dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython", "pydoc-markdown"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -47,7 +47,7 @@ git_describe_command = 'git describe --tags --match="integrations/weaviate-v[0-9
 
 [tool.hatch.envs.default]
 installer = "uv"
-dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython", "pydoc-markdown"]
+dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython", "haystack-pydoc-markdown"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -47,7 +47,7 @@ git_describe_command = 'git describe --tags --match="integrations/weaviate-v[0-9
 
 [tool.hatch.envs.default]
 installer = "uv"
-dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython", "haystack-pydoc-markdown"]
+dependencies = ["coverage[toml]>=6.5", "pytest", "pytest-rerunfailures", "ipython", "haystack-pydoc-tools"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"


### PR DESCRIPTION
### Related Issues

- fixes dependency conflicts

### Proposed Changes:

- we had conflicting packages when installing weaviate with other doctores due to pinning the pydoc markdown package

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
