### PR TITLE
chore: remove `jsonschema` dependency from `default` environment

### DIFF
--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
-  "jsonschema",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
-  "jsonschema",  # needed for Tool
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
-  "jsonschema" # for tools
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
-  "jsonschema",  # needed for Tool
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
-  "jsonschema",  # needed for Tool
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "pytest-rerunfailures",
     "haystack-pydoc-tools",
     "transformers[sentencepiece]",
-    "jsonschema",  # needed for Tool
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -44,7 +44,6 @@ git_describe_command = 'git describe --tags --match="integrations/mistral-v[0-9]
 installer = "uv"
 dependencies = [
   "coverage[toml]>=6.5",
-  "jsonschema",
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "pytest",
     "pytest-rerunfailures",
     "haystack-pydoc-tools",
-    "jsonschema",  # needed for Tool
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"


### PR DESCRIPTION
### Related Issues

- fixes #1323

### Proposed Changes:
- remove `jsonschema` dependency from `default` environment for all `ChatGenerators`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
