### PR TITLE
fix: Chroma - relax dataframe/blob test

### DIFF
--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -244,8 +244,10 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, FilterDocuments
 
         document_store.write_documents([doc_mixed])
 
-        expected_doc = Document(id=doc_mixed.id, content="test")
-        assert document_store.filter_documents() == [expected_doc]
+        retrieved_doc = document_store.filter_documents()[0]
+        assert retrieved_doc.content == "test"
+        assert retrieved_doc.blob is None
+        assert not hasattr(retrieved_doc, "dataframe") or retrieved_doc.dataframe is None
 
     @pytest.mark.integration
     def test_to_dict(self, request):


### PR DESCRIPTION
### Related Issues

- nightly tests are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13360047675
- the test was introduced in #1373, but for some reason the test temporarily passed

### Proposed Changes:
- relax the test
  - check that `content` has the expected value
  - check that `blob` and `dataframe` are absent or `None`
  - do not make assertions about the `embedding` field, which is automatically computed by Chroma

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
