### PR TITLE
ci: skip tests when only CHANGELOG.md is modified

### DIFF
--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -10,6 +10,7 @@ on:
       - "integrations/amazon_bedrock/**"
       - "!integrations/amazon_bedrock/CHANGELOG.md"
       - ".github/workflows/amazon_bedrock.yml"
+      
 defaults:
   run:
     working-directory: integrations/amazon_bedrock

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/amazon_bedrock/**"
-      - "!integrations/amazon_bedrock/CHANGELOG.md"
+      - "!integrations/amazon_bedrock/*.md"
       - ".github/workflows/amazon_bedrock.yml"
 
 defaults:

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     paths:
       - "integrations/amazon_bedrock/**"
+      - "!integrations/amazon_bedrock/CHANGELOG.md"
       - ".github/workflows/amazon_bedrock.yml"
-
 defaults:
   run:
     working-directory: integrations/amazon_bedrock

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -10,7 +10,7 @@ on:
       - "integrations/amazon_bedrock/**"
       - "!integrations/amazon_bedrock/CHANGELOG.md"
       - ".github/workflows/amazon_bedrock.yml"
-      
+
 defaults:
   run:
     working-directory: integrations/amazon_bedrock

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -10,7 +10,7 @@ on:
       - "integrations/amazon_sagemaker/**"
       - "!integrations/amazon_sagemaker/CHANGELOG.md"
       - ".github/workflows/amazon_sagemaker.yml"
-      
+
 defaults:
   run:
     working-directory: integrations/amazon_sagemaker

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     paths:
       - "integrations/amazon_sagemaker/**"
+      - "!integrations/amazon_sagemaker/CHANGELOG.md"
       - ".github/workflows/amazon_sagemaker.yml"
-
 defaults:
   run:
     working-directory: integrations/amazon_sagemaker

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/amazon_sagemaker/**"
-      - "!integrations/amazon_sagemaker/CHANGELOG.md"
+      - "!integrations/amazon_sagemaker/*.md"
       - ".github/workflows/amazon_sagemaker.yml"
 
 defaults:

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -10,6 +10,7 @@ on:
       - "integrations/amazon_sagemaker/**"
       - "!integrations/amazon_sagemaker/CHANGELOG.md"
       - ".github/workflows/amazon_sagemaker.yml"
+      
 defaults:
   run:
     working-directory: integrations/amazon_sagemaker

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     paths:
       - "integrations/anthropic/**"
+      - "!integrations/anthropic/CHANGELOG.md"
       - ".github/workflows/anthropic.yml"
-
 defaults:
   run:
     working-directory: integrations/anthropic

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/anthropic/**"
-      - "!integrations/anthropic/CHANGELOG.md"
+      - "!integrations/anthropic/*.md"
       - ".github/workflows/anthropic.yml"
 
 defaults:

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -10,6 +10,7 @@ on:
       - "integrations/anthropic/**"
       - "!integrations/anthropic/CHANGELOG.md"
       - ".github/workflows/anthropic.yml"
+      
 defaults:
   run:
     working-directory: integrations/anthropic

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -10,7 +10,7 @@ on:
       - "integrations/anthropic/**"
       - "!integrations/anthropic/CHANGELOG.md"
       - ".github/workflows/anthropic.yml"
-      
+
 defaults:
   run:
     working-directory: integrations/anthropic

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/astra/**"
-      - "!integrations/astra/CHANGELOG.md"
+      - "!integrations/astra/*.md"
       - ".github/workflows/astra.yml"
 
 defaults:

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/astra/**"
+      - "!integrations/astra/CHANGELOG.md"
       - ".github/workflows/astra.yml"
 
 defaults:

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/azure_ai_search/**"
-      - "!integrations/azure_ai_search/CHANGELOG.md"
+      - "!integrations/azure_ai_search/*.md"
       - ".github/workflows/azure_ai_search.yml"
 
 concurrency:

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/azure_ai_search/**"
+      - "!integrations/azure_ai_search/CHANGELOG.md"
       - ".github/workflows/azure_ai_search.yml"
 
 concurrency:

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/chroma/**"
+      - "!integrations/chroma/CHANGELOG.md"
       - ".github/workflows/chroma.yml"
 
 defaults:

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/chroma/**"
-      - "!integrations/chroma/CHANGELOG.md"
+      - "!integrations/chroma/*.md"
       - ".github/workflows/chroma.yml"
 
 defaults:

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/cohere/**"
-      - "!integrations/cohere/CHANGELOG.md"
+      - "!integrations/cohere/*.md"
       - ".github/workflows/cohere.yml"
 
 defaults:

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/cohere/**"
+      - "!integrations/cohere/CHANGELOG.md"
       - ".github/workflows/cohere.yml"
 
 defaults:

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/deepeval/**"
-      - "!integrations/deepeval/CHANGELOG.md"
+      - "!integrations/deepeval/*.md"
       - ".github/workflows/deepeval.yml"
 
 defaults:

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -10,6 +10,7 @@ on:
       - "integrations/deepeval/**"
       - "!integrations/deepeval/CHANGELOG.md"
       - ".github/workflows/deepeval.yml"
+      
 defaults:
   run:
     working-directory: integrations/deepeval

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -10,7 +10,7 @@ on:
       - "integrations/deepeval/**"
       - "!integrations/deepeval/CHANGELOG.md"
       - ".github/workflows/deepeval.yml"
-      
+
 defaults:
   run:
     working-directory: integrations/deepeval

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     paths:
       - "integrations/deepeval/**"
+      - "!integrations/deepeval/CHANGELOG.md"
       - ".github/workflows/deepeval.yml"
-
 defaults:
   run:
     working-directory: integrations/deepeval

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -10,7 +10,7 @@ on:
       - "integrations/elasticsearch/**"
       - "!integrations/elasticsearch/CHANGELOG.md"
       - ".github/workflows/elasticsearch.yml"
-      
+
 defaults:
   run:
     working-directory: integrations/elasticsearch

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     paths:
       - "integrations/elasticsearch/**"
+      - "!integrations/elasticsearch/CHANGELOG.md"
       - ".github/workflows/elasticsearch.yml"
-
 defaults:
   run:
     working-directory: integrations/elasticsearch

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/elasticsearch/**"
-      - "!integrations/elasticsearch/CHANGELOG.md"
+      - "!integrations/elasticsearch/*.md"
       - ".github/workflows/elasticsearch.yml"
 
 defaults:

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -10,6 +10,7 @@ on:
       - "integrations/elasticsearch/**"
       - "!integrations/elasticsearch/CHANGELOG.md"
       - ".github/workflows/elasticsearch.yml"
+      
 defaults:
   run:
     working-directory: integrations/elasticsearch

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     paths:
       - "integrations/fastembed/**"
+      - "!integrations/fastembed/CHANGELOG.md"
       - ".github/workflows/fastembed.yml"
-
 defaults:
   run:
     working-directory: integrations/fastembed

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -8,6 +8,7 @@ on:
       - "integrations/fastembed/**"
       - "!integrations/fastembed/CHANGELOG.md"
       - ".github/workflows/fastembed.yml"
+      
 defaults:
   run:
     working-directory: integrations/fastembed

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -8,7 +8,7 @@ on:
       - "integrations/fastembed/**"
       - "!integrations/fastembed/CHANGELOG.md"
       - ".github/workflows/fastembed.yml"
-      
+
 defaults:
   run:
     working-directory: integrations/fastembed

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "integrations/fastembed/**"
-      - "!integrations/fastembed/CHANGELOG.md"
+      - "!integrations/fastembed/*.md"
       - ".github/workflows/fastembed.yml"
 
 defaults:

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -10,7 +10,7 @@ on:
       - "integrations/google_ai/**"
       - "!integrations/google_ai/CHANGELOG.md"
       - ".github/workflows/google_ai.yml"
-      
+
 defaults:
   run:
     working-directory: integrations/google_ai

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     paths:
       - "integrations/google_ai/**"
+      - "!integrations/google_ai/CHANGELOG.md"
       - ".github/workflows/google_ai.yml"
-
 defaults:
   run:
     working-directory: integrations/google_ai

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/google_ai/**"
-      - "!integrations/google_ai/CHANGELOG.md"
+      - "!integrations/google_ai/*.md"
       - ".github/workflows/google_ai.yml"
 
 defaults:

--- a/.github/workflows/google_ai.yml
+++ b/.github/workflows/google_ai.yml
@@ -10,6 +10,7 @@ on:
       - "integrations/google_ai/**"
       - "!integrations/google_ai/CHANGELOG.md"
       - ".github/workflows/google_ai.yml"
+      
 defaults:
   run:
     working-directory: integrations/google_ai

--- a/.github/workflows/google_vertex.yml
+++ b/.github/workflows/google_vertex.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/google_vertex/**"
+      - "!integrations/google_vertex/CHANGELOG.md"
       - ".github/workflows/google_vertex.yml"
 
 defaults:

--- a/.github/workflows/google_vertex.yml
+++ b/.github/workflows/google_vertex.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/google_vertex/**"
-      - "!integrations/google_vertex/CHANGELOG.md"
+      - "!integrations/google_vertex/*.md"
       - ".github/workflows/google_vertex.yml"
 
 defaults:

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "integrations/instructor_embedders/**"
-      - "!integrations/instructor_embedders/CHANGELOG.md"
+      - "!integrations/instructor_embedders/*.md"
       - ".github/workflows/instructor_embedders.yml"
 
 defaults:

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - "integrations/instructor_embedders/**"
+      - "!integrations/instructor_embedders/CHANGELOG.md"
       - ".github/workflows/instructor_embedders.yml"
 
 defaults:

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/jina/**"
+      - "!integrations/jina/CHANGELOG.md"
       - ".github/workflows/jina.yml"
 
 defaults:

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/jina/**"
-      - "!integrations/jina/CHANGELOG.md"
+      - "!integrations/jina/*.md"
       - ".github/workflows/jina.yml"
 
 defaults:

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/langfuse/**"
+      - "!integrations/langfuse/CHANGELOG.md"
       - ".github/workflows/langfuse.yml"
 
 defaults:

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/langfuse/**"
-      - "!integrations/langfuse/CHANGELOG.md"
+      - "!integrations/langfuse/*.md"
       - ".github/workflows/langfuse.yml"
 
 defaults:

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/llama_cpp/**"
+      - "!integrations/llama_cpp/CHANGELOG.md"
       - ".github/workflows/llama_cpp.yml"
 
 defaults:

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/llama_cpp/**"
-      - "!integrations/llama_cpp/CHANGELOG.md"
+      - "!integrations/llama_cpp/*.md"
       - ".github/workflows/llama_cpp.yml"
 
 defaults:

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/mistral/**"
+      - "!integrations/mistral/CHANGELOG.md"
       - ".github/workflows/mistral.yml"
 
 defaults:

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/mistral/**"
-      - "!integrations/mistral/CHANGELOG.md"
+      - "!integrations/mistral/*.md"
       - ".github/workflows/mistral.yml"
 
 defaults:

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - 'integrations/mongodb_atlas/**'
+      - '!integrations/mongodb_atlas/CHANGELOG.md'
       - '.github/workflows/mongodb_atlas.yml'
 
 defaults:

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - 'integrations/mongodb_atlas/**'
-      - '!integrations/mongodb_atlas/CHANGELOG.md'
+      - '!integrations/mongodb_atlas/*.md'
       - '.github/workflows/mongodb_atlas.yml'
 
 defaults:

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/nvidia/**"
-      - "!integrations/nvidia/CHANGELOG.md"
+      - "!integrations/nvidia/*.md"
       - ".github/workflows/nvidia.yml"
 
 defaults:

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/nvidia/**"
+      - "!integrations/nvidia/CHANGELOG.md"
       - ".github/workflows/nvidia.yml"
 
 defaults:

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/ollama/**"
-      - "!integrations/ollama/CHANGELOG.md"
+      - "!integrations/ollama/*.md"
       - ".github/workflows/ollama.yml"
 
 defaults:

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/ollama/**"
+      - "!integrations/ollama/CHANGELOG.md"
       - ".github/workflows/ollama.yml"
 
 defaults:

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/opensearch/**"
+      - "!integrations/opensearch/CHANGELOG.md"
       - ".github/workflows/opensearch.yml"
 
 concurrency:

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/opensearch/**"
-      - "!integrations/opensearch/CHANGELOG.md"
+      - "!integrations/opensearch/*.md"
       - ".github/workflows/opensearch.yml"
 
 concurrency:

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/optimum/**"
+      - "!integrations/optimum/CHANGELOG.md"
       - ".github/workflows/optimum.yml"
 
 defaults:

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/optimum/**"
-      - "!integrations/optimum/CHANGELOG.md"
+      - "!integrations/optimum/*.md"
       - ".github/workflows/optimum.yml"
 
 defaults:

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/pgvector/**"
-      - "!integrations/pgvector/CHANGELOG.md"
+      - "!integrations/pgvector/*.md"
       - ".github/workflows/pgvector.yml"
 
 concurrency:

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/pgvector/**"
+      - "!integrations/pgvector/CHANGELOG.md"
       - ".github/workflows/pgvector.yml"
 
 concurrency:

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/pinecone/**"
+      - "!integrations/pinecone/CHANGELOG.md"
       - ".github/workflows/pinecone.yml"
 
 defaults:

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/pinecone/**"
-      - "!integrations/pinecone/CHANGELOG.md"
+      - "!integrations/pinecone/*.md"
       - ".github/workflows/pinecone.yml"
 
 defaults:

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/qdrant/**"
-      - "!integrations/qdrant/CHANGELOG.md"
+      - "!integrations/qdrant/*.md"
       - ".github/workflows/qdrant.yml"
 
 defaults:

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/qdrant/**"
+      - "!integrations/qdrant/CHANGELOG.md"
       - ".github/workflows/qdrant.yml"
 
 defaults:

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/ragas/**"
-      - "!integrations/ragas/CHANGELOG.md"
+      - "!integrations/ragas/*.md"
       - ".github/workflows/ragas.yml"
 
 defaults:

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/ragas/**"
+      - "!integrations/ragas/CHANGELOG.md"
       - ".github/workflows/ragas.yml"
 
 defaults:

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/snowflake/**"
-      - "!integrations/snowflake/CHANGELOG.md"
+      - "!integrations/snowflake/*.md"
       - ".github/workflows/snowflake.yml"
 
 defaults:

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "integrations/snowflake/**"
+      - "!integrations/snowflake/CHANGELOG.md"
       - ".github/workflows/snowflake.yml"
 
 defaults:

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - "integrations/unstructured/**"
       - ".github/workflows/unstructured.yml"
-      - "!integrations/unstructured/CHANGELOG.md"
+      - "!integrations/unstructured/*.md"
 
 defaults:
   run:

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "integrations/unstructured/**"
       - ".github/workflows/unstructured.yml"
+      - "!integrations/unstructured/CHANGELOG.md"
 
 defaults:
   run:

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - "integrations/weaviate/**"
       - ".github/workflows/weaviate.yml"
-      - "!integrations/weaviate/CHANGELOG.md"
+      - "!integrations/weaviate/*.md"
 
 defaults:
   run:

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "integrations/weaviate/**"
       - ".github/workflows/weaviate.yml"
+      - "!integrations/weaviate/CHANGELOG.md"
 
 defaults:
   run:


### PR DESCRIPTION
### Related Issues

After #1330, every time we release a new integration, a PR with the proposed CHANGELOG change is opened and tests run on it, wasting time and computational resources.

### Proposed Changes:
- for each integration, do not run tests if only CHANGELOG.md is modified

### How did you test it?
Not easy to test before merging.
Some tests failures are unrelated to this PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
