### PR TITLE
chore!: Elasticsearch - remove dataframe support

### DIFF
--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -159,5 +159,5 @@ minversion = "6.0"
 markers = ["unit: unit tests", "integration: integration tests"]
 
 [[tool.mypy.overrides]]
-module = ["haystack.*", "haystack_integrations.*", "pytest.*"]
+module = ["haystack.*", "haystack_integrations.*", "numpy.*", "pytest.*"]
 ignore_missing_imports = true

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -331,7 +331,6 @@ class ElasticsearchDocumentStore:
             data["metadata"]["highlighted"] = hit["highlight"]
         data["score"] = hit["_score"]
 
-        # Remove the `dataframe` field if it exists
         if "dataframe" in data:
             dataframe = data.pop("dataframe")
             if dataframe:

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -258,6 +258,15 @@ class ElasticsearchDocumentStore:
         elasticsearch_actions = []
         for doc in documents:
             doc_dict = doc.to_dict()
+            if "dataframe" in doc_dict:
+                dataframe = doc_dict.pop("dataframe")
+                if dataframe:
+                    logger.warning(
+                        "Document %s has the `dataframe` field set,"
+                        "ElasticsearchDocumentStore no longer supports dataframes and this field will be ignored. "
+                        "The `dataframe` field will soon be removed from Haystack Document.",
+                        doc.id,
+                    )
             if "sparse_embedding" in doc_dict:
                 sparse_embedding = doc_dict.pop("sparse_embedding", None)
                 if sparse_embedding:
@@ -322,6 +331,16 @@ class ElasticsearchDocumentStore:
             data["metadata"]["highlighted"] = hit["highlight"]
         data["score"] = hit["_score"]
 
+        # Remove the `dataframe` field if it exists
+        if "dataframe" in data:
+            dataframe = data.pop("dataframe")
+            if dataframe:
+                logger.warning(
+                    "Document %s has the `dataframe` field set,"
+                    "ElasticsearchDocumentStore no longer supports dataframes and this field will be ignored. "
+                    "The `dataframe` field will soon be removed from Haystack Document.",
+                    data["id"],
+                )
         return Document.from_dict(data)
 
     def delete_documents(self, document_ids: List[str]) -> None:

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/filters.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/filters.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from haystack.errors import FilterError
-from pandas import DataFrame
 
 
 def _normalize_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
@@ -57,7 +56,7 @@ def _equal(field: str, value: Any) -> Dict[str, Any]:
                 }
             }
         }
-    if field in ["text", "dataframe"]:
+    if field == "text":
         # We want to fully match the text field.
         return {"match": {field: {"query": value, "minimum_should_match": "100%"}}}
     return {"term": {field: value}}
@@ -69,7 +68,7 @@ def _not_equal(field: str, value: Any) -> Dict[str, Any]:
 
     if isinstance(value, list):
         return {"bool": {"must_not": {"terms": {field: value}}}}
-    if field in ["text", "dataframe"]:
+    if field == "text":
         # We want to fully match the text field.
         return {"bool": {"must_not": {"match": {field: {"query": value, "minimum_should_match": "100%"}}}}}
 
@@ -92,7 +91,7 @@ def _greater_than(field: str, value: Any) -> Dict[str, Any]:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return {"range": {field: {"gt": value}}}
@@ -114,7 +113,7 @@ def _greater_than_equal(field: str, value: Any) -> Dict[str, Any]:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return {"range": {field: {"gte": value}}}
@@ -136,7 +135,7 @@ def _less_than(field: str, value: Any) -> Dict[str, Any]:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return {"range": {field: {"lt": value}}}
@@ -158,7 +157,7 @@ def _less_than_equal(field: str, value: Any) -> Dict[str, Any]:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return {"range": {field: {"lte": value}}}
@@ -212,8 +211,6 @@ def _parse_comparison_condition(condition: Dict[str, Any]) -> Dict[str, Any]:
         raise FilterError(msg)
     operator: str = condition["operator"]
     value: Any = condition["value"]
-    if isinstance(value, DataFrame):
-        value = value.to_json()
 
     return COMPARISON_OPERATORS[operator](field, value)
 

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -147,11 +147,12 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
     def test_deserialize_document_dataframe_ignored(self, document_store: ElasticsearchDocumentStore):
         hit = {
-            "_source": {"id": "1", "content": "test", "dataframe": {"a": [1, 2, 3]}},
+            "_source": {"id": "1", "content": "test", "dataframe": {"a": [1, 2, 3]}, "_score": 1.0},
         }
         doc = document_store._deserialize_document(hit)
         assert doc.id == "1"
         assert doc.content == "test"
+        assert doc.score == 1.0
         assert not hasattr(doc, "dataframe") or doc.dataframe is None
 
     def test_bm25_retrieval(self, document_store: ElasticsearchDocumentStore):

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -11,7 +11,7 @@ from elasticsearch.exceptions import BadRequestError  # type: ignore[import-not-
 from haystack.dataclasses.document import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
-from haystack.testing.document_store import DocumentStoreBaseTests, FilterDocumentsTestWithDataframe
+from haystack.testing.document_store import DocumentStoreBaseTests
 
 from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
 
@@ -70,7 +70,7 @@ def test_from_dict(_mock_elasticsearch_client):
 
 
 @pytest.mark.integration
-class TestDocumentStore(DocumentStoreBaseTests, FilterDocumentsTestWithDataframe):
+class TestDocumentStore(DocumentStoreBaseTests):
     """
     Common test cases will be provided by `DocumentStoreBaseTests` but
     you can add more to this class.
@@ -129,6 +129,29 @@ class TestDocumentStore(DocumentStoreBaseTests, FilterDocumentsTestWithDataframe
         assert document_store.write_documents(docs) == 1
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents(docs, DuplicatePolicy.FAIL)
+
+    def test_write_documents_dataframe_ignored(self, document_store: ElasticsearchDocumentStore):
+        doc = Document(id="1", content="test")
+        doc.dataframe = "placeholder_for_dataframe"
+
+        document_store.write_documents([doc])
+
+        res = document_store.filter_documents()
+        assert len(res) == 1
+
+        assert res[0].id == "1"
+        assert res[0].content == "test"
+
+        assert not hasattr(res[0], "dataframe") or res[0].dataframe is None
+
+    def test_deserialize_document_dataframe_ignored(self, document_store: ElasticsearchDocumentStore):
+        hit = {
+            "_source": {"id": "1", "content": "test", "dataframe": "placeholder_for_dataframe"},
+        }
+        doc = document_store._deserialize_document(hit)
+        assert doc.id == "1"
+        assert doc.content == "test"
+        assert not hasattr(doc, "dataframe") or doc.dataframe is None
 
     def test_bm25_retrieval(self, document_store: ElasticsearchDocumentStore):
         document_store.write_documents(

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -147,7 +147,8 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
     def test_deserialize_document_dataframe_ignored(self, document_store: ElasticsearchDocumentStore):
         hit = {
-            "_source": {"id": "1", "content": "test", "dataframe": {"a": [1, 2, 3]}, "_score": 1.0},
+            "_source": {"id": "1", "content": "test", "dataframe": {"a": [1, 2, 3]}},
+            "_score": 1.0,
         }
         doc = document_store._deserialize_document(hit)
         assert doc.id == "1"

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -12,6 +12,7 @@ from haystack.dataclasses.document import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
+from pandas import DataFrame
 
 from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
 
@@ -132,7 +133,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
     def test_write_documents_dataframe_ignored(self, document_store: ElasticsearchDocumentStore):
         doc = Document(id="1", content="test")
-        doc.dataframe = "placeholder_for_dataframe"
+        doc.dataframe = DataFrame({"a": [1, 2, 3]})
 
         document_store.write_documents([doc])
 
@@ -146,7 +147,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
     def test_deserialize_document_dataframe_ignored(self, document_store: ElasticsearchDocumentStore):
         hit = {
-            "_source": {"id": "1", "content": "test", "dataframe": "placeholder_for_dataframe"},
+            "_source": {"id": "1", "content": "test", "dataframe": {"a": [1, 2, 3]}},
         }
         doc = document_store._deserialize_document(hit)
         assert doc.id == "1"


### PR DESCRIPTION
### Related Issues

- part of #1371

### Proposed Changes:
- Remove dataframe support from Elasticsearch
- This is a breaking change -> I will release a major version of this integration.

### How did you test it?
CI; new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
