### PR TITLE
fix: adapt to Ollama client 0.4.0

### DIFF
--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "ollama"]
+dependencies = ["haystack-ai", "ollama>=0.4.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ollama#readme"

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -63,7 +62,7 @@ cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 
 [tool.hatch.envs.lint]

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/__init__.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/__init__.py
@@ -1,4 +1,4 @@
 from .document_embedder import OllamaDocumentEmbedder
 from .text_embedder import OllamaTextEmbedder
 
-__all__ = ["OllamaTextEmbedder", "OllamaDocumentEmbedder"]
+__all__ = ["OllamaDocumentEmbedder", "OllamaTextEmbedder"]

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
@@ -100,7 +100,7 @@ class OllamaDocumentEmbedder:
             range(0, len(texts_to_embed), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
         ):
             batch = texts_to_embed[i]  # Single batch only
-            result = self._client.embeddings(model=self.model, prompt=batch, options=generation_kwargs)
+            result = self._client.embeddings(model=self.model, prompt=batch, options=generation_kwargs).model_dump()
             all_embeddings.append(result["embedding"])
 
         meta["model"] = self.model

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
@@ -122,7 +122,7 @@ class OllamaDocumentEmbedder:
             - `documents`: Documents with embedding information attached
             - `meta`: The metadata collected during the embedding process
         """
-        if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
+        if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = (
                 "OllamaDocumentEmbedder expects a list of Documents as input."
                 "In case you want to embed a list of strings, please use the OllamaTextEmbedder."

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
@@ -62,7 +62,7 @@ class OllamaTextEmbedder:
             - `embedding`: The computed embeddings
             - `meta`: The metadata collected during the embedding process
         """
-        result = self._client.embeddings(model=self.model, prompt=text, options=generation_kwargs)
+        result = self._client.embeddings(model=self.model, prompt=text, options=generation_kwargs).model_dump()
         result["meta"] = {"model": self.model}
 
         return result

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/__init__.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/__init__.py
@@ -1,4 +1,4 @@
 from .chat.chat_generator import OllamaChatGenerator
 from .generator import OllamaGenerator
 
-__all__ = ["OllamaGenerator", "OllamaChatGenerator"]
+__all__ = ["OllamaChatGenerator", "OllamaGenerator"]

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, ChatRole
-from ollama._types import ResponseError
+from ollama._types import ChatResponse, ResponseError
 
 from haystack_integrations.components.generators.ollama import OllamaChatGenerator
 
@@ -86,18 +86,18 @@ class TestOllamaChatGenerator:
     def test_build_message_from_ollama_response(self):
         model = "some_model"
 
-        ollama_response = {
-            "model": model,
-            "created_at": "2023-12-12T14:13:43.416799Z",
-            "message": {"role": "assistant", "content": "Hello! How are you today?"},
-            "done": True,
-            "total_duration": 5191566416,
-            "load_duration": 2154458,
-            "prompt_eval_count": 26,
-            "prompt_eval_duration": 383809000,
-            "eval_count": 298,
-            "eval_duration": 4799921000,
-        }
+        ollama_response = ChatResponse(
+            model=model,
+            created_at="2023-12-12T14:13:43.416799Z",
+            message={"role": "assistant", "content": "Hello! How are you today?"},
+            done=True,
+            total_duration=5191566416,
+            load_duration=2154458,
+            prompt_eval_count=26,
+            prompt_eval_duration=383809000,
+            eval_count=298,
+            eval_duration=4799921000,
+        )
 
         observed = OllamaChatGenerator(model=model)._build_message_from_ollama_response(ollama_response)
 


### PR DESCRIPTION
### Related Issues

- tests are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/11963832597/job/33355031427
- yesterday, a new version of the Ollama python client was released: they introduce pydantic and this breaks some of our assumptions to use python dictionaries
- See https://github.com/ollama/ollama-python/releases/tag/v0.4.0; https://github.com/ollama/ollama-python/pull/276

### Proposed Changes:
- update our code to make it work with `ollama>=0.4.0`
- pin `ollama>=0.4.0`

### How did you test it?
CI, manual tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
