### PR TITLE
feat: support model_arn in AmazonBedrockGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -271,12 +271,17 @@ class AmazonBedrockGenerator:
         return {"replies": replies}
 
     @classmethod
-    def get_model_adapter(cls, model: str, model_family: Optional[str]) -> Type[BedrockModelAdapter]:
+    def get_model_adapter(cls, model: str, model_family: Optional[str] = None) -> Type[BedrockModelAdapter]:
         """
         Gets the model adapter for the given model.
 
+        If `model_family` is provided, the adapter for the model family is returned.
+        If `model_family` is not provided, the adapter is auto-detected based on the model name.
+
         :param model: The model name.
+        :param model_family: The model family.
         :returns: The model adapter class, or None if no adapter is found.
+        :raises AmazonBedrockConfigurationError: If the model family is not supported or the model cannot be auto-detected.
         """
         if model_family:
             if model_family not in cls.SUPPORTED_MODEL_FAMILIES:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -281,7 +281,8 @@ class AmazonBedrockGenerator:
         :param model: The model name.
         :param model_family: The model family.
         :returns: The model adapter class, or None if no adapter is found.
-        :raises AmazonBedrockConfigurationError: If the model family is not supported or the model cannot be auto-detected.
+        :raises AmazonBedrockConfigurationError: If the model family is not supported or the model cannot be
+            auto-detected.
         """
         if model_family:
             if model_family not in cls.SUPPORTED_MODEL_FAMILIES:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -126,7 +126,8 @@ class AmazonBedrockGenerator:
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param boto3_config: The configuration for the boto3 client.
-        :param model_family: The model family to use. If not provided, the model adapter is selected based on the model name.
+        :param model_family: The model family to use. If not provided, the model adapter is selected based on the model
+            name.
         :param kwargs: Additional keyword arguments to be passed to the model.
         These arguments are specific to the model. You can find them in the model's documentation.
         :raises ValueError: If the model name is empty or None.
@@ -147,6 +148,7 @@ class AmazonBedrockGenerator:
         self.streaming_callback = streaming_callback
         self.boto3_config = boto3_config
         self.kwargs = kwargs
+        self.model_family = model_family
 
         def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
             return secret.resolve_value() if secret else None
@@ -285,8 +287,11 @@ class AmazonBedrockGenerator:
         for pattern, adapter in cls.SUPPORTED_MODEL_PATTERNS.items():
             if re.fullmatch(pattern, model):
                 return adapter
-    
-        msg = f"Could not auto-detect model family of {model}. `model_family` parameter must be one of {get_args(cls.MODEL_FAMILIES)}."
+
+        msg = (
+            f"Could not auto-detect model family of {model}. "
+            f"`model_family` parameter must be one of {get_args(cls.MODEL_FAMILIES)}."
+        )
         raise AmazonBedrockConfigurationError(msg)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -309,6 +314,7 @@ class AmazonBedrockGenerator:
             truncate=self.truncate,
             streaming_callback=callback_name,
             boto3_config=self.boto3_config,
+            model_family=self.model_family,
             **self.kwargs,
         )
 

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -15,6 +15,7 @@ from haystack_integrations.components.generators.amazon_bedrock.adapters import 
     MetaLlamaAdapter,
     MistralAdapter,
 )
+from integrations.amazon_bedrock.src.haystack_integrations.common.amazon_bedrock.errors import AmazonBedrockConfigurationError
 
 
 @pytest.mark.parametrize(
@@ -294,15 +295,51 @@ def test_long_prompt_is_not_truncated_when_truncate_false(mock_boto3_session):
         ("eu.mistral.mixtral-8x7b-instruct-v0:1", MistralAdapter),  # cross-region inference
         ("us.mistral.mistral-large-2402-v1:0", MistralAdapter),  # cross-region inference
         ("mistral.mistral-medium-v8:0", MistralAdapter),  # artificial
-        ("unknown_model", None),
     ],
 )
 def test_get_model_adapter(model: str, expected_model_adapter: Optional[Type[BedrockModelAdapter]]):
     """
     Test that the correct model adapter is returned for a given model
     """
-    model_adapter = AmazonBedrockGenerator.get_model_adapter(model=model)
+    model_adapter = AmazonBedrockGenerator.get_model_adapter(model=model, model_family=None)
     assert model_adapter == expected_model_adapter
+
+
+@pytest.mark.parametrize(
+    "model_family, expected_model_adapter",
+    [
+        ("anthropic.claude", AnthropicClaudeAdapter),
+        ("cohere.command", CohereCommandAdapter),
+        ("cohere.command-r", CohereCommandRAdapter),
+        ("ai21.j2", AI21LabsJurassic2Adapter),
+        ("amazon.titan-text", AmazonTitanAdapter),
+        ("meta.llama", MetaLlamaAdapter),
+        ("mistral", MistralAdapter),
+    ],
+)
+def test_get_model_adapter_with_model_family(model_family: str, expected_model_adapter: Optional[Type[BedrockModelAdapter]]):
+    """
+    Test that the correct model adapter is returned for a given model
+    """
+    model_adapter = AmazonBedrockGenerator.get_model_adapter(model="arn:123435423", model_family=model_family)
+    assert model_adapter == expected_model_adapter
+
+
+def test_get_model_adapter_with_invalid_model_family():
+    """
+    Test that the correct model adapter is returned for a given model
+    """
+    with pytest.raises(AmazonBedrockConfigurationError):
+        AmazonBedrockGenerator.get_model_adapter(model="arn:123435423", model_family="invalid")
+
+
+def test_get_model_adapter_auto_detect_family_fails():
+    """
+    Test that the correct model adapter is returned for a given model
+    """
+    with pytest.raises(AmazonBedrockConfigurationError):
+        AmazonBedrockGenerator.get_model_adapter(model="arn:123435423", model_family=None)
+
 
 
 class TestAnthropicClaudeAdapter:

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -319,7 +319,7 @@ def test_get_model_adapter(model: str, expected_model_adapter: Optional[Type[Bed
 )
 def test_get_model_adapter_with_model_family(model_family: str, expected_model_adapter: Optional[Type[BedrockModelAdapter]]):
     """
-    Test that the correct model adapter is returned for a given model
+    Test that the correct model adapter is returned for a given model model_family
     """
     model_adapter = AmazonBedrockGenerator.get_model_adapter(model="arn:123435423", model_family=model_family)
     assert model_adapter == expected_model_adapter
@@ -327,7 +327,7 @@ def test_get_model_adapter_with_model_family(model_family: str, expected_model_a
 
 def test_get_model_adapter_with_invalid_model_family():
     """
-    Test that the correct model adapter is returned for a given model
+    Test that an error is raised when an invalid model_family is provided
     """
     with pytest.raises(AmazonBedrockConfigurationError):
         AmazonBedrockGenerator.get_model_adapter(model="arn:123435423", model_family="invalid")
@@ -335,11 +335,20 @@ def test_get_model_adapter_with_invalid_model_family():
 
 def test_get_model_adapter_auto_detect_family_fails():
     """
-    Test that the correct model adapter is returned for a given model
+    Test that an error is raised when auto-detection of model_family fails
     """
     with pytest.raises(AmazonBedrockConfigurationError):
         AmazonBedrockGenerator.get_model_adapter(model="arn:123435423", model_family=None)
 
+
+def test_get_model_adapter_model_family_over_auto_detection():
+    """
+    Test that the model_family is used over auto-detection
+    """
+    model_adapter = AmazonBedrockGenerator.get_model_adapter(
+        model="cohere.command-text-v14", model_family="anthropic.claude"
+    )
+    assert model_adapter == AnthropicClaudeAdapter
 
 
 class TestAnthropicClaudeAdapter:

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -306,7 +306,7 @@ def test_get_model_adapter(model: str, expected_model_adapter: Optional[Type[Bed
     """
     Test that the correct model adapter is returned for a given model
     """
-    model_adapter = AmazonBedrockGenerator.get_model_adapter(model=model, model_family=None)
+    model_adapter = AmazonBedrockGenerator.get_model_adapter(model=model)
     assert model_adapter == expected_model_adapter
 
 
@@ -345,7 +345,7 @@ def test_get_model_adapter_auto_detect_family_fails():
     Test that an error is raised when auto-detection of model_family fails
     """
     with pytest.raises(AmazonBedrockConfigurationError):
-        AmazonBedrockGenerator.get_model_adapter(model="arn:123435423", model_family=None)
+        AmazonBedrockGenerator.get_model_adapter(model="arn:123435423")
 
 
 def test_get_model_adapter_model_family_over_auto_detection():

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from haystack.dataclasses import StreamingChunk
 
+from haystack_integrations.common.amazon_bedrock.errors import (
+    AmazonBedrockConfigurationError,
+)
 from haystack_integrations.components.generators.amazon_bedrock import AmazonBedrockGenerator
 from haystack_integrations.components.generators.amazon_bedrock.adapters import (
     AI21LabsJurassic2Adapter,
@@ -15,7 +18,6 @@ from haystack_integrations.components.generators.amazon_bedrock.adapters import 
     MetaLlamaAdapter,
     MistralAdapter,
 )
-from integrations.amazon_bedrock.src.haystack_integrations.common.amazon_bedrock.errors import AmazonBedrockConfigurationError
 
 
 @pytest.mark.parametrize(
@@ -49,6 +51,7 @@ def test_to_dict(mock_boto3_session: Any, boto3_config: Optional[Dict[str, Any]]
             "temperature": 10,
             "streaming_callback": None,
             "boto3_config": boto3_config,
+            "model_family": None,
         },
     }
 
@@ -80,6 +83,7 @@ def test_from_dict(mock_boto3_session: Any, boto3_config: Optional[Dict[str, Any
                 "model": "anthropic.claude-v2",
                 "max_length": 99,
                 "boto3_config": boto3_config,
+                "model_family": "anthropic.claude",
             },
         }
     )
@@ -87,6 +91,7 @@ def test_from_dict(mock_boto3_session: Any, boto3_config: Optional[Dict[str, Any
     assert generator.max_length == 99
     assert generator.model == "anthropic.claude-v2"
     assert generator.boto3_config == boto3_config
+    assert generator.model_family == "anthropic.claude"
 
 
 def test_default_constructor(mock_boto3_session, set_env_variables):
@@ -317,7 +322,9 @@ def test_get_model_adapter(model: str, expected_model_adapter: Optional[Type[Bed
         ("mistral", MistralAdapter),
     ],
 )
-def test_get_model_adapter_with_model_family(model_family: str, expected_model_adapter: Optional[Type[BedrockModelAdapter]]):
+def test_get_model_adapter_with_model_family(
+    model_family: str, expected_model_adapter: Optional[Type[BedrockModelAdapter]]
+):
     """
     Test that the correct model adapter is returned for a given model model_family
     """


### PR DESCRIPTION
### Related Issues

- fixes support for model_arn as model_id

### Proposed Changes:
- `model_family` param which explicitly chooses model adapter if it can't be infered from model name

### How did you test it?
- added tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
