### PR TITLE
fix: PgvectorDocumentStore - use appropriate schema name if dropping index

### DIFF
--- a/integrations/pgvector/README.md
+++ b/integrations/pgvector/README.md
@@ -22,7 +22,7 @@ pip install pgvector-haystack
 
 Ensure that you have a PostgreSQL running with the `pgvector` extension. For a quick setup using Docker, run:
 ```
-docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres ankane/pgvector
+docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres pgvector/pgvector:pg17
 ```
 
 then run the tests:

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -394,18 +394,6 @@ class PgvectorDocumentStore:
         )
         self._execute_sql(sql_drop_index, error_msg="Could not drop HNSW index")
 
-        index_exists_after_deletion = bool(
-            self._execute_sql(
-                "SELECT 1 FROM pg_indexes WHERE schemaname = %s AND tablename = %s AND indexname = %s",
-                (self.schema_name, self.table_name, self.hnsw_index_name),
-                "Could not check if HNSW index exists",
-            ).fetchone()
-        )
-
-        if index_exists and index_exists_after_deletion:
-            error_message = "The HNSW was not dropped"
-            raise DocumentStoreError(error_message)
-
         self._create_hnsw_index()
 
     def _create_hnsw_index(self):

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import random
-import string
 from unittest.mock import patch
 
 import numpy as np
@@ -266,38 +263,44 @@ def test_from_pg_to_haystack_documents():
 
 
 @pytest.mark.integration
-def test_hnsw_index_recreation_in_new_schema():
-    # Set your Postgres connection string (or set PG_CONN_STR in your environment directly).
-    os.environ["PG_CONN_STR"] = "postgresql://postgres:postgres@localhost:5432/postgres"
+def test_hnsw_index_recreation():
+    def get_index_oid(document_store, schema_name, index_name):
+        sql_get_index_oid = """
+            SELECT c.oid
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind = 'i'
+            AND n.nspname = %s
+            AND c.relname = %s;
+        """
+        return document_store.cursor.execute(sql_get_index_oid, (schema_name, index_name)).fetchone()[0]
 
-    table_name = "test_table"
-    index_name = f"{table_name}_index"
-    schema_name = "".join(random.choices(string.ascii_letters, k=8)).lower()  # noqa: S311
-    embedding_dimension = 1024
+    # create a new schema
+    connection_string = "postgresql://postgres:postgres@localhost:5432/postgres"
+    schema_name = "test_schema"
+    with psycopg.connect(connection_string, autocommit=True) as conn:
+        conn.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
 
-    # Create the new schema if it doesn't exist.
-    with psycopg.connect(os.environ["PG_CONN_STR"]) as connection:
-        with connection.cursor() as cursor:
-            cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name};")
-            connection.commit()
+    # create a first document store and trigger the creation of the hnsw index
+    params = {
+        "connection_string": Secret.from_token(connection_string),
+        "schema_name": schema_name,
+        "table_name": "haystack_test_hnsw_index_recreation",
+        "search_strategy": "hnsw",
+    }
+    ds1 = PgvectorDocumentStore(**params)
+    ds1._initialize_table()
 
-    # Instantiate the document store in the new schema with HNSW indexing.
-    document_store = PgvectorDocumentStore(
-        embedding_dimension=embedding_dimension,
-        schema_name=schema_name,
-        vector_function="cosine_similarity",
-        recreate_table=False,
-        search_strategy="hnsw",
-        table_name=table_name,
-        hnsw_index_name=index_name,
-        hnsw_recreate_index_if_exists=True,  # This ensures we drop/re-create the index if it exists
-        keyword_index_name=f"{table_name}_keyword_index",
-    )
+    # get the hnsw index oid
+    hnws_index_name = "haystack_hnsw_index"
+    first_oid = get_index_oid(ds1, ds1.schema_name, hnws_index_name)
 
-    # First write documents
-    docs1 = [Document(content="Test Content 1", embedding=[0.8] * embedding_dimension)]
-    document_store.write_documents(docs1)
+    # create second document store with recreation enabled
+    ds2 = PgvectorDocumentStore(**params, hnsw_recreate_index_if_exists=True)
+    ds2._initialize_table()
 
-    # Second write documents
-    docs2 = [Document(content="Test Content 2", embedding=[0.7] * embedding_dimension)]
-    document_store.write_documents(docs2)
+    # get the index oid
+    second_oid = get_index_oid(ds2, ds2.schema_name, hnws_index_name)
+
+    # verify that oids differ
+    assert second_oid != first_oid, "Index was not recreated (OID remained the same)"


### PR DESCRIPTION
### Related Issues

- fixes #1275

### Proposed Changes:

In pgvector if HNSW index should drop, only index_name was used, but not schema_name. So if there were multiple schemas, the index was not dropped and could not be recreated.

### How did you test it?

The check was added directly to the code, so if the index existed and should be dropped, the Error is raised, because I consider it as critical Error.

### Notes for the reviewer

I tested this on multiple machines with similar setups, and the behavior was not consistent. On one PC this fix was needed, but on the other PC this fix was not needed, and it was working even without the fix, but I was not able to discover the difference...
But I believe that the fix is correct, and should be applied.

### Checklist

- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x]  I have updated the related issue with new insights and changes
- [x]  I added unit tests and updated the docstrings
- [x]  I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
