### PR TITLE
feat: add array_contains and array_overlaps.

### DIFF
--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -96,6 +96,28 @@ class TestFilters(FilterDocumentsTest, FilterDocumentsTestWithDataframe):
             ],
         )
 
+    def test_array_contains_filter(self, document_store):
+        docs = [
+            Document(content="doc1", meta={"tags": ["tag1", "tag2"]}),
+            Document(content="doc2", meta={"tags": ["tag2", "tag3"]}),
+            Document(content="doc3", meta={"tags": ["tag1", "tag3"]}),
+        ]
+        document_store.write_documents(docs)
+        filters = {"field": "meta.tags", "operator": "array_contains", "value": ["tag1", "tag2"]}
+        result = document_store.filter_documents(filters=filters)
+        self.assert_documents_are_equal(result, [docs[0]])
+
+    def test_array_overlaps_filter(self, document_store):
+        docs = [
+            Document(content="doc1", meta={"tags": ["tag1", "tag2"]}),
+            Document(content="doc2", meta={"tags": ["tag2", "tag3"]}),
+            Document(content="doc3", meta={"tags": ["tag4"]}),
+        ]
+        document_store.write_documents(docs)
+        filters = {"field": "meta.tags", "operator": "array_overlaps", "value": ["tag1", "tag3"]}
+        result = document_store.filter_documents(filters=filters)
+        self.assert_documents_are_equal(result, [docs[0], docs[1]])
+
     def test_complex_filter(self, document_store, filterable_docs):
         document_store.write_documents(filterable_docs)
         filters = {
@@ -141,10 +163,37 @@ def test_treat_meta_field():
     assert _treat_meta_field(field="meta.bool", value=True) == "(meta->>'bool')::boolean"
     assert _treat_meta_field(field="meta.bool", value=[True, False, True]) == "(meta->>'bool')::boolean"
 
+    # Array operators should keep JSON type
+    assert _treat_meta_field(field="meta.tags", value=["a", "b"], operator="array_contains") == "meta->'tags'"
+    assert _treat_meta_field(field="meta.tags", value=["a", "b"], operator="array_overlaps") == "meta->'tags'"
+
     # do not cast the field if its value is not one of the known types, an empty list or None
     assert _treat_meta_field(field="meta.other", value={"a": 3, "b": "example"}) == "meta->>'other'"
     assert _treat_meta_field(field="meta.empty_list", value=[]) == "meta->>'empty_list'"
     assert _treat_meta_field(field="meta.name", value=None) == "meta->>'name'"
+
+
+def test_array_contains_operator():
+    condition = {"field": "meta.tags", "operator": "array_contains", "value": ["tag1", "tag2"]}
+    field, values = _parse_comparison_condition(condition)
+    assert field == "meta->'tags' @> %s"
+    assert values[0].obj == Jsonb(["tag1", "tag2"]).obj
+
+
+def test_array_overlaps_operator():
+    condition = {"field": "meta.tags", "operator": "array_overlaps", "value": ["tag1", "tag2"]}
+    field, values = _parse_comparison_condition(condition)
+    assert field == "meta->'tags' ?| %s"
+    assert isinstance(values[0], list)
+    assert values[0] == ["tag1", "tag2"]
+
+
+def test_array_operators_require_list():
+    with pytest.raises(FilterError, match="must be a list when using 'array_contains' operator"):
+        _parse_comparison_condition({"field": "meta.tags", "operator": "array_contains", "value": "not_a_list"})
+
+    with pytest.raises(FilterError, match="must be a list when using 'array_overlaps' operator"):
+        _parse_comparison_condition({"field": "meta.tags", "operator": "array_overlaps", "value": "not_a_list"})
 
 
 def test_comparison_condition_dataframe_jsonb_conversion():


### PR DESCRIPTION
### Related Issues

- proposal for #1351

### Proposed Changes:

Add `array_contains` (all items must be present in array) and `array_overlaps` (at least on item must be present in array) operators for PGVector metadata filtering.

### How did you test it?

Since `filterable_docs` did not contain arrays in the document metadata, I added tests with custom documents containing arrays of tags in their metadata.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
