### PR TITLE
chore: Langfuse - pin `haystack-ai>=2.9.0` and simplify message conversion

### DIFF
--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.1.0", "langfuse"]
+dependencies = ["haystack-ai>=2.9.0", "langfuse"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -6,15 +6,11 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 
 from haystack import logging
 from haystack.dataclasses import ChatMessage
-from haystack.lazy_imports import LazyImport
 from haystack.tracing import Span, Tracer
 from haystack.tracing import tracer as proxy_tracer
 from haystack.tracing import utils as tracing_utils
 
 import langfuse
-
-with LazyImport("") as openai_utils_import:
-    from haystack.components.generators.openai_utils import _convert_message_to_openai_format
 
 logger = logging.getLogger(__name__)
 
@@ -86,24 +82,14 @@ class LangfuseSpan(Span):
             return
         if key.endswith(".input"):
             if "messages" in value:
-                if openai_utils_import.is_successful():
-                    # Haystack < 2.9.0
-                    messages = [_convert_message_to_openai_format(m) for m in value["messages"]]
-                else:
-                    # Haystack >= 2.9.0
-                    messages = [m.to_openai_dict_format() for m in value["messages"]]
+                messages = [m.to_openai_dict_format() for m in value["messages"]]
                 self._span.update(input=messages)
             else:
                 self._span.update(input=value)
         elif key.endswith(".output"):
             if "replies" in value:
                 if all(isinstance(r, ChatMessage) for r in value["replies"]):
-                    if openai_utils_import.is_successful():
-                        # Haystack < 2.9.0
-                        replies = [_convert_message_to_openai_format(m) for m in value["replies"]]
-                    else:
-                        # Haystack >= 2.9.0
-                        replies = [m.to_openai_dict_format() for m in value["replies"]]
+                    replies = [m.to_openai_dict_format() for m in value["replies"]]
                 else:
                     replies = value["replies"]
                 self._span.update(output=replies)


### PR DESCRIPTION
### Related Issues
- part of #1273
- in #1272, I introduced a not-so-nice check to make the tracer compatible with both Haystack 2.8.0 and 2.9.0

### Proposed Changes:
- pin `haystack-ai>=2.9.0`
- simplify message conversion

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
