### PR TITLE
fix: remove setting `query_type="simple"` in retrieval request

### DIFF
--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -477,7 +477,7 @@ class AzureAISearchDocumentStore:
             msg = "query must not be None"
             raise ValueError(msg)
 
-        result = self.client.search(search_text=query, filter=filters, top=top_k, query_type="simple", **kwargs)
+        result = self.client.search(search_text=query, filter=filters, top=top_k, **kwargs)
         azure_docs = list(result)
         return self._convert_search_result_to_documents(azure_docs)
 
@@ -520,7 +520,6 @@ class AzureAISearchDocumentStore:
             vector_queries=[vector_query],
             filter=filters,
             top=top_k,
-            query_type="simple",
             **kwargs,
         )
         azure_docs = list(result)


### PR DESCRIPTION
### Related Issues

- fixes currently, `query_type = "simple"` is set in the `client.search` request for BM25 and hybrid retrieval. This is blocking semantic queries as the user should be able to pass `query_type = "semantic"`  in `kwargs` along with semantic configuration. 

### Proposed Changes:

Remove setting `query_type = "simple"` from `_bm25_retrieval` and `_hybrid_retrieval` methods of `AzureAISearchDocumentStore`. By removing this specification the type will still default to "simple", leaving the behaviour unchanged. 

### How did you test it?
CI / and locally tested semantic queries

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
