### PR TITLE
feat: Add Secret handling in OpenSearchDocumentStore

### DIFF
--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -263,6 +263,65 @@ class TestAuth:
             },
         }
 
+    @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+    def test_init_with_env_var_secrets(self, _mock_opensearch_client, monkeypatch):
+        """Test the default initialization using environment variables"""
+        monkeypatch.setenv("OPENSEARCH_USERNAME", "user")
+        monkeypatch.setenv("OPENSEARCH_PASSWORD", "pass")
+
+        document_store = OpenSearchDocumentStore(hosts="testhost")
+        assert document_store.client
+        _mock_opensearch_client.assert_called_once()
+        assert _mock_opensearch_client.call_args[1]["http_auth"] == ("user", "pass")
+
+    @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+    def test_init_with_missing_env_vars(self, _mock_opensearch_client):
+        """Test that auth is None when environment variables are missing"""
+        document_store = OpenSearchDocumentStore(hosts="testhost")
+        assert document_store.client
+        _mock_opensearch_client.assert_called_once()
+        assert _mock_opensearch_client.call_args[1]["http_auth"] is None
+
+    @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+    def test_to_dict_with_env_var_secrets(self, _mock_opensearch_client, monkeypatch):
+        """Test serialization with environment variables"""
+        monkeypatch.setenv("OPENSEARCH_USERNAME", "user")
+        monkeypatch.setenv("OPENSEARCH_PASSWORD", "pass")
+
+        document_store = OpenSearchDocumentStore(hosts="testhost")
+        serialized = document_store.to_dict()
+
+        assert "http_auth" in serialized["init_parameters"]
+        auth = serialized["init_parameters"]["http_auth"]
+        assert isinstance(auth, tuple)
+        # Check that we have two Secret dictionaries with correct env vars
+        assert auth[0]["type"] == "env_var"
+        assert auth[0]["env_vars"] == ["OPENSEARCH_USERNAME"]
+        assert auth[1]["type"] == "env_var"
+        assert auth[1]["env_vars"] == ["OPENSEARCH_PASSWORD"]
+
+    @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+    def test_from_dict_with_env_var_secrets(self, _mock_opensearch_client, monkeypatch):
+        """Test deserialization with environment variables"""
+        # Set environment variables so the secrets resolve properly
+        monkeypatch.setenv("OPENSEARCH_USERNAME", "user")
+        monkeypatch.setenv("OPENSEARCH_PASSWORD", "pass")
+
+        data = {
+            "type": "haystack_integrations.document_stores.opensearch.document_store.OpenSearchDocumentStore",
+            "init_parameters": {
+                "hosts": "testhost",
+                "http_auth": (
+                    {"type": "env_var", "env_vars": ["OPENSEARCH_USERNAME"], "strict": False},
+                    {"type": "env_var", "env_vars": ["OPENSEARCH_PASSWORD"], "strict": False},
+                ),
+            },
+        }
+        document_store = OpenSearchDocumentStore.from_dict(data)
+        assert document_store.client
+        _mock_opensearch_client.assert_called_once()
+        assert _mock_opensearch_client.call_args[1]["http_auth"] == ("user", "pass")
+
 
 @pytest.mark.integration
 class TestDocumentStore(DocumentStoreBaseTests):


### PR DESCRIPTION
### Why:
Enhances the authentication mechanism within the OpenSearch integration to allow for sensitive credentials to be managed securely using environment variables.

- fixes https://github.com/deepset-ai/haystack/issues/8659

### What:
- Introduced new capability to read OpenSearch credentials (`username` and `password`) from environment variables using the `Secret` class.
- Updated the initialization process to handle missing environment variables gracefully.
- Extended serialization and deserialization methods to include the handling of `Secret` objects for secure storage and retrieval of credentials.

### How can it be used:
Environment variable-based authentication can be leveraged by setting:
```bash
export OPENSEARCH_USERNAME="your_username"
export OPENSEARCH_PASSWORD="your_password"
```
Then, initialize the `OpenSearchDocumentStore` as follows:
```python
document_store = OpenSearchDocumentStore(hosts="your_host")
```

### How did you test it:
Testing involved mocking the `OpenSearch` client to verify the correct behavior of the authentication logic, including the execution of environment variable-based initialization and validation of serialized objects to check the correct capture of credentials as `Secret` dictionaries.

### Notes for the reviewer:
Focus on the sections handling the `http_auth` in dict serialization and the test cases for environment-based authentication to ensure consistent and secure handling of credentials. Verify that no credentials are logged or exposed improperly.