### PR TITLE
fix: make llama.cpp Chat Generator compatible with new `ChatMessage`

### DIFF
--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -280,10 +280,12 @@ class VertexAIGeminiChatGenerator:
                 # Remove content from metadata
                 metadata.pop("content", None)
                 if part._raw_part.text != "":
-                    replies.append(ChatMessage.from_assistant(part._raw_part.text, meta=metadata))
+                    replies.append(ChatMessage.from_assistant(content=part._raw_part.text, meta=metadata))
                 elif part.function_call:
                     metadata["function_call"] = part.function_call
-                    new_message = ChatMessage.from_assistant(json.dumps(dict(part.function_call.args)), meta=metadata)
+                    new_message = ChatMessage.from_assistant(
+                        content=json.dumps(dict(part.function_call.args)), meta=metadata
+                    )
                     new_message.name = part.function_call.name
                     replies.append(new_message)
         return replies

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -280,12 +280,10 @@ class VertexAIGeminiChatGenerator:
                 # Remove content from metadata
                 metadata.pop("content", None)
                 if part._raw_part.text != "":
-                    replies.append(ChatMessage.from_assistant(content=part._raw_part.text, meta=metadata))
+                    replies.append(ChatMessage.from_assistant(part._raw_part.text, meta=metadata))
                 elif part.function_call:
                     metadata["function_call"] = part.function_call
-                    new_message = ChatMessage.from_assistant(
-                        content=json.dumps(dict(part.function_call.args)), meta=metadata
-                    )
+                    new_message = ChatMessage.from_assistant(json.dumps(dict(part.function_call.args)), meta=metadata)
                     new_message.name = part.function_call.name
                     replies.append(new_message)
         return replies

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from haystack import component
-from haystack.dataclasses import ChatMessage, ChatRole
+from haystack.dataclasses import ChatMessage
 from llama_cpp import Llama
 from llama_cpp.llama_tokenizer import LlamaHFTokenizer
 
@@ -20,6 +20,10 @@ def _convert_message_to_llamacpp_format(message: ChatMessage) -> Dict[str, str]:
     formatted_msg = {"role": message.role.value, "content": message.text}
     if message.name:
         formatted_msg["name"] = message.name
+
+    if formatted_msg["role"] == "tool":
+        formatted_msg["name"] = message.tool_call_result.origin.tool_name
+        formatted_msg["content"] = message.tool_call_result.result
 
     return formatted_msg
 
@@ -114,26 +118,26 @@ class LlamaCppChatGenerator:
         formatted_messages = [_convert_message_to_llamacpp_format(msg) for msg in messages]
 
         response = self.model.create_chat_completion(messages=formatted_messages, **updated_generation_kwargs)
-        replies = [
-            ChatMessage(
-                content=choice["message"]["content"],
-                role=ChatRole[choice["message"]["role"].upper()],
-                name=None,
-                meta={
-                    "response_id": response["id"],
-                    "model": response["model"],
-                    "created": response["created"],
-                    "index": choice["index"],
-                    "finish_reason": choice["finish_reason"],
-                    "usage": response["usage"],
-                },
-            )
-            for choice in response["choices"]
-        ]
 
-        for reply, choice in zip(replies, response["choices"]):
+        replies = []
+
+        for choice in response["choices"]:
+            meta = {
+                "response_id": response["id"],
+                "model": response["model"],
+                "created": response["created"],
+                "index": choice["index"],
+                "finish_reason": choice["finish_reason"],
+                "usage": response["usage"],
+            }
+
+            name = None
             tool_calls = choice.get("message", {}).get("tool_calls", [])
             if tool_calls:
-                reply.meta["tool_calls"] = tool_calls
-        reply.name = tool_calls[0]["function"]["name"] if tool_calls else None
+                meta["tool_calls"] = tool_calls
+                name = tool_calls[0]["function"]["name"]
+
+            reply = ChatMessage.from_assistant(choice["message"]["content"], meta=meta, name=name)
+            replies.append(reply)
+
         return {"replies": replies}

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -137,7 +137,12 @@ class LlamaCppChatGenerator:
                 meta["tool_calls"] = tool_calls
                 name = tool_calls[0]["function"]["name"]
 
-            reply = ChatMessage.from_assistant(choice["message"]["content"], meta=meta, name=name)
+            reply = ChatMessage.from_assistant(choice["message"]["content"], meta=meta)
+            if name:
+                if hasattr(reply, "_name"):
+                    reply._name = name  # new ChatMessage
+                elif hasattr(reply, "name"):
+                    reply.name = name  # legacy ChatMessage
             replies.append(reply)
 
         return {"replies": replies}

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -41,11 +41,11 @@ def test_convert_message_to_llamacpp_format():
     assert _convert_message_to_llamacpp_format(message) == {"role": "user", "content": "I have a question"}
 
     message = ChatMessage.from_function("Function call", "function_name")
-    assert _convert_message_to_llamacpp_format(message) == {
-        "role": "function",
-        "content": "Function call",
-        "name": "function_name",
-    }
+    converted_message = _convert_message_to_llamacpp_format(message)
+
+    assert converted_message["role"] in ("function", "tool")
+    assert converted_message["name"] == "function_name"
+    assert converted_message["content"] == "Function call"
 
 
 class TestLlamaCppChatGenerator:


### PR DESCRIPTION
### Related Issues
- part of #1249: read the issue for details

### Proposed Changes:
- fixes to ensure that the llama.cpp Chat Generator is compatible with both old and new `ChatMessage`

### How did you test it?
CI; local tests with Haystack main branch

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
