### PR TITLE
test: adapt Mistral to OpenAI refactoring

### DIFF
--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -80,17 +80,23 @@ class TestMistralChatGenerator:
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
         component = MistralChatGenerator()
         data = component.to_dict()
-        assert data == {
-            "type": "haystack_integrations.components.generators.mistral.chat.chat_generator.MistralChatGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["MISTRAL_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "mistral-tiny",
-                "organization": None,
-                "streaming_callback": None,
-                "api_base_url": "https://api.mistral.ai/v1",
-                "generation_kwargs": {},
-            },
+
+        assert (
+            data["type"]
+            == "haystack_integrations.components.generators.mistral.chat.chat_generator.MistralChatGenerator"
+        )
+
+        expected_params = {
+            "api_key": {"env_vars": ["MISTRAL_API_KEY"], "strict": True, "type": "env_var"},
+            "model": "mistral-tiny",
+            "organization": None,
+            "streaming_callback": None,
+            "api_base_url": "https://api.mistral.ai/v1",
+            "generation_kwargs": {},
         }
+
+        for key, value in expected_params.items():
+            assert data["init_parameters"][key] == value
 
     def test_to_dict_with_parameters(self, monkeypatch):
         monkeypatch.setenv("ENV_VAR", "test-api-key")
@@ -102,17 +108,22 @@ class TestMistralChatGenerator:
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
         data = component.to_dict()
-        assert data == {
-            "type": "haystack_integrations.components.generators.mistral.chat.chat_generator.MistralChatGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
-                "model": "mistral-small",
-                "api_base_url": "test-base-url",
-                "organization": None,
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-            },
+
+        assert (
+            data["type"]
+            == "haystack_integrations.components.generators.mistral.chat.chat_generator.MistralChatGenerator"
+        )
+
+        expected_params = {
+            "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
+            "model": "mistral-small",
+            "api_base_url": "test-base-url",
+            "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+            "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
         }
+
+        for key, value in expected_params.items():
+            assert data["init_parameters"][key] == value
 
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "fake-api-key")
@@ -187,7 +198,12 @@ class TestMistralChatGenerator:
         ]
 
         for m in messages:
-            component._check_finish_reason(m)
+            try:
+                # Haystack >= 2.9.0
+                component._check_finish_reason(m.meta)
+            except AttributeError:
+                # Haystack < 2.9.0
+                component._check_finish_reason(m)
 
         # check truncation warning
         message_template = (


### PR DESCRIPTION
### Related Issues

- `OpenAIChatGenerator` was refactored in https://github.com/deepset-ai/haystack/pull/8666 and Mistral inherits from it
- failing nightly tests with Haystack main: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12575726108/job/35051031568

### Proposed Changes:
Fix tests

### How did you test it?
CI; local tests with Haystack main.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
