### PR TITLE
feat: LangfuseConnector - add httpx.Client init param

### DIFF
--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.9.0", "langfuse", "httpx"]
+dependencies = ["haystack-ai>=2.9.0", "langfuse"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"
@@ -72,7 +72,6 @@ dependencies = [
     "black>=23.1.0",
     "mypy>=1.0.0",
     "ruff>=0.0.243",
-    "httpx",  # needed for types
 ]
 
 [tool.hatch.envs.lint.scripts]
@@ -173,6 +172,7 @@ module = [
   "haystack_integrations.*",
   "pytest.*",
   "numpy.*",
+  "httpx.*",
 ]
 ignore_missing_imports = true
 

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.9.0", "langfuse"]
+dependencies = ["haystack-ai>=2.9.0", "langfuse", "httpx"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"
@@ -67,7 +67,13 @@ python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 [tool.hatch.envs.lint]
 installer = "uv"
 detached = true
-dependencies = ["pip", "black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
+dependencies = [
+    "pip",
+    "black>=23.1.0",
+    "mypy>=1.0.0",
+    "ruff>=0.0.243",
+    "httpx",  # needed for types
+]
 
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional
 
+import httpx
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
 from haystack.utils import Secret, deserialize_secrets_inplace
 
@@ -101,6 +102,7 @@ class LangfuseConnector:
         public: bool = False,
         public_key: Optional[Secret] = Secret.from_env_var("LANGFUSE_PUBLIC_KEY"),  # noqa: B008
         secret_key: Optional[Secret] = Secret.from_env_var("LANGFUSE_SECRET_KEY"),  # noqa: B008
+        httpx_client: Optional[httpx.Client] = None,
     ):
         """
         Initialize the LangfuseConnector component.
@@ -112,6 +114,7 @@ class LangfuseConnector:
             only accessible to the Langfuse account owner. The default is `False`.
         :param public_key: The Langfuse public key. Defaults to reading from LANGFUSE_PUBLIC_KEY environment variable.
         :param secret_key: The Langfuse secret key. Defaults to reading from LANGFUSE_SECRET_KEY environment variable.
+        :param httpx_client: Optional custom httpx.Client instance to use for Langfuse API calls.
         """
         self.name = name
         self.public = public
@@ -121,6 +124,7 @@ class LangfuseConnector:
             tracer=Langfuse(
                 secret_key=secret_key.resolve_value() if secret_key else None,
                 public_key=public_key.resolve_value() if public_key else None,
+                httpx_client=httpx_client,
             ),
             name=name,
             public=public,
@@ -158,6 +162,7 @@ class LangfuseConnector:
             public=self.public,
             secret_key=self.secret_key.to_dict() if self.secret_key else None,
             public_key=self.public_key.to_dict() if self.public_key else None,
+            # Note: httpx_client is not serialized as it's not serializable
         )
 
     @classmethod

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -114,7 +114,9 @@ class LangfuseConnector:
             only accessible to the Langfuse account owner. The default is `False`.
         :param public_key: The Langfuse public key. Defaults to reading from LANGFUSE_PUBLIC_KEY environment variable.
         :param secret_key: The Langfuse secret key. Defaults to reading from LANGFUSE_SECRET_KEY environment variable.
-        :param httpx_client: Optional custom httpx.Client instance to use for Langfuse API calls.
+        :param httpx_client: Optional custom httpx.Client instance to use for Langfuse API calls. Note that this client
+            is not serializable, so when recreating a pipeline from YAML, any custom client passed here will not be
+            preserved - a new default client will be used instead.
         """
         self.name = name
         self.public = public

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -114,7 +114,7 @@ class LangfuseConnector:
             only accessible to the Langfuse account owner. The default is `False`.
         :param public_key: The Langfuse public key. Defaults to reading from LANGFUSE_PUBLIC_KEY environment variable.
         :param secret_key: The Langfuse secret key. Defaults to reading from LANGFUSE_SECRET_KEY environment variable.
-        :param httpx_client: Optional custom httpx.Client instance to use for Langfuse API calls. Note that when 
+        :param httpx_client: Optional custom httpx.Client instance to use for Langfuse API calls. Note that when
             deserializing a pipeline from YAML, any custom client is discarded and Langfuse will create its own default
             client, since HTTPX clients cannot be serialized.
         """

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -114,9 +114,9 @@ class LangfuseConnector:
             only accessible to the Langfuse account owner. The default is `False`.
         :param public_key: The Langfuse public key. Defaults to reading from LANGFUSE_PUBLIC_KEY environment variable.
         :param secret_key: The Langfuse secret key. Defaults to reading from LANGFUSE_SECRET_KEY environment variable.
-        :param httpx_client: Optional custom httpx.Client instance to use for Langfuse API calls. Note that this client
-            is not serializable, so when recreating a pipeline from YAML, any custom client passed here will not be
-            preserved - a new default client will be used instead.
+        :param httpx_client: Optional custom httpx.Client instance to use for Langfuse API calls. Note that when 
+            deserializing a pipeline from YAML, any custom client is discarded and Langfuse will create its own default
+            client, since HTTPX clients cannot be serialized.
         """
         self.name = name
         self.public = public


### PR DESCRIPTION
### Why:
Enhances the LangfuseConnector by adding support for custom HTTP clients, allowing for greater flexibility and control over API communication.

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1151

### What:
- Introduced an optional `httpx.Client` parameter to the `LangfuseConnector` to allow custom HTTP client usage.
- Updated constructor and documentation to include the new `httpx_client` parameter.
- Ensured that the `httpx_client` is integrated into the Langfuse API call handling.

### How can it be used:
With these changes, users can now pass a custom HTTP client to the LangfuseConnector as shown in the code snippet below:

```python
from httpx import Client
from haystack_integrations.components.connectors.langfuse import LangfuseConnector

custom_client = Client(timeout=10.0)
connector = LangfuseConnector(httpx_client=custom_client)
```

### How did you test it:
Manual testing was conducted to validate the integration of the custom `httpx.Client` with the LangfuseConnector's API calls, ensuring proper function and no regressions in behavior.

### Notes for the reviewer:
Attention should be given to ensure that the `httpx_client` integration does not introduce side effects or unintended behavior with existing configurations. Consider edge cases where no custom client is provided.