### PR TITLE
fix: logger for index deletion failures in Azure AI

### DIFF
--- a/integrations/azure_ai_search/tests/conftest.py
+++ b/integrations/azure_ai_search/tests/conftest.py
@@ -11,9 +11,12 @@ from haystack.document_stores.types import DuplicatePolicy
 
 from haystack_integrations.document_stores.azure_ai_search import AzureAISearchDocumentStore
 
+logger = logging.getLogger(__name__)
+
+
 # This is the approximate time in seconds it takes for the documents to be available in Azure Search index
 SLEEP_TIME_IN_SECONDS = 10
-MAX_WAIT_TIME_FOR_INDEX_DELETION = 5
+MAX_WAIT_TIME_FOR_INDEX_DELETION = 10
 
 
 @pytest.fixture()
@@ -75,8 +78,8 @@ def document_store(request):
     try:
         client.delete_index(index_name)
         if not wait_for_index_deletion(client, index_name):
-            logging.error(f"Index {index_name} was not properly deleted.")
+            logger.error(f"Index {index_name} was not properly deleted.")
     except ResourceNotFoundError:
-        logging.info(f"Index {index_name} was already deleted or not found.")
+        logger.info(f"Index {index_name} was already deleted or not found.")
     except Exception as e:
-        logging.error(f"Unexpected error when deleting index {index_name}: {e}")
+        logger.error(f"Unexpected error when deleting index {index_name}: {e}")


### PR DESCRIPTION
### Related Issues

During nightly tests, some indexes are not being properly deleted, which eventually causes the allowed index quota to be exceeded.
### Proposed Changes:

- Increase the wait time for index deletion to ensure adequate time for the operation to complete.
- Fix the logger configuration for tests to capture errors correctly.
- The immediate goal is to verify if errors related to index deletion can be logged; the broader objective is to debug and understand the root cause of index deletion failures.

### How did you test it?

NA

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
