### PR TITLE
test: remove tests involving serialization of lambdas

### DIFF
--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -81,25 +81,6 @@ class TestAnthropicChatGenerator:
             },
         }
 
-    def test_to_dict_with_lambda_streaming_callback(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        component = AnthropicChatGenerator(
-            model="claude-3-5-sonnet-20240620",
-            streaming_callback=lambda x: x,
-            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-        )
-        data = component.to_dict()
-        assert data == {
-            "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "claude-3-5-sonnet-20240620",
-                "streaming_callback": "tests.test_chat_generator.<lambda>",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "ignore_tools_thinking_messages": True,
-            },
-        }
-
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-api-key")
         data = {

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -98,26 +98,6 @@ class TestCohereChatGenerator:
             },
         }
 
-    def test_to_dict_with_lambda_streaming_callback(self, monkeypatch):
-        monkeypatch.setenv("COHERE_API_KEY", "test-api-key")
-        component = CohereChatGenerator(
-            model="command-r",
-            streaming_callback=lambda x: x,
-            api_base_url="test-base-url",
-            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-        )
-        data = component.to_dict()
-        assert data == {
-            "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
-            "init_parameters": {
-                "model": "command-r",
-                "api_base_url": "test-base-url",
-                "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
-                "streaming_callback": "tests.test_cohere_chat_generator.<lambda>",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-            },
-        }
-
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("COHERE_API_KEY", "fake-api-key")
         monkeypatch.setenv("CO_API_KEY", "fake-api-key")


### PR DESCRIPTION
### Related Issues
Anthropic and Cohere nightly tests with Haystack main are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12681186127/job/35344406772 - https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12681372385/job/35344956395

This happens after we explicitly prohibited the serialization of lambdas in https://github.com/deepset-ai/haystack/pull/8683

### Proposed Changes:
- Remove the affected tests - serialization of callables is already tested in other tests in the respective test suites, with proper functions

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
