### PR TITLE
fix: Fastembed - Change default Sparse model as the used one is deprecated due to a typo

### DIFF
--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -16,7 +16,7 @@ class FastembedSparseDocumentEmbedder:
     from haystack.dataclasses import Document
 
     sparse_doc_embedder = FastembedSparseDocumentEmbedder(
-        model="prithvida/Splade_PP_en_v1",
+        model="prithivida/Splade_PP_en_v1",
         batch_size=32,
     )
 
@@ -53,7 +53,7 @@ class FastembedSparseDocumentEmbedder:
 
     def __init__(
         self,
-        model: str = "prithvida/Splade_PP_en_v1",
+        model: str = "prithivida/Splade_PP_en_v1",
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
         batch_size: int = 32,
@@ -68,7 +68,7 @@ class FastembedSparseDocumentEmbedder:
         Create an FastembedDocumentEmbedder component.
 
         :param model: Local path or name of the model in Hugging Face's model hub,
-            such as `prithvida/Splade_PP_en_v1`.
+            such as `prithivida/Splade_PP_en_v1`.
         :param cache_dir: The path to the cache directory.
                 Can be set using the `FASTEMBED_CACHE_PATH` env variable.
                 Defaults to `fastembed_cache` in the system's temp directory.

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -19,7 +19,7 @@ class FastembedSparseTextEmbedder:
             "The disk comes and it does not, only Windows. Do Not order this if you have a Mac!!")
 
     sparse_text_embedder = FastembedSparseTextEmbedder(
-        model="prithvida/Splade_PP_en_v1"
+        model="prithivida/Splade_PP_en_v1"
     )
     sparse_text_embedder.warm_up()
 
@@ -29,7 +29,7 @@ class FastembedSparseTextEmbedder:
 
     def __init__(
         self,
-        model: str = "prithvida/Splade_PP_en_v1",
+        model: str = "prithivida/Splade_PP_en_v1",
         cache_dir: Optional[str] = None,
         threads: Optional[int] = None,
         progress_bar: bool = True,
@@ -40,7 +40,7 @@ class FastembedSparseTextEmbedder:
         """
         Create a FastembedSparseTextEmbedder component.
 
-        :param model: Local path or name of the model in Fastembed's model hub, such as `prithvida/Splade_PP_en_v1`
+        :param model: Local path or name of the model in Fastembed's model hub, such as `prithivida/Splade_PP_en_v1`
         :param cache_dir: The path to the cache directory.
                 Can be set using the `FASTEMBED_CACHE_PATH` env variable.
                 Defaults to `fastembed_cache` in the system's temp directory.

--- a/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
@@ -15,8 +15,8 @@ class TestFastembedSparseDocumentEmbedderDoc:
         """
         Test default initialization parameters for FastembedSparseDocumentEmbedder.
         """
-        embedder = FastembedSparseDocumentEmbedder(model="prithvida/Splade_PP_en_v1")
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        embedder = FastembedSparseDocumentEmbedder(model="prithivida/Splade_PP_en_v1")
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir is None
         assert embedder.threads is None
         assert embedder.batch_size == 32
@@ -31,7 +31,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         Test custom initialization parameters for FastembedSparseDocumentEmbedder.
         """
         embedder = FastembedSparseDocumentEmbedder(
-            model="prithvida/Splade_PP_en_v1",
+            model="prithivida/Splade_PP_en_v1",
             cache_dir="fake_dir",
             threads=2,
             batch_size=64,
@@ -41,7 +41,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir == "fake_dir"
         assert embedder.threads == 2
         assert embedder.batch_size == 64
@@ -55,12 +55,12 @@ class TestFastembedSparseDocumentEmbedderDoc:
         """
         Test serialization of FastembedSparseDocumentEmbedder to a dictionary, using default initialization parameters.
         """
-        embedder = FastembedSparseDocumentEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseDocumentEmbedder(model="prithivida/Splade_PP_en_v1")
         embedder_dict = embedder.to_dict()
         assert embedder_dict == {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_document_embedder.FastembedSparseDocumentEmbedder",  #  noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": None,
                 "threads": None,
                 "batch_size": 32,
@@ -78,7 +78,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         Test serialization of FastembedSparseDocumentEmbedder to a dictionary, using custom initialization parameters.
         """
         embedder = FastembedSparseDocumentEmbedder(
-            model="prithvida/Splade_PP_en_v1",
+            model="prithivida/Splade_PP_en_v1",
             cache_dir="fake_dir",
             threads=2,
             batch_size=64,
@@ -92,7 +92,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         assert embedder_dict == {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_document_embedder.FastembedSparseDocumentEmbedder",  #  noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": "fake_dir",
                 "threads": 2,
                 "batch_size": 64,
@@ -113,7 +113,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         embedder_dict = {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_document_embedder.FastembedSparseDocumentEmbedder",  #  noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": None,
                 "threads": None,
                 "batch_size": 32,
@@ -125,7 +125,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
             },
         }
         embedder = default_from_dict(FastembedSparseDocumentEmbedder, embedder_dict)
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir is None
         assert embedder.threads is None
         assert embedder.batch_size == 32
@@ -143,7 +143,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         embedder_dict = {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_document_embedder.FastembedSparseDocumentEmbedder",  #  noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": "fake_dir",
                 "threads": 2,
                 "batch_size": 64,
@@ -155,7 +155,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
             },
         }
         embedder = default_from_dict(FastembedSparseDocumentEmbedder, embedder_dict)
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir == "fake_dir"
         assert embedder.threads == 2
         assert embedder.batch_size == 64
@@ -172,11 +172,11 @@ class TestFastembedSparseDocumentEmbedderDoc:
         """
         Test for checking embedder instances after warm-up.
         """
-        embedder = FastembedSparseDocumentEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseDocumentEmbedder(model="prithivida/Splade_PP_en_v1")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="prithvida/Splade_PP_en_v1",
+            model_name="prithivida/Splade_PP_en_v1",
             cache_dir=None,
             threads=None,
             local_files_only=False,
@@ -190,7 +190,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         """
         Test for checking backend instances after multiple warm-ups.
         """
-        embedder = FastembedSparseDocumentEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseDocumentEmbedder(model="prithivida/Splade_PP_en_v1")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         embedder.warm_up()
@@ -211,7 +211,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         """
         Test for checking output dimensions and embedding dimensions.
         """
-        embedder = FastembedSparseDocumentEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseDocumentEmbedder(model="prithivida/Splade_PP_en_v1")
         embedder.embedding_backend = MagicMock()
         embedder.embedding_backend.embed = lambda x, **kwargs: self._generate_mocked_sparse_embedding(  # noqa: ARG005
             len(x)
@@ -235,7 +235,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
         """
         Test for checking incorrect input format when creating embedding.
         """
-        embedder = FastembedSparseDocumentEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseDocumentEmbedder(model="prithivida/Splade_PP_en_v1")
 
         string_input = "text"
         list_integers_input = [1, 2, 3]
@@ -330,7 +330,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
     @pytest.mark.integration
     def test_run(self):
         embedder = FastembedSparseDocumentEmbedder(
-            model="prithvida/Splade_PP_en_v1",
+            model="prithivida/Splade_PP_en_v1",
         )
         embedder.warm_up()
 

--- a/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_text_embedder.py
@@ -15,8 +15,8 @@ class TestFastembedSparseTextEmbedder:
         """
         Test default initialization parameters for FastembedSparseTextEmbedder.
         """
-        embedder = FastembedSparseTextEmbedder(model="prithvida/Splade_PP_en_v1")
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        embedder = FastembedSparseTextEmbedder(model="prithivida/Splade_PP_en_v1")
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir is None
         assert embedder.threads is None
         assert embedder.progress_bar is True
@@ -27,13 +27,13 @@ class TestFastembedSparseTextEmbedder:
         Test custom initialization parameters for FastembedSparseTextEmbedder.
         """
         embedder = FastembedSparseTextEmbedder(
-            model="prithvida/Splade_PP_en_v1",
+            model="prithivida/Splade_PP_en_v1",
             cache_dir="fake_dir",
             threads=2,
             progress_bar=False,
             parallel=1,
         )
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir == "fake_dir"
         assert embedder.threads == 2
         assert embedder.progress_bar is False
@@ -43,12 +43,12 @@ class TestFastembedSparseTextEmbedder:
         """
         Test serialization of FastembedSparseTextEmbedder to a dictionary, using default initialization parameters.
         """
-        embedder = FastembedSparseTextEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseTextEmbedder(model="prithivida/Splade_PP_en_v1")
         embedder_dict = embedder.to_dict()
         assert embedder_dict == {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_text_embedder.FastembedSparseTextEmbedder",  # noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": None,
                 "threads": None,
                 "progress_bar": True,
@@ -63,7 +63,7 @@ class TestFastembedSparseTextEmbedder:
         Test serialization of FastembedSparseTextEmbedder to a dictionary, using custom initialization parameters.
         """
         embedder = FastembedSparseTextEmbedder(
-            model="prithvida/Splade_PP_en_v1",
+            model="prithivida/Splade_PP_en_v1",
             cache_dir="fake_dir",
             threads=2,
             progress_bar=False,
@@ -74,7 +74,7 @@ class TestFastembedSparseTextEmbedder:
         assert embedder_dict == {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_text_embedder.FastembedSparseTextEmbedder",  # noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": "fake_dir",
                 "threads": 2,
                 "progress_bar": False,
@@ -91,7 +91,7 @@ class TestFastembedSparseTextEmbedder:
         embedder_dict = {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_text_embedder.FastembedSparseTextEmbedder",  # noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": None,
                 "threads": None,
                 "progress_bar": True,
@@ -99,7 +99,7 @@ class TestFastembedSparseTextEmbedder:
             },
         }
         embedder = default_from_dict(FastembedSparseTextEmbedder, embedder_dict)
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir is None
         assert embedder.threads is None
         assert embedder.progress_bar is True
@@ -112,7 +112,7 @@ class TestFastembedSparseTextEmbedder:
         embedder_dict = {
             "type": "haystack_integrations.components.embedders.fastembed.fastembed_sparse_text_embedder.FastembedSparseTextEmbedder",  # noqa
             "init_parameters": {
-                "model": "prithvida/Splade_PP_en_v1",
+                "model": "prithivida/Splade_PP_en_v1",
                 "cache_dir": "fake_dir",
                 "threads": 2,
                 "progress_bar": False,
@@ -120,7 +120,7 @@ class TestFastembedSparseTextEmbedder:
             },
         }
         embedder = default_from_dict(FastembedSparseTextEmbedder, embedder_dict)
-        assert embedder.model_name == "prithvida/Splade_PP_en_v1"
+        assert embedder.model_name == "prithivida/Splade_PP_en_v1"
         assert embedder.cache_dir == "fake_dir"
         assert embedder.threads == 2
         assert embedder.progress_bar is False
@@ -133,11 +133,11 @@ class TestFastembedSparseTextEmbedder:
         """
         Test for checking embedder instances after warm-up.
         """
-        embedder = FastembedSparseTextEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseTextEmbedder(model="prithivida/Splade_PP_en_v1")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name="prithvida/Splade_PP_en_v1",
+            model_name="prithivida/Splade_PP_en_v1",
             cache_dir=None,
             threads=None,
             local_files_only=False,
@@ -151,7 +151,7 @@ class TestFastembedSparseTextEmbedder:
         """
         Test for checking backend instances after multiple warm-ups.
         """
-        embedder = FastembedSparseTextEmbedder(model="prithvida/Splade_PP_en_v1")
+        embedder = FastembedSparseTextEmbedder(model="prithivida/Splade_PP_en_v1")
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         embedder.warm_up()
@@ -252,7 +252,7 @@ class TestFastembedSparseTextEmbedder:
     @pytest.mark.integration
     def test_run(self):
         embedder = FastembedSparseTextEmbedder(
-            model="prithvida/Splade_PP_en_v1",
+            model="prithivida/Splade_PP_en_v1",
         )
         embedder.warm_up()
 


### PR DESCRIPTION
The name of the model prithvida/Splade_PP_en_v1 has a typo and is being replaced by prithivida/Splade_PP_en_v1? There's a Deprecation warning about it.
I changed it everywhere in the class & the tests

### How did you test it?

Unit tests

### Notes for the reviewer

This is changing the behavior if users have not set the model name when creating a FastembedSparseDocumentEmbedder() or FastembedSparseTextEmbedder() as it is the default model in our implementation.

The code in the init on the fastembed side has this code (https://github.com/qdrant/fastembed/blob/main/fastembed/sparse/sparse_text_embedding.py#L58) that raises the deprecation and changes the model.
if model_name == "prithvida/Splade_PP_en_v1":
            warnings.warn(
                "The right spelling is prithivida/Splade_PP_en_v1. "
                "Support of this name will be removed soon, please fix the model_name",
                DeprecationWarning,
                stacklevel=2,
            )
            model_name = "prithivida/Splade_PP_en_v1"

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
