### PR TITLE
chore: Mistral - pin  `haystack-ai>=2.9.0` and simplify test

### DIFF
--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai"]
+dependencies = ["haystack-ai>=2.9.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mistral#readme"

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -198,12 +198,7 @@ class TestMistralChatGenerator:
         ]
 
         for m in messages:
-            try:
-                # Haystack >= 2.9.0
-                component._check_finish_reason(m.meta)
-            except AttributeError:
-                # Haystack < 2.9.0
-                component._check_finish_reason(m)
+            component._check_finish_reason(m.meta)
 
         # check truncation warning
         message_template = (


### PR DESCRIPTION
### Related Issues
- part of #1273
- in #1271, I modified Mistral tests to be compatible with both Haystack 2.8.0 and 2.9.0

### Proposed Changes:
- pin `haystack-ai>=2.9.0`
- simplify test

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
