### PR TITLE
test: GoogleAI - reduce tests concurrency

### DIFF
--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.10"]
+      max-parallel: 2  # to avoid "429 Resource has been exhausted"
 
     steps:
       - name: Support longpaths


### PR DESCRIPTION
### Related Issues

- nightly tests are often failing with "429 Resource has been exhausted": https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13103967998/job/36555829567
- this likely happens because too many requests are sent in a short period of time (https://groups.google.com/g/adwords-api/c/gcKvh1C3GX4?pli=1)

### Proposed Changes:
- set `max-parallel: 2` in the GitHub workflow to have a maximum of 2 jobs running at the same time ([docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel))

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
