### PR TITLE
Add the batch size to reduce the memory load during writing to Elastic Search. 

### DIFF
--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -125,8 +125,10 @@ class TestDocumentStore(DocumentStoreBaseTests, FilterDocumentsTestWithDataframe
         assert document_store.client._headers["user-agent"].startswith("haystack-py-ds/")
 
     def test_write_documents(self, document_store: ElasticsearchDocumentStore):
-        docs = [Document(id="1")]
-        assert document_store.write_documents(docs) == 1
+        num_docs = 50000
+        batch_size = 5000
+        docs = [Document(id=f"{i}") for i in range(num_docs)]
+        assert document_store.write_documents(docs, batch_size) == num_docs
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents(docs, DuplicatePolicy.FAIL)
 


### PR DESCRIPTION
### Related Issues

- fixes #1338 

### Proposed Changes:

Add a batch size to reduce the size of the elasticsearch_actions list and consequently reduce the memory load.

### How did you test it?

I used [memray](https://github.com/bloomberg/memray) to profile the memory load and these are the results based on indexing 500k documents versus indexing the same amount of documents but with a batch size of 5k. The memory load is 64% less. (358MB to 130MB).

<img width="1084" alt="Screenshot 2025-01-31 at 14 33 23" src="https://github.com/user-attachments/assets/4964642b-f595-4d47-a948-e1f0553177f7" />
<img width="1036" alt="Screenshot 2025-01-31 at 14 33 43" src="https://github.com/user-attachments/assets/bd06d447-f65b-4429-8994-7dd974621b62" />


### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
