### PR TITLE
chore: Vertex - gently handle the future removal of `FUNCTION` role

### DIFF
--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -215,7 +215,7 @@ class VertexAIGeminiChatGenerator:
             return p
         elif message.is_from(ChatRole.SYSTEM) or message.is_from(ChatRole.ASSISTANT):
             return Part.from_text(message.text)
-        elif message.is_from(ChatRole.FUNCTION):
+        elif "FUNCTION" in ChatRole._member_names_ and message.is_from(ChatRole.FUNCTION):
             return Part.from_function_response(name=message.name, response=message.text)
         elif message.is_from(ChatRole.USER):
             return self._convert_part(message.text)
@@ -227,14 +227,15 @@ class VertexAIGeminiChatGenerator:
                 part.function_call.args[k] = v
         elif message.is_from(ChatRole.SYSTEM) or message.is_from(ChatRole.ASSISTANT):
             part = Part.from_text(message.text)
-        elif message.is_from(ChatRole.FUNCTION):
+        elif "FUNCTION" in ChatRole._member_names_ and message.is_from(ChatRole.FUNCTION):
             part = Part.from_function_response(name=message.name, response=message.text)
         elif message.is_from(ChatRole.USER):
             part = self._convert_part(message.text)
         else:
             msg = f"Unsupported message role {message.role}"
             raise ValueError(msg)
-        role = "user" if message.is_from(ChatRole.USER) or message.is_from(ChatRole.FUNCTION) else "model"
+
+        role = "model" if message.is_from(ChatRole.ASSISTANT) or message.is_from(ChatRole.SYSTEM) else "user"
         return Content(parts=[part], role=role)
 
     @component.output_types(replies=List[ChatMessage])


### PR DESCRIPTION
### Related Issues

Nightly tests with Haystack main are failing due to the removal of `FUNCTION` role in https://github.com/deepset-ai/haystack/pull/8725

failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12799206032/job/35684798292

### Proposed Changes:
- Gently handle the removal, checking if `FUNCTION` role is available

### How did you test it?
CI; local tests with Haystack main branch

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
