### PR TITLE
test: Langfuse - wait before retrieving the trace in `test_custom_span_handler`

### DIFF
--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -237,6 +237,8 @@ def test_custom_span_handler():
     uuid = os.path.basename(urlparse(trace_url).path)
     url = f"https://cloud.langfuse.com/api/public/traces/{uuid}"
 
+    time.sleep(10)
+
     # Poll the Langfuse API
     attempts = 5
     delay = 1

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -237,7 +237,8 @@ def test_custom_span_handler():
     uuid = os.path.basename(urlparse(trace_url).path)
     url = f"https://cloud.langfuse.com/api/public/traces/{uuid}"
 
-    time.sleep(10)
+    # we first need to wait for the response to be available and the trace to be created
+    time.sleep(5)
 
     # Poll the Langfuse API
     attempts = 5


### PR DESCRIPTION
### Related Issues

- nightly tests often fail: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13190420961/job/36822188315

### Proposed Changes:
- add `time.sleep(5)` to `test_custom_span_handler`: we need to wait for the response to be generated and the trace to be created

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
