### PR TITLE
fix: deepeval - pin indirect dependencies based on python version

### DIFF
--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval==0.20.57"]
+dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2.9"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2.9"]
+dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2"]
+dependencies = ["haystack-ai", "deepeval==0.20.57", "langchain<0.2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2; python_version < '3.9'"]
+dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2; python_version < '3.10'"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval==0.20.57", "langchain<0.2"]
+dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2; python_version < '3.9'"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval==0.20.57", "pydantic<2; python_version < '3.10'"]
+dependencies = ["haystack-ai", "deepeval==0.20.57", "langchain<0.3; python_version < '3.10'"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"


### PR DESCRIPTION
### Related Issues

- nightly tests are failing for python 3.9 https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11807852571

### Proposed Changes:
- pin `langchain` dependency for python 3.9

### How did you test it?
CI

### Notes for the reviewer
In the long run, I would like to unpin `deepeval` and support more recent versions,
but it's not trivial (we haven't done that for a while).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
