### PR TITLE
ci: make nightly tests actually run with Haystack main branch

### DIFF
--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/google_vertex.yml
+++ b/.github/workflows/google_vertex.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/google_vertex.yml
+++ b/.github/workflows/google_vertex.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
-          hatch run pip install git+https://github.com/deepset-ai/haystack.git
+          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
           hatch run cov-retry -m "not integration"
 
       - name: Send event to Datadog for nightly failures


### PR DESCRIPTION
### Related Issues
After the release of the new `ChatMessage` in https://github.com/deepset-ai/haystack/pull/8640, I was expecting several failures in the nightly tests with Haystack main.

Indeed, I encountered these failures locally by executing the following steps:

```shell
...
 cd "$dir"
hatch env prune
hatch run uv pip install git+https://github.com/deepset-ai/haystack.git
hatch run uv pip freeze
```

However the nightly CI tests did not fail... :thinking: 

Then I realized what's the difference:
https://github.com/deepset-ai/haystack-core-integrations/blob/3a3419a21bcc08da7cdf52d033c89656112dad98/.github/workflows/amazon_bedrock.yml#L84

We are not using uv there, so the tests don't run with Haystack main, but with the latest stable release.

### Proposed Changes:
- use uv to install Haystack main in the test environment

### How did you test it?
Local tests, CI

### Notes for the reviewer
Failing tests are unrelated to this PR

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
