### PR TITLE
feat: Anthropic - support for Tools + refactoring

### DIFF
--- a/integrations/anthropic/example/prompt_caching.py
+++ b/integrations/anthropic/example/prompt_caching.py
@@ -59,7 +59,7 @@ system_message = ChatMessage.from_system(
 )
 
 if ENABLE_PROMPT_CACHING:
-    system_message.meta["cache_control"] = {"type": "ephemeral"}
+    system_message._meta["cache_control"] = {"type": "ephemeral"}
 
 questions = [
     "What's this paper about?",

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "anthropic"]
+dependencies = ["haystack-ai>=2.9.0", "anthropic"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/anthropic#readme"
@@ -48,6 +48,7 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
+  "jsonschema",  # needed for Tool
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -1,63 +1,152 @@
 import json
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
+from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall, ToolCallResult
+from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
 from anthropic import Anthropic, Stream
-from anthropic.types import (
-    ContentBlockDeltaEvent,
-    Message,
-    MessageDeltaEvent,
-    MessageStartEvent,
-    MessageStreamEvent,
-    TextBlock,
-    TextDelta,
-    ToolUseBlock,
-)
 
 logger = logging.getLogger(__name__)
+
+
+def _update_anthropic_message_with_tool_call_results(
+    tool_call_results: List[ToolCallResult], anthropic_msg: Dict[str, Any]
+) -> None:
+    """
+    Update an Anthropic message with tool call results.
+
+    :param tool_call_results: The list of ToolCallResults to update the message with.
+    :param anthropic_msg: The Anthropic message to update.
+    """
+    if "content" not in anthropic_msg:
+        anthropic_msg["content"] = []
+
+    for tool_call_result in tool_call_results:
+        if tool_call_result.origin.id is None:
+            msg = "`ToolCall` must have a non-null `id` attribute to be used with Anthropic."
+            raise ValueError(msg)
+        anthropic_msg["content"].append(
+            {
+                "type": "tool_result",
+                "tool_use_id": tool_call_result.origin.id,
+                "content": [{"type": "text", "text": tool_call_result.result}],
+                "is_error": tool_call_result.error,
+            }
+        )
+
+
+def _convert_tool_calls_to_anthropic_format(tool_calls: List[ToolCall]) -> List[Dict[str, Any]]:
+    """
+    Convert a list of tool calls to the format expected by Anthropic Chat API.
+
+    :param tool_calls: The list of ToolCalls to convert.
+    :return: A list of dictionaries in the format expected by Anthropic API.
+    """
+    anthropic_tool_calls = []
+    for tc in tool_calls:
+        if tc.id is None:
+            msg = "`ToolCall` must have a non-null `id` attribute to be used with Anthropic."
+            raise ValueError(msg)
+        anthropic_tool_calls.append(
+            {
+                "type": "tool_use",
+                "id": tc.id,
+                "name": tc.tool_name,
+                "input": tc.arguments,
+            }
+        )
+    return anthropic_tool_calls
+
+
+def _convert_messages_to_anthropic_format(
+    messages: List[ChatMessage],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """
+    Convert a list of messages to the format expected by Anthropic Chat API.
+
+    :param messages: The list of ChatMessages to convert.
+    :return: A tuple of two lists:
+        - A list of system message dictionaries in the format expected by Anthropic API.
+        - A list of non-system message dictionaries in the format expected by Anthropic API.
+    """
+
+    anthropic_system_messages = []
+    anthropic_non_system_messages = []
+
+    i = 0
+    while i < len(messages):
+        message = messages[i]
+
+        # allow passing cache_control
+        cache_control = {"cache_control": message.meta.get("cache_control")} if "cache_control" in message.meta else {}
+
+        # system messages have special format requirements for Anthropic API
+        # they can have only type and text fields, and they need to be passed separately
+        # to the Anthropic API endpoint
+        if message.is_from(ChatRole.SYSTEM):
+            anthropic_system_messages.append({"type": "text", "text": message.text, **cache_control})
+            i += 1
+            continue
+
+        anthropic_msg: Dict[str, Any] = {"role": message._role.value, "content": [], **cache_control}
+
+        if message.texts and message.texts[0]:
+            anthropic_msg["content"].append({"type": "text", "text": message.texts[0]})
+        if message.tool_calls:
+            anthropic_msg["content"] += _convert_tool_calls_to_anthropic_format(message.tool_calls)
+
+        if message.tool_call_results:
+            results = message.tool_call_results.copy()
+            # Handle consecutive tool call results
+            while (i + 1) < len(messages) and messages[i + 1].tool_call_results:
+                i += 1
+                results.extend(messages[i].tool_call_results)
+
+            _update_anthropic_message_with_tool_call_results(results, anthropic_msg)
+            anthropic_msg["role"] = "user"
+
+        if not anthropic_msg["content"]:
+            msg = "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, or `ToolCallResult`."
+            raise ValueError(msg)
+
+        anthropic_non_system_messages.append(anthropic_msg)
+        i += 1
+
+    return anthropic_system_messages, anthropic_non_system_messages
 
 
 @component
 class AnthropicChatGenerator:
     """
-    Enables text generation using Anthropic state-of-the-art Claude 3 family of large language models (LLMs) through
-    the Anthropic messaging API.
+    Completes chats using Anthropic's large language models (LLMs).
 
-    It supports models like `claude-3-5-sonnet`, `claude-3-opus`, `claude-3-sonnet`, and `claude-3-haiku`,
-    accessed through the [`/v1/messages`](https://docs.anthropic.com/en/api/messages) API endpoint.
+    It uses [ChatMessage](https://docs.haystack.deepset.ai/docs/data-classes#chatmessage)
+    format in input and output.
 
-    Users can pass any text generation parameters valid for the Anthropic messaging API directly to this component
-    via the `generation_kwargs` parameter in `__init__` or the `generation_kwargs` parameter in the `run` method.
+    You can customize how the text is generated by passing parameters to the
+    Anthropic API. Use the `**generation_kwargs` argument when you initialize
+    the component or when you run it. Any parameter that works with
+    `anthropic.Message.create` will work here too.
 
-    For more details on the parameters supported by the Anthropic API, refer to the
-    Anthropic Message API [documentation](https://docs.anthropic.com/en/api/messages).
+    For details on Anthropic API parameters, see
+    [Anthropic documentation](https://docs.anthropic.com/en/api/messages).
 
+    Usage example:
     ```python
-    from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
-    from haystack.dataclasses import ChatMessage
+    from haystack_experimental.components.generators.anthropic import AnthropicChatGenerator
+    from haystack_experimental.dataclasses import ChatMessage
 
-    messages = [ChatMessage.from_user("What's Natural Language Processing?")]
-    client = AnthropicChatGenerator(model="claude-3-5-sonnet-20240620")
-    response = client.run(messages)
-    print(response)
+    generator = AnthropicChatGenerator(model="claude-3-5-sonnet-20240620",
+                                       generation_kwargs={
+                                           "max_tokens": 1000,
+                                           "temperature": 0.7,
+                                       })
 
-    >> {'replies': [ChatMessage(content='Natural Language Processing (NLP) is a field of artificial intelligence that
-    >> focuses on enabling computers to understand, interpret, and generate human language. It involves developing
-    >> techniques and algorithms to analyze and process text or speech data, allowing machines to comprehend and
-    >> communicate in natural languages like English, Spanish, or Chinese.', role=<ChatRole.ASSISTANT: 'assistant'>,
-    >> name=None, meta={'model': 'claude-3-5-sonnet-20240620', 'index': 0, 'finish_reason': 'end_turn',
-    >> 'usage': {'input_tokens': 15, 'output_tokens': 64}})]}
-    ```
-
-    For more details on supported models and their capabilities, refer to the Anthropic
-    [documentation](https://docs.anthropic.com/claude/docs/intro-to-claude).
-
-    Note: We only support text input/output modalities, and
-    image [modality](https://docs.anthropic.com/en/docs/build-with-claude/vision) is not supported in
-    this version of AnthropicChatGenerator.
+    messages = [ChatMessage.from_system("You are a helpful, respectful and honest assistant"),
+                ChatMessage.from_user("What's Natural Language Processing?")]
+    print(generator.run(messages=messages))
     """
 
     # The parameters that can be passed to the Anthropic API https://docs.anthropic.com/claude/reference/messages_post
@@ -81,6 +170,7 @@ class AnthropicChatGenerator:
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         ignore_tools_thinking_messages: bool = True,
+        tools: Optional[List[Tool]] = None,
     ):
         """
         Creates an instance of AnthropicChatGenerator.
@@ -107,13 +197,18 @@ class AnthropicChatGenerator:
             `ignore_tools_thinking_messages` is `True`, the generator will drop so-called thinking messages when tool
             use is detected. See the Anthropic [tools](https://docs.anthropic.com/en/docs/tool-use#chain-of-thought-tool-use)
             for more details.
+        :param tools: A list of Tool objects that the model can use. Each tool should have a unique name.
+
         """
+        _check_duplicate_tool_names(tools)
+
         self.api_key = api_key
         self.model = model
         self.generation_kwargs = generation_kwargs or {}
         self.streaming_callback = streaming_callback
         self.client = Anthropic(api_key=self.api_key.resolve_value())
         self.ignore_tools_thinking_messages = ignore_tools_thinking_messages
+        self.tools = tools
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -129,6 +224,7 @@ class AnthropicChatGenerator:
             The serialized component as a dictionary.
         """
         callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
+        serialized_tools = [tool.to_dict() for tool in self.tools] if self.tools else None
         return default_to_dict(
             self,
             model=self.model,
@@ -136,6 +232,7 @@ class AnthropicChatGenerator:
             generation_kwargs=self.generation_kwargs,
             api_key=self.api_key.to_dict(),
             ignore_tools_thinking_messages=self.ignore_tools_thinking_messages,
+            tools=serialized_tools,
         )
 
     @classmethod
@@ -148,180 +245,130 @@ class AnthropicChatGenerator:
             The deserialized component instance.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        deserialize_tools_inplace(data["init_parameters"], key="tools")
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
             data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
+
         return default_from_dict(cls, data)
 
-    @component.output_types(replies=List[ChatMessage])
-    def run(self, messages: List[ChatMessage], generation_kwargs: Optional[Dict[str, Any]] = None):
+    @staticmethod
+    def _get_openai_compatible_usage(response_dict: dict) -> dict:
         """
-        Invoke the text generation inference based on the provided messages and generation parameters.
-
-        :param messages: A list of ChatMessage instances representing the input messages.
-        :param generation_kwargs: Additional keyword arguments for text generation. These parameters will
-                                  potentially override the parameters passed in the `__init__` method.
-                                  For more details on the parameters supported by the Anthropic API, refer to the
-                                  Anthropic [documentation](https://www.anthropic.com/python-library).
-
-        :returns:
-            - `replies`: A list of ChatMessage instances representing the generated responses.
+        Converts Anthropic usage metadata to OpenAI compatible format.
         """
+        usage = response_dict.get("usage", {})
+        if usage:
+            if "input_tokens" in usage:
+                usage["prompt_tokens"] = usage.pop("input_tokens")
+            if "output_tokens" in usage:
+                usage["completion_tokens"] = usage.pop("output_tokens")
 
-        # update generation kwargs by merging with the generation kwargs passed to the run method
-        generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
-        filtered_generation_kwargs = {k: v for k, v in generation_kwargs.items() if k in self.ALLOWED_PARAMS}
-        disallowed_params = set(generation_kwargs) - set(self.ALLOWED_PARAMS)
-        if disallowed_params:
-            logger.warning(
-                f"Model parameters {disallowed_params} are not allowed and will be ignored. "
-                f"Allowed parameters are {self.ALLOWED_PARAMS}."
-            )
-        system_messages: List[ChatMessage] = [msg for msg in messages if msg.is_from(ChatRole.SYSTEM)]
-        non_system_messages: List[ChatMessage] = [msg for msg in messages if not msg.is_from(ChatRole.SYSTEM)]
-        system_messages_formatted: List[Dict[str, Any]] = (
-            self._convert_to_anthropic_format(system_messages) if system_messages else []
-        )
-        messages_formatted: List[Dict[str, Any]] = (
-            self._convert_to_anthropic_format(non_system_messages) if non_system_messages else []
-        )
+        return usage
 
-        extra_headers = filtered_generation_kwargs.get("extra_headers", {})
-        prompt_caching_on = "anthropic-beta" in extra_headers and "prompt-caching" in extra_headers["anthropic-beta"]
-        has_cached_messages = any("cache_control" in m for m in system_messages_formatted) or any(
-            "cache_control" in m for m in messages_formatted
-        )
-        if has_cached_messages and not prompt_caching_on:
-            # this avoids Anthropic errors when prompt caching is not enabled
-            # but user requested individual messages to be cached
-            logger.warn(
-                "Prompt caching is not enabled but you requested individual messages to be cached. "
-                "Messages will be sent to the API without prompt caching."
-            )
-            system_messages_formatted = list(map(self._remove_cache_control, system_messages_formatted))
-            messages_formatted = list(map(self._remove_cache_control, messages_formatted))
-
-        response: Union[Message, Stream[MessageStreamEvent]] = self.client.messages.create(
-            max_tokens=filtered_generation_kwargs.pop("max_tokens", 512),
-            system=system_messages_formatted or filtered_generation_kwargs.pop("system", ""),
-            model=self.model,
-            messages=messages_formatted,
-            stream=self.streaming_callback is not None,
-            **filtered_generation_kwargs,
-        )
-
-        completions: List[ChatMessage] = []
-        # if streaming is enabled, the response is a Stream[MessageStreamEvent]
-        if isinstance(response, Stream):
-            chunks: List[StreamingChunk] = []
-            stream_event, delta, start_event = None, None, None
-            for stream_event in response:
-                if isinstance(stream_event, MessageStartEvent):
-                    # capture start message to count input tokens
-                    start_event = stream_event
-                if isinstance(stream_event, ContentBlockDeltaEvent):
-                    chunk_delta: StreamingChunk = self._build_chunk(stream_event.delta)
-                    chunks.append(chunk_delta)
-                    if self.streaming_callback:
-                        self.streaming_callback(chunk_delta)  # invoke callback with the chunk_delta
-                if isinstance(stream_event, MessageDeltaEvent):
-                    # capture stop reason and stop sequence
-                    delta = stream_event
-            completions = [self._connect_chunks(chunks, start_event, delta)]
-
-        # if streaming is disabled, the response is an Anthropic Message
-        elif isinstance(response, Message):
-            has_tools_msgs = any(isinstance(content_block, ToolUseBlock) for content_block in response.content)
-            if has_tools_msgs and self.ignore_tools_thinking_messages:
-                response.content = [block for block in response.content if isinstance(block, ToolUseBlock)]
-            completions = [self._build_message(content_block, response) for content_block in response.content]
-
-        # rename the meta key to be inline with OpenAI meta output keys
-        for response in completions:
-            if response.meta is not None and "usage" in response.meta:
-                response.meta["usage"]["prompt_tokens"] = response.meta["usage"].pop("input_tokens")
-                response.meta["usage"]["completion_tokens"] = response.meta["usage"].pop("output_tokens")
-
-        return {"replies": completions}
-
-    def _build_message(self, content_block: Union[TextBlock, ToolUseBlock], message: Message) -> ChatMessage:
-        """
-        Converts the non-streaming Anthropic Message to a ChatMessage.
-        :param content_block: The content block of the message.
-        :param message: The non-streaming Anthropic Message.
-        :returns: The ChatMessage.
-        """
-        if isinstance(content_block, TextBlock):
-            chat_message = ChatMessage.from_assistant(content_block.text)
-        else:
-            chat_message = ChatMessage.from_assistant(json.dumps(content_block.model_dump(mode="json")))
-        chat_message.meta.update(
-            {
-                "model": message.model,
-                "index": 0,
-                "finish_reason": message.stop_reason,
-                "usage": dict(message.usage or {}),
-            }
-        )
-        return chat_message
-
-    def _convert_to_anthropic_format(self, messages: List[ChatMessage]) -> List[Dict[str, Any]]:
-        """
-        Converts the list of ChatMessage to the list of messages in the format expected by the Anthropic API.
-        :param messages: The list of ChatMessage.
-        :returns: The list of messages in the format expected by the Anthropic API.
-        """
-        anthropic_formatted_messages = []
-        for m in messages:
-            message_dict = m.to_dict()
-            formatted_message = {}
-
-            # legacy format
-            if "role" in message_dict and "content" in message_dict:
-                formatted_message = {k: v for k, v in message_dict.items() if k in {"role", "content"} and v}
-            # new format
-            elif "_role" in message_dict and "_content" in message_dict:
-                formatted_message = {"role": m.role.value, "content": m.text}
-
-            if m.is_from(ChatRole.SYSTEM):
-                # system messages are treated differently and MUST be in the format expected by the Anthropic API
-                # remove role and content from the message dict, add type and text
-                formatted_message.pop("role")
-                formatted_message["type"] = "text"
-                formatted_message["text"] = formatted_message.pop("content")
-            formatted_message.update(m.meta or {})
-            anthropic_formatted_messages.append(formatted_message)
-        return anthropic_formatted_messages
-
-    def _connect_chunks(
-        self, chunks: List[StreamingChunk], message_start: MessageStartEvent, delta: MessageDeltaEvent
+    def _convert_chat_completion_to_chat_message(
+        self, anthropic_response: Any, ignore_tools_thinking_messages: bool
     ) -> ChatMessage:
         """
-        Connects the streaming chunks into a single ChatMessage.
-        :param chunks: The list of all chunks returned by the Anthropic API.
-        :param message_start: The MessageStartEvent.
-        :param delta: The MessageDeltaEvent.
-        :returns: The complete ChatMessage.
+        Converts the response from the Anthropic API to a ChatMessage.
         """
-        complete_response = ChatMessage.from_assistant("".join([chunk.content for chunk in chunks]))
-        complete_response.meta.update(
+        tool_calls = [
+            ToolCall(tool_name=block.name, arguments=block.input, id=block.id)
+            for block in anthropic_response.content
+            if block.type == "tool_use"
+        ]
+
+        # Extract and join text blocks, respecting ignore_tools_thinking_messages
+        text = ""
+        if not (ignore_tools_thinking_messages and tool_calls):
+            text = " ".join(block.text for block in anthropic_response.content if block.type == "text")
+
+        message = ChatMessage.from_assistant(text=text, tool_calls=tool_calls)
+
+        # Dump the chat completion to a dict
+        response_dict = anthropic_response.model_dump()
+        usage = self._get_openai_compatible_usage(response_dict)
+        message._meta.update(
             {
-                "model": self.model,
+                "model": response_dict.get("model", None),
                 "index": 0,
-                "finish_reason": delta.delta.stop_reason if delta else "end_turn",
-                "usage": {**dict(message_start.message.usage, **dict(delta.usage))} if delta and message_start else {},
+                "finish_reason": response_dict.get("stop_reason", None),
+                "usage": usage,
             }
         )
-        return complete_response
+        return message
 
-    def _build_chunk(self, delta: TextDelta) -> StreamingChunk:
+    def _convert_anthropic_chunk_to_streaming_chunk(self, chunk: Any) -> StreamingChunk:
         """
-        Converts the ContentBlockDeltaEvent to a StreamingChunk.
-        :param delta: The ContentBlockDeltaEvent.
-        :returns: The StreamingChunk.
+        Converts an Anthropic StreamEvent to a StreamingChunk.
         """
-        return StreamingChunk(content=delta.text)
+        content = ""
+        if chunk.type == "content_block_delta" and chunk.delta.type == "text_delta":
+            content = chunk.delta.text
+
+        return StreamingChunk(content=content, meta=chunk.model_dump())
+
+    def _convert_streaming_chunks_to_chat_message(
+        self, chunks: List[StreamingChunk], model: Optional[str] = None
+    ) -> ChatMessage:
+        """
+        Converts a list of StreamingChunks to a ChatMessage.
+        """
+        full_content = ""
+        tool_calls = []
+        current_tool_call: Optional[Dict[str, Any]] = {}
+
+        # loop through chunks and call the appropriate handler
+        for chunk in chunks:
+            chunk_type = chunk.meta.get("type")
+            if chunk_type == "content_block_start":
+                if chunk.meta.get("content_block", {}).get("type") == "tool_use":
+                    delta_block = chunk.meta.get("content_block")
+                    current_tool_call = {
+                        "id": delta_block.get("id"),
+                        "name": delta_block.get("name"),
+                        "arguments": "",
+                    }
+            elif chunk_type == "content_block_delta":
+                delta = chunk.meta.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    full_content += delta.get("text", "")
+                elif delta.get("type") == "input_json_delta" and current_tool_call:
+                    current_tool_call["arguments"] += delta.get("partial_json", "")
+            elif chunk_type == "message_delta":
+                if chunk.meta.get("delta", {}).get("stop_reason") == "tool_use" and current_tool_call:
+                    try:
+                        # arguments is a string, convert to json
+                        tool_calls.append(
+                            ToolCall(
+                                id=current_tool_call.get("id"),
+                                tool_name=str(current_tool_call.get("name")),
+                                arguments=json.loads(current_tool_call.get("arguments", {})),
+                            )
+                        )
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Anthropic returned a malformed JSON string for tool call arguments. "
+                            f"This tool call will be skipped. Arguments: {current_tool_call.get('arguments', '')}",
+                        )
+                    current_tool_call = None
+
+        message = ChatMessage.from_assistant(full_content, tool_calls=tool_calls)
+
+        # Update meta information
+        last_chunk_meta = chunks[-1].meta
+        usage = self._get_openai_compatible_usage(last_chunk_meta)
+        message._meta.update(
+            {
+                "model": model,
+                "index": 0,
+                "finish_reason": last_chunk_meta.get("delta", {}).get("stop_reason", None),
+                "usage": usage,
+            }
+        )
+
+        return message
 
     def _remove_cache_control(self, message: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -330,3 +377,104 @@ class AnthropicChatGenerator:
         :returns: The message with the cache_control key removed.
         """
         return {k: v for k, v in message.items() if k != "cache_control"}
+
+    @component.output_types(replies=List[ChatMessage])
+    def run(
+        self,
+        messages: List[ChatMessage],
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        tools: Optional[List[Tool]] = None,
+    ):
+        """
+        Invokes the Anthropic API with the given messages and generation kwargs.
+
+        :param messages: A list of ChatMessage instances representing the input messages.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param tools: A list of tools for which the model can prepare calls. If set, it will override
+        the `tools` parameter set during component initialization.
+        :returns: A dictionary with the following keys:
+            - `replies`: The responses from the model
+        """
+        # update generation kwargs by merging with the generation kwargs passed to the run method
+        generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+        disallowed_params = set(generation_kwargs) - set(self.ALLOWED_PARAMS)
+        if disallowed_params:
+            logger.warning(
+                "Model parameters %s are not allowed and will be ignored. Allowed parameters are %s.",
+                disallowed_params,
+                self.ALLOWED_PARAMS,
+            )
+        generation_kwargs = {k: v for k, v in generation_kwargs.items() if k in self.ALLOWED_PARAMS}
+
+        system_messages, non_system_messages = _convert_messages_to_anthropic_format(messages)
+
+        # prompt caching
+        extra_headers = generation_kwargs.get("extra_headers", {})
+        prompt_caching_on = "anthropic-beta" in extra_headers and "prompt-caching" in extra_headers["anthropic-beta"]
+        has_cached_messages = any("cache_control" in m for m in system_messages) or any(
+            "cache_control" in m for m in non_system_messages
+        )
+        if has_cached_messages and not prompt_caching_on:
+            # this avoids Anthropic errors when prompt caching is not enabled
+            # but user requested individual messages to be cached
+            logger.warn(
+                "Prompt caching is not enabled but you requested individual messages to be cached. "
+                "Messages will be sent to the API without prompt caching."
+            )
+            system_messages = list(map(self._remove_cache_control, system_messages))
+            non_system_messages = list(map(self._remove_cache_control, non_system_messages))
+
+        # tools management
+        tools = tools or self.tools
+        _check_duplicate_tool_names(tools)
+        anthropic_tools = (
+            [
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "input_schema": tool.parameters,
+                }
+                for tool in tools
+            ]
+            if tools
+            else []
+        )
+
+        streaming_callback = streaming_callback or self.streaming_callback
+
+        response = self.client.messages.create(
+            model=self.model,
+            messages=non_system_messages,
+            system=system_messages,
+            tools=anthropic_tools,
+            stream=streaming_callback is not None,
+            max_tokens=generation_kwargs.pop("max_tokens", 1024),
+            **generation_kwargs,
+        )
+
+        if isinstance(response, Stream):
+            chunks: List[StreamingChunk] = []
+            model: Optional[str] = None
+            for chunk in response:
+                if chunk.type == "message_start":
+                    model = chunk.message.model
+                elif chunk.type in [
+                    "content_block_start",
+                    "content_block_delta",
+                    "message_delta",
+                ]:
+                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk)
+                    chunks.append(streaming_chunk)
+                    if streaming_callback:
+                        streaming_callback(streaming_chunk)
+
+            completion = self._convert_streaming_chunks_to_chat_message(chunks, model)
+            return {"replies": [completion]}
+        else:
+            return {
+                "replies": [
+                    self._convert_chat_completion_to_chat_message(response, self.ignore_tools_thinking_messages)
+                ]
+            }

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -1,117 +1,254 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
 import json
+import logging
 import os
+from unittest.mock import patch
 
 import anthropic
 import pytest
+from anthropic.types import (
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    Message,
+    MessageStartEvent,
+    TextBlockParam,
+    TextDelta,
+)
+from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
+from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
+from haystack.tools import Tool
 from haystack.utils.auth import Secret
 
-from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
+from haystack_integrations.components.generators.anthropic.chat.chat_generator import (
+    AnthropicChatGenerator,
+    _convert_messages_to_anthropic_format,
+)
+
+
+@pytest.fixture
+def tools():
+    tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+    tool = Tool(
+        name="weather",
+        description="useful to determine the weather in a given location",
+        parameters=tool_parameters,
+        function=lambda x: x,
+    )
+
+    return [tool]
 
 
 @pytest.fixture
 def chat_messages():
     return [
-        ChatMessage.from_system("\\nYou are a helpful assistant, be super brief in your responses."),
-        ChatMessage.from_user("What's the capital of France?"),
+        ChatMessage.from_user("What's the capital of France"),
     ]
+
+
+@pytest.fixture
+def mock_anthropic_completion():
+    with patch("anthropic.resources.messages.Messages.create") as mock_anthropic:
+        completion = Message(
+            id="foo",
+            type="message",
+            model="claude-3-5-sonnet-20240620",
+            role="assistant",
+            content=[TextBlockParam(type="text", text="Hello! I'm Claude.")],
+            stop_reason="end_turn",
+            usage={"input_tokens": 10, "output_tokens": 20},
+        )
+        mock_anthropic.return_value = completion
+        yield mock_anthropic
 
 
 class TestAnthropicChatGenerator:
     def test_init_default(self, monkeypatch):
+        """
+        Test the default initialization of the AnthropicChatGenerator component.
+        """
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
         component = AnthropicChatGenerator()
         assert component.client.api_key == "test-api-key"
         assert component.model == "claude-3-5-sonnet-20240620"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
-        assert component.ignore_tools_thinking_messages
+        assert component.tools is None
 
     def test_init_fail_wo_api_key(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component fails to initialize without an API key.
+        """
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError):
             AnthropicChatGenerator()
 
-    def test_init_with_parameters(self):
+    def test_init_fail_with_duplicate_tool_names(self, monkeypatch, tools):
+        """
+        Test that the AnthropicChatGenerator component fails to initialize with duplicate tool names.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+
+        duplicate_tools = [tools[0], tools[0]]
+        with pytest.raises(ValueError):
+            AnthropicChatGenerator(tools=duplicate_tools)
+
+    def test_init_with_parameters(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component initializes with parameters.
+        """
+        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=lambda x: x)
+
+        monkeypatch.setenv("OPENAI_TIMEOUT", "100")
+        monkeypatch.setenv("OPENAI_MAX_RETRIES", "10")
         component = AnthropicChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             model="claude-3-5-sonnet-20240620",
             streaming_callback=print_streaming_chunk,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-            ignore_tools_thinking_messages=False,
+            tools=[tool],
         )
         assert component.client.api_key == "test-api-key"
         assert component.model == "claude-3-5-sonnet-20240620"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
-        assert component.ignore_tools_thinking_messages is False
+        assert component.tools == [tool]
+
+    def test_init_with_parameters_and_env_vars(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component initializes with parameters and env vars.
+        """
+        monkeypatch.setenv("OPENAI_TIMEOUT", "100")
+        monkeypatch.setenv("OPENAI_MAX_RETRIES", "10")
+        component = AnthropicChatGenerator(
+            model="claude-3-5-sonnet-20240620",
+            api_key=Secret.from_token("test-api-key"),
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+        )
+        assert component.client.api_key == "test-api-key"
+        assert component.model == "claude-3-5-sonnet-20240620"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
     def test_to_dict_default(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component can be serialized to a dictionary.
+        """
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
         component = AnthropicChatGenerator()
         data = component.to_dict()
         assert data == {
             "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
+                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "type": "env_var", "strict": True},
                 "model": "claude-3-5-sonnet-20240620",
                 "streaming_callback": None,
-                "generation_kwargs": {},
                 "ignore_tools_thinking_messages": True,
+                "generation_kwargs": {},
+                "tools": None,
             },
         }
 
     def test_to_dict_with_parameters(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component can be serialized to a dictionary with parameters.
+        """
+        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
+
         monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = AnthropicChatGenerator(
             api_key=Secret.from_env_var("ENV_VAR"),
+            model="claude-3-5-sonnet-20240620",
             streaming_callback=print_streaming_chunk,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+            tools=[tool],
         )
         data = component.to_dict()
+
         assert data == {
             "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
+                "api_key": {"env_vars": ["ENV_VAR"], "type": "env_var", "strict": True},
                 "model": "claude-3-5-sonnet-20240620",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "ignore_tools_thinking_messages": True,
+                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+                "tools": [
+                    {
+                        "data": {
+                            "description": "description",
+                            "function": "builtins.print",
+                            "name": "name",
+                            "parameters": {
+                                "x": {
+                                    "type": "string",
+                                },
+                            },
+                        },
+                        "type": "haystack.tools.tool.Tool",
+                    }
+                ],
             },
         }
 
     def test_from_dict(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component can be deserialized from a dictionary.
+        """
         monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-api-key")
         data = {
             "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
+                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "type": "env_var", "strict": True},
                 "model": "claude-3-5-sonnet-20240620",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "ignore_tools_thinking_messages": True,
+                "tools": [
+                    {
+                        "type": "haystack.tools.tool.Tool",
+                        "data": {
+                            "description": "description",
+                            "function": "builtins.print",
+                            "name": "name",
+                            "parameters": {
+                                "x": {
+                                    "type": "string",
+                                },
+                            },
+                        },
+                    },
+                ],
             },
         }
         component = AnthropicChatGenerator.from_dict(data)
+
+        assert isinstance(component, AnthropicChatGenerator)
         assert component.model == "claude-3-5-sonnet-20240620"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
         assert component.api_key == Secret.from_env_var("ANTHROPIC_API_KEY")
+        assert component.tools == [
+            Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
+        ]
 
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component fails to deserialize from a dictionary without an API key.
+        """
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         data = {
             "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
             "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
+                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "type": "env_var", "strict": True},
                 "model": "claude-3-5-sonnet-20240620",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "ignore_tools_thinking_messages": True,
             },
         }
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError):
             AnthropicChatGenerator.from_dict(data)
 
     def test_run(self, chat_messages, mock_chat_completion):
@@ -125,23 +262,323 @@ class TestAnthropicChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    def test_run_with_params(self, chat_messages, mock_chat_completion):
+    def test_run_with_params(self, chat_messages, mock_anthropic_completion):
+        """
+        Test that the AnthropicChatGenerator component can run with parameters.
+        """
         component = AnthropicChatGenerator(
             api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
         )
         response = component.run(chat_messages)
 
-        # check that the component calls the Anthropic API with the correct parameters
-        _, kwargs = mock_chat_completion.call_args
+        # Check that the component calls the Anthropic API with the correct parameters
+        _, kwargs = mock_anthropic_completion.call_args
         assert kwargs["max_tokens"] == 10
         assert kwargs["temperature"] == 0.5
 
-        # check that the component returns the correct response
+        # Check that the component returns the correct response
         assert isinstance(response, dict)
         assert "replies" in response
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) == 1
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert isinstance(response["replies"][0], ChatMessage)
+        assert "Hello! I'm Claude." in response["replies"][0].text
+        assert response["replies"][0].meta["model"] == "claude-3-5-sonnet-20240620"
+        assert response["replies"][0].meta["finish_reason"] == "end_turn"
+
+    def test_check_duplicate_tool_names(self, tools):
+        """Test that the AnthropicChatGenerator component fails to initialize with duplicate tool names."""
+        with pytest.raises(ValueError):
+            AnthropicChatGenerator(tools=tools + tools)
+
+    def test_convert_anthropic_chunk_to_streaming_chunk(self):
+        """
+        Test converting Anthropic stream events to Haystack StreamingChunks
+        """
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+
+        # Test text delta chunk
+        text_delta_chunk = ContentBlockDeltaEvent(
+            type="content_block_delta", index=0, delta=TextDelta(type="text_delta", text="Hello, world!")
+        )
+        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(text_delta_chunk)
+        assert streaming_chunk.content == "Hello, world!"
+        assert streaming_chunk.meta == {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello, world!"},
+        }
+
+        # Test non-text chunk (should have empty content)
+        message_start_chunk = MessageStartEvent(
+            type="message_start",
+            message={
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-3-5-sonnet-20240620",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 25, "output_tokens": 1},
+            },
+        )
+        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(message_start_chunk)
+        assert streaming_chunk.content == ""
+        assert streaming_chunk.meta == {
+            "type": "message_start",
+            "message": {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-3-5-sonnet-20240620",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {
+                    "input_tokens": 25,
+                    "output_tokens": 1,
+                    "cache_creation_input_tokens": None,
+                    "cache_read_input_tokens": None,
+                },
+            },
+        }
+
+        # Test tool use chunk (should have empty content)
+        tool_use_chunk = ContentBlockStartEvent(
+            type="content_block_start",
+            index=1,
+            content_block={"type": "tool_use", "id": "toolu_123", "name": "weather", "input": {"city": "Paris"}},
+        )
+        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(tool_use_chunk)
+        assert streaming_chunk.content == ""
+        assert streaming_chunk.meta == {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "tool_use", "id": "toolu_123", "name": "weather", "input": {"city": "Paris"}},
+        }
+
+    def test_convert_streaming_chunks_to_chat_message(self):
+        """
+        Test converting streaming chunks to a chat message with tool calls
+        """
+        # Create a sequence of streaming chunks that simulate Anthropic's response
+        chunks = [
+            # Initial text content
+            StreamingChunk(
+                content="",
+                meta={"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            ),
+            StreamingChunk(
+                content="Let me check",
+                meta={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Let me check"},
+                },
+            ),
+            StreamingChunk(
+                content=" the weather",
+                meta={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": " the weather"},
+                },
+            ),
+            StreamingChunk(content="", meta={"type": "content_block_stop", "index": 0}),
+            # Tool use content
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "content_block_start",
+                    "index": 1,
+                    "content_block": {"type": "tool_use", "id": "toolu_123", "name": "weather", "input": {}},
+                },
+            ),
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"city":'},
+                },
+            ),
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {"type": "input_json_delta", "partial_json": ' "Paris"}'},
+                },
+            ),
+            StreamingChunk(content="", meta={"type": "content_block_stop", "index": 1}),
+            # Final message delta
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+                    "usage": {"completion_tokens": 40},
+                },
+            ),
+        ]
+
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        message = component._convert_streaming_chunks_to_chat_message(chunks, model="claude-3-sonnet")
+
+        # Verify the message content
+        assert message.text == "Let me check the weather"
+
+        # Verify tool calls
+        assert len(message.tool_calls) == 1
+        tool_call = message.tool_calls[0]
+        assert tool_call.id == "toolu_123"
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+
+        # Verify meta information
+        assert message._meta["model"] == "claude-3-sonnet"
+        assert message._meta["index"] == 0
+        assert message._meta["finish_reason"] == "tool_use"
+        assert message._meta["usage"] == {"completion_tokens": 40}
+
+    def test_convert_streaming_chunks_to_chat_message_malformed_json(self, caplog):
+        """
+        Test converting streaming chunks with malformed JSON in tool arguments (increases coverage)
+        """
+        chunks = [
+            # Initial text content
+            StreamingChunk(
+                content="",
+                meta={"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            ),
+            StreamingChunk(
+                content="Let me check the weather",
+                meta={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Let me check the weather"},
+                },
+            ),
+            StreamingChunk(content="", meta={"type": "content_block_stop", "index": 0}),
+            # Tool use content with malformed JSON
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "content_block_start",
+                    "index": 1,
+                    "content_block": {"type": "tool_use", "id": "toolu_123", "name": "weather", "input": {}},
+                },
+            ),
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"city":'},
+                },
+            ),
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": ' "Paris',  # Missing closing quote and brace, malformed JSON
+                    },
+                },
+            ),
+            StreamingChunk(content="", meta={"type": "content_block_stop", "index": 1}),
+            # Final message delta
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+                    "usage": {"completion_tokens": 40},
+                },
+            ),
+        ]
+
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        message = component._convert_streaming_chunks_to_chat_message(chunks, model="claude-3-sonnet")
+
+        # Verify the message content is preserve
+        assert message.text == "Let me check the weather"
+
+        # But the tool_calls are empty
+        assert len(message.tool_calls) == 0
+
+        # and we have logged a warning
+        with caplog.at_level(logging.WARNING):
+            assert "Anthropic returned a malformed JSON string" in caplog.text
+
+    def test_serde_in_pipeline(self):
+        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
+
+        generator = AnthropicChatGenerator(
+            api_key=Secret.from_env_var("ANTHROPIC_API_KEY", strict=False),
+            model="claude-3-5-sonnet-20240620",
+            generation_kwargs={"temperature": 0.6},
+            tools=[tool],
+        )
+
+        pipeline = Pipeline()
+        pipeline.add_component("generator", generator)
+
+        pipeline_dict = pipeline.to_dict()
+        type_ = "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator"
+        assert pipeline_dict == {
+            "metadata": {},
+            "max_runs_per_component": 100,
+            "components": {
+                "generator": {
+                    "type": type_,
+                    "init_parameters": {
+                        "api_key": {"type": "env_var", "env_vars": ["ANTHROPIC_API_KEY"], "strict": False},
+                        "model": "claude-3-5-sonnet-20240620",
+                        "generation_kwargs": {"temperature": 0.6},
+                        "ignore_tools_thinking_messages": True,
+                        "streaming_callback": None,
+                        "tools": [
+                            {
+                                "type": "haystack.tools.tool.Tool",
+                                "data": {
+                                    "name": "name",
+                                    "description": "description",
+                                    "parameters": {"x": {"type": "string"}},
+                                    "function": "builtins.print",
+                                },
+                            }
+                        ],
+                    },
+                }
+            },
+            "connections": [],
+        }
+
+        pipeline_yaml = pipeline.dumps()
+
+        new_pipeline = Pipeline.loads(pipeline_yaml)
+        assert new_pipeline == pipeline
+
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY", None),
+        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run(self):
+        """
+        Integration test that the AnthropicChatGenerator component can run with default parameters.
+        """
+        component = AnthropicChatGenerator()
+        results = component.run(messages=[ChatMessage.from_user("What's the capital of France?")])
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "claude-3-5-sonnet-20240620" in message.meta["model"]
+        assert message.meta["finish_reason"] == "end_turn"
 
     @pytest.mark.skipif(
         not os.environ.get("ANTHROPIC_API_KEY", None),
@@ -155,94 +592,347 @@ class TestAnthropicChatGenerator:
 
     @pytest.mark.skipif(
         not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+        reason="Export an env var called ANTHROPIC_API_KEY containing the OpenAI API key to run this test.",
     )
     @pytest.mark.integration
-    def test_default_inference_params(self, chat_messages):
-        client = AnthropicChatGenerator()
-        response = client.run(chat_messages)
+    def test_live_run_streaming(self):
+        """
+        Integration test that the AnthropicChatGenerator component can run with streaming.
+        """
 
-        assert "replies" in response, "Response does not contain 'replies' key"
-        replies = response["replies"]
-        assert isinstance(replies, list), "Replies is not a list"
-        assert len(replies) > 0, "No replies received"
+        class Callback:
+            def __init__(self):
+                self.responses = ""
+                self.counter = 0
 
-        first_reply = replies[0]
-        assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.text, "First reply has no text"
-        assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "paris" in first_reply.text.lower(), "First reply does not contain 'paris'"
-        assert first_reply.meta, "First reply has no metadata"
+            def __call__(self, chunk: StreamingChunk) -> None:
+                self.counter += 1
+                self.responses += chunk.content if chunk.content else ""
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_default_inference_with_streaming(self, chat_messages):
-        streaming_callback_called = False
-        paris_found_in_response = False
+        callback = Callback()
+        component = AnthropicChatGenerator(streaming_callback=callback)
+        results = component.run([ChatMessage.from_user("What's the capital of France?")])
 
-        def streaming_callback(chunk: StreamingChunk):
-            nonlocal streaming_callback_called, paris_found_in_response
-            streaming_callback_called = True
-            assert isinstance(chunk, StreamingChunk)
-            assert chunk.content is not None
-            if not paris_found_in_response:
-                paris_found_in_response = "paris" in chunk.content.lower()
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
 
-        client = AnthropicChatGenerator(streaming_callback=streaming_callback)
-        response = client.run(chat_messages)
+        assert "claude-3-5-sonnet-20240620" in message.meta["model"]
+        assert message.meta["finish_reason"] == "end_turn"
 
-        assert streaming_callback_called, "Streaming callback was not called"
-        assert paris_found_in_response, "The streaming callback response did not contain 'paris'"
-        replies = response["replies"]
-        assert isinstance(replies, list), "Replies is not a list"
-        assert len(replies) > 0, "No replies received"
+        assert callback.counter > 1
+        assert "Paris" in callback.responses
 
-        first_reply = replies[0]
-        assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.text, "First reply has no text"
-        assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "paris" in first_reply.text.lower(), "First reply does not contain 'paris'"
-        assert first_reply.meta, "First reply has no metadata"
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_tools_use(self):
-        # See https://docs.anthropic.com/en/docs/tool-use for more information
-        tools_schema = {
-            "name": "get_stock_price",
-            "description": "Retrieves the current stock price for a given ticker symbol.",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "ticker": {"type": "string", "description": "The stock ticker symbol, e.g. AAPL for Apple Inc."}
-                },
-                "required": ["ticker"],
-            },
-        }
-        client = AnthropicChatGenerator()
-        response = client.run(
-            messages=[ChatMessage.from_user("What is the current price of AAPL?")],
-            generation_kwargs={"tools": [tools_schema]},
+    def test_convert_message_to_anthropic_format(self):
+        """
+        Test that the AnthropicChatGenerator component can convert a ChatMessage to Anthropic format.
+        """
+        messages = [ChatMessage.from_system("You are good assistant")]
+        assert _convert_messages_to_anthropic_format(messages) == (
+            [{"type": "text", "text": "You are good assistant"}],
+            [],
         )
-        replies = response["replies"]
-        assert isinstance(replies, list), "Replies is not a list"
-        assert len(replies) > 0, "No replies received"
 
-        first_reply = replies[0]
-        assert isinstance(first_reply, ChatMessage), "First reply is not a ChatMessage instance"
-        assert first_reply.text, "First reply has no text"
-        assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT), "First reply is not from the assistant"
-        assert "get_stock_price" in first_reply.text.lower(), "First reply does not contain get_stock_price"
-        assert first_reply.meta, "First reply has no metadata"
-        fc_response = json.loads(first_reply.text)
-        assert "name" in fc_response, "First reply does not contain name of the tool"
-        assert "input" in fc_response, "First reply does not contain input of the tool"
+        messages = [ChatMessage.from_user("I have a question")]
+        assert _convert_messages_to_anthropic_format(messages) == (
+            [],
+            [{"role": "user", "content": [{"type": "text", "text": "I have a question"}]}],
+        )
+
+        messages = [ChatMessage.from_assistant(text="I have an answer", meta={"finish_reason": "stop"})]
+        assert _convert_messages_to_anthropic_format(messages) == (
+            [],
+            [{"role": "assistant", "content": [{"type": "text", "text": "I have an answer"}]}],
+        )
+
+        messages = [
+            ChatMessage.from_assistant(
+                tool_calls=[ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})]
+            )
+        ]
+        result = _convert_messages_to_anthropic_format(messages)
+        assert result == (
+            [],
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "123", "name": "weather", "input": {"city": "Paris"}}],
+                }
+            ],
+        )
+
+        messages = [
+            ChatMessage.from_assistant(
+                text="",  # this should not happen, but we should handle it without errors
+                tool_calls=[ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})],
+            )
+        ]
+        result = _convert_messages_to_anthropic_format(messages)
+        assert result == (
+            [],
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "123", "name": "weather", "input": {"city": "Paris"}}],
+                }
+            ],
+        )
+
+        tool_result = json.dumps({"weather": "sunny", "temperature": "25"})
+        messages = [
+            ChatMessage.from_tool(
+                tool_result=tool_result, origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})
+            )
+        ]
+        assert _convert_messages_to_anthropic_format(messages) == (
+            [],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "123",
+                            "content": [{"type": "text", "text": '{"weather": "sunny", "temperature": "25"}'}],
+                            "is_error": False,
+                        }
+                    ],
+                }
+            ],
+        )
+
+        messages = [
+            ChatMessage.from_assistant(
+                text="For that I'll need to check the weather",
+                tool_calls=[ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})],
+            )
+        ]
+        result = _convert_messages_to_anthropic_format(messages)
+        assert result == (
+            [],
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "For that I'll need to check the weather"},
+                        {"type": "tool_use", "id": "123", "name": "weather", "input": {"city": "Paris"}},
+                    ],
+                }
+            ],
+        )
+
+    def test_convert_message_to_anthropic_format_complex(self):
+        """
+        Test that the AnthropicChatGenerator can convert a complex sequence of ChatMessages to Anthropic format.
+        In particular, we check that different tool results are packed in a single dictionary with role=user.
+        """
+
+        messages = [
+            ChatMessage.from_system("You are good assistant"),
+            ChatMessage.from_user("What's the weather like in Paris? And how much is 2+2?"),
+            ChatMessage.from_assistant(
+                text="",
+                tool_calls=[
+                    ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"}),
+                    ToolCall(id="456", tool_name="math", arguments={"expression": "2+2"}),
+                ],
+            ),
+            ChatMessage.from_tool(
+                tool_result="22° C", origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})
+            ),
+            ChatMessage.from_tool(
+                tool_result="4", origin=ToolCall(id="456", tool_name="math", arguments={"expression": "2+2"})
+            ),
+        ]
+
+        system_messages, non_system_messages = _convert_messages_to_anthropic_format(messages)
+
+        assert system_messages == [{"type": "text", "text": "You are good assistant"}]
+        assert non_system_messages == [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "What's the weather like in Paris? And how much is 2+2?"}],
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "123", "name": "weather", "input": {"city": "Paris"}},
+                    {"type": "tool_use", "id": "456", "name": "math", "input": {"expression": "2+2"}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "123",
+                        "content": [{"type": "text", "text": "22° C"}],
+                        "is_error": False,
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "456",
+                        "content": [{"type": "text", "text": "4"}],
+                        "is_error": False,
+                    },
+                ],
+            },
+        ]
+
+    def test_convert_message_to_anthropic_invalid(self):
+        """
+        Test that the AnthropicChatGenerator component fails to convert an invalid ChatMessage to Anthropic format.
+        """
+        message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[])
+        with pytest.raises(ValueError):
+            _convert_messages_to_anthropic_format([message])
+
+        tool_call_null_id = ToolCall(id=None, tool_name="weather", arguments={"city": "Paris"})
+        message = ChatMessage.from_assistant(tool_calls=[tool_call_null_id])
+        with pytest.raises(ValueError):
+            _convert_messages_to_anthropic_format([message])
+
+        message = ChatMessage.from_tool(tool_result="result", origin=tool_call_null_id)
+        with pytest.raises(ValueError):
+            _convert_messages_to_anthropic_format([message])
+
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY", None),
+        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_with_tools(self, tools):
+        """
+        Integration test that the AnthropicChatGenerator component can run with tools.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator(tools=tools)
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.id is not None
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_use"
+
+        new_messages = [
+            *initial_messages,
+            message,
+            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+        ]
+        # the model tends to make tool calls if provided with tools, so we don't pass them here
+        results = component.run(new_messages, generation_kwargs={"max_tokens": 50})
+
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
+
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY", None),
+        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_with_tools_streaming(self, tools):
+        """
+        Integration test that the AnthropicChatGenerator component can run with tools and streaming.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator(tools=tools, streaming_callback=print_streaming_chunk)
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        # this is Antropic thinking message prior to tool call
+        assert message.text is not None
+        assert "weather" in message.text.lower()
+        assert "paris" in message.text.lower()
+
+        # now we have the tool call
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.id is not None
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_use"
+
+        new_messages = [
+            *initial_messages,
+            message,
+            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+        ]
+        results = component.run(new_messages)
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
+
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY", None),
+        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_with_parallel_tools(self, tools):
+        """
+        Integration test that the AnthropicChatGenerator component can run with parallel tools.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris and Berlin?")]
+        component = AnthropicChatGenerator(tools=tools)
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        # now we have the tool call
+        assert len(message.tool_calls) == 2
+        tool_call_paris = message.tool_calls[0]
+        assert isinstance(tool_call_paris, ToolCall)
+        assert tool_call_paris.id is not None
+        assert tool_call_paris.tool_name == "weather"
+        assert tool_call_paris.arguments["city"] in {"Paris", "Berlin"}
+        assert message.meta["finish_reason"] == "tool_use"
+
+        tool_call_berlin = message.tool_calls[1]
+        assert isinstance(tool_call_berlin, ToolCall)
+        assert tool_call_berlin.id is not None
+        assert tool_call_berlin.tool_name == "weather"
+        assert tool_call_berlin.arguments["city"] in {"Berlin", "Paris"}
+
+        # Anthropic expects results from both tools in the same message
+        # https://docs.anthropic.com/en/docs/build-with-claude/tool-use#handling-tool-use-and-tool-result-content-blocks
+        # [optional] Continue the conversation by sending a new message with the role of user, and a content block
+        # containing the tool_result type and the following information:
+        # tool_use_id: The id of the tool use request this is a result for.
+        # content: The result of the tool, as a string (e.g. "content": "15 degrees") or list of
+        # nested content blocks (e.g. "content": [{"type": "text", "text": "15 degrees"}]).
+        # These content blocks can use the text or image types.
+        # is_error (optional): Set to true if the tool execution resulted in an error.
+        new_messages = [
+            *initial_messages,
+            message,
+            ChatMessage.from_tool(tool_result="22° C", origin=tool_call_paris, error=False),
+            ChatMessage.from_tool(tool_result="12° C", origin=tool_call_berlin, error=False),
+        ]
+
+        # Response from the model contains results from both tools
+        results = component.run(new_messages)
+        message = results["replies"][0]
+        assert not message.tool_calls
+        assert len(message.text) > 0
+        assert "paris" in message.text.lower()
+        assert "berlin" in message.text.lower()
+        assert "22°" in message.text
+        assert "12°" in message.text
+        assert message.meta["finish_reason"] == "end_turn"
 
     def test_prompt_caching_enabled(self, monkeypatch):
         """
@@ -267,7 +957,7 @@ class TestAnthropicChatGenerator:
 
         # Add cache_control to messages
         for msg in messages:
-            msg.meta["cache_control"] = {"type": "ephemeral"}
+            msg._meta["cache_control"] = {"type": "ephemeral"}
 
         # Invoke run with messages
         component.run(messages)
@@ -333,57 +1023,10 @@ class TestAnthropicChatGenerator:
         component = AnthropicChatGenerator.from_dict(data)
         assert component.generation_kwargs["extra_headers"]["anthropic-beta"] == "prompt-caching-2024-07-31"
 
-    def test_convert_messages_to_anthropic_format(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        generator = AnthropicChatGenerator()
-
-        # Test scenario 1: Regular user and assistant messages
-        messages = [
-            ChatMessage.from_user("Hello"),
-            ChatMessage.from_assistant("Hi there!"),
-        ]
-        result = generator._convert_to_anthropic_format(messages)
-        assert result == [
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi there!"},
-        ]
-
-        # Test scenario 2: System message
-        messages = [ChatMessage.from_system("You are a helpful assistant.")]
-        result = generator._convert_to_anthropic_format(messages)
-        assert result == [{"type": "text", "text": "You are a helpful assistant."}]
-
-        # Test scenario 3: Mixed message types
-        messages = [
-            ChatMessage.from_system("Be concise."),
-            ChatMessage.from_user("What's AI?"),
-            ChatMessage.from_assistant("Artificial Intelligence."),
-        ]
-        result = generator._convert_to_anthropic_format(messages)
-        assert result == [
-            {"type": "text", "text": "Be concise."},
-            {"role": "user", "content": "What's AI?"},
-            {"role": "assistant", "content": "Artificial Intelligence."},
-        ]
-
-        # Test scenario 4: metadata
-        messages = [
-            ChatMessage.from_user("What's AI?"),
-            ChatMessage.from_assistant("Artificial Intelligence.", meta={"confidence": 0.9}),
-        ]
-        result = generator._convert_to_anthropic_format(messages)
-        assert result == [
-            {"role": "user", "content": "What's AI?"},
-            {"role": "assistant", "content": "Artificial Intelligence.", "confidence": 0.9},
-        ]
-
-        # Test scenario 5: Empty message list
-        assert generator._convert_to_anthropic_format([]) == []
-
     @pytest.mark.integration
     @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY", None), reason="ANTHROPIC_API_KEY not set")
     @pytest.mark.parametrize("cache_enabled", [True, False])
-    def test_prompt_caching(self, cache_enabled):
+    def test_prompt_caching_live_run(self, cache_enabled):
         generation_kwargs = {"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}} if cache_enabled else {}
 
         claude_llm = AnthropicChatGenerator(
@@ -393,7 +1036,7 @@ class TestAnthropicChatGenerator:
         # see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-limitations
         system_message = ChatMessage.from_system("This is the cached, here we make it at least 1024 tokens long." * 70)
         if cache_enabled:
-            system_message.meta["cache_control"] = {"type": "ephemeral"}
+            system_message._meta["cache_control"] = {"type": "ephemeral"}
 
         messages = [system_message, ChatMessage.from_user("What's in cached content?")]
         result = claude_llm.run(messages)

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -57,6 +57,7 @@ class TestAnthropicVertexChatGenerator:
                 "streaming_callback": None,
                 "generation_kwargs": {},
                 "ignore_tools_thinking_messages": True,
+                "tools": None,
             },
         }
 
@@ -80,6 +81,7 @@ class TestAnthropicVertexChatGenerator:
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "ignore_tools_thinking_messages": True,
+                "tools": None,
             },
         }
 


### PR DESCRIPTION
### Related Issues

- fixes #1258

### Proposed Changes:

@vblagoje 
This started as a simple porting of your work from experimental.

Then I realized that some parts were missing and implemented them:
- prompt caching support
- Open-AI compatible usage meta
- (adaptation for Anthropic on Vertex)

### How did you test it?
CI, new tests
I tried to port tests from experimental, but also keep existing ones that cover otherwise untested behaviors.

### Notes for the reviewer
Technically, this change could be non-breaking, but I would prefer to release a new major version to be sure, since we changed the implementation a lot.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
