### PR TITLE
feat: add STACKITChatGenerator

### DIFF
--- a/integrations/stackit/LICENSE.txt
+++ b/integrations/stackit/LICENSE.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/integrations/stackit/README.md
+++ b/integrations/stackit/README.md
@@ -1,0 +1,21 @@
+# stackit
+
+[![PyPI - Version](https://img.shields.io/pypi/v/stackit.svg)](https://pypi.org/project/stackit)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stackit.svg)](https://pypi.org/project/stackit)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install stackit-haystack
+```
+
+## License
+
+`stackit-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/integrations/stackit/examples/chat_as_component.py
+++ b/integrations/stackit/examples/chat_as_component.py
@@ -1,0 +1,9 @@
+# To run this example, you will need to set a `STACKIT_API_KEY` environment variable.
+
+from haystack_integrations.components.generators.stackit import STACKITChatGenerator
+from haystack.dataclasses import ChatMessage
+
+generator = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
+
+result = generator.run([ChatMessage.from_user("Tell me a joke.")])
+print(result)

--- a/integrations/stackit/examples/chat_as_pipeline.py
+++ b/integrations/stackit/examples/chat_as_pipeline.py
@@ -1,0 +1,23 @@
+# To run this example, you will need to set a `STACKIT_API_KEY` environment variable.
+
+from haystack import Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.generators.stackit import STACKITChatGenerator
+
+
+prompt_builder = ChatPromptBuilder()
+llm = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
+
+messages = [ChatMessage.from_user("Question: {{question}} \\n")]
+
+pipeline = Pipeline()
+pipeline.add_component("prompt_builder", prompt_builder)
+pipeline.add_component("llm", llm)
+
+pipeline.connect("prompt_builder.prompt", "llm.messages")
+
+result = pipeline.run({"prompt_builder": {"template_variables": {"question": "Tell me a joke."}, "template": messages}})
+
+print(result)

--- a/integrations/stackit/examples/streaming_chat_with_rag.py
+++ b/integrations/stackit/examples/streaming_chat_with_rag.py
@@ -1,0 +1,61 @@
+# To run this example, you will need to set a `STACKIT_API_KEY` environment variable.
+# The HTMLToDocument requires an additional dependency to be installed via `pip install trafilatura`.
+# This example streams chat replies to the console.
+
+from haystack import Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.converters import HTMLToDocument
+from haystack.components.fetchers import LinkContentFetcher
+from haystack.components.generators.utils import print_streaming_chunk
+from haystack.components.preprocessors import DocumentSplitter
+from haystack.components.retrievers import InMemoryBM25Retriever
+from haystack.components.writers import DocumentWriter
+from haystack.dataclasses import ChatMessage
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+from haystack_integrations.components.generators.stackit import STACKITChatGenerator
+
+document_store = InMemoryDocumentStore()
+fetcher = LinkContentFetcher()
+converter = HTMLToDocument()
+chunker = DocumentSplitter()
+writer = DocumentWriter(document_store=document_store)
+
+indexing = Pipeline()
+
+indexing.add_component(name="fetcher", instance=fetcher)
+indexing.add_component(name="converter", instance=converter)
+indexing.add_component(name="chunker", instance=chunker)
+indexing.add_component(name="writer", instance=writer)
+
+indexing.connect("fetcher", "converter")
+indexing.connect("converter", "chunker")
+indexing.connect("chunker", "writer")
+
+indexing.run(data={"fetcher": {"urls": ["https://www.stackit.de/en/"]}})
+
+retriever = InMemoryBM25Retriever(document_store=document_store)
+prompt_builder = ChatPromptBuilder(variables=["documents"])
+llm = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8", streaming_callback=print_streaming_chunk)
+
+messages = [ChatMessage.from_user("Here are some of the documents: {{documents}} \\n Question: {{query}} \\n Answer:")]
+
+rag_pipeline = Pipeline()
+rag_pipeline.add_component("retriever", retriever)
+rag_pipeline.add_component("prompt_builder", prompt_builder)
+rag_pipeline.add_component("llm", llm)
+
+rag_pipeline.connect("retriever.documents", "prompt_builder.documents")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
+
+question = "What does STACKIT offer?"
+
+result = rag_pipeline.run(
+    {
+        "retriever": {"query": question},
+        "prompt_builder": {"template_variables": {"query": question}, "template": messages},
+        "llm": {"generation_kwargs": {"max_tokens": 165}},
+    }
+)
+
+print(result)

--- a/integrations/stackit/pydoc/config.yml
+++ b/integrations/stackit/pydoc/config.yml
@@ -1,0 +1,29 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../src]
+    modules: [
+      "haystack_integrations.components.generators.stackit.chat.chat_generator",
+    ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.ReadmeIntegrationRenderer
+  excerpt: STACKIT integration for Haystack
+  category_slug: integrations-api
+  title: STACKIT
+  slug: integrations-stackit
+  order: 150
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: _readme_stackit.md

--- a/integrations/stackit/pyproject.toml
+++ b/integrations/stackit/pyproject.toml
@@ -1,0 +1,176 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "stackit-haystack"
+dynamic = ["version"]
+description = 'An integration of STACKIT as a StackitChatGenerator'
+readme = "README.md"
+requires-python = ">=3.8"
+license = "Apache-2.0"
+keywords = []
+authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = ["haystack-ai"]
+
+[project.urls]
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/stackit#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/stackit"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/haystack_integrations"]
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = 'integrations\/stackit-v(?P<version>.*)'
+
+[tool.hatch.version.raw-options]
+root = "../.."
+git_describe_command = 'git describe --tags --match="integrations/stackit-v[0-9]*"'
+
+[tool.hatch.envs.default]
+installer = "uv"
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+  "pytest-rerunfailures",
+  "haystack-pydoc-tools",
+]
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
+cov-report = ["- coverage combine", "coverage report"]
+cov = ["test-cov", "cov-report"]
+cov-retry = ["test-cov-retry", "cov-report"]
+docs = ["pydoc-markdown pydoc/config.yml"]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11"]
+
+[tool.hatch.envs.lint]
+installer = "uv"
+detached = true
+dependencies = ["pip", "black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
+[tool.hatch.envs.lint.scripts]
+typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+style = [
+  "ruff check {args:}",
+  "black --check --diff {args:.}",
+]
+fmt = ["black {args:.}", "ruff check --fix {args:}", "style"]
+all = ["style", "typing"]
+
+[tool.black]
+target-version = ["py38"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py38"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "DTZ",
+  "E",
+  "EM",
+  "F",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
+ignore = [
+  # Allow non-abstract empty methods in abstract base classes
+  "B027",
+  # Ignore checks for possible passwords
+  "S105",
+  "S106",
+  "S107",
+  # Ignore complexity
+  "C901",
+  "PLR0911",
+  "PLR0912",
+  "PLR0913",
+  "PLR0915",
+  # Misc
+  "B008",
+  "S101",
+]
+unfixable = [
+  # Don't touch unused imports
+  "F401",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["haystack_integrations"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "parents"
+
+[tool.ruff.lint.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+source = ["haystack_integrations"]
+branch = true
+parallel = false
+
+
+[tool.coverage.report]
+omit = ["*/tests/*", "*/__init__.py"]
+show_missing = true
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
+
+
+[[tool.mypy.overrides]]
+module = [
+  "stackit.*",
+  "haystack.*",
+  "haystack_integrations.*",
+  "openai.*",
+  "pytest.*",
+  "numpy.*",
+]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+  "integration: integration tests",
+  "unit: unit tests",
+  "embedders: embedders tests",
+  "chat_generators: chat_generators tests",
+]
+log_cli = true

--- a/integrations/stackit/src/haystack_integrations/components/generators/stackit/__init__.py
+++ b/integrations/stackit/src/haystack_integrations/components/generators/stackit/__init__.py
@@ -1,0 +1,3 @@
+from .chat.chat_generator import STACKITChatGenerator
+
+__all__ = ["STACKITChatGenerator"]

--- a/integrations/stackit/src/haystack_integrations/components/generators/stackit/chat/chat_generator.py
+++ b/integrations/stackit/src/haystack_integrations/components/generators/stackit/chat/chat_generator.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Callable, Dict, Optional, List
+
+from haystack import component
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.generators.chat.openai import StreamingCallbackT
+from haystack.dataclasses import StreamingChunk, ChatMessage, Tool
+from haystack.utils.auth import Secret
+
+
+@component
+class STACKITChatGenerator(OpenAIChatGenerator):
+    """
+    Enables text generation using STACKIT generative models via their model serving service.
+
+    Users can pass any text generation parameters valid for the STACKIT Chat Completion API
+    directly to this component via the `generation_kwargs` parameter in `__init__` or the `generation_kwargs`
+    parameter in `run` method.
+
+    This component uses the ChatMessage format for structuring both input and output,
+    ensuring coherent and contextually relevant responses in chat-based text generation scenarios.
+    Details on the ChatMessage format can be found in the
+    [Haystack docs](https://docs.haystack.deepset.ai/v2.0/docs/data-classes#chatmessage)
+
+    Usage example:
+    ```python
+    from haystack_integrations.components.generators.stackit import STACKITChatGenerator
+    from haystack.dataclasses import ChatMessage
+
+    generator = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
+
+    result = generator.run([ChatMessage.from_user("Tell me a joke.")])
+    print(result)
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Secret = Secret.from_env_var("STACKIT_API_KEY"),
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        api_base_url: Optional[str] = "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Creates an instance of class STACKITChatGenerator.
+
+        :param model:
+            The name of the chat completion model to use.
+        :param api_key:
+            The STACKIT API key.
+        :param streaming_callback:
+            A callback function that is called when a new token is received from the stream.
+            The callback function accepts StreamingChunk as an argument.
+        :param api_base_url:
+            The STACKIT API Base url.
+        :param generation_kwargs:
+            Other parameters to use for the model. These parameters are all sent directly to
+            the STACKIT endpoint.
+            Some of the supported parameters:
+            - `max_tokens`: The maximum number of tokens the output text can have.
+            - `temperature`: What sampling temperature to use. Higher values mean the model will take more risks.
+                Try 0.9 for more creative applications and 0 (argmax sampling) for ones with a well-defined answer.
+            - `top_p`: An alternative to sampling with temperature, called nucleus sampling, where the model
+                considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens
+                comprising the top 10% probability mass are considered.
+            - `stream`: Whether to stream back partial progress. If set, tokens will be sent as data-only server-sent
+                events as they become available, with the stream terminated by a data: [DONE] message.
+            - `safe_prompt`: Whether to inject a safety prompt before all conversations.
+            - `random_seed`: The seed to use for random sampling.
+        """
+        super(STACKITChatGenerator, self).__init__(  # noqa: UP008
+            model=model,
+            api_key=api_key,
+            streaming_callback=streaming_callback,
+            api_base_url=api_base_url,
+            organization=None,
+            generation_kwargs=generation_kwargs,
+        )
+
+    def _prepare_api_call(  # noqa: PLR0913
+        self,
+        *,
+        messages: List[ChatMessage],
+        streaming_callback: Optional[StreamingCallbackT] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        tools: Optional[List[Tool]] = None,
+        tools_strict: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        prepared_api_call = super(STACKITChatGenerator, self)._prepare_api_call(
+            messages=messages,
+            streaming_callback=streaming_callback,
+            generation_kwargs=generation_kwargs,
+            tools=tools,
+            tools_strict=tools_strict,
+        )
+        prepared_api_call.pop("tools")
+        return prepared_api_call

--- a/integrations/stackit/tests/__init__.py
+++ b/integrations/stackit/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/stackit/tests/test_stackit_chat_generator.py
+++ b/integrations/stackit/tests/test_stackit_chat_generator.py
@@ -61,7 +61,7 @@ class TestSTACKITChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("STACKIT_API_KEY", raising=False)
         with pytest.raises(ValueError, match="None of the .* environment variables are set"):
-            STACKITChatGenerator()
+            STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
 
     def test_init_with_parameters(self):
         component = STACKITChatGenerator(
@@ -78,7 +78,7 @@ class TestSTACKITChatGenerator:
 
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("STACKIT_API_KEY", "test-api-key")
-        component = STACKITChatGenerator()
+        component = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
         data = component.to_dict()
 
         assert (
@@ -147,7 +147,7 @@ class TestSTACKITChatGenerator:
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         monkeypatch.delenv("STACKIT_API_KEY", raising=False)
         data = {
-            "type": "haystack_integrations.components.generators.mistral.chat.chat_generator.STACKITChatGenerator",
+            "type": "haystack_integrations.components.generators.stackit.chat.chat_generator.STACKITChatGenerator",
             "init_parameters": {
                 "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
@@ -161,7 +161,7 @@ class TestSTACKITChatGenerator:
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("STACKIT_API_KEY", "fake-api-key")
-        component = STACKITChatGenerator()
+        component = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
         response = component.run(chat_messages)
 
         # check that the component returns the correct ChatMessage response
@@ -173,7 +173,7 @@ class TestSTACKITChatGenerator:
 
     def test_run_with_params(self, chat_messages, mock_chat_completion, monkeypatch):
         monkeypatch.setenv("STACKIT_API_KEY", "fake-api-key")
-        component = STACKITChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        component = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8", generation_kwargs={"max_tokens": 10, "temperature": 0.5})
         response = component.run(chat_messages)
 
         # check that the component calls the OpenAI API with the correct parameters
@@ -189,7 +189,7 @@ class TestSTACKITChatGenerator:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
     def test_check_abnormal_completions(self, caplog):
-        component = STACKITChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8", api_key=Secret.from_token("test-api-key"))
         messages = [
             ChatMessage.from_assistant(
                 "", meta={"finish_reason": "content_filter" if i % 2 == 0 else "length", "index": i}
@@ -226,12 +226,12 @@ class TestSTACKITChatGenerator:
     @pytest.mark.integration
     def test_live_run(self):
         chat_messages = [ChatMessage.from_user("What's the capital of France")]
-        component = STACKITChatGenerator()
+        component = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
-        assert "mistral-tiny" in message.meta["model"]
+        assert "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
     @pytest.mark.skipif(
@@ -260,14 +260,14 @@ class TestSTACKITChatGenerator:
                 self.responses += chunk.content if chunk.content else ""
 
         callback = Callback()
-        component = STACKITChatGenerator(streaming_callback=callback)
+        component = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8", streaming_callback=callback)
         results = component.run([ChatMessage.from_user("What's the capital of France?")])
 
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
 
-        assert "mistral-tiny" in message.meta["model"]
+        assert "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
         assert callback.counter > 1

--- a/integrations/stackit/tests/test_stackit_chat_generator.py
+++ b/integrations/stackit/tests/test_stackit_chat_generator.py
@@ -1,0 +1,274 @@
+import os
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+import pytz
+from haystack.components.generators.utils import print_streaming_chunk
+from haystack.dataclasses import ChatMessage, StreamingChunk
+from haystack.utils.auth import Secret
+from openai import OpenAIError
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+
+from haystack_integrations.components.generators.stackit.chat.chat_generator import STACKITChatGenerator
+
+
+@pytest.fixture
+def chat_messages():
+    return [
+        ChatMessage.from_system("You are a helpful assistant"),
+        ChatMessage.from_user("What's the capital of France"),
+    ]
+
+
+@pytest.fixture
+def mock_chat_completion():
+    """
+    Mock the OpenAI API completion response and reuse it for tests
+    """
+    with patch("openai.resources.chat.completions.Completions.create") as mock_chat_completion_create:
+        completion = ChatCompletion(
+            id="foo",
+            model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
+            object="chat.completion",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    logprobs=None,
+                    index=0,
+                    message=ChatCompletionMessage(content="Hello world!", role="assistant"),
+                )
+            ],
+            created=int(datetime.now(tz=pytz.timezone("UTC")).timestamp()),
+            usage={"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
+        )
+
+        mock_chat_completion_create.return_value = completion
+        yield mock_chat_completion_create
+
+
+class TestSTACKITChatGenerator:
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("STACKIT_API_KEY", "test-api-key")
+        component = STACKITChatGenerator(model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8")
+        assert component.client.api_key == "test-api-key"
+        assert component.model == "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8"
+        assert component.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
+        assert component.streaming_callback is None
+        assert not component.generation_kwargs
+
+    def test_init_fail_wo_api_key(self, monkeypatch):
+        monkeypatch.delenv("STACKIT_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+            STACKITChatGenerator()
+
+    def test_init_with_parameters(self):
+        component = STACKITChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
+            streaming_callback=print_streaming_chunk,
+            api_base_url="test-base-url",
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+        )
+        assert component.client.api_key == "test-api-key"
+        assert component.model == "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+
+    def test_to_dict_default(self, monkeypatch):
+        monkeypatch.setenv("STACKIT_API_KEY", "test-api-key")
+        component = STACKITChatGenerator()
+        data = component.to_dict()
+
+        assert (
+            data["type"]
+            == "haystack_integrations.components.generators.stackit.chat.chat_generator.STACKITChatGenerator"
+        )
+
+        expected_params = {
+            "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
+            "model": "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
+            "organization": None,
+            "streaming_callback": None,
+            "api_base_url": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+            "generation_kwargs": {},
+        }
+
+        for key, value in expected_params.items():
+            assert data["init_parameters"][key] == value
+
+    def test_to_dict_with_parameters(self, monkeypatch):
+        monkeypatch.setenv("ENV_VAR", "test-api-key")
+        component = STACKITChatGenerator(
+            api_key=Secret.from_env_var("ENV_VAR"),
+            model="neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
+            streaming_callback=print_streaming_chunk,
+            api_base_url="test-base-url",
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+        )
+        data = component.to_dict()
+
+        assert (
+            data["type"]
+            == "haystack_integrations.components.generators.stackit.chat.chat_generator.STACKITChatGenerator"
+        )
+
+        expected_params = {
+            "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
+            "model": "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
+            "api_base_url": "test-base-url",
+            "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+            "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+        }
+
+        for key, value in expected_params.items():
+            assert data["init_parameters"][key] == value
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("STACKIT_API_KEY", "fake-api-key")
+        data = {
+            "type": "haystack_integrations.components.generators.stackit.chat.chat_generator.STACKITChatGenerator",
+            "init_parameters": {
+                "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
+                "model": "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
+                "api_base_url": "test-base-url",
+                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+            },
+        }
+        component = STACKITChatGenerator.from_dict(data)
+        assert component.model == "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.api_base_url == "test-base-url"
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.api_key == Secret.from_env_var("STACKIT_API_KEY")
+
+    def test_from_dict_fail_wo_env_var(self, monkeypatch):
+        monkeypatch.delenv("STACKIT_API_KEY", raising=False)
+        data = {
+            "type": "haystack_integrations.components.generators.mistral.chat.chat_generator.STACKITChatGenerator",
+            "init_parameters": {
+                "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
+                "model": "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8",
+                "api_base_url": "test-base-url",
+                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+            },
+        }
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+            STACKITChatGenerator.from_dict(data)
+
+    def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
+        monkeypatch.setenv("STACKIT_API_KEY", "fake-api-key")
+        component = STACKITChatGenerator()
+        response = component.run(chat_messages)
+
+        # check that the component returns the correct ChatMessage response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    def test_run_with_params(self, chat_messages, mock_chat_completion, monkeypatch):
+        monkeypatch.setenv("STACKIT_API_KEY", "fake-api-key")
+        component = STACKITChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        response = component.run(chat_messages)
+
+        # check that the component calls the OpenAI API with the correct parameters
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.5
+
+        # check that the component returns the correct response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    def test_check_abnormal_completions(self, caplog):
+        component = STACKITChatGenerator(api_key=Secret.from_token("test-api-key"))
+        messages = [
+            ChatMessage.from_assistant(
+                "", meta={"finish_reason": "content_filter" if i % 2 == 0 else "length", "index": i}
+            )
+            for i, _ in enumerate(range(4))
+        ]
+
+        for m in messages:
+            try:
+                # Haystack >= 2.9.0
+                component._check_finish_reason(m.meta)
+            except AttributeError:
+                # Haystack < 2.9.0
+                component._check_finish_reason(m)
+
+        # check truncation warning
+        message_template = (
+            "The completion for index {index} has been truncated before reaching a natural stopping point. "
+            "Increase the max_tokens parameter to allow for longer completions."
+        )
+
+        for index in [1, 3]:
+            assert caplog.records[index].message == message_template.format(index=index)
+
+        # check content filter warning
+        message_template = "The completion for index {index} has been truncated due to the content filter."
+        for index in [0, 2]:
+            assert caplog.records[index].message == message_template.format(index=index)
+
+    @pytest.mark.skipif(
+        not os.environ.get("STACKIT_API_KEY", None),
+        reason="Export an env var called STACKIT_API_KEY containing the API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run(self):
+        chat_messages = [ChatMessage.from_user("What's the capital of France")]
+        component = STACKITChatGenerator()
+        results = component.run(chat_messages)
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "mistral-tiny" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+    @pytest.mark.skipif(
+        not os.environ.get("STACKIT_API_KEY", None),
+        reason="Export an env var called STACKIT_API_KEY containing the API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_wrong_model(self, chat_messages):
+        component = STACKITChatGenerator(model="something-obviously-wrong")
+        with pytest.raises(OpenAIError):
+            component.run(chat_messages)
+
+    @pytest.mark.skipif(
+        not os.environ.get("STACKIT_API_KEY", None),
+        reason="Export an env var called STACKIT_API_KEY containing the API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_streaming(self):
+        class Callback:
+            def __init__(self):
+                self.responses = ""
+                self.counter = 0
+
+            def __call__(self, chunk: StreamingChunk) -> None:
+                self.counter += 1
+                self.responses += chunk.content if chunk.content else ""
+
+        callback = Callback()
+        component = STACKITChatGenerator(streaming_callback=callback)
+        results = component.run([ChatMessage.from_user("What's the capital of France?")])
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+
+        assert "mistral-tiny" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+        assert callback.counter > 1
+        assert "Paris" in callback.responses


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/97

### Proposed Changes:

- Add a new integration with STACKITChatGenerator component that inherits from OpenAIChatGenerator but overwrites `_prepare_api_call`
- Add unit and integration tests
- Add three examples

### How did you test it?

Ran unit tests, integration tests, and the examples

### Notes for the reviewer

I was thinking about setting a `model` by default, which would simplify initialization of the component. However, there is no obvious default value. That's why I made the `model` parameter mandatory. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
