### PR TITLE
Add SpanHandler

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from .tracer import LangfuseTracer
+from .tracer import LangfuseTracer, SpanHandler
 
-__all__ = ["LangfuseTracer"]
+__all__ = ["LangfuseTracer", "SpanHandler"]

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from .tracer import LangfuseTracer, SpanHandler
+from .tracer import DefaultSpanHandler, LangfuseSpan, LangfuseTracer, SpanHandler
 
-__all__ = ["LangfuseTracer", "SpanHandler"]
+__all__ = ["DefaultSpanHandler", "LangfuseSpan", "LangfuseTracer", "SpanHandler"]

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -1,6 +1,7 @@
 import os
 import time
 from urllib.parse import urlparse
+from typing import Optional
 
 import pytest
 import requests
@@ -15,6 +16,8 @@ import httpx
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
 from haystack_integrations.components.generators.cohere import CohereChatGenerator
+from haystack_integrations.tracing.langfuse import LangfuseSpan, DefaultSpanHandler
+from haystack_integrations.tracing.langfuse.tracer import _COMPONENT_OUTPUT_KEY
 
 # don't remove (or move) this env var setting from here, it's needed to turn tracing on
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
@@ -169,3 +172,86 @@ def test_pipeline_serialization(monkeypatch):
 
     # Verify pipeline is the same
     assert new_pipe == pipe
+
+
+class QualityCheckSpanHandler(DefaultSpanHandler):
+    """Extends default handler to add quality checks with warning levels."""
+
+    def handle(self, span: LangfuseSpan, component_type: Optional[str]) -> None:
+        # First do the default handling (model, usage, etc.)
+        super().handle(span, component_type)
+
+        # Then add our custom quality checks
+        if component_type == "OpenAIChatGenerator":
+            output = span._data.get(_COMPONENT_OUTPUT_KEY, {})
+            replies = output.get("replies", [])
+
+            if not replies:
+                span._span.update(level="ERROR", status_message="No response received")
+                return
+
+            reply = replies[0]
+            if "error" in reply.meta:
+                span._span.update(level="ERROR", status_message=f"OpenAI error: {reply.meta['error']}")
+            elif len(reply.text) > 10:
+                span._span.update(level="WARNING", status_message="Response too long (> 10 chars)")
+            else:
+                span._span.update(level="DEFAULT", status_message="Success")
+
+
+@pytest.mark.integration
+def test_custom_span_handler():
+    """Test that custom span handler properly sets Langfuse levels."""
+    if not all(
+        [os.environ.get("LANGFUSE_SECRET_KEY"), os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get("OPENAI_API_KEY")]
+    ):
+        pytest.skip("Missing required environment variables")
+
+    pipe = Pipeline()
+    pipe.add_component(
+        "tracer",
+        LangfuseConnector(
+            name="Quality Check Example",
+            public=True,
+            span_handler=QualityCheckSpanHandler(),
+        ),
+    )
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
+    pipe.connect("prompt_builder.prompt", "llm.messages")
+
+    # Test short response
+    messages = [
+        ChatMessage.from_system("Respond with exactly 3 words."),
+        ChatMessage.from_user("What is Berlin?"),
+    ]
+
+    response = pipe.run(
+        data={
+            "prompt_builder": {"template_variables": {}, "template": messages},
+            "tracer": {"invocation_context": {"user_id": "test_user"}},
+        }
+    )
+
+    trace_url = response["tracer"]["trace_url"]
+    uuid = os.path.basename(urlparse(trace_url).path)
+    url = f"https://cloud.langfuse.com/api/public/traces/{uuid}"
+
+    # Poll the Langfuse API
+    attempts = 5
+    delay = 1
+    while attempts >= 0:
+        res = requests.get(
+            url, auth=HTTPBasicAuth(os.environ["LANGFUSE_PUBLIC_KEY"], os.environ["LANGFUSE_SECRET_KEY"])
+        )
+        if attempts > 0 and res.status_code != 200:
+            attempts -= 1
+            time.sleep(delay)
+            delay *= 2
+            continue
+
+        assert res.status_code == 200
+        content = str(res.content)
+        assert "WARNING" in content
+        assert "Response too long" in content
+        break


### PR DESCRIPTION
### Why:
Enhances the Langfuse integration by introducing added functionality for custom span processing, allowing flexibility in how spans are handled and converted. Developers can now further customize what is exactly logged to Langfuse. 

### What:
- Added a new `SpanHandler` class and its default implementation `DefaultSpanHandler` for customizing span creation and processing.
- Updated the `LangfuseConnector` and `LangfuseTracer` to support custom span handlers.
- Modified tests to verify the new functionality and its impact on span handling.

### How can it be used:
Developers can utilize custom span handlers by providing their implementations that extend the `SpanHandler` class:

```python
class CustomSpanHandler(DefaultSpanHandler):
    def handle(self, span: LangfuseSpan, component_type: Optional[str]) -> None:
        # Custom handling logic
        pass

connector = LangfuseConnector(span_handler=CustomSpanHandler())
```

### How did you test it:
Tests were conducted using the `QualityCheckSpanHandler` to ensure span levels are set correctly. Different response scenarios were simulated to check the handler's response, and the Langfuse API was polled to verify the output.

### Notes for the reviewer:
Pay attention to the `SpanHandler`'s implementation to ensure it meets necessary specifications and seamlessly integrates with the existing `LangfuseTracer`. Additionally, confirm that the new test scenarios cover diverse usage cases adequately.