### PR TITLE
chore!: Weaviate - remove dataframe support

### DIFF
--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -160,3 +159,6 @@ module = [
   "grpc",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+markers = ["integration: integration tests"]

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/_filters.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/_filters.py
@@ -6,7 +6,6 @@ from typing import Any, Dict
 
 from dateutil import parser
 from haystack.errors import FilterError
-from pandas import DataFrame
 
 import weaviate
 from weaviate.collections.classes.filters import Filter, FilterReturn
@@ -129,7 +128,7 @@ def _greater_than(field: str, value: Any) -> FilterReturn:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return weaviate.classes.query.Filter.by_property(field).greater_than(_handle_date(value))
@@ -151,7 +150,7 @@ def _greater_than_equal(field: str, value: Any) -> FilterReturn:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return weaviate.classes.query.Filter.by_property(field).greater_or_equal(_handle_date(value))
@@ -173,7 +172,7 @@ def _less_than(field: str, value: Any) -> FilterReturn:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return weaviate.classes.query.Filter.by_property(field).less_than(_handle_date(value))
@@ -195,7 +194,7 @@ def _less_than_equal(field: str, value: Any) -> FilterReturn:
                 "Strings are only comparable if they are ISO formatted dates."
             )
             raise FilterError(msg) from exc
-    if type(value) in [list, DataFrame]:
+    if isinstance(value, list):
         msg = f"Filter value can't be of type {type(value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
     return weaviate.classes.query.Filter.by_property(field).less_or_equal(_handle_date(value))
@@ -248,8 +247,6 @@ def _parse_comparison_condition(condition: Dict[str, Any]) -> FilterReturn:
         raise FilterError(msg)
     operator: str = condition["operator"]
     value: Any = condition["value"]
-    if isinstance(value, DataFrame):
-        value = value.to_json()
 
     return COMPARISON_OPERATORS[operator](field, value)
 

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -297,20 +297,20 @@ class WeaviateDocumentStore:
             dataframe = data.pop("dataframe")
             if dataframe:
                 logger.warning(
-                    "Document %s has the `dataframe` field set. "
+                    "Document {id} has the `dataframe` field set. "
                     "WeaviateDocumentStore no longer supports dataframes and this field will be ignored. "
                     "The `dataframe` field will soon be removed from Haystack Document.",
-                    data["_original_id"],
+                    id=data["_original_id"],
                 )
 
         if "sparse_embedding" in data:
             sparse_embedding = data.pop("sparse_embedding", None)
             if sparse_embedding:
                 logger.warning(
-                    "Document %s has the `sparse_embedding` field set,"
+                    "Document {id} has the `sparse_embedding` field set,"
                     "but storing sparse embeddings in Weaviate is not currently supported."
                     "The `sparse_embedding` field will be ignored.",
-                    data["_original_id"],
+                    id=data["_original_id"],
                 )
 
         return data
@@ -342,10 +342,10 @@ class WeaviateDocumentStore:
             dataframe = document_data.pop("dataframe")
             if dataframe:
                 logger.warning(
-                    "Document %s has the `dataframe` field set. "
+                    "Document {id} has the `dataframe` field set. "
                     "WeaviateDocumentStore no longer supports dataframes and this field will be ignored. "
                     "The `dataframe` field will soon be removed from Haystack Document.",
-                    document_data["id"],
+                    id=document_data["id"],
                 )
 
         for key, value in document_data.items():

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -289,7 +289,8 @@ class WeaviateDocumentStore:
         if "_split_overlap" in data:
             data.pop("_split_overlap")
             logger.warning(
-                "Document %s has the unsupported `_split_overlap` meta field. It will be ignored.", data["_original_id"]
+                "Document {id} has the unsupported `_split_overlap` meta field. It will be ignored.",
+                id=data["_original_id"],
             )
 
         if "dataframe" in data:

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -39,7 +39,6 @@ logger = logging.getLogger(__name__)
 DOCUMENT_COLLECTION_PROPERTIES = [
     {"name": "_original_id", "dataType": ["text"]},
     {"name": "content", "dataType": ["text"]},
-    {"name": "dataframe", "dataType": ["text"]},
     {"name": "blob_data", "dataType": ["blob"]},
     {"name": "blob_mime_type", "dataType": ["text"]},
     {"name": "score", "dataType": ["number"]},
@@ -105,7 +104,6 @@ class WeaviateDocumentStore:
             properties:
             - _original_id: text
             - content: text
-            - dataframe: text
             - blob_data: blob
             - blob_mime_type: text
             - score: number
@@ -294,6 +292,16 @@ class WeaviateDocumentStore:
                 "Document %s has the unsupported `_split_overlap` meta field. It will be ignored.", data["_original_id"]
             )
 
+        if "dataframe" in data:
+            dataframe = data.pop("dataframe")
+            if dataframe:
+                logger.warning(
+                    "Document %s has the `dataframe` field set. "
+                    "WeaviateDocumentStore no longer supports dataframes and this field will be ignored. "
+                    "The `dataframe` field will soon be removed from Haystack Document.",
+                    data["_original_id"],
+                )
+
         if "sparse_embedding" in data:
             sparse_embedding = data.pop("sparse_embedding", None)
             if sparse_embedding:
@@ -328,6 +336,16 @@ class WeaviateDocumentStore:
         # We always delete these fields as they're not part of the Document dataclass
         document_data.pop("blob_data", None)
         document_data.pop("blob_mime_type", None)
+
+        if "dataframe" in document_data:
+            dataframe = document_data.pop("dataframe")
+            if dataframe:
+                logger.warning(
+                    "Document %s has the `dataframe` field set. "
+                    "WeaviateDocumentStore no longer supports dataframes and this field will be ignored. "
+                    "The `dataframe` field will soon be removed from Haystack Document.",
+                    document_data["id"],
+                )
 
         for key, value in document_data.items():
             if isinstance(value, datetime.datetime):

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -4,10 +4,10 @@
 import base64
 import datetime
 import json
-import logging
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
+from haystack import logging
 from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses.document import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError

--- a/integrations/weaviate/tests/test_bm25_retriever.py
+++ b/integrations/weaviate/tests/test_bm25_retriever.py
@@ -46,7 +46,6 @@ def test_to_dict(_mock_weaviate):
                         "properties": [
                             {"name": "_original_id", "dataType": ["text"]},
                             {"name": "content", "dataType": ["text"]},
-                            {"name": "dataframe", "dataType": ["text"]},
                             {"name": "blob_data", "dataType": ["blob"]},
                             {"name": "blob_mime_type", "dataType": ["text"]},
                             {"name": "score", "dataType": ["number"]},
@@ -81,7 +80,6 @@ def test_from_dict(_mock_weaviate):
                             "properties": [
                                 {"name": "_original_id", "dataType": ["text"]},
                                 {"name": "content", "dataType": ["text"]},
-                                {"name": "dataframe", "dataType": ["text"]},
                                 {"name": "blob_data", "dataType": ["blob"]},
                                 {"name": "blob_mime_type", "dataType": ["text"]},
                                 {"name": "score", "dataType": ["number"]},
@@ -119,7 +117,6 @@ def test_from_dict_no_filter_policy(_mock_weaviate):
                             "properties": [
                                 {"name": "_original_id", "dataType": ["text"]},
                                 {"name": "content", "dataType": ["text"]},
-                                {"name": "dataframe", "dataType": ["text"]},
                                 {"name": "blob_data", "dataType": ["blob"]},
                                 {"name": "blob_mime_type", "dataType": ["text"]},
                                 {"name": "score", "dataType": ["number"]},

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -16,7 +16,6 @@ from haystack.testing.document_store import (
     CountDocumentsTest,
     DeleteDocumentsTest,
     FilterDocumentsTest,
-    FilterDocumentsTestWithDataframe,
     WriteDocumentsTest,
     create_filterable_docs,
 )
@@ -24,6 +23,7 @@ from haystack.utils.auth import Secret
 from numpy import array as np_array
 from numpy import array_equal as np_array_equal
 from numpy import float32 as np_float32
+from pandas import DataFrame
 from weaviate.collections.classes.data import DataObject
 from weaviate.config import AdditionalConfig, ConnectionConfig, Proxies, Timeout
 from weaviate.embedded import (
@@ -48,9 +48,7 @@ def test_init_is_lazy(_mock_client):
 
 
 @pytest.mark.integration
-class TestWeaviateDocumentStore(
-    CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsTest, FilterDocumentsTest, FilterDocumentsTestWithDataframe
-):
+class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsTest, FilterDocumentsTest):
     @pytest.fixture
     def document_store(self, request) -> WeaviateDocumentStore:
         # Use a different index for each test so we can run them in parallel
@@ -78,21 +76,7 @@ class TestWeaviateDocumentStore(
         Weaviate forces RFC 3339 date strings.
         The original fixture uses ISO 8601 date strings.
         """
-        documents = create_filterable_docs(include_dataframe_docs=False)
-        for i in range(len(documents)):
-            if date := documents[i].meta.get("date"):
-                documents[i].meta["date"] = f"{date}Z"
-        return documents
-
-    @pytest.fixture
-    def filterable_docs_with_dataframe(self) -> List[Document]:
-        """
-        This fixture has been copied from haystack/testing/document_store.py and modified to
-        use a different date format.
-        Weaviate forces RFC 3339 date strings.
-        The original fixture uses ISO 8601 date strings.
-        """
-        documents = create_filterable_docs(include_dataframe_docs=True)
+        documents = create_filterable_docs()
         for i in range(len(documents)):
             if date := documents[i].meta.get("date"):
                 documents[i].meta["date"] = f"{date}Z"
@@ -202,7 +186,6 @@ class TestWeaviateDocumentStore(
                     "properties": [
                         {"name": "_original_id", "dataType": ["text"]},
                         {"name": "content", "dataType": ["text"]},
-                        {"name": "dataframe", "dataType": ["text"]},
                         {"name": "blob_data", "dataType": ["blob"]},
                         {"name": "blob_mime_type", "dataType": ["text"]},
                         {"name": "score", "dataType": ["number"]},
@@ -284,7 +267,6 @@ class TestWeaviateDocumentStore(
             "properties": [
                 {"name": "_original_id", "dataType": ["text"]},
                 {"name": "content", "dataType": ["text"]},
-                {"name": "dataframe", "dataType": ["text"]},
                 {"name": "blob_data", "dataType": ["blob"]},
                 {"name": "blob_mime_type", "dataType": ["text"]},
                 {"name": "score", "dataType": ["number"]},
@@ -312,7 +294,6 @@ class TestWeaviateDocumentStore(
         assert data == {
             "_original_id": doc.id,
             "content": doc.content,
-            "dataframe": None,
             "score": None,
         }
 
@@ -329,10 +310,19 @@ class TestWeaviateDocumentStore(
             "content": doc.content,
             "blob_data": base64.b64encode(image.data).decode(),
             "blob_mime_type": "image/jpeg",
-            "dataframe": None,
             "score": None,
             "key": "value",
         }
+
+    def test_to_data_object_skips_dataframe(self, document_store):
+        doc = Document(id="test_id", content="test content")
+        doc.dataframe = DataFrame([{"a": 1, "b": 2}, {"a": 3, "b": 4}])
+
+        data = document_store._to_data_object(doc)
+
+        assert data["_original_id"] == "test_id"
+        assert data["content"] == "test content"
+        assert "dataframe" not in data
 
     def test_to_document(self, document_store, test_files_path):
         image = ByteStream.from_file_path(test_files_path / "robot1.jpg", mime_type="image/jpeg")
@@ -342,7 +332,6 @@ class TestWeaviateDocumentStore(
                 "content": "some content",
                 "blob_data": base64.b64encode(image.data).decode(),
                 "blob_mime_type": "image/jpeg",
-                "dataframe": None,
                 "score": None,
                 "key": "value",
             },
@@ -356,6 +345,20 @@ class TestWeaviateDocumentStore(
         assert doc.embedding == [1, 2, 3]
         assert doc.score is None
         assert doc.meta == {"key": "value"}
+
+    def test_to_document_skips_dataframe(self, document_store):
+        data = DataObject(
+            properties={
+                "_original_id": "test_id",
+                "content": "test content",
+                "dataframe": {"a": [1, 2, 3]},
+            }
+        )
+
+        doc = document_store._to_document(data)
+        assert doc.id == "test_id"
+        assert doc.content == "test content"
+        assert not hasattr(doc, "dataframe") or doc.dataframe is None
 
     def test_write_documents(self, document_store):
         """
@@ -467,10 +470,6 @@ class TestWeaviateDocumentStore(
                 and parser.isoparse(d.meta["date"]) <= parser.isoparse("1969-07-21T20:17:40Z")
             ],
         )
-
-    @pytest.mark.skip(reason="Weaviate for some reason is not returning what we expect")
-    def test_comparison_not_equal_with_dataframe(self, document_store, filterable_docs):
-        return super().test_comparison_not_equal_with_dataframe(document_store, filterable_docs)
 
     def test_meta_split_overlap_is_skipped(self, document_store):
         doc = Document(

--- a/integrations/weaviate/tests/test_embedding_retriever.py
+++ b/integrations/weaviate/tests/test_embedding_retriever.py
@@ -56,7 +56,6 @@ def test_to_dict(_mock_weaviate):
                         "properties": [
                             {"name": "_original_id", "dataType": ["text"]},
                             {"name": "content", "dataType": ["text"]},
-                            {"name": "dataframe", "dataType": ["text"]},
                             {"name": "blob_data", "dataType": ["blob"]},
                             {"name": "blob_mime_type", "dataType": ["text"]},
                             {"name": "score", "dataType": ["number"]},
@@ -93,7 +92,6 @@ def test_from_dict(_mock_weaviate):
                             "properties": [
                                 {"name": "_original_id", "dataType": ["text"]},
                                 {"name": "content", "dataType": ["text"]},
-                                {"name": "dataframe", "dataType": ["text"]},
                                 {"name": "blob_data", "dataType": ["blob"]},
                                 {"name": "blob_mime_type", "dataType": ["text"]},
                                 {"name": "score", "dataType": ["number"]},
@@ -135,7 +133,6 @@ def test_from_dict_no_filter_policy(_mock_weaviate):
                             "properties": [
                                 {"name": "_original_id", "dataType": ["text"]},
                                 {"name": "content", "dataType": ["text"]},
-                                {"name": "dataframe", "dataType": ["text"]},
                                 {"name": "blob_data", "dataType": ["blob"]},
                                 {"name": "blob_mime_type", "dataType": ["text"]},
                                 {"name": "score", "dataType": ["number"]},


### PR DESCRIPTION
### Related Issues

- part of #1371

### Proposed Changes:
- Remove dataframe support from Weaviate
- This is a breaking change -> I will release a major version of this integration.

### How did you test it?
CI; added specific tests;
I also tested locally that a collection created with the current version of the Document Store still works with the new version (but skips dataframe during writing and reading).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
