### PR TITLE
fix: `JinaReaderConnector` - fix the name of the output edge

### DIFF
--- a/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
+++ b/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
@@ -103,7 +103,7 @@ class JinaReaderConnector:
         document = Document(content=content, meta=data)
         return document
 
-    @component.output_types(document=List[Document])
+    @component.output_types(documents=List[Document])
     def run(self, query: str, headers: Optional[Dict[str, str]] = None):
         """
         Process the query/URL using the Jina AI reader service.


### PR DESCRIPTION
### Related Issues
In the `JinaReaderConnector`, the name of the output edge has been incorrectly set to `document` instead of `documents`.
This is wrong and not consistent with the name of the key in the returned dictionary (`documents`).

### Proposed Changes:
Rename the output edge to `documents`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
