### PR TITLE
chore: Chroma - pin `tokenizers`

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -45,7 +45,6 @@ root = "../.."
 git_describe_command = 'git describe --tags --match="integrations/chroma-v[0-9]*"'
 
 [tool.hatch.envs.default]
-python = "3.8"
 installer = "uv"
 dependencies = [
   "coverage[toml]>=6.5",

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai",
+dependencies = [
+  "haystack-ai",
   "chromadb>=0.5.17",
   "typing_extensions>=4.8.0",
   "tokenizers>=0.13.2,<=0.20.3"  # TODO: remove when Chroma pins tokenizers internally

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -22,7 +22,11 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "chromadb>=0.5.17", "typing_extensions>=4.8.0", "tokenizers"]
+dependencies = ["haystack-ai",
+  "chromadb>=0.5.17",
+  "typing_extensions>=4.8.0",
+  "tokenizers>=0.13.2,<=0.20.3"  # TODO: remove when Chroma pins tokenizers internally
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma#readme"
@@ -41,6 +45,7 @@ root = "../.."
 git_describe_command = 'git describe --tags --match="integrations/chroma-v[0-9]*"'
 
 [tool.hatch.envs.default]
+python = "3.8"
 installer = "uv"
 dependencies = [
   "coverage[toml]>=6.5",

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "chromadb>=0.5.17", "typing_extensions>=4.8.0"]
+dependencies = ["haystack-ai", "chromadb>=0.5.17", "typing_extensions>=4.8.0", "tokenizers"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma#readme"


### PR DESCRIPTION
### Related Issues

- Chroma tests on python 3.8 are failing due to missing `tokenizers`: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12060032349/job/33629714424
- this happens because the latest version of `tokenizers` does not have binaries for python 3.8 (see https://github.com/chroma-core/chroma/pull/3202)


### Proposed Changes:

- pin `tokenizers`, as they do in https://github.com/chroma-core/chroma/pull/3211

### How did you test it?
CI

### Notes for the reviewer
- the pin will be removed as soon as Chroma releases a new version where they adopt the pin themselves
- (in general, we should think about when to discontinue python 3.8 compatibility)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
