### PR TITLE
fix: Bedrock - pin `transformers!=4.48.0`

### DIFF
--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "boto3>=1.28.57", "transformers"]
+dependencies = ["haystack-ai", "boto3>=1.28.57", "transformers!=4.48.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_bedrock#readme"


### PR DESCRIPTION
### Related Issues

- nightly tests have been failing for several days: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12858522724/job/35847742797
- this happens because of a bug in Transformers 4.48.0: https://github.com/huggingface/transformers/issues/35639

### Proposed Changes:
- Since the maintainers of Transformers do not plan to publish a bugfix release, pin `transformers!=4.48.0`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
