### PR TITLE
chore: use `text` instead of `content` for `ChatMessage` in Cohere and Anthropic

### DIFF
--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -188,9 +188,9 @@ class TestAnthropicChatGenerator:
 
         first_reply = replies[0]
         assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.content, "First reply has no content"
+        assert first_reply.text, "First reply has no text"
         assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "paris" in first_reply.content.lower(), "First reply does not contain 'paris'"
+        assert "paris" in first_reply.text.lower(), "First reply does not contain 'paris'"
         assert first_reply.meta, "First reply has no metadata"
 
     @pytest.mark.skipif(
@@ -221,9 +221,9 @@ class TestAnthropicChatGenerator:
 
         first_reply = replies[0]
         assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.content, "First reply has no content"
+        assert first_reply.text, "First reply has no text"
         assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "paris" in first_reply.content.lower(), "First reply does not contain 'paris'"
+        assert "paris" in first_reply.text.lower(), "First reply does not contain 'paris'"
         assert first_reply.meta, "First reply has no metadata"
 
     @pytest.mark.skipif(
@@ -255,11 +255,11 @@ class TestAnthropicChatGenerator:
 
         first_reply = replies[0]
         assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.content, "First reply has no content"
+        assert first_reply.text, "First reply has no text"
         assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "get_stock_price" in first_reply.content.lower(), "First reply does not contain get_stock_price"
+        assert "get_stock_price" in first_reply.text.lower(), "First reply does not contain get_stock_price"
         assert first_reply.meta, "First reply has no metadata"
-        fc_response = json.loads(first_reply.content)
+        fc_response = json.loads(first_reply.text)
         assert "name" in fc_response, "First reply does not contain name of the tool"
         assert "input" in fc_response, "First reply does not contain input of the tool"
 

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -188,9 +188,9 @@ class TestAnthropicVertexChatGenerator:
 
         first_reply = replies[0]
         assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.content, "First reply has no content"
+        assert first_reply.text, "First reply has no text"
         assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "paris" in first_reply.content.lower(), "First reply does not contain 'paris'"
+        assert "paris" in first_reply.text.lower(), "First reply does not contain 'paris'"
         assert first_reply.meta, "First reply has no metadata"
 
     # Anthropic messages API is similar for AnthropicVertex and Anthropic endpoint,

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -136,7 +136,7 @@ class CohereChatGenerator:
 
     def _message_to_dict(self, message: ChatMessage) -> Dict[str, str]:
         role = "User" if message.role == ChatRole.USER else "Chatbot"
-        chat_message = {"user_name": role, "text": message.content}
+        chat_message = {"user_name": role, "text": message.text}
         return chat_message
 
     @component.output_types(replies=List[ChatMessage])
@@ -157,7 +157,7 @@ class CohereChatGenerator:
         chat_history = [self._message_to_dict(m) for m in messages[:-1]]
         if self.streaming_callback:
             response = self.client.chat_stream(
-                message=messages[-1].content,
+                message=messages[-1].text,
                 model=self.model,
                 chat_history=chat_history,
                 **generation_kwargs,
@@ -190,7 +190,7 @@ class CohereChatGenerator:
                 )
         else:
             response = self.client.chat(
-                message=messages[-1].content,
+                message=messages[-1].text,
                 model=self.model,
                 chat_history=chat_history,
                 **generation_kwargs,

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -67,4 +67,4 @@ class CohereGenerator(CohereChatGenerator):
         chat_message = ChatMessage.from_user(prompt)
         # Note we have to call super() like this because of the way components are dynamically built with the decorator
         results = super(CohereGenerator, self).run([chat_message])  # noqa
-        return {"replies": [results["replies"][0].content], "meta": [results["replies"][0].meta]}
+        return {"replies": [results["replies"][0].text], "meta": [results["replies"][0].meta]}

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -169,7 +169,7 @@ class TestCohereChatGenerator:
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.content
+        assert "Paris" in message.text
         assert "usage" in message.meta
         assert "prompt_tokens" in message.meta["usage"]
         assert "completion_tokens" in message.meta["usage"]
@@ -205,7 +205,7 @@ class TestCohereChatGenerator:
 
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.content
+        assert "Paris" in message.text
 
         assert message.meta["finish_reason"] == "COMPLETE"
 
@@ -227,7 +227,7 @@ class TestCohereChatGenerator:
         results = component.run(chat_messages, generation_kwargs={"connectors": [{"id": "web-search"}]})
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.content
+        assert "Paris" in message.text
         assert message.meta["documents"] is not None
         assert "citations" in message.meta  # Citations might be None
 
@@ -253,7 +253,7 @@ class TestCohereChatGenerator:
 
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.content
+        assert "Paris" in message.text
 
         assert message.meta["finish_reason"] == "COMPLETE"
 
@@ -291,10 +291,10 @@ class TestCohereChatGenerator:
 
         first_reply = replies[0]
         assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.content, "First reply has no content"
+        assert first_reply.text, "First reply has no text"
         assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "get_stock_price" in first_reply.content.lower(), "First reply does not contain get_stock_price"
+        assert "get_stock_price" in first_reply.text.lower(), "First reply does not contain get_stock_price"
         assert first_reply.meta, "First reply has no metadata"
-        fc_response = json.loads(first_reply.content)
+        fc_response = json.loads(first_reply.text)
         assert "name" in fc_response, "First reply does not contain name of the tool"
         assert "parameters" in fc_response, "First reply does not contain parameters of the tool"


### PR DESCRIPTION
### Related Issues

- part of #1236

### Proposed Changes:
- use `text` instead of `content` for `ChatMessage` in Cohere and Anthropic
- I did the changes in a single PR because for Anthropic we are only changing tests, so we don't need a release

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
