### PR TITLE
fix: AmazonBedrockChatGenerator with Claude raises moot warning for stream…

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/adapters.py
@@ -212,6 +212,8 @@ class AnthropicClaudeChatAdapter(BedrockModelChatAdapter):
         stop_sequences = inference_kwargs.get("stop_sequences", []) + inference_kwargs.pop("stop_words", [])
         if stop_sequences:
             inference_kwargs["stop_sequences"] = stop_sequences
+        # pop stream kwarg from inference_kwargs as Anthropic does not support it (if provided)
+        inference_kwargs.pop("stream", None)
         params = self._get_params(inference_kwargs, default_params, self.ALLOWED_PARAMS)
         body = {**self.prepare_chat_messages(messages=messages), **params}
         return body


### PR DESCRIPTION
This pull request includes a minor update to the `prepare_body` method in the `amazon_bedrock` integration. The change ensures compatibility with Anthropic by removing the unsupported `stream` keyword argument from `inference_kwargs`.

We need to leave "stream" kwarg as some other models like [Cohere](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command.html) and other LLM foundations models are able to tolerate its presence.  We'll completely rewrite entire AmazonBedrockChatGenerator codebase to use [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html) anyway. 