### PR TITLE
fix: updates for Chroma 0.6.0

### DIFF
--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Support longpaths

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -7,7 +7,7 @@ name = "chroma-haystack"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "John Doe", email = "jd@example.com" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -24,8 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "chromadb>=0.5.17",
-  "typing_extensions>=4.8.0"
+  "chromadb>=0.6.0",
   ]
 
 [project.urls]

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -116,7 +116,7 @@ class ChromaDocumentStore:
             if "hnsw:space" not in self._metadata:
                 self._metadata["hnsw:space"] = self._distance_function
 
-            if self._collection_name in [c.name for c in client.list_collections()]:
+            if self._collection_name in client.list_collections():
                 self._collection = client.get_collection(self._collection_name, embedding_function=self._embedding_func)
 
                 if self._metadata != self._collection.metadata:


### PR DESCRIPTION
### Related Issues

- nightly tests are failing https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12575566340/job/35050656749 due to a breaking change in Chroma v0.6.0 - https://docs.trychroma.com/production/administration/migration#migration-log

### Proposed Changes:
- small fix in the code
- pin `chromadb>=0.6.0`
- since Chroma no longer supports python 3.8, drop it in our integration (and run tests with 3.11 instead)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
