### PR TITLE
fix: make GoogleAI Chat Generator compatible with new `ChatMessage`; small fixes to Cohere tests

### DIFF
--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -27,7 +27,7 @@ def streaming_chunk(text: str):
 
 @pytest.fixture
 def chat_messages():
-    return [ChatMessage.from_assistant(content="What's the capital of France")]
+    return [ChatMessage.from_assistant("What's the capital of France")]
 
 
 class TestCohereChatGenerator:

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -279,13 +279,9 @@ class GoogleAIGeminiChatGenerator:
             msg = f"Unsupported message role {message.role}"
             raise ValueError(msg)
 
-        role = "model"
-        if (
-            message.is_from(ChatRole.USER)
-            or message.is_from(ChatRole.FUNCTION)
-            or ("TOOL" in ChatRole._member_names_ and message.is_from(ChatRole.TOOL))
-        ):
-            role = "user"
+        role = "user"
+        if message.is_from(ChatRole.ASSISTANT) or message.is_from(ChatRole.SYSTEM):
+            role = "model"
         return Content(parts=[part], role=role)
 
     @component.output_types(replies=List[ChatMessage])

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -275,8 +275,6 @@ class GoogleAIGeminiChatGenerator:
             part = Part()
             part.function_response.name = message.tool_call_result.origin.tool_name
             part.function_response.response = message.tool_call_result.result
-        elif message.is_from(ChatRole.USER):
-            part = self._convert_part(message.text)
         else:
             msg = f"Unsupported message role {message.role}"
             raise ValueError(msg)

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -280,13 +280,14 @@ class GoogleAIGeminiChatGenerator:
         else:
             msg = f"Unsupported message role {message.role}"
             raise ValueError(msg)
-        role = (
-            "user"
-            if message.is_from(ChatRole.USER)
+
+        role = "model"
+        if (
+            message.is_from(ChatRole.USER)
             or message.is_from(ChatRole.FUNCTION)
             or ("TOOL" in ChatRole._member_names_ and message.is_from(ChatRole.TOOL))
-            else "model"
-        )
+        ):
+            role = "user"
         return Content(parts=[part], role=role)
 
     @component.output_types(replies=List[ChatMessage])

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -272,9 +272,8 @@ def test_run_with_streaming_callback():
     assert "function_call" in chat_message.meta
     assert json.loads(chat_message.text) == {"location": "Berlin", "unit": "celsius"}
 
-    weather = str(get_current_weather(**json.loads(response["replies"][0].text)))
+    weather = get_current_weather(**json.loads(chat_message.text))
     messages += response["replies"] + [ChatMessage.from_function(weather, name="get_current_weather")]
-    print(messages)
     response = gemini_chat.run(messages=messages)
     assert "replies" in response
     assert len(response["replies"]) > 0

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -215,7 +215,7 @@ def test_run():
 
     tool = Tool(function_declarations=[get_current_weather_func])
     gemini_chat = GoogleAIGeminiChatGenerator(model="gemini-pro", tools=[tool])
-    messages = [ChatMessage.from_user(content="What is the temperature in celsius in Berlin?")]
+    messages = [ChatMessage.from_user("What is the temperature in celsius in Berlin?")]
     response = gemini_chat.run(messages=messages)
     assert "replies" in response
     assert len(response["replies"]) > 0
@@ -227,7 +227,7 @@ def test_run():
     assert json.loads(chat_message.text) == {"location": "Berlin", "unit": "celsius"}
 
     weather = get_current_weather(**json.loads(chat_message.text))
-    messages += response["replies"] + [ChatMessage.from_function(content=weather, name="get_current_weather")]
+    messages += response["replies"] + [ChatMessage.from_function(weather, name="get_current_weather")]
     response = gemini_chat.run(messages=messages)
     assert "replies" in response
     assert len(response["replies"]) > 0
@@ -260,7 +260,7 @@ def test_run_with_streaming_callback():
 
     tool = Tool(function_declarations=[get_current_weather_func])
     gemini_chat = GoogleAIGeminiChatGenerator(model="gemini-pro", tools=[tool], streaming_callback=streaming_callback)
-    messages = [ChatMessage.from_user(content="What is the temperature in celsius in Berlin?")]
+    messages = [ChatMessage.from_user("What is the temperature in celsius in Berlin?")]
     response = gemini_chat.run(messages=messages)
     assert "replies" in response
     assert len(response["replies"]) > 0
@@ -272,8 +272,9 @@ def test_run_with_streaming_callback():
     assert "function_call" in chat_message.meta
     assert json.loads(chat_message.text) == {"location": "Berlin", "unit": "celsius"}
 
-    weather = get_current_weather(**json.loads(response["replies"][0].text))
-    messages += response["replies"] + [ChatMessage.from_function(content=weather, name="get_current_weather")]
+    weather = str(get_current_weather(**json.loads(response["replies"][0].text)))
+    messages += response["replies"] + [ChatMessage.from_function(weather, name="get_current_weather")]
+    print(messages)
     response = gemini_chat.run(messages=messages)
     assert "replies" in response
     assert len(response["replies"]) > 0
@@ -289,10 +290,10 @@ def test_run_with_streaming_callback():
 def test_past_conversation():
     gemini_chat = GoogleAIGeminiChatGenerator(model="gemini-pro")
     messages = [
-        ChatMessage.from_system(content="You are a knowledageable mathematician."),
-        ChatMessage.from_user(content="What is 2+2?"),
-        ChatMessage.from_assistant(content="It's an arithmetic operation."),
-        ChatMessage.from_user(content="Yeah, but what's the result?"),
+        ChatMessage.from_system("You are a knowledageable mathematician."),
+        ChatMessage.from_user("What is 2+2?"),
+        ChatMessage.from_assistant("It's an arithmetic operation."),
+        ChatMessage.from_user("Yeah, but what's the result?"),
     ]
     response = gemini_chat.run(messages=messages)
     assert "replies" in response


### PR DESCRIPTION
### Related Issues
- part of #1249: read the issue for details

### Proposed Changes:
- fixes to ensure the Google AI Chat Generator is compatible with both old and new `ChatMessage`
- small fixes in Cohere tests (no need to release a new version for them)

### How did you test it?
CI; local tests with Haystack main branch

### Notes for the reviewer
These changes are temporary. I hope to get rid of them soon, once we reimplement this ChatGenerator to add proper tool support.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
