### PR TITLE
fix: Fix tag name for version release

### DIFF
--- a/integrations/azure_ai_search/pyproject.toml
+++ b/integrations/azure_ai_search/pyproject.toml
@@ -33,11 +33,11 @@ packages = ["src/haystack_integrations"]
 
 [tool.hatch.version]
 source = "vcs"
-tag-pattern = 'integrations\/azure-ai-search-v(?P<version>.*)'
+tag-pattern = 'integrations\/azure_ai_search-v(?P<version>.*)'
 
 [tool.hatch.version.raw-options]
 root = "../.."
-git_describe_command = 'git describe --tags --match="integrations/azure-ai-search-v[0-9]*"'
+git_describe_command = 'git describe --tags --match="integrations/azure_ai_search-v[0-9]*"'
 
 [tool.hatch.envs.default]
 dependencies = [


### PR DESCRIPTION
### Related Issues

- fixes: a failing job likely caused due to mismatch of tag name for release
https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11952076315/job/33317043747

### Proposed Changes:

Fix the tag name in `pyproject.toml` file.

### How did you test it?

NA
### Notes for the reviewer

NA
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
