### PR TITLE
chore: pgvector - remove support for dataframe

### DIFF
--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -163,6 +163,7 @@ markers = ["integration: integration tests"]
 module = [
   "haystack.*",
   "haystack_integrations.*",
+  "numpy.*",
   "pgvector.*",
   "psycopg.*",
   "pytest.*",

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -591,11 +591,19 @@ class PgvectorDocumentStore:
             blob_data = haystack_dict.pop("blob_data")
             blob_meta = haystack_dict.pop("blob_meta")
             blob_mime_type = haystack_dict.pop("blob_mime_type")
+            dataframe = haystack_dict.pop("dataframe", None)
 
-            # postgresql returns the embedding as a string
-            # so we need to convert it to a list of floats
+            # convert the embedding to a list of floats
             if document.get("embedding") is not None:
                 haystack_dict["embedding"] = document["embedding"].tolist()
+
+            if dataframe:
+                logger.warning(
+                    "Document %s has the `dataframe` field set. "
+                    "PgvectorDocumentStore no longer supports dataframes and this field will be ignored. "
+                    "The `dataframe` field will soon be removed from Haystack Document.",
+                    haystack_dict["id"],
+                )
 
             haystack_document = Document.from_dict(haystack_dict)
 

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -6,7 +6,6 @@ from itertools import chain
 from typing import Any, Dict, List, Literal, Tuple
 
 from haystack.errors import FilterError
-from pandas import DataFrame
 from psycopg.sql import SQL
 from psycopg.types.json import Jsonb
 
@@ -93,10 +92,6 @@ def _parse_comparison_condition(condition: Dict[str, Any]) -> Tuple[str, List[An
         raise FilterError(msg)
 
     value: Any = condition["value"]
-    if isinstance(value, DataFrame):
-        # DataFrames are stored as JSONB and we query them as such
-        value = Jsonb(value.to_json())
-        field = f"({field})::jsonb"
 
     if field.startswith("meta."):
         field = _treat_meta_field(field, value)


### PR DESCRIPTION
### Related Issues

- part of #1371

### Proposed Changes:

This is the first PR to remove support for `dataframe` in document stores.
I'm doing that for Pgvector.
This is a breaking change -> I will release a major version of this integration.

### How did you test it?
CI;
I also tested locally that a table created with the current version of the Document Store still works with the new version (but does not support writing `dataframe`).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
