### PR TITLE
test: langfuse - make polling more robust in tests

### DIFF
--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -26,7 +26,7 @@ os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 def poll_langfuse(url: str):
     """Utility function to poll Langfuse API until the trace is ready"""
     # Initial wait for trace creation
-    time.sleep(5)
+    time.sleep(10)
 
     auth = HTTPBasicAuth(os.environ["LANGFUSE_PUBLIC_KEY"], os.environ["LANGFUSE_SECRET_KEY"])
 

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -29,21 +29,22 @@ def poll_langfuse(url: str):
     time.sleep(5)
 
     auth = HTTPBasicAuth(os.environ["LANGFUSE_PUBLIC_KEY"], os.environ["LANGFUSE_SECRET_KEY"])
-    
+
     attempts = 5
     delay = 1
-    
+
     while attempts > 0:
         res = requests.get(url, auth=auth)
         if res.status_code == 200:
             return res
-            
+
         attempts -= 1
         if attempts > 0:
             time.sleep(delay)
             delay *= 2
-    
+
     return res
+
 
 @pytest.fixture
 def pipeline_with_env_vars(llm_class, expected_trace):


### PR DESCRIPTION
### Related Issues

- langfuse nightly tests failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13319664714/job/37201718240

### Proposed Changes:
- make polling the Langfuse API more robust in tests:
  - always sleep 10 seconds before calling the API (5 seconds is too short a time)
  - centralize the logic in a utility function

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
