### PR TITLE
fix: make Anthropic compatible with new `ChatMessage`; fix prompt caching tests

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -1,4 +1,3 @@
-import dataclasses
 import json
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 
@@ -275,8 +274,16 @@ class AnthropicChatGenerator:
         """
         anthropic_formatted_messages = []
         for m in messages:
-            message_dict = dataclasses.asdict(m)
-            formatted_message = {k: v for k, v in message_dict.items() if k in {"role", "content"} and v}
+            message_dict = m.to_dict()
+            formatted_message = {}
+
+            # legacy format
+            if "role" in message_dict and "content" in message_dict:
+                formatted_message = {k: v for k, v in message_dict.items() if k in {"role", "content"} and v}
+            # new format
+            elif "_role" in message_dict and "_content" in message_dict:
+                formatted_message = {"role": m.role.value, "content": m.text}
+
             if m.is_from(ChatRole.SYSTEM):
                 # system messages are treated differently and MUST be in the format expected by the Anthropic API
                 # remove role and content from the message dict, add type and text

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -421,8 +421,6 @@ class TestAnthropicChatGenerator:
         assert len(result["replies"]) == 1
         token_usage = result["replies"][0].meta.get("usage")
 
-        print(token_usage)
-
         if cache_enabled:
             # either we created cache or we read it (depends on how you execute this integration test)
             assert (

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -421,6 +421,8 @@ class TestAnthropicChatGenerator:
         assert len(result["replies"]) == 1
         token_usage = result["replies"][0].meta.get("usage")
 
+        print(token_usage)
+
         if cache_enabled:
             # either we created cache or we read it (depends on how you execute this integration test)
             assert (
@@ -428,5 +430,5 @@ class TestAnthropicChatGenerator:
                 or token_usage.get("cache_read_input_tokens") > 1024
             )
         else:
-            assert "cache_creation_input_tokens" not in token_usage
-            assert "cache_read_input_tokens" not in token_usage
+            assert token_usage["cache_creation_input_tokens"] == 0
+            assert token_usage["cache_read_input_tokens"] == 0


### PR DESCRIPTION
### Related Issues

- part of #1249: read the issue for details
- nigthly test failing, related to prompt caching: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12383597750/job/34566600812

### Proposed Changes:

- make the Chat Generator compatible with both new and old `ChatMessage` (this is temporary: we will port soon the Chat Generator with Tool support from experimental)
- fix prompt caching tests

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
