### PR TITLE
fix: Cohere - fix `ChatMessage` creation

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -172,7 +172,7 @@ class CohereChatGenerator:
                     response_text += event.text
                 elif event.event_type == "stream-end":
                     finish_response = event.response
-            chat_message = ChatMessage.from_assistant(content=response_text)
+            chat_message = ChatMessage.from_assistant(response_text)
 
             if finish_response and finish_response.meta:
                 if finish_response.meta.billed_units:
@@ -219,7 +219,7 @@ class CohereChatGenerator:
             # TODO revisit to see if we need to handle multiple tool calls
             message = ChatMessage.from_assistant(cohere_response.tool_calls[0].json())
         elif cohere_response.text:
-            message = ChatMessage.from_assistant(content=cohere_response.text)
+            message = ChatMessage.from_assistant(cohere_response.text)
         message.meta.update(
             {
                 "model": self.model,

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -144,7 +144,7 @@ class TestCohereChatGenerator:
     )
     @pytest.mark.integration
     def test_live_run(self):
-        chat_messages = [ChatMessage.from_user(content="What's the capital of France")]
+        chat_messages = [ChatMessage.from_user("What's the capital of France")]
         component = CohereChatGenerator(generation_kwargs={"temperature": 0.8})
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
@@ -181,7 +181,7 @@ class TestCohereChatGenerator:
 
         callback = Callback()
         component = CohereChatGenerator(streaming_callback=callback)
-        results = component.run([ChatMessage.from_user(content="What's the capital of France? answer in a word")])
+        results = component.run([ChatMessage.from_user("What's the capital of France? answer in a word")])
 
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
@@ -202,7 +202,7 @@ class TestCohereChatGenerator:
     )
     @pytest.mark.integration
     def test_live_run_with_connector(self):
-        chat_messages = [ChatMessage.from_user(content="What's the capital of France")]
+        chat_messages = [ChatMessage.from_user("What's the capital of France")]
         component = CohereChatGenerator(generation_kwargs={"temperature": 0.8})
         results = component.run(chat_messages, generation_kwargs={"connectors": [{"id": "web-search"}]})
         assert len(results["replies"]) == 1
@@ -227,7 +227,7 @@ class TestCohereChatGenerator:
                 self.responses += chunk.content if chunk.content else ""
 
         callback = Callback()
-        chat_messages = [ChatMessage.from_user(content="What's the capital of France? answer in a word")]
+        chat_messages = [ChatMessage.from_user("What's the capital of France? answer in a word")]
         component = CohereChatGenerator(streaming_callback=callback)
         results = component.run(chat_messages, generation_kwargs={"connectors": [{"id": "web-search"}]})
 


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/8583
- nightly test failure: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12778810943/job/35622334343

### Proposed Changes:
Create Chat Messages appropriately

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
