### PR TITLE
chore: use `text` instead of `content` for `ChatMessage` in Ollama

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -109,7 +109,7 @@ class OllamaChatGenerator:
         return default_from_dict(cls, data)
 
     def _message_to_dict(self, message: ChatMessage) -> Dict[str, str]:
-        return {"role": message.role.value, "content": message.content}
+        return {"role": message.role.value, "content": message.text}
 
     def _build_message_from_ollama_response(self, ollama_response: ChatResponse) -> ChatMessage:
         """

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -102,7 +102,7 @@ class TestOllamaChatGenerator:
         observed = OllamaChatGenerator(model=model)._build_message_from_ollama_response(ollama_response)
 
         assert observed.role == "assistant"
-        assert observed.content == "Hello! How are you today?"
+        assert observed.text == "Hello! How are you today?"
 
     @pytest.mark.integration
     def test_run(self):
@@ -121,7 +121,7 @@ class TestOllamaChatGenerator:
 
             assert isinstance(response, dict)
             assert isinstance(response["replies"], list)
-            assert answer in response["replies"][0].content
+            assert answer in response["replies"][0].text
 
     @pytest.mark.integration
     def test_run_with_chat_history(self):
@@ -137,7 +137,7 @@ class TestOllamaChatGenerator:
 
         assert isinstance(response, dict)
         assert isinstance(response["replies"], list)
-        assert "Manchester" in response["replies"][-1].content or "Glasgow" in response["replies"][-1].content
+        assert "Manchester" in response["replies"][-1].text or "Glasgow" in response["replies"][-1].text
 
     @pytest.mark.integration
     def test_run_model_unavailable(self):
@@ -166,4 +166,4 @@ class TestOllamaChatGenerator:
 
         assert isinstance(response, dict)
         assert isinstance(response["replies"], list)
-        assert "Manchester" in response["replies"][-1].content or "Glasgow" in response["replies"][-1].content
+        assert "Manchester" in response["replies"][-1].text or "Glasgow" in response["replies"][-1].text


### PR DESCRIPTION
### Related Issues

- part of #1236

### Proposed Changes:

- use `text` instead of `content` for `ChatMessage` in Ollama

- (this change won't last long. Ollama proper support for Tools and new messages has already been done in experimental)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
