### PR TITLE
fix: Optimum - do not explictly pin `transformers`

### DIFF
--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "transformers[sentencepiece]",
+  "transformers[sentencepiece]!=4.48.0",
   # The main export function of Optimum into ONNX has hidden dependencies.
   # It depends on either "sentence-transformers", "diffusers" or "timm", based
   # on which model is loaded from HF Hub.

--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "transformers[sentencepiece]!=4.48.0",
   # The main export function of Optimum into ONNX has hidden dependencies.
   # It depends on either "sentence-transformers", "diffusers" or "timm", based
   # on which model is loaded from HF Hub.

--- a/integrations/optimum/tests/test_optimum_document_embedder.py
+++ b/integrations/optimum/tests/test_optimum_document_embedder.py
@@ -99,7 +99,9 @@ class TestOptimumDocumentEmbedder:
         assert embedder._backend.parameters.optimizer_settings is None
         assert embedder._backend.parameters.quantizer_settings is None
 
-    def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode):  # noqa: ARG002
+    def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode, monkeypatch):  # noqa: ARG002
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)
+        monkeypatch.delenv("HF_TOKEN", raising=False)        
         component = OptimumDocumentEmbedder()
         data = component.to_dict()
 

--- a/integrations/optimum/tests/test_optimum_document_embedder.py
+++ b/integrations/optimum/tests/test_optimum_document_embedder.py
@@ -101,7 +101,7 @@ class TestOptimumDocumentEmbedder:
 
     def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode, monkeypatch):  # noqa: ARG002
         monkeypatch.delenv("HF_API_TOKEN", raising=False)
-        monkeypatch.delenv("HF_TOKEN", raising=False)        
+        monkeypatch.delenv("HF_TOKEN", raising=False)
         component = OptimumDocumentEmbedder()
         data = component.to_dict()
 

--- a/integrations/optimum/tests/test_optimum_text_embedder.py
+++ b/integrations/optimum/tests/test_optimum_text_embedder.py
@@ -84,7 +84,9 @@ class TestOptimumTextEmbedder:
         assert embedder._backend.parameters.optimizer_settings is None
         assert embedder._backend.parameters.quantizer_settings is None
 
-    def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode):  # noqa: ARG002
+    def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode, monkeypatch):  # noqa: ARG002
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)
+        monkeypatch.delenv("HF_TOKEN", raising=False)        
         component = OptimumTextEmbedder()
         data = component.to_dict()
 

--- a/integrations/optimum/tests/test_optimum_text_embedder.py
+++ b/integrations/optimum/tests/test_optimum_text_embedder.py
@@ -86,7 +86,7 @@ class TestOptimumTextEmbedder:
 
     def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode, monkeypatch):  # noqa: ARG002
         monkeypatch.delenv("HF_API_TOKEN", raising=False)
-        monkeypatch.delenv("HF_TOKEN", raising=False)        
+        monkeypatch.delenv("HF_TOKEN", raising=False)
         component = OptimumTextEmbedder()
         data = component.to_dict()
 


### PR DESCRIPTION
### Related Issues

- tests have been failing for several days: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/12858475671
- there are 2 types of errors: one is related to `transformers==4.48.0` (https://github.com/huggingface/transformers/issues/35639)
- another error is `AttributeError: 'ORTModelForFeatureExtraction' object has no attribute 'input_names'. Did you mean: 'inputs_names'`. I cannot reproduce it locally but only in the CI.
- my impression is that pinning `transformers` causes strange dependency resolution. I also think we don't need that specific pin: it is already pinned by Optimum - see https://github.com/huggingface/optimum/blob/0a2b843ed4da48002e36d529fee5b1c607d6f301/setup.py#L51

### Proposed Changes:
- unpin `transformers` and let `optimum` handle the dependency

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
