### PR TITLE
feat: Add SpanHandler customization to langfuse integration

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from .tracer import LangfuseTracer
+from .tracer import LangfuseTracer, SpanHandler
 
-__all__ = ["LangfuseTracer"]
+__all__ = ["LangfuseTracer", "SpanHandler"]


### PR DESCRIPTION
### Why:
Enhances the Langfuse integration by adding a flexible mechanism for custom span processing, allowing users to define how spans should be handled within their specific LLM components.

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1310

### What:
- Introduced `SpanHandler`, a callable type for custom span processing
- Added span handler support to `LangfuseConnector` and `LangfuseTracer`
- Default span processing behavior is preserved through `default_span_handler`

### How can it be used:
```python
from haystack import Pipeline
from haystack_integrations.components.connectors.langfuse import LangfuseConnector
from haystack_integrations.components.generators.custom import CustomChatGenerator

def custom_span_handler(span, component_type):
    if component_type == "CustomChatGenerator":
        output = span._data.get("haystack.component.output", {})
        span._span.update(
            usage=output.get("usage"),
            model="custom-llm-model",
            custom_metadata=output.get("extra_info")
        )

# Add to your pipeline
pipe = Pipeline()
pipe.add_component(
    "tracer",
    LangfuseConnector(
        name="Custom LLM Pipeline",
        span_handler=custom_span_handler
    )
)
pipe.add_component("llm", CustomChatGenerator())
```

### How did you test it:
- Unit tests for span handler serialization/deserialization
- Integration tests with custom span handler
- Verified traces appear correctly in Langfuse UI

### Notes for the reviewer:
The callable approach was chosen over a class-based one for simplicity and better serialization support. The handler has access to both span data and component type, making it flexible enough for custom LLM integrations.
