### PR TITLE
ci: Automatically open PR for subproject CHANGELOG.md updates

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -57,11 +57,21 @@ jobs:
             --include-path "${{ steps.pathfinder.outputs.project_path }}/**/*"
             --tag-pattern "${{ steps.pathfinder.outputs.project_path }}-v*"
 
-      - name: Commit changelog
-        uses: EndBug/add-and-commit@v9
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          author_name: "HaystackBot"
-          author_email: "accounts@deepset.ai"
-          message: "Update the changelog"
-          add: ${{ steps.pathfinder.outputs.project_path }}
-          push: origin HEAD:main
+          token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
+          commit-message: "Update changelog for ${{ steps.pathfinder.outputs.project_path }}"
+          branch: update-changelog-${{ steps.pathfinder.outputs.project_path }}
+          title: "docs: update changelog for ${{ steps.pathfinder.outputs.project_path }}"
+          add-paths: |
+            ${{ steps.pathfinder.outputs.project_path }}/CHANGELOG.md
+          body: |
+            This PR updates the changelog for ${{ steps.pathfinder.outputs.project_path }} integration
+            with the latest changes just released on PyPi. Please review the changelog diff below and adjust it
+            if necessary.
+
+            A good changelog diff simply lists these latest changes on top of the CHANGELOG.md file.
+            If there are some diffs that seem out of place, please adjust the CHANGELOG.md file manually.
+            Either way, please merge this PR as soon as possible.
+


### PR DESCRIPTION
### Why:
To address issues with unpredictable automatic changelog commits in pypi releases of our subprojects, this PR introduces automated pull requests for changelog updates. This provides more control and flexibility, enabling quick reviews, easy edits, and better handling of edge cases. It also allows us to refine the `cliff.toml` configuration without the risk of unexpected errors in changelogs.

### What:
- Replaced the `add-and-commit` action with the `create-pull-request` action to open pull requests for changelog updates instead of committing directly.
- Configured the action to create a new branch and a well-structured pull request for each changelog modification.
- Improved messaging in created PRs 

### How can it be used:
Upon each release, the workflow will execute the following:
```yaml
uses: peter-evans/create-pull-request@v7
with:
  token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
  commit-message: "Update changelog for ${{ steps.pathfinder.outputs.project_path }}"
  branch: update-changelog-${{ steps.pathfinder.outputs.project_path }}
  title: "docs: update changelog for ${{ steps.pathfinder.outputs.project_path }}"
  add-paths: |
    ${{ steps.pathfinder.outputs.project_path }}/CHANGELOG.md
```
This generates a pull request for the changelog update with clear branch names and commit messages, making it easier to review and edit before merging.

### How did you test it:
The changes were tested in a controlled environment to ensure the workflow correctly generates pull requests for changelog updates. Validation included confirming:
- Proper branch naming conventions.
- Accurate commit messages.
- Consistent changelog updates for the specified project path.
- Smooth integration with the `cliff.toml` configuration.

### Notes for the reviewer:
- Review the branch naming conventions and commit messages in the `create-pull-request` action to confirm they align with repository standards.
- Ensure the proposed messaging in PR is clear