### PR TITLE
feat: add model `nvidia/llama-3.2-nv-rerankqa-1b-v2` to `_MODEL_ENDPOINT_MAP`

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -19,7 +19,7 @@ _DEFAULT_MODEL = "nvidia/nv-rerankqa-mistral-4b-v3"
 _MODEL_ENDPOINT_MAP = {
     "nvidia/nv-rerankqa-mistral-4b-v3": "https://ai.api.nvidia.com/v1/retrieval/nvidia/nv-rerankqa-mistral-4b-v3/reranking",
     "nvidia/llama-3.2-nv-rerankqa-1b-v1": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v1/reranking",
-    "nvidia/llama-3.2-nv-rerankqa-1b-v2": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking"
+    "nvidia/llama-3.2-nv-rerankqa-1b-v2": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking",
 }
 
 

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -19,6 +19,7 @@ _DEFAULT_MODEL = "nvidia/nv-rerankqa-mistral-4b-v3"
 _MODEL_ENDPOINT_MAP = {
     "nvidia/nv-rerankqa-mistral-4b-v3": "https://ai.api.nvidia.com/v1/retrieval/nvidia/nv-rerankqa-mistral-4b-v3/reranking",
     "nvidia/llama-3.2-nv-rerankqa-1b-v1": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v1/reranking",
+    "nvidia/llama-3.2-nv-rerankqa-1b-v2": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking"
 }
 
 


### PR DESCRIPTION
### Related Issues

- fixes #1259

### Proposed Changes:

Model `nvidia/llama-3.2-nv-rerankqa-1b-v2` be added to set of known model's by adding it's endpoint to `_MODEL_ENDPOINT_MAP`.
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
Simple addition of  `"nvidia/llama-3_2-nv-rerankqa-1b-v2": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking"`  to the map.
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Running the Hatch tests and manual verification by importing the changed `NvidiaRanker()` instead.

### Notes for the reviewer

Run the Google Colab provided in #1259 to reproduce the issue.

This was set to `feat:` instead of `fix:` on comparing with #1183.

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
