### PR TITLE
fix: Fix failing automatic PR generation for changelog

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -63,6 +63,7 @@ jobs:
           token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
           commit-message: "Update changelog for ${{ steps.pathfinder.outputs.project_path }}"
           branch: update-changelog-${{ steps.pathfinder.outputs.project_path }}
+          base: main
           title: "docs: update changelog for ${{ steps.pathfinder.outputs.project_path }}"
           add-paths: |
             ${{ steps.pathfinder.outputs.project_path }}/CHANGELOG.md


### PR DESCRIPTION
A fix for previous PR that missed the base branch target for https://github.com/deepset-ai/haystack-core-integrations/pull/1328