### PR TITLE
fix: End langfuse generation spans properly

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -202,7 +202,7 @@ class LangfuseTracer(Tracer):
 
         raw_span = span.raw_span()
 
-        # In this section, we finalize both regular spans and generation spans that were created using the LangfuseSpan class.
+        # In this section, we finalize both regular spans and generation spans created using the LangfuseSpan class.
         # It's important to end() these spans to ensure they are properly closed and all relevant data is recorded.
         # Note that we do not call end() on the main trace span itself, as its lifecycle is managed differently.
         if isinstance(raw_span, (langfuse.client.StatefulSpanClient, langfuse.client.StatefulGenerationClient)):

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -201,7 +201,11 @@ class LangfuseTracer(Tracer):
                 )
 
         raw_span = span.raw_span()
-        if isinstance(raw_span, langfuse.client.StatefulSpanClient):
+
+        # In this section, we finalize both regular spans and generation spans that were created using the LangfuseSpan class.
+        # It's important to end() these spans to ensure they are properly closed and all relevant data is recorded.
+        # Note that we do not call end() on the main trace span itself, as its lifecycle is managed differently.
+        if isinstance(raw_span, (langfuse.client.StatefulSpanClient, langfuse.client.StatefulGenerationClient)):
             raw_span.end()
         self._context.pop()
 


### PR DESCRIPTION
### Why:
Refines the tracing logic to handle different types of spans and their proper end()ing. 

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1262

### What:
- Added support for finalizing both regular and generation spans by extending type checks.
- Introduced comments to clarify the span ending logic and lifecycle management.

### How can it be used:
Internal change not visible to clients

### How did you test it:
- Relying on existing unit tests
- Verified manually via `chat.py` example that generated this [trace](https://cloud.langfuse.com/trace/5c85a1ff-9b01-40fd-891d-042bb860a085)
- Contrast that trace to [this one](https://cloud.langfuse.com/project/clvdk4bcb000099hzwhts3g66/traces/4fdfd20a-fc29-4e61-a6ba-1e7062d78483) that doesn't have end() called for generation. The end result is that the latency for generation is not calculated and thus the entire trace doesn't have latency calculated as well. The difference is very subtle to notice. Below are images of both:
1) With generation.end() invoked:
<img width="398" alt="Screenshot 2025-01-20 at 11 09 44" src="https://github.com/user-attachments/assets/718cca90-9da6-4a58-8a57-e6ffdea620ff" />

2) generation.end() NOT invoked: 
<img width="397" alt="Screenshot 2025-01-20 at 11 10 09" src="https://github.com/user-attachments/assets/8e0e8328-4030-48d3-b3a4-4881f345a71f" />

  

### Notes for the reviewer:
NA
