### PR TITLE
docs: fixing typo in Langfuse API docstring

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -28,7 +28,7 @@ class LangfuseConnector:
     enable Haystack tracing in your pipeline.
 
     Lastly, you may disable flushing the data after each component by setting the `HAYSTACK_LANGFUSE_ENFORCE_FLUSH`
-    environent variable to `false`. By default, the data is flushed after each component and blocks the thread until
+    environment variable to `false`. By default, the data is flushed after each component and blocks the thread until
     the data is sent to Langfuse. **Caution**: Disabling this feature may result in data loss if the program crashes
     before the data is sent to Langfuse. Make sure you will call langfuse.flush() explicitly before the program exits.
     E.g. by using tracer.actual_tracer.flush():


### PR DESCRIPTION
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
