### PR TITLE
chore: Chroma - unpin `tokenizers`

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -25,9 +25,8 @@ classifiers = [
 dependencies = [
   "haystack-ai",
   "chromadb>=0.5.17",
-  "typing_extensions>=4.8.0",
-  "tokenizers>=0.13.2,<=0.20.3"  # TODO: remove when Chroma pins tokenizers internally
-]
+  "typing_extensions>=4.8.0"
+  ]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma#readme"


### PR DESCRIPTION
### Related Issues

- fixes #1225

### Proposed Changes:
Now that Chroma internally pin the `tokenizers` library, remove our pin

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
