### PR TITLE
fix: make Ollama Chat Generator compatible with new `ChatMessage`

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -116,7 +116,7 @@ class OllamaChatGenerator:
         Converts the non-streaming response from the Ollama API to a ChatMessage.
         """
         response_dict = ollama_response.model_dump()
-        message = ChatMessage.from_assistant(content=response_dict["message"]["content"])
+        message = ChatMessage.from_assistant(response_dict["message"]["content"])
         message.meta.update({key: value for key, value in response_dict.items() if key != "message"})
         return message
 


### PR DESCRIPTION
### Related Issues
- part of #1249: read the issue for details

### Proposed Changes:
- small fix to ensure that the Ollama Chat Generator is compatible with both old and new `ChatMessage`

### How did you test it?
CI; local tests with Haystack main branch

### Notes for the reviewer
These changes are temporary. We will soon port Ollama from experimental to introduce proper tool support.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
