### PR TITLE
chore: Google-AI - gently handle the removal of `FUNCTION` role and `ChatMessage.from_function`

### DIFF
--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "google-generativeai>=0.3.1"]
+dependencies = ["haystack-ai>=2.9.0", "google-generativeai>=0.3.1"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_ai_haystack#readme"
@@ -56,7 +56,7 @@ cov = ["test-cov", "cov-report"]
 cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11"]
 
 [tool.hatch.envs.lint]
 installer = "uv"

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -242,12 +242,12 @@ class GoogleAIGeminiChatGenerator:
             p = Part()
             p.text = message.text
             return p
-        elif message.is_from(ChatRole.FUNCTION):
+        elif "FUNCTION" in ChatRole._member_names_ and message.is_from(ChatRole.FUNCTION):
             p = Part()
             p.function_response.name = message.name
             p.function_response.response = message.text
             return p
-        elif "TOOL" in ChatRole._member_names_ and message.is_from(ChatRole.TOOL):
+        elif message.is_from(ChatRole.TOOL):
             p = Part()
             p.function_response.name = message.tool_call_result.origin.tool_name
             p.function_response.response = message.tool_call_result.result
@@ -265,13 +265,13 @@ class GoogleAIGeminiChatGenerator:
         elif message.is_from(ChatRole.SYSTEM) or message.is_from(ChatRole.ASSISTANT):
             part = Part()
             part.text = message.text
-        elif message.is_from(ChatRole.FUNCTION):
+        elif "FUNCTION" in ChatRole._member_names_ and message.is_from(ChatRole.FUNCTION):
             part = Part()
             part.function_response.name = message.name
             part.function_response.response = message.text
         elif message.is_from(ChatRole.USER):
             part = self._convert_part(message.text)
-        elif "TOOL" in ChatRole._member_names_ and message.is_from(ChatRole.TOOL):
+        elif message.is_from(ChatRole.TOOL):
             part = Part()
             part.function_response.name = message.tool_call_result.origin.tool_name
             part.function_response.response = message.tool_call_result.result

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -227,16 +227,17 @@ def test_run():
     assert json.loads(chat_message.text) == {"location": "Berlin", "unit": "celsius"}
 
     weather = get_current_weather(**json.loads(chat_message.text))
-    messages += response["replies"] + [ChatMessage.from_function(weather, name="get_current_weather")]
-    response = gemini_chat.run(messages=messages)
-    assert "replies" in response
-    assert len(response["replies"]) > 0
-    assert all(reply.role == ChatRole.ASSISTANT for reply in response["replies"])
+    if hasattr(ChatMessage, "from_function"):
+        messages += response["replies"] + [ChatMessage.from_function(weather, name="get_current_weather")]
+        response = gemini_chat.run(messages=messages)
+        assert "replies" in response
+        assert len(response["replies"]) > 0
+        assert all(reply.role == ChatRole.ASSISTANT for reply in response["replies"])
 
-    # check the second response is not a function call
-    chat_message = response["replies"][0]
-    assert "function_call" not in chat_message.meta
-    assert isinstance(chat_message.text, str)
+        # check the second response is not a function call
+        chat_message = response["replies"][0]
+        assert "function_call" not in chat_message.meta
+        assert isinstance(chat_message.text, str)
 
 
 @pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")
@@ -273,16 +274,17 @@ def test_run_with_streaming_callback():
     assert json.loads(chat_message.text) == {"location": "Berlin", "unit": "celsius"}
 
     weather = get_current_weather(**json.loads(chat_message.text))
-    messages += response["replies"] + [ChatMessage.from_function(weather, name="get_current_weather")]
-    response = gemini_chat.run(messages=messages)
-    assert "replies" in response
-    assert len(response["replies"]) > 0
-    assert all(reply.role == ChatRole.ASSISTANT for reply in response["replies"])
+    if hasattr(ChatMessage, "from_function"):
+        messages += response["replies"] + [ChatMessage.from_function(weather, name="get_current_weather")]
+        response = gemini_chat.run(messages=messages)
+        assert "replies" in response
+        assert len(response["replies"]) > 0
+        assert all(reply.role == ChatRole.ASSISTANT for reply in response["replies"])
 
-    # check the second response is not a function call
-    chat_message = response["replies"][0]
-    assert "function_call" not in chat_message.meta
-    assert isinstance(chat_message.text, str)
+        # check the second response is not a function call
+        chat_message = response["replies"][0]
+        assert "function_call" not in chat_message.meta
+        assert isinstance(chat_message.text, str)
 
 
 @pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")


### PR DESCRIPTION
### Related Issues

Nightly tests with Haystack main are failing due to the removal of `FUNCTION` role and  `ChatMessage.from_function` in https://github.com/deepset-ai/haystack/pull/8725

failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12799530567/job/35685749382

### Proposed Changes:
- Gently handle the removal, checking if `FUNCTION` role is available
- avoid using `ChatMessage.from_function` in tests - if not available

### How did you test it?
CI; local tests with Haystack main branch

### Notes for the reviewer
You may notice how this PR is doing some workarounds to avoid tests failing.
I'll soon create an issue to keep track of proper implementation of Tool support in Google AI.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
