### PR TITLE
ci: make Ollama testing workflow more robust

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -33,8 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
-      max-parallel: 1       
+        python-version: ["3.9", "3.10", "3.11"]  
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -34,13 +34,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11"]
+      max-parallel: 2       
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Ollama and pull the required models
         run: |
-          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.5 sh
+          curl -fsSL https://ollama.com/install.sh | sh
           ollama serve &
 
           # Check if the service is up and running with a timeout of 60 seconds
@@ -57,31 +58,7 @@ jobs:
           fi
 
           ollama pull ${{ env.LLM_FOR_TESTS }}
-          # Check if the service is up and running with a timeout of 60 seconds
-          timeout=60
-          while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
-            echo "Waiting for Ollama service to start..."
-            sleep 5
-            ((timeout-=5))
-          done
-
-          if [ $timeout -eq 0 ]; then
-            echo "Timed out waiting for Ollama service to start."
-            exit 1
-          fi          
           ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
-          # Check if the service is up and running with a timeout of 60 seconds
-          timeout=60
-          while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
-            echo "Waiting for Ollama service to start..."
-            sleep 5
-            ((timeout-=5))
-          done
-
-          if [ $timeout -eq 0 ]; then
-            echo "Timed out waiting for Ollama service to start."
-            exit 1
-          fi          
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Ollama and pull the required models
+      - name: Install and run Ollama
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 2
@@ -60,11 +60,21 @@ jobs:
               exit 1
             fi
 
+            echo "Ollama service started successfully."
+      
+      - name: Pull models
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          command: |
             ollama pull ${{ env.LLM_FOR_TESTS }}
             ollama list | grep -q "${{ env.LLM_FOR_TESTS }}" || { echo "Model ${{ env.LLM_FOR_TESTS }} not pulled."; exit 1; }
 
             ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
             ollama list | grep -q "${{ env.EMBEDDER_FOR_TESTS }}" || { echo "Model ${{ env.EMBEDDER_FOR_TESTS }} not pulled."; exit 1; }
+
+            echo "Models pulled successfully."
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -61,7 +61,10 @@ jobs:
             fi
 
             ollama pull ${{ env.LLM_FOR_TESTS }}
+            ollama list | grep -q "${{ env.LLM_FOR_TESTS }}" || { echo "Model ${{ env.LLM_FOR_TESTS }} not pulled."; exit 1; }
+
             ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
+            ollama list | grep -q "${{ env.EMBEDDER_FOR_TESTS }}" || { echo "Model ${{ env.EMBEDDER_FOR_TESTS }} not pulled."; exit 1; }
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11"]
-      max-parallel: 2       
+      max-parallel: 1       
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Ollama and pull the required models
         run: |
-          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.5 sh
+          curl -fsSL https://ollama.com/install.sh | sh
           ollama serve &
 
           # Check if the service is up and running with a timeout of 60 seconds

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -57,7 +57,31 @@ jobs:
           fi
 
           ollama pull ${{ env.LLM_FOR_TESTS }}
+          # Check if the service is up and running with a timeout of 60 seconds
+          timeout=60
+          while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
+            echo "Waiting for Ollama service to start..."
+            sleep 5
+            ((timeout-=5))
+          done
+
+          if [ $timeout -eq 0 ]; then
+            echo "Timed out waiting for Ollama service to start."
+            exit 1
+          fi          
           ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
+          # Check if the service is up and running with a timeout of 60 seconds
+          timeout=60
+          while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
+            echo "Waiting for Ollama service to start..."
+            sleep 5
+            ((timeout-=5))
+          done
+
+          if [ $timeout -eq 0 ]; then
+            echo "Timed out waiting for Ollama service to start."
+            exit 1
+          fi          
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Ollama and pull the required models
         run: |
-          curl -fsSL https://ollama.com/install.sh | sh
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.5 sh
           ollama serve &
 
           # Check if the service is up and running with a timeout of 60 seconds

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -66,7 +66,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 2
-          max_attempts: 3
+          max_attempts: 5
           command: |
             ollama pull ${{ env.LLM_FOR_TESTS }}
             ollama list | grep -q "${{ env.LLM_FOR_TESTS }}" || { echo "Model ${{ env.LLM_FOR_TESTS }} not pulled."; exit 1; }

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Ollama and pull the required models
         run: |
-          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.6 sh
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.5 sh
           ollama serve &
 
           # Check if the service is up and running with a timeout of 60 seconds

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Ollama and pull the required models
         run: |
-          curl -fsSL https://ollama.com/install.sh | sh
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.6 sh
           ollama serve &
 
           # Check if the service is up and running with a timeout of 60 seconds

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -40,25 +40,29 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Ollama and pull the required models
-        run: |
-          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.5 sh
-          ollama serve &
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          command: |
+            curl -fsSL https://ollama.com/install.sh | sh
+            ollama serve &
 
-          # Check if the service is up and running with a timeout of 60 seconds
-          timeout=60
-          while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
-            echo "Waiting for Ollama service to start..."
-            sleep 5
-            ((timeout-=5))
-          done
+            # Check if the service is up and running with a timeout of 60 seconds
+            timeout=60
+            while [ $timeout -gt 0 ] && ! curl -sSf http://localhost:11434/ > /dev/null; do
+              echo "Waiting for Ollama service to start..."
+              sleep 5
+              ((timeout-=5))
+            done
 
-          if [ $timeout -eq 0 ]; then
-            echo "Timed out waiting for Ollama service to start."
-            exit 1
-          fi
+            if [ $timeout -eq 0 ]; then
+              echo "Timed out waiting for Ollama service to start."
+              exit 1
+            fi
 
-          ollama pull ${{ env.LLM_FOR_TESTS }}
-          ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
+            ollama pull ${{ env.LLM_FOR_TESTS }}
+            ollama pull ${{ env.EMBEDDER_FOR_TESTS }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Ollama and pull the required models
         run: |
-          curl -fsSL https://ollama.com/install.sh | sh
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.5 sh
           ollama serve &
 
           # Check if the service is up and running with a timeout of 60 seconds


### PR DESCRIPTION
### Related Issues

- Ollama tests are failing often: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13147246857/job/36687949059
- this happens for several reasons, including network errors and subtle bugs on some Ollama versions

### Proposed Changes:
After some attempts, I decide to make this testing workflow more structured and robust:
- separate Ollama installation and model pulling
- add a retry mechanism for these different steps: if they fail, it's not possible that python tests will pass
- (python tests already have a retry mechanism)

### How did you test it?
CI
if you look at latest CI runs, you'll notice that the pulling step sometimes failed and has been retried

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
