### PR TITLE
test: remove more tests involving serialization of lambdas

### DIFF
--- a/integrations/anthropic/tests/test_generator.py
+++ b/integrations/anthropic/tests/test_generator.py
@@ -70,25 +70,6 @@ class TestAnthropicGenerator:
             },
         }
 
-    def test_to_dict_with_lambda_streaming_callback(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        component = AnthropicGenerator(
-            model="claude-3-sonnet-20240229",
-            streaming_callback=lambda x: x,
-            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-        )
-        data = component.to_dict()
-        assert data == {
-            "type": "haystack_integrations.components.generators.anthropic.generator.AnthropicGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "claude-3-sonnet-20240229",
-                "streaming_callback": "tests.test_generator.<lambda>",
-                "system_prompt": None,
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-            },
-        }
-
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-api-key")
         data = {

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -83,30 +83,6 @@ class TestAnthropicVertexChatGenerator:
             },
         }
 
-    def test_to_dict_with_lambda_streaming_callback(self):
-        component = AnthropicVertexChatGenerator(
-            region="us-central1",
-            project_id="test-project-id",
-            model="claude-3-5-sonnet@20240620",
-            streaming_callback=lambda x: x,
-            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-        )
-        data = component.to_dict()
-        assert data == {
-            "type": (
-                "haystack_integrations.components.generators."
-                "anthropic.chat.vertex_chat_generator.AnthropicVertexChatGenerator"
-            ),
-            "init_parameters": {
-                "region": "us-central1",
-                "project_id": "test-project-id",
-                "model": "claude-3-5-sonnet@20240620",
-                "streaming_callback": "tests.test_vertex_chat_generator.<lambda>",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "ignore_tools_thinking_messages": True,
-            },
-        }
-
     def test_from_dict(self):
         data = {
             "type": (

--- a/integrations/cohere/tests/test_cohere_generator.py
+++ b/integrations/cohere/tests/test_cohere_generator.py
@@ -78,27 +78,6 @@ class TestCohereGenerator:
             },
         }
 
-    def test_to_dict_with_lambda_streaming_callback(self, monkeypatch):
-        monkeypatch.setenv("COHERE_API_KEY", "test-api-key")
-        component = CohereGenerator(
-            model="command-r",
-            max_tokens=10,
-            some_test_param="test-params",
-            streaming_callback=lambda x: x,
-            api_base_url="test-base-url",
-        )
-        data = component.to_dict()
-        assert data == {
-            "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
-            "init_parameters": {
-                "model": "command-r",
-                "streaming_callback": "tests.test_cohere_generator.<lambda>",
-                "api_base_url": "test-base-url",
-                "api_key": {"type": "env_var", "env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True},
-                "generation_kwargs": {},
-            },
-        }
-
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("COHERE_API_KEY", "fake-api-key")
         monkeypatch.setenv("CO_API_KEY", "fake-api-key")


### PR DESCRIPTION
### Related Issues
In #1281, I forgot to remove some tests and nightly tests failed again.

https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12700578430
https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12700763790

### Proposed Changes:
- Remove the affected tests - serialization of callables is already tested in other tests in the respective test suites, with proper functions


### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
