### PR TITLE
Fix(Bedrock): Reranker fails when document list is Empty

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -192,6 +192,9 @@ class BedrockRanker:
             msg = f"top_k must be > 0, but got {top_k}"
             raise ValueError(msg)
 
+        if not documents:
+            return {"documents": []}
+
         bedrock_input_docs = self._prepare_bedrock_input_docs(documents)
         if len(bedrock_input_docs) > MAX_NUM_DOCS_FOR_BEDROCK_RANKER:
             logger.warning(

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -101,3 +101,19 @@ def test_bedrock_ranker_serialization(mock_aws_session):
     assert isinstance(deserialized, BedrockRanker)
     assert deserialized.model_name == "cohere.rerank-v3-5:0"
     assert deserialized.top_k == 2
+
+
+def test_bedrock_ranker_empty_documents(mock_aws_session):
+    ranker = BedrockRanker(
+        model="cohere.rerank-v3-5:0",
+        top_k=2,
+        aws_access_key_id=Secret.from_token("test_access_key"),
+        aws_secret_access_key=Secret.from_token("test_secret_key"),
+        aws_region_name=Secret.from_token("us-east-1"),
+    )
+
+    docs = []
+    result = ranker.run(query="test query", documents=docs)
+
+    # Check that we get back an empty list of documents
+    assert len(result["documents"]) == 0


### PR DESCRIPTION
### Related Issues

Issue not created

### Proposed Changes:

A tiny fix for the Ranker models I integrated in previous MR to handle cases where document list is empty (that can happens with Retrievers or filters after retrieval). The Ranker should just return the empty document list instead of crashing (AWS Bedrock API doesn't like an empty document list and throw an error).

### How did you test it?

Added a new unit test to confirm the good behaviour.

### Notes for the reviewer

None. It's a small minor bug fix with no breaking change

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
