### PR TITLE
feat: Pgvector - add like and not like filters

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -238,11 +238,13 @@ def _like(field: str, value: Any) -> Tuple[str, Any]:
         raise FilterError(msg)
     return f"{field} LIKE %s", value
 
+
 def _not_like(field: str, value: Any) -> Tuple[str, Any]:
     if not isinstance(value, str):
         msg = f"{field}'s value must be a str when using 'LIKE' "
         raise FilterError(msg)
     return f"{field} NOT LIKE %s", value
+
 
 COMPARISON_OPERATORS = {
     "==": _equal,

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -232,6 +232,19 @@ def _in(field: str, value: Any) -> Tuple[str, List]:
     return f"{field} = ANY(%s)", [value]
 
 
+def _like(field: str, value: Any) -> Tuple[str, Any]:
+    if not isinstance(value, str):
+        msg = f"{field}'s value must be a str when using 'LIKE' "
+        raise FilterError(msg)
+    return f"{field} LIKE %s", value
+
+
+def _not_like(field: str, value: Any) -> Tuple[str, Any]:
+    if not isinstance(value, str):
+        msg = f"{field}'s value must be a str when using 'LIKE' "
+        raise FilterError(msg)
+    return f"{field} NOT LIKE %s", value
+
 COMPARISON_OPERATORS = {
     "==": _equal,
     "!=": _not_equal,
@@ -241,4 +254,6 @@ COMPARISON_OPERATORS = {
     "<=": _less_than_equal,
     "in": _in,
     "not in": _not_in,
+    "like": _like,
+    "not like": _not_like,
 }

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -238,7 +238,6 @@ def _like(field: str, value: Any) -> Tuple[str, Any]:
         raise FilterError(msg)
     return f"{field} LIKE %s", value
 
-
 def _not_like(field: str, value: Any) -> Tuple[str, Any]:
     if not isinstance(value, str):
         msg = f"{field}'s value must be a str when using 'LIKE' "

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -40,6 +40,62 @@ class TestFilters(FilterDocumentsTest, FilterDocumentsTestWithDataframe):
     @pytest.mark.skip(reason="NOT operator is not supported in PgvectorDocumentStore")
     def test_not_operator(self, document_store, filterable_docs): ...
 
+    def test_like_operator(self, document_store, filterable_docs):
+        document_store.write_documents(filterable_docs)
+        filters = {"field": "content", "operator": "like", "value": "%Foo%"}
+        result = document_store.filter_documents(filters=filters)
+
+        self.assert_documents_are_equal(result, [d for d in filterable_docs if "Foo" in d.content])
+
+    def test_like_operator_startswith(self, document_store, filterable_docs):
+        document_store.write_documents(filterable_docs)
+        filters = {"field": "content", "operator": "like", "value": "Foo%"}
+        result = document_store.filter_documents(filters=filters)
+
+        self.assert_documents_are_equal(result, [d for d in filterable_docs if d.content.startswith("Foo")])
+
+    def test_like_operator_nb_chars(self, document_store, filterable_docs):
+        document_store.write_documents(filterable_docs)
+        filters = {"field": "content", "operator": "like", "value": "A Foobar Document__"}
+        result = document_store.filter_documents(filters=filters)
+
+        self.assert_documents_are_equal(
+            result,
+            [
+                d
+                for d in filterable_docs
+                if (d.content.startswith("A Foobar Document") and len(d.content) == (len("A Foobar Document") + 2))
+            ],
+        )
+
+    def test_not_like_operator(self, document_store, filterable_docs):
+        document_store.write_documents(filterable_docs)
+        filters = {"field": "content", "operator": "not like", "value": "%Foo%"}
+        result = document_store.filter_documents(filters=filters)
+
+        self.assert_documents_are_equal(result, [d for d in filterable_docs if "Foo" not in d.content])
+
+    def test_not_like_operator_startswith(self, document_store, filterable_docs):
+        document_store.write_documents(filterable_docs)
+        filters = {"field": "content", "operator": "not like", "value": "Foo%"}
+        result = document_store.filter_documents(filters=filters)
+
+        self.assert_documents_are_equal(result, [d for d in filterable_docs if not d.content.startswith("Foo")])
+
+    def test_not_like_operator_nb_chars(self, document_store, filterable_docs):
+        document_store.write_documents(filterable_docs)
+        filters = {"field": "content", "operator": "not like", "value": "A Foobar Document__"}
+        result = document_store.filter_documents(filters=filters)
+
+        self.assert_documents_are_equal(
+            result,
+            [
+                d
+                for d in filterable_docs
+                if not (d.content.startswith("A Foobar Document") and len(d.content) == (len("A Foobar Document") + 2))
+            ],
+        )
+
     def test_complex_filter(self, document_store, filterable_docs):
         document_store.write_documents(filterable_docs)
         filters = {


### PR DESCRIPTION
### Related Issues

- fixes: #1340
### Proposed Changes:
Currently the metadata used for filtering are limited to : 
- `==`
- `!=`
- `>`
- `>=`
- `<`
- `<=`
- `in`
- `not in`

According to this haystack page: [here](https://docs.haystack.deepset.ai/docs/metadata-filtering)

I came upon a problem that I wanted to check if a specific metadata include a specific string (this is similar to str contains in python). 

I resolved this by manually adding the LIKE and NOT_LIKE operator to haystack pg vector.

Maybe we need to update it for all other databases as welll? 

