### PR TITLE
ci: Fix changelog generation

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           config: cliff.toml
           args: >
-            --include-path "${{ steps.pathfinder.outputs.project_path }}/*"
+            --include-path "${{ steps.pathfinder.outputs.project_path }}/**/*"
             --tag-pattern "${{ steps.pathfinder.outputs.project_path }}-v*"
 
       - name: Commit changelog

--- a/cliff.toml
+++ b/cliff.toml
@@ -19,8 +19,23 @@ body = """
     ## [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
+    {#
+        Skip the whole section if it contains only a single commit
+        and it's the commit that updated the changelog.
+        If we don't do this we get an empty section since we don't show
+        commits that update the changelog
+    #}\
+    {% if commits | length == 1 and commits[0].message == 'Update the changelog' %}\
+        {% continue %}\
+    {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
-    {% for commit in commits %}
+    {% for commit in commits %}\
+        {#
+            Skip commits that update the changelog, they're not useful to the user
+        #}\
+        {% if commit.message == 'Update the changelog' %}\
+            {% continue %}\
+        {% endif %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
             {#

--- a/cliff.toml
+++ b/cliff.toml
@@ -23,7 +23,24 @@ body = """
     {% for commit in commits %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }}\
+            {#
+                We first try to render the conventional commit message if present.
+                If it's not a conventional commit we get the PR title if present.
+                If the commit is neither conventional, nor has a PR title set
+                we fallback to whatever the commit message is.
+
+                We do this cause when merging PRs with multiple commits that don't
+                have a title following conventional commit guidelines we might get
+                a commit message that is multiple lines. That makes the changelog
+                look a bit funky so we handle it like so.
+            #}\
+            {% if commit.conventional %}\
+                {{ commit.message | upper_first }}\
+            {% elif commit.remote.pr_title %}\
+                {{ commit.remote.pr_title | upper_first }}\
+            {% else %}\
+                {{ commit.message | upper_first }}\
+            {% endif %}\
     {% endfor %}
 {% endfor %}\n
 """
@@ -84,3 +101,7 @@ topo_order = false
 sort_commits = "oldest"
 # limit the number of commits included in the changelog.
 # limit_commits = 42
+
+[remote.github]
+owner = "deepset-ai"
+repo = "haystack-core-integrations"

--- a/cliff.toml
+++ b/cliff.toml
@@ -35,7 +35,7 @@ footer = """
 trim = true
 # postprocessors
 postprocessors = [
-  # { pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" }, # replace repository URL
+    # { pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" }, # replace repository URL
 ]
 
 [git]
@@ -47,24 +47,26 @@ filter_unconventional = false
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-  # Replace issue numbers
-  #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
-  # Check spelling of the commit with https://github.com/crate-ci/typos
-  # If the spelling is incorrect, it will be automatically fixed.
-  #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+    # Replace issue numbers
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit with https://github.com/crate-ci/typos
+    # If the spelling is incorrect, it will be automatically fixed.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "^feat", group = "<!-- 0 -->🚀 Features" },
-  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
-  { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
-  { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
-  { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
-  { message = "^style", group = "<!-- 5 -->🎨 Styling" },
-  { message = "^test", group = "<!-- 6 -->🧪 Testing" },
-  { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
-  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
-  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { body = ".*security", group = "<!-- 7 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 8 -->◀️ Revert" },
+    { message = "^ci", group = "<!-- 9 -->⚙️ CI" },
+    { message = "^chore", group = "<!-- 10 -->🧹 Chores" },
+    { message = ".*", group = "<!-- 11 -->🌀 Miscellaneous" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/cliff.toml
+++ b/cliff.toml
@@ -87,16 +87,16 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
-    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
-    { body = ".*security", group = "<!-- 7 -->🛡️ Security" },
-    { message = "^revert", group = "<!-- 8 -->◀️ Revert" },
-    { message = "^ci", group = "<!-- 9 -->⚙️ CI" },
+    { message = "^feat", group = "<!-- 00 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 01 -->🐛 Bug Fixes" },
+    { message = "^refactor", group = "<!-- 02 -->🚜 Refactor" },
+    { message = "^doc", group = "<!-- 03 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 04 -->⚡ Performance" },
+    { message = "^style", group = "<!-- 05 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 06 -->🧪 Testing" },
+    { body = ".*security", group = "<!-- 07 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 08 -->◀️ Revert" },
+    { message = "^ci", group = "<!-- 09 -->⚙️ CI" },
     { message = "^chore", group = "<!-- 10 -->🧹 Chores" },
     { message = ".*", group = "<!-- 11 -->🌀 Miscellaneous" },
 ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -37,7 +37,7 @@ body = """
             {% if commit.conventional %}\
                 {{ commit.message | upper_first }}\
             {% elif commit.remote.pr_title %}\
-                {{ commit.remote.pr_title | upper_first }}\
+                {{ commit.remote.pr_title | upper_first }} (#{{ commit.remote.pr_number }})\
             {% else %}\
                 {{ commit.message | upper_first }}\
             {% endif %}\


### PR DESCRIPTION
### Related Issues

- fixes #1176 

### Proposed Changes:

Change the `--include-path` glob to include all files in the integration folder to track for changelog generation.

Change the `cliff.toml` config file so that PRs that don't follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) appear in the changelog in a separate category.

I also split CI and Chores sections.

### How did you test it?

I tested this locally.
This is the before:

```markdown
# Changelog

## [unreleased]

## [integrations/langfuse-v0.6.0] - 2024-11-18

### 🚀 Features

- Add support for ttft (#1161)

### ⚙️ Miscellaneous Tasks

- Adopt uv as installer (#1142)

## [integrations/langfuse-v0.5.0] - 2024-10-01

### ⚙️ Miscellaneous Tasks

- Update ruff linting scripts and settings (#1105)

### Langfuse

- Add invocation_context to identify traces (#1089)

## [integrations/langfuse-v0.4.0] - 2024-09-17

### 🚀 Features

- Langfuse - support generation span for more LLMs (#1087)

### 🚜 Refactor

- Remove usage of deprecated `ChatMessage.to_openai_format` (#1001)

### 📚 Documentation

- Add link to langfuse in LangfuseConnector (#981)

### 🧪 Testing

- Do not retry tests in `hatch run test` command (#954)

### ⚙️ Miscellaneous Tasks

- Retry tests to reduce flakyness (#836)
- `Langfuse` - replace DynamicChatPromptBuilder with ChatPromptBuilder (#925)
- Remove all `DynamicChatPromptBuilder` references in Langfuse integration (#931)

## [integrations/langfuse-v0.2.0] - 2024-06-18

## [integrations/langfuse-v0.1.0] - 2024-06-13

### 🚀 Features

- Langfuse integration (#686)

### 🐛 Bug Fixes

- Performance optimizations and value error when streaming in langfuse (#798)

### ⚙️ Miscellaneous Tasks

- Use ChatMessage to_openai_format, update unit tests, pydocs (#725)

<!-- generated by git-cliff -->

```

After:
```markdown
# Changelog

## [unreleased]


## [integrations/langfuse-v0.6.0] - 2024-11-18

### 🚀 Features

- Add support for ttft (#1161)

### ⚙️ CI

- Adopt uv as installer (#1142)

### 🌀 Miscellaneous

- Fixed TypeError in LangfuseTrace (#1184)

## [integrations/langfuse-v0.5.0] - 2024-10-01

### 🧹 Chores

- Update ruff linting scripts and settings (#1105)

### 🌀 Miscellaneous

- Fix: Add delay to flush the Langfuse traces (#1091)
- Add invocation_context to identify traces (#1089)

## [integrations/langfuse-v0.4.0] - 2024-09-17

### 🚀 Features

- Langfuse - support generation span for more LLMs (#1087)

### 🚜 Refactor

- Remove usage of deprecated `ChatMessage.to_openai_format` (#1001)

### 📚 Documentation

- Add link to langfuse in LangfuseConnector (#981)

### 🧪 Testing

- Do not retry tests in `hatch run test` command (#954)

### ⚙️ CI

- Retry tests to reduce flakyness (#836)

### 🧹 Chores

- `Langfuse` - replace DynamicChatPromptBuilder with ChatPromptBuilder (#925)
- Remove all `DynamicChatPromptBuilder` references in Langfuse integration (#931)

### 🌀 Miscellaneous

- Ci: install `pytest-rerunfailures` where needed; add retry config to `test-cov` script (#845)
- Chore: Update Langfuse README to avoid common initialization issues (#952)
- Chore: langfuse - ruff update, don't ruff tests (#992)

## [integrations/langfuse-v0.2.0] - 2024-06-18

### 🌀 Miscellaneous

- Feat: add support for Azure generators (#815)

## [integrations/langfuse-v0.1.0] - 2024-06-13

### 🚀 Features

- Langfuse integration (#686)

### 🐛 Bug Fixes

- Performance optimizations and value error when streaming in langfuse (#798)

### 🧹 Chores

- Use ChatMessage to_openai_format, update unit tests, pydocs (#725)

### 🌀 Miscellaneous

- Chore: change the pydoc renderer class (#718)
- Docs: add missing api references (#728)

<!-- generated by git-cliff -->
```

### Notes for the reviewer

We should be more careful before merging PRs and add conventional commits prefixes so the changelog is nicely formatted in the future.

Notice also that if the commit message is multiple lines those will be shown in the changelog too, but we can deal with that for the time being.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
