### PR TITLE
chore: improve README release section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,8 @@ GitHub. The GitHub Actions workflow will take care of the rest.
     git push --tags origin
     ```
 3. Wait for the CI to do its magic
+
+> [!IMPORTANT]  
+> When releasing a new integration version, always tag a commit that includes the changes for that integration 
+> (usually the PR merge commit). If you tag a commit that doesn’t include changes for the integration being released, 
+> the generated changelog will be incorrect.

--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ GitHub. The GitHub Actions workflow will take care of the rest.
 
 > [!IMPORTANT]  
 > When releasing a new integration version, always tag a commit that includes the changes for that integration 
-> (usually the PR merge commit). If you tag a commit that doesn’t include changes for the integration being released, 
+> (usually the PR merge commit). If you tag a commit that doesn't include changes for the integration being released, 
 > the generated changelog will be incorrect.


### PR DESCRIPTION
### Proposed Changes:
I think this information should be present here.

This should help maintainers not forget to tag the right commit.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
