### PR TITLE
fix: VertexAIGeminiChatGenerator - do not create messages with empty text

### DIFF
--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -383,7 +383,7 @@ class VertexAIGeminiChatGenerator:
                             arguments=dict(part.function_call.args),
                         )
                     )
-            reply = ChatMessage.from_assistant(text=text, tool_calls=tool_calls, meta=candidate_metadata)
+            reply = ChatMessage.from_assistant(text=text or None, tool_calls=tool_calls, meta=candidate_metadata)
             replies.append(reply)
         return replies
 

--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -414,6 +414,7 @@ class TestVertexAIGeminiChatGenerator:
         assert "replies" in response
         reply = response["replies"][0]
         assert reply.role == ChatRole.ASSISTANT
+        assert not reply.texts
         assert not reply.text
         assert len(reply.tool_calls) == 1
         assert reply.tool_calls[0].tool_name == "get_current_weather"
@@ -492,6 +493,7 @@ class TestVertexAIGeminiChatGenerator:
         assert "replies" in response
         reply = response["replies"][0]
         assert reply.role == ChatRole.ASSISTANT
+        assert not reply.texts
         assert not reply.text
         assert len(reply.tool_calls) == 2
         assert reply.tool_calls[0].tool_name == "get_current_weather"


### PR DESCRIPTION
### Related Issues
The usage example in the [docstring](https://github.com/deepset-ai/haystack-core-integrations/blob/3b5efec90a280dbc36565941a057653efa6383bc/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py#L84) is failing with:

`google.api_core.exceptions.BadRequest: 400 POST https://us-central1-aiplatform.googleapis.com/v1/projects/gen-lang-client-0206209522/locations/us-central1/publishers/google/models/gemini-2.0-flash-exp:generateContent?%24alt=json%3Benum-encoding%3Dint: Unable to submit request because it has an empty text parameter. Add a value to the parameter and try again. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini`

This happens because when building assistant response, an empty `text` is created if no text is provided.

### Proposed Changes:
- `ChatMessage.from_assistant(text or None)`

### How did you test it?
CI; small addition to tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
