### PR TITLE
feat: add `create_extension` parameter to control vector extension creation

### DIFF
--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     services:
       pgvector:
-        image: ankane/pgvector:latest
+        image: pgvector/pgvector:pg17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -90,6 +90,7 @@ class PgvectorDocumentStore:
         hnsw_index_name: str = "haystack_hnsw_index",
         hnsw_ef_search: Optional[int] = None,
         keyword_index_name: str = "haystack_keyword_index",
+        create_extension: bool = True,
     ):
         """
         Creates a new PgvectorDocumentStore instance.
@@ -135,6 +136,7 @@ class PgvectorDocumentStore:
             `"hnsw"`. You can find more information about this parameter in the
             [pgvector documentation](https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw).
         :param keyword_index_name: Index name for the Keyword index.
+        :param create_extension: create pgvector extension if it doesn't exist.'
         """
 
         self.connection_string = connection_string
@@ -153,6 +155,7 @@ class PgvectorDocumentStore:
         self.hnsw_ef_search = hnsw_ef_search
         self.keyword_index_name = keyword_index_name
         self.language = language
+        self.create_extension = create_extension
         self._connection = None
         self._cursor = None
         self._dict_cursor = None
@@ -194,7 +197,8 @@ class PgvectorDocumentStore:
         conn_str = self.connection_string.resolve_value() or ""
         connection = connect(conn_str)
         connection.autocommit = True
-        connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        if self.create_extension:
+            connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
         register_vector(connection)  # Note: this must be called before creating the cursors.
 
         self._connection = connection

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -66,6 +66,7 @@ def test_init(monkeypatch):
     monkeypatch.setenv("PG_CONN_STR", "some_connection_string")
 
     document_store = PgvectorDocumentStore(
+        create_extension=True,
         schema_name="my_schema",
         table_name="my_table",
         embedding_dimension=512,
@@ -79,6 +80,7 @@ def test_init(monkeypatch):
         keyword_index_name="my_keyword_index",
     )
 
+    assert document_store.create_extension
     assert document_store.schema_name == "my_schema"
     assert document_store.table_name == "my_table"
     assert document_store.embedding_dimension == 512
@@ -97,6 +99,7 @@ def test_to_dict(monkeypatch):
     monkeypatch.setenv("PG_CONN_STR", "some_connection_string")
 
     document_store = PgvectorDocumentStore(
+        create_extension=False,
         table_name="my_table",
         embedding_dimension=512,
         vector_function="l2_distance",
@@ -113,6 +116,7 @@ def test_to_dict(monkeypatch):
         "type": "haystack_integrations.document_stores.pgvector.document_store.PgvectorDocumentStore",
         "init_parameters": {
             "connection_string": {"env_vars": ["PG_CONN_STR"], "strict": True, "type": "env_var"},
+            "create_extension": False,
             "table_name": "my_table",
             "schema_name": "public",
             "embedding_dimension": 512,

--- a/integrations/pgvector/tests/test_retrievers.py
+++ b/integrations/pgvector/tests/test_retrievers.py
@@ -50,6 +50,7 @@ class TestEmbeddingRetriever:
                     "type": "haystack_integrations.document_stores.pgvector.document_store.PgvectorDocumentStore",
                     "init_parameters": {
                         "connection_string": {"env_vars": ["PG_CONN_STR"], "strict": True, "type": "env_var"},
+                        "create_extension": True,
                         "schema_name": "public",
                         "table_name": "haystack",
                         "embedding_dimension": 768,
@@ -82,6 +83,7 @@ class TestEmbeddingRetriever:
                     "type": "haystack_integrations.document_stores.pgvector.document_store.PgvectorDocumentStore",
                     "init_parameters": {
                         "connection_string": {"env_vars": ["PG_CONN_STR"], "strict": True, "type": "env_var"},
+                        "create_extension": False,
                         "table_name": "haystack_test_to_dict",
                         "embedding_dimension": 768,
                         "vector_function": "cosine_similarity",
@@ -106,6 +108,7 @@ class TestEmbeddingRetriever:
 
         assert isinstance(document_store, PgvectorDocumentStore)
         assert isinstance(document_store.connection_string, EnvVarSecret)
+        assert not document_store.create_extension
         assert document_store.table_name == "haystack_test_to_dict"
         assert document_store.embedding_dimension == 768
         assert document_store.vector_function == "cosine_similarity"
@@ -176,6 +179,7 @@ class TestKeywordRetriever:
                     "type": "haystack_integrations.document_stores.pgvector.document_store.PgvectorDocumentStore",
                     "init_parameters": {
                         "connection_string": {"env_vars": ["PG_CONN_STR"], "strict": True, "type": "env_var"},
+                        "create_extension": True,
                         "schema_name": "public",
                         "table_name": "haystack",
                         "embedding_dimension": 768,
@@ -207,6 +211,7 @@ class TestKeywordRetriever:
                     "type": "haystack_integrations.document_stores.pgvector.document_store.PgvectorDocumentStore",
                     "init_parameters": {
                         "connection_string": {"env_vars": ["PG_CONN_STR"], "strict": True, "type": "env_var"},
+                        "create_extension": False,
                         "table_name": "haystack_test_to_dict",
                         "embedding_dimension": 768,
                         "vector_function": "cosine_similarity",
@@ -230,6 +235,7 @@ class TestKeywordRetriever:
 
         assert isinstance(document_store, PgvectorDocumentStore)
         assert isinstance(document_store.connection_string, EnvVarSecret)
+        assert not document_store.create_extension
         assert document_store.table_name == "haystack_test_to_dict"
         assert document_store.embedding_dimension == 768
         assert document_store.vector_function == "cosine_similarity"


### PR DESCRIPTION
Related Issues
Normal Postgresql User failed to connect PG host, because missing the admin role.
Create Extension need HIGH Permission in many cloud environment, like Azure https://learn.microsoft.com/en-us/azure/postgresql/extensions/how-to-allow-extensions?tabs=portal#create-extension

Proposed Changes:
Recommend to remove to check extension if exists pgvector in every connection.

Operational Level like DBA can create Vector extension once
Developer can connect it without considering this precondition.
How did you test it?
manual tests

Notes for the reviewer
Checklist
I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
I have updated the related issue with new insights and changes
I added unit tests and updated the docstrings
I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: fix:, feat:, build:, chore:, ci:, docs:, style:, refactor:, perf:, test:.