### PR TITLE
chore: llama.cpp - gently handle the removal of `ChatMessage.from_function`

### DIFF
--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "llama-cpp-python>=0.2.87"]
+dependencies = ["haystack-ai>=2.9.0", "llama-cpp-python>=0.2.87"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/llama_cpp#readme"

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -138,11 +138,7 @@ class LlamaCppChatGenerator:
                 name = tool_calls[0]["function"]["name"]
 
             reply = ChatMessage.from_assistant(choice["message"]["content"], meta=meta)
-            if name:
-                if hasattr(reply, "_name"):
-                    reply._name = name  # new ChatMessage
-                elif hasattr(reply, "name"):
-                    reply.name = name  # legacy ChatMessage
+            reply._name = name or None
             replies.append(reply)
 
         return {"replies": replies}


### PR DESCRIPTION
### Related Issues

Nightly tests with Haystack main are failing due to the removal of `ChatMessage.from_function` in https://github.com/deepset-ai/haystack/pull/8725

failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12799444834/job/35685509040

### Proposed Changes:
- Avoid using `ChatMessage.from_function` in tests - if not available
- Partially unrelated: pin `haystack-ai>=2.9.0` to remove a previously introduced compatibility check


### How did you test it?
CI; local tests with Haystack main branch

### Notes for the reviewer
You may notice how this PR is doing some workarounds to avoid tests failing.
I'll soon create an issue to keep track of proper implementation of Tool support in llama.cpp.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
