### PR TITLE
refactor: Migrate Cohere to V2

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
@@ -128,8 +128,7 @@ class CohereDocumentEmbedder:
         deserialize_secrets_inplace(init_params, ["api_key"])
 
         # Convert embedding_type string to EmbeddingTypes enum value
-        if "embedding_type" in init_params:
-            init_params["embedding_type"] = EmbeddingTypes.from_str(init_params["embedding_type"])
+        init_params["embedding_type"] = EmbeddingTypes.from_str(init_params["embedding_type"])
 
         return default_from_dict(cls, data)
 

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, List, Optional
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
 
-from cohere import AsyncClient, Client
+from cohere import AsyncClientV2, ClientV2
+from haystack_integrations.components.embedders.cohere.embedding_types import EmbeddingTypes
 from haystack_integrations.components.embedders.cohere.utils import get_async_response, get_response
 
 
@@ -47,6 +48,7 @@ class CohereDocumentEmbedder:
         progress_bar: bool = True,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
+        embedding_type: Optional[EmbeddingTypes] = None,
     ):
         """
         :param api_key: the Cohere API key.
@@ -72,6 +74,8 @@ class CohereDocumentEmbedder:
                              to keep the logs clean.
         :param meta_fields_to_embed: list of meta fields that should be embedded along with the Document text.
         :param embedding_separator: separator used to concatenate the meta fields to the Document text.
+        :param embedding_type: the type of embeddings to return. Defaults to float embeddings.
+            Note that int8, uint8, binary, and ubinary are only valid for v3 models.
         """
 
         self.api_key = api_key
@@ -85,6 +89,7 @@ class CohereDocumentEmbedder:
         self.progress_bar = progress_bar
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
+        self.embedding_type = embedding_type or EmbeddingTypes.FLOAT
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -106,6 +111,7 @@ class CohereDocumentEmbedder:
             progress_bar=self.progress_bar,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
+            embedding_type=self.embedding_type.value,
         )
 
     @classmethod
@@ -120,6 +126,11 @@ class CohereDocumentEmbedder:
         """
         init_params = data.get("init_parameters", {})
         deserialize_secrets_inplace(init_params, ["api_key"])
+
+        # Convert embedding_type string to EmbeddingTypes enum value
+        if "embedding_type" in init_params:
+            init_params["embedding_type"] = EmbeddingTypes.from_str(init_params["embedding_type"])
+
         return default_from_dict(cls, data)
 
     def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:
@@ -163,17 +174,19 @@ class CohereDocumentEmbedder:
         assert api_key is not None
 
         if self.use_async_client:
-            cohere_client = AsyncClient(
+            cohere_client = AsyncClientV2(
                 api_key,
                 base_url=self.api_base_url,
                 timeout=self.timeout,
                 client_name="haystack",
             )
             all_embeddings, metadata = asyncio.run(
-                get_async_response(cohere_client, texts_to_embed, self.model, self.input_type, self.truncate)
+                get_async_response(
+                    cohere_client, texts_to_embed, self.model, self.input_type, self.truncate, self.embedding_type
+                )
             )
         else:
-            cohere_client = Client(
+            cohere_client = ClientV2(
                 api_key,
                 base_url=self.api_base_url,
                 timeout=self.timeout,
@@ -187,6 +200,7 @@ class CohereDocumentEmbedder:
                 self.truncate,
                 self.batch_size,
                 self.progress_bar,
+                self.embedding_type,
             )
 
         for doc, embeddings in zip(documents, all_embeddings):

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/embedding_types.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/embedding_types.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from enum import Enum
+
+
+class EmbeddingTypes(Enum):
+    """
+    Supported types for Cohere embeddings.
+
+    FLOAT: Default float embeddings. Valid for all models.
+    INT8: Signed int8 embeddings. Valid for only v3 models.
+    UINT8: Unsigned int8 embeddings. Valid for only v3 models.
+    BINARY: Signed binary embeddings. Valid for only v3 models.
+    UBINARY: Unsigned binary embeddings. Valid for only v3 models.
+    """
+
+    FLOAT = "float"
+    INT8 = "int8"
+    UINT8 = "uint8"
+    BINARY = "binary"
+    UBINARY = "ubinary"
+
+    def __str__(self):
+        return self.value
+
+    @staticmethod
+    def from_str(string: str) -> "EmbeddingTypes":
+        """
+        Convert a string to an EmbeddingTypes enum.
+        """
+        enum_map = {e.value: e for e in EmbeddingTypes}
+        embedding_type = enum_map.get(string.lower())
+        if embedding_type is None:
+            msg = f"Unknown embedding type '{string}'. Supported types are: {list(enum_map.keys())}"
+            raise ValueError(msg)
+        return embedding_type

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
 
-from cohere import AsyncClient, Client
+from cohere import AsyncClientV2, ClientV2
+from haystack_integrations.components.embedders.cohere.embedding_types import EmbeddingTypes
 from haystack_integrations.components.embedders.cohere.utils import get_async_response, get_response
 
 
@@ -40,6 +41,7 @@ class CohereTextEmbedder:
         truncate: str = "END",
         use_async_client: bool = False,
         timeout: int = 120,
+        embedding_type: Optional[EmbeddingTypes] = None,
     ):
         """
         :param api_key: the Cohere API key.
@@ -60,6 +62,8 @@ class CohereTextEmbedder:
         :param use_async_client: flag to select the AsyncClient. It is recommended to use
             AsyncClient for applications with many concurrent calls.
         :param timeout: request timeout in seconds.
+        :param embedding_type: the type of embeddings to return. Defaults to float embeddings.
+            Note that int8, uint8, binary, and ubinary are only valid for v3 models.
         """
 
         self.api_key = api_key
@@ -69,6 +73,7 @@ class CohereTextEmbedder:
         self.truncate = truncate
         self.use_async_client = use_async_client
         self.timeout = timeout
+        self.embedding_type = embedding_type or EmbeddingTypes.FLOAT
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -86,6 +91,7 @@ class CohereTextEmbedder:
             truncate=self.truncate,
             use_async_client=self.use_async_client,
             timeout=self.timeout,
+            embedding_type=self.embedding_type.value,
         )
 
     @classmethod
@@ -100,6 +106,11 @@ class CohereTextEmbedder:
         """
         init_params = data.get("init_parameters", {})
         deserialize_secrets_inplace(init_params, ["api_key"])
+
+        # Convert embedding_type string to EmbeddingTypes enum value
+        if "embedding_type" in init_params:
+            init_params["embedding_type"] = EmbeddingTypes.from_str(init_params["embedding_type"])
+
         return default_from_dict(cls, data)
 
     @component.output_types(embedding=List[float], meta=Dict[str, Any])
@@ -125,22 +136,26 @@ class CohereTextEmbedder:
         assert api_key is not None
 
         if self.use_async_client:
-            cohere_client = AsyncClient(
+            cohere_client = AsyncClientV2(
                 api_key,
                 base_url=self.api_base_url,
                 timeout=self.timeout,
                 client_name="haystack",
             )
             embedding, metadata = asyncio.run(
-                get_async_response(cohere_client, [text], self.model, self.input_type, self.truncate)
+                get_async_response(
+                    cohere_client, [text], self.model, self.input_type, self.truncate, self.embedding_type
+                )
             )
         else:
-            cohere_client = Client(
+            cohere_client = ClientV2(
                 api_key,
                 base_url=self.api_base_url,
                 timeout=self.timeout,
                 client_name="haystack",
             )
-            embedding, metadata = get_response(cohere_client, [text], self.model, self.input_type, self.truncate)
+            embedding, metadata = get_response(
+                cohere_client, [text], self.model, self.input_type, self.truncate, embedding_type=self.embedding_type
+            )
 
         return {"embedding": embedding[0], "meta": metadata}

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
@@ -108,8 +108,7 @@ class CohereTextEmbedder:
         deserialize_secrets_inplace(init_params, ["api_key"])
 
         # Convert embedding_type string to EmbeddingTypes enum value
-        if "embedding_type" in init_params:
-            init_params["embedding_type"] = EmbeddingTypes.from_str(init_params["embedding_type"])
+        init_params["embedding_type"] = EmbeddingTypes.from_str(init_params["embedding_type"])
 
         return default_from_dict(cls, data)
 

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/utils.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/utils.py
@@ -47,8 +47,10 @@ async def get_async_response(
     for emb_tuple in response.embeddings:
         # emb_tuple[0] is a str denoting the embedding type (e.g. "float", "int8", etc.)
         if emb_tuple[1] is not None:
-            # ok we have embeddings for this type, let's take all the embeddings (a list of embeddings)
+            # ok we have embeddings for this type, let's take all
+            # the embeddings (a list of embeddings) and break the loop
             all_embeddings.extend(emb_tuple[1])
+            break
 
     return all_embeddings, metadata
 

--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -40,7 +40,7 @@ class CohereRanker:
         max_chunks_per_doc: Optional[int] = None,
         meta_fields_to_embed: Optional[List[str]] = None,
         meta_data_separator: str = "\n",
-        max_tokens_per_doc: int = 4096
+        max_tokens_per_doc: int = 4096,
     ):
         """
         Creates an instance of the 'CohereRanker'.

--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -58,7 +58,7 @@ class CohereRanker:
             with the document content for reranking.
         :param meta_data_separator: Separator used to concatenate the meta fields
             to the Document content.
-        :param max_tokens_per_doc: The maximum number of tokens to embed for each document.
+        :param max_tokens_per_doc: The maximum number of tokens to embed for each document defaults to 4096.
         """
         self.model_name = model
         self.api_key = api_key

--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -40,7 +40,7 @@ class CohereRanker:
         max_chunks_per_doc: Optional[int] = None,
         meta_fields_to_embed: Optional[List[str]] = None,
         meta_data_separator: str = "\n",
-        max_tokens_per_doc: Optional[int] = None,
+        max_tokens_per_doc: int = 4096
     ):
         """
         Creates an instance of the 'CohereRanker'.

--- a/integrations/cohere/tests/test_cohere_ranker.py
+++ b/integrations/cohere/tests/test_cohere_ranker.py
@@ -20,7 +20,7 @@ def mock_ranker_response():
                                       RerankResult<document['text']: "", index: 0, relevance_score: 0.98>,
                                       RerankResult<document['text']: "", index: 1, relevance_score: 0.04>]
     """
-    with patch("cohere.Client.rerank", autospec=True) as mock_ranker_response:
+    with patch("cohere.ClientV2.rerank", autospec=True) as mock_ranker_response:
 
         mock_response = Mock()
 
@@ -48,6 +48,7 @@ class TestCohereRanker:
         assert component.max_chunks_per_doc is None
         assert component.meta_fields_to_embed == []
         assert component.meta_data_separator == "\n"
+        assert component.max_tokens_per_doc is None
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("CO_API_KEY", raising=False)
@@ -65,6 +66,7 @@ class TestCohereRanker:
             max_chunks_per_doc=40,
             meta_fields_to_embed=["meta_field_1", "meta_field_2"],
             meta_data_separator=",",
+            max_tokens_per_doc=100,
         )
         assert component.model_name == "rerank-multilingual-v2.0"
         assert component.top_k == 5
@@ -73,6 +75,7 @@ class TestCohereRanker:
         assert component.max_chunks_per_doc == 40
         assert component.meta_fields_to_embed == ["meta_field_1", "meta_field_2"]
         assert component.meta_data_separator == ","
+        assert component.max_tokens_per_doc == 100
 
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
@@ -88,6 +91,7 @@ class TestCohereRanker:
                 "max_chunks_per_doc": None,
                 "meta_fields_to_embed": [],
                 "meta_data_separator": "\n",
+                "max_tokens_per_doc": None,
             },
         }
 
@@ -101,6 +105,7 @@ class TestCohereRanker:
             max_chunks_per_doc=50,
             meta_fields_to_embed=["meta_field_1", "meta_field_2"],
             meta_data_separator=",",
+            max_tokens_per_doc=100,
         )
         data = component.to_dict()
         assert data == {
@@ -113,6 +118,7 @@ class TestCohereRanker:
                 "max_chunks_per_doc": 50,
                 "meta_fields_to_embed": ["meta_field_1", "meta_field_2"],
                 "meta_data_separator": ",",
+                "max_tokens_per_doc": 100,
             },
         }
 
@@ -128,6 +134,7 @@ class TestCohereRanker:
                 "max_chunks_per_doc": 50,
                 "meta_fields_to_embed": ["meta_field_1", "meta_field_2"],
                 "meta_data_separator": ",",
+                "max_tokens_per_doc": 100,
             },
         }
         component = CohereRanker.from_dict(data)
@@ -138,6 +145,7 @@ class TestCohereRanker:
         assert component.max_chunks_per_doc == 50
         assert component.meta_fields_to_embed == ["meta_field_1", "meta_field_2"]
         assert component.meta_data_separator == ","
+        assert component.max_tokens_per_doc == 100
 
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         monkeypatch.delenv("CO_API_KEY", raising=False)
@@ -149,6 +157,7 @@ class TestCohereRanker:
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "top_k": 2,
                 "max_chunks_per_doc": 50,
+                "max_tokens_per_doc": 100,
             },
         }
         with pytest.raises(ValueError, match="None of the following authentication environment variables are set: *"):

--- a/integrations/cohere/tests/test_cohere_ranker.py
+++ b/integrations/cohere/tests/test_cohere_ranker.py
@@ -48,7 +48,7 @@ class TestCohereRanker:
         assert component.max_chunks_per_doc is None
         assert component.meta_fields_to_embed == []
         assert component.meta_data_separator == "\n"
-        assert component.max_tokens_per_doc is None
+        assert component.max_tokens_per_doc = 4096
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("CO_API_KEY", raising=False)

--- a/integrations/cohere/tests/test_cohere_ranker.py
+++ b/integrations/cohere/tests/test_cohere_ranker.py
@@ -91,7 +91,7 @@ class TestCohereRanker:
                 "max_chunks_per_doc": None,
                 "meta_fields_to_embed": [],
                 "meta_data_separator": "\n",
-                "max_tokens_per_doc": None,
+                "max_tokens_per_doc": 4096,
             },
         }
 

--- a/integrations/cohere/tests/test_cohere_ranker.py
+++ b/integrations/cohere/tests/test_cohere_ranker.py
@@ -48,7 +48,7 @@ class TestCohereRanker:
         assert component.max_chunks_per_doc is None
         assert component.meta_fields_to_embed == []
         assert component.meta_data_separator == "\n"
-        assert component.max_tokens_per_doc = 4096
+        assert component.max_tokens_per_doc == 4096
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("CO_API_KEY", raising=False)

--- a/integrations/cohere/tests/test_document_embedder.py
+++ b/integrations/cohere/tests/test_document_embedder.py
@@ -8,6 +8,7 @@ from haystack import Document
 from haystack.utils import Secret
 
 from haystack_integrations.components.embedders.cohere import CohereDocumentEmbedder
+from haystack_integrations.components.embedders.cohere.embedding_types import EmbeddingTypes
 
 pytestmark = pytest.mark.embedders
 COHERE_API_URL = "https://api.cohere.com"
@@ -27,6 +28,7 @@ class TestCohereDocumentEmbedder:
         assert embedder.progress_bar is True
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
+        assert embedder.embedding_type == EmbeddingTypes.FLOAT
 
     def test_init_with_parameters(self):
         embedder = CohereDocumentEmbedder(
@@ -53,6 +55,7 @@ class TestCohereDocumentEmbedder:
         assert embedder.progress_bar is False
         assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == "-"
+        assert embedder.embedding_type == EmbeddingTypes.FLOAT
 
     def test_to_dict(self):
         embedder_component = CohereDocumentEmbedder()
@@ -71,6 +74,7 @@ class TestCohereDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
+                "embedding_type": "float",
             },
         }
 
@@ -87,6 +91,7 @@ class TestCohereDocumentEmbedder:
             progress_bar=False,
             meta_fields_to_embed=["text_field"],
             embedding_separator="-",
+            embedding_type=EmbeddingTypes.INT8,
         )
         component_dict = embedder_component.to_dict()
         assert component_dict == {
@@ -103,6 +108,7 @@ class TestCohereDocumentEmbedder:
                 "progress_bar": False,
                 "meta_fields_to_embed": ["text_field"],
                 "embedding_separator": "-",
+                "embedding_type": "int8",
             },
         }
 
@@ -112,7 +118,7 @@ class TestCohereDocumentEmbedder:
     )
     @pytest.mark.integration
     def test_run(self):
-        embedder = CohereDocumentEmbedder()
+        embedder = CohereDocumentEmbedder(model="embed-english-v2.0", embedding_type=EmbeddingTypes.FLOAT)
 
         docs = [
             Document(content="I love cheese", meta={"topic": "Cuisine"}),

--- a/integrations/cohere/tests/test_text_embedder.py
+++ b/integrations/cohere/tests/test_text_embedder.py
@@ -7,6 +7,7 @@ import pytest
 from haystack.utils import Secret
 
 from haystack_integrations.components.embedders.cohere import CohereTextEmbedder
+from haystack_integrations.components.embedders.cohere.embedding_types import EmbeddingTypes
 
 pytestmark = pytest.mark.embedders
 COHERE_API_URL = "https://api.cohere.com"
@@ -47,6 +48,7 @@ class TestCohereTextEmbedder:
         assert embedder.truncate == "START"
         assert embedder.use_async_client is True
         assert embedder.timeout == 60
+        assert embedder.embedding_type == EmbeddingTypes.FLOAT
 
     def test_to_dict(self):
         """
@@ -64,6 +66,7 @@ class TestCohereTextEmbedder:
                 "truncate": "END",
                 "use_async_client": False,
                 "timeout": 120,
+                "embedding_type": "float",
             },
         }
 
@@ -79,6 +82,7 @@ class TestCohereTextEmbedder:
             truncate="START",
             use_async_client=True,
             timeout=60,
+            embedding_type=EmbeddingTypes.INT8,
         )
         component_dict = embedder_component.to_dict()
         assert component_dict == {
@@ -91,6 +95,7 @@ class TestCohereTextEmbedder:
                 "truncate": "START",
                 "use_async_client": True,
                 "timeout": 60,
+                "embedding_type": "int8",
             },
         }
 


### PR DESCRIPTION
### Why:
- Migrates our Cohere integration to V2 (embedder(s) and ranker).
- Embedders can now use `embedding_types` to choose the size of the embeddings, providing more control over memory usage and performance.
- (Chat)Generator migration is done in a separate [PR](https://github.com/deepset-ai/haystack-core-integrations/pull/1318).

### What:
- Introduced `EmbeddingTypes` enum to define and manage supported embedding types:
  - **Allowed values**:
    - `float`: Default float embeddings (valid for all models).
    - `int8`: Signed int8 embeddings (valid for v3 models only).
    - `uint8`: Unsigned int8 embeddings (valid for v3 models only).
    - `binary`: Signed binary embeddings (valid for v3 models only).
    - `ubinary`: Unsigned binary embeddings (valid for v3 models only).
- Updated `CohereDocumentEmbedder` and `CohereTextEmbedder` to handle multiple embedding types.
- Updated `CohereRanker` to use Cohere V2 API, added `max_tokens_per_doc` for token-level control, and deprecated the use of `max_chunks_per_doc` (now ignored).

### How can it be used:
Users can specify the desired embedding type and initialize the embedders or ranker:

```python
from haystack_integrations.components.embedders.cohere import CohereDocumentEmbedder
from haystack_integrations.components.embedders.cohere.embedding_types import EmbeddingTypes
from haystack_integrations.components.rankers.cohere import CohereRanker

embedder = CohereDocumentEmbedder(
    api_key="your_api_key",
    model="embed-english-v3.0",
    embedding_type=EmbeddingTypes.INT8,
)

ranker = CohereRanker(
    api_key="your_api_key",
    model="rerank-english-v2.0",
    max_tokens_per_doc=500,
)
```

### How did you test it:
- Updated and added unit tests for `CohereDocumentEmbedder` and `CohereTextEmbedder` to validate functionality with multiple embedding types.
- Verified correct handling of embedding type combinations (e.g., `int8`, `binary`).
- Updated  `CohereRanker` tests

### Notes for the reviewer:
- Check the handling of `embedding_types` in the embedders to ensure that only valid types are accepted for v3 models.
- Verify that `max_tokens_per_doc` in `CohereRanker` works as intended and aligns with the Cohere V2 API.
- Ensure the integration supports seamless switching between embedding types and document configurations.
- To be merged in tandem with [PR](https://github.com/deepset-ai/haystack-core-integrations/pull/1318) and then a new major version of cohere-haystack integration should be released.
