### PR TITLE
fix: Astra - fix embedding retrieval top-k limit

### DIFF
--- a/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
@@ -202,7 +202,7 @@ class AstraClient:
         return QueryResponse(final_res)
 
     def _query(self, vector, top_k, filters=None):
-        query = {"sort": {"$vector": vector}, "options": {"limit": top_k, "includeSimilarity": True}}
+        query = {"sort": {"$vector": vector}, "limit": top_k, "includeSimilarity": True}
 
         if filters is not None:
             query["filter"] = filters
@@ -222,6 +222,7 @@ class AstraClient:
             filter=find_query.get("filter"),
             sort=find_query.get("sort"),
             limit=find_query.get("limit"),
+            include_similarity=find_query.get("includeSimilarity"),
             projection={"*": 1},
         )
 

--- a/integrations/astra/tests/test_embedding_retrieval.py
+++ b/integrations/astra/tests/test_embedding_retrieval.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+from haystack import Document
+from haystack.document_stores.types import DuplicatePolicy
+
+from haystack_integrations.document_stores.astra import AstraDocumentStore
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.environ.get("ASTRA_DB_APPLICATION_TOKEN", "") == "", reason="ASTRA_DB_APPLICATION_TOKEN env var not set"
+)
+@pytest.mark.skipif(os.environ.get("ASTRA_DB_API_ENDPOINT", "") == "", reason="ASTRA_DB_API_ENDPOINT env var not set")
+class TestEmbeddingRetrieval:
+
+    @pytest.fixture
+    def document_store(self) -> AstraDocumentStore:
+        return AstraDocumentStore(
+            collection_name="haystack_integration",
+            duplicates_policy=DuplicatePolicy.OVERWRITE,
+            embedding_dimension=768,
+        )
+
+    @pytest.fixture(autouse=True)
+    def run_before_and_after_tests(self, document_store: AstraDocumentStore):
+        """
+        Cleaning up document store
+        """
+        document_store.delete_documents(delete_all=True)
+        assert document_store.count_documents() == 0
+
+    def test_search_with_top_k(self, document_store):
+        query_embedding = [0.1] * 768
+        common_embedding = [0.8] * 768
+
+        documents = [Document(content=f"This is document number {i}", embedding=common_embedding) for i in range(0, 3)]
+
+        document_store.write_documents(documents)
+
+        top_k = 2
+
+        result = document_store.search(query_embedding, top_k)
+
+        assert top_k == len(result)
+
+        for document in result:
+            assert document.score is not None


### PR DESCRIPTION
### Related Issues

- fixes #1204

### Proposed Changes:

 - After upgrading the astrapy lib [#1145](https://github.com/deepset-ai/haystack-core-integrations/pull/1145) there is a bug that don't limit the number of results when using an embedding search. As a result of this, many more expected documents are retrieved.

### How did you test it?

- Integration test.

### Notes for the reviewer

- Add `test_embedding_retrieval.py` following the same pattern as in other store integrations.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
