### PR TITLE
chore!: pinecone - remove dataframe support

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -1,12 +1,10 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import io
 import logging
 from copy import copy
 from typing import Any, Dict, List, Literal, Optional
 
-import pandas as pd
 from haystack import default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.document_stores.types import DuplicatePolicy
@@ -291,10 +289,14 @@ class PineconeDocumentStore:
         for pinecone_doc in pinecone_docs:
             content = pinecone_doc["metadata"].pop("content", None)
 
-            dataframe = None
-            dataframe_string = pinecone_doc["metadata"].pop("dataframe", None)
-            if dataframe_string:
-                dataframe = pd.read_json(io.StringIO(dataframe_string))
+            dataframe = pinecone_doc["metadata"].pop("dataframe", None)
+            if dataframe:
+                logger.warning(
+                    "Document %s has the `dataframe` field set. "
+                    "PineconeDocumentStore no longer supports dataframes and this field will be ignored. "
+                    "The `dataframe` field will soon be removed from Haystack Document.",
+                    pinecone_doc["id"],
+                )
 
             # we always store vectors during writing but we don't want to return them if they are dummy vectors
             embedding = None
@@ -304,7 +306,6 @@ class PineconeDocumentStore:
             doc = Document(
                 id=pinecone_doc["id"],
                 content=content,
-                dataframe=dataframe,
                 meta=self._convert_meta_to_int(pinecone_doc["metadata"]),
                 embedding=embedding,
                 score=pinecone_doc["score"],
@@ -360,11 +361,16 @@ class PineconeDocumentStore:
 
             doc_for_pinecone = {"id": document.id, "values": embedding, "metadata": dict(document.meta)}
 
-            # we save content/dataframe as metadata
+            # we save content as metadata
             if document.content is not None:
                 doc_for_pinecone["metadata"]["content"] = document.content
             if document.dataframe is not None:
-                doc_for_pinecone["metadata"]["dataframe"] = document.dataframe.to_json()
+                logger.warning(
+                    "Document %s has the `dataframe` field set. "
+                    "PineconeDocumentStore no longer supports dataframes and this field will be ignored. "
+                    "The `dataframe` field will soon be removed from Haystack Document.",
+                    document.id,
+                )
             # currently, storing blob in Pinecone is not supported
             if document.blob is not None:
                 logger.warning(

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/filters.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/filters.py
@@ -4,7 +4,6 @@
 from typing import Any, Dict
 
 from haystack.errors import FilterError
-from pandas import DataFrame
 
 
 def _normalize_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
@@ -61,8 +60,6 @@ def _parse_comparison_condition(condition: Dict[str, Any]) -> Dict[str, Any]:
         field = field[5:]
 
     value: Any = condition["value"]
-    if isinstance(value, DataFrame):
-        value = value.to_json()
 
     return COMPARISON_OPERATORS[operator](field, value)
 

--- a/integrations/pinecone/tests/test_filters.py
+++ b/integrations/pinecone/tests/test_filters.py
@@ -5,13 +5,12 @@ import pytest
 from haystack.dataclasses.document import Document
 from haystack.testing.document_store import (
     FilterDocumentsTest,
-    FilterDocumentsTestWithDataframe,
 )
 
 
 @pytest.mark.integration
 @pytest.mark.skipif("PINECONE_API_KEY" not in os.environ, reason="PINECONE_API_KEY not set")
-class TestFilters(FilterDocumentsTest, FilterDocumentsTestWithDataframe):
+class TestFilters(FilterDocumentsTest):
     def assert_documents_are_equal(self, received: List[Document], expected: List[Document]):
         for doc in received:
             # Pinecone seems to convert integers to floats (undocumented behavior)
@@ -26,10 +25,6 @@ class TestFilters(FilterDocumentsTest, FilterDocumentsTestWithDataframe):
         for received_doc, expected_doc in zip(received, expected):
             assert received_doc.meta == expected_doc.meta
             assert received_doc.content == expected_doc.content
-            if received_doc.dataframe is None:
-                assert expected_doc.dataframe is None
-            else:
-                assert received_doc.dataframe.equals(expected_doc.dataframe)
             # unfortunately, Pinecone returns a slightly different embedding
             if received_doc.embedding is None:
                 assert expected_doc.embedding is None
@@ -73,9 +68,6 @@ class TestFilters(FilterDocumentsTest, FilterDocumentsTestWithDataframe):
     # see https://github.com/deepset-ai/haystack-core-integrations/issues/590
     @pytest.mark.skip(reason="Pinecone does not include null values in the result of the $ne operator")
     def test_comparison_not_equal(self, document_store, filterable_docs): ...
-
-    @pytest.mark.skip(reason="Pinecone does not include null values in the result of the $ne operator")
-    def test_comparison_not_equal_with_dataframe(self, document_store, filterable_docs): ...
 
     @pytest.mark.skip(
         reason="Pinecone has inconsistent behavior with respect to other Document Stores with the $or operator"


### PR DESCRIPTION
### Related Issues

- part of #1371

### Proposed Changes:
- remove dataframe support from Pinecone
This is a breaking change -> I will release a major version of this integration.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
