### PR TITLE
feat: add nv-rerank-qa-mistral-4b:1 reranker

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MODEL = "nvidia/nv-rerankqa-mistral-4b-v3"
 
 _MODEL_ENDPOINT_MAP = {
+    "nv-rerank-qa-mistral-4b:1": "https://ai.api.nvidia.com/v1/retrieval/nvidia/reranking",
     "nvidia/nv-rerankqa-mistral-4b-v3": "https://ai.api.nvidia.com/v1/retrieval/nvidia/nv-rerankqa-mistral-4b-v3/reranking",
     "nvidia/llama-3.2-nv-rerankqa-1b-v1": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v1/reranking",
     "nvidia/llama-3.2-nv-rerankqa-1b-v2": "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking",


### PR DESCRIPTION
### Related Issues

None

### Proposed Changes:

*Feature*: adds Fine-tuned Mistral-7B-v0.1 LLM as reranker to the set of known model's by adding it's endpoint to `_MODEL_ENDPOINT_MAP`

### How did you test it?

* ran `pytest tests/test_ranker.py`
* ran locally with test code with hatch venv `nvidia-haystack`

```py
from haystack_integrations.components.rankers.nvidia import NvidiaRanker
from haystack.utils import Secret

ranker = NvidiaRanker(
    model="nv-rerank-qa-mistral-4b:1",
    api_key=Secret.from_env_var("NVIDIA_API_KEY"),
)

ranker.warm_up()
```

### Notes for the reviewer

https://build.nvidia.com/nvidia/rerank-qa-mistral-4b?snippet_tab=Python

https://docs.api.nvidia.com/nim/reference/nvidia-rerank-qa-mistral-4b

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.