### PR TITLE
feat: warn if LangfuseTracer initialized without tracing enabled

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 from haystack import logging
 from haystack.components.generators.openai_utils import _convert_message_to_openai_format
 from haystack.dataclasses import ChatMessage
-from haystack.tracing import Span, Tracer, tracer
+from haystack.tracing import Span, Tracer
+from haystack.tracing import tracer as proxy_tracer
 from haystack.tracing import utils as tracing_utils
 
 import langfuse
@@ -78,7 +79,7 @@ class LangfuseSpan(Span):
         :param key: The content tag key.
         :param value: The content tag value.
         """
-        if not tracer.is_content_tracing_enabled:
+        if not proxy_tracer.is_content_tracing_enabled:
             return
         if key.endswith(".input"):
             if "messages" in value:
@@ -126,6 +127,12 @@ class LangfuseTracer(Tracer):
         be publicly accessible to anyone with the tracing URL. If set to `False`, the tracing data will be private
         and only accessible to the Langfuse account owner.
         """
+        if not proxy_tracer.is_content_tracing_enabled:
+            logger.warning(
+                "Traces will not be logged to Langfuse because Haystack tracing is disabled. "
+                "To enable, set the HAYSTACK_CONTENT_TRACING_ENABLED environment variable to true "
+                "before importing Haystack."
+            )
         self._tracer = tracer
         self._context: List[LangfuseSpan] = []
         self._name = name


### PR DESCRIPTION
### Related Issues

- fixes #1230 

### Proposed Changes:

Add a warning during `LangfuseTracer` initialization in case tracing is disabled.

### How did you test it?

Tested locally by running the tracer with `LangufuseConnector` in the following cases:
- importing `haystack.Pipeline` before setting `HAYSTACK_CONTENT_TRACING_ENABLED` (warning raised)
- importing `haystack.Pipeline` after setting `HAYSTACK_CONTENT_TRACING_ENABLED` (no warning)

### Notes for the reviewer
I have not added unit tests because it requires to clear haystack modules and re-import it while having the appropriate HAYSTACK_CONTENT_TRACING_ENABLED env variable set. I though about adding it by removing haystack imports via sys.modules, and re-importing having HAYSTACK_CONTENT_TRACING_ENABLED=false for raising the warning, but apparently by doing so other tests fails, I think I would have to re-import the module while having HAYSTACK_CONTENT_TRACING_ENABLED=true. Let me know if adding a test for it is necessary. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
