### PR TITLE
fix: make Google Vertex Chat Generator compatible with new ChatMessage

### DIFF
--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -280,11 +280,11 @@ class VertexAIGeminiChatGenerator:
                 # Remove content from metadata
                 metadata.pop("content", None)
                 if part._raw_part.text != "":
-                    replies.append(ChatMessage.from_assistant(content=part._raw_part.text, meta=metadata))
+                    replies.append(ChatMessage.from_assistant(part._raw_part.text, meta=metadata))
                 elif part.function_call:
                     metadata["function_call"] = part.function_call
                     new_message = ChatMessage.from_assistant(
-                        content=json.dumps(dict(part.function_call.args)), meta=metadata
+                        json.dumps(dict(part.function_call.args)), meta=metadata
                     )
                     new_message.name = part.function_call.name
                     replies.append(new_message)

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -283,9 +283,7 @@ class VertexAIGeminiChatGenerator:
                     replies.append(ChatMessage.from_assistant(part._raw_part.text, meta=metadata))
                 elif part.function_call:
                     metadata["function_call"] = part.function_call
-                    new_message = ChatMessage.from_assistant(
-                        json.dumps(dict(part.function_call.args)), meta=metadata
-                    )
+                    new_message = ChatMessage.from_assistant(json.dumps(dict(part.function_call.args)), meta=metadata)
                     new_message.name = part.function_call.name
                     replies.append(new_message)
         return replies


### PR DESCRIPTION
### Related Issues
- part of #1249: read the issue for details

### Proposed Changes:
- small fixes to ensure that the Google Vertex Chat Generator is compatible with both old and new `ChatMessage`

### How did you test it?
CI; local tests with Haystack main branch

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
