### PR TITLE
feat: OpenSearch - async support

### DIFF
--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "pytest-xdist",
+  "pytest-asyncio",
   "haystack-pydoc-tools",
   "boto3",
 ]
@@ -128,6 +129,8 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
+  # Ignore asserts
+  "S101",
 ]
 unfixable = [
   # Don't touch unused imports
@@ -159,6 +162,7 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 [tool.pytest.ini_options]
 minversion = "6.0"
 markers = ["unit: unit tests", "integration: integration tests"]
+asyncio_mode = "auto"
 
 [[tool.mypy.overrides]]
 module = ["botocore.*", "boto3.*", "haystack.*", "haystack_integrations.*", "pytest.*", "opensearchpy.*"]

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import logging
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import component, default_from_dict, default_to_dict
+from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
@@ -152,6 +151,42 @@ class OpenSearchBM25Retriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
         return default_from_dict(cls, data)
 
+    def _prepare_bm25_args(
+        self,
+        *,
+        query: str,
+        filters: Optional[Dict[str, Any]],
+        all_terms_must_match: Optional[bool],
+        top_k: Optional[int],
+        fuzziness: Optional[Union[str, int]],
+        scale_score: Optional[bool],
+        custom_query: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
+
+        if filters is None:
+            filters = self._filters
+        if all_terms_must_match is None:
+            all_terms_must_match = self._all_terms_must_match
+        if top_k is None:
+            top_k = self._top_k
+        if fuzziness is None:
+            fuzziness = self._fuzziness
+        if scale_score is None:
+            scale_score = self._scale_score
+        if custom_query is None:
+            custom_query = self._custom_query
+
+        return {
+            "query": query,
+            "filters": filters,
+            "fuzziness": fuzziness,
+            "top_k": top_k,
+            "scale_score": scale_score,
+            "all_terms_must_match": all_terms_must_match,
+            "custom_query": custom_query,
+        }
+
     @component.output_types(documents=List[Document])
     def run(
         self,
@@ -215,41 +250,83 @@ class OpenSearchBM25Retriever:
             - documents: List of retrieved Documents.
 
         """
-        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
-
-        if filters is None:
-            filters = self._filters
-        if all_terms_must_match is None:
-            all_terms_must_match = self._all_terms_must_match
-        if top_k is None:
-            top_k = self._top_k
-        if fuzziness is None:
-            fuzziness = self._fuzziness
-        if scale_score is None:
-            scale_score = self._scale_score
-        if custom_query is None:
-            custom_query = self._custom_query
-
         docs: List[Document] = []
 
+        bm25_args = self._prepare_bm25_args(
+            query=query,
+            filters=filters,
+            all_terms_must_match=all_terms_must_match,
+            top_k=top_k,
+            fuzziness=fuzziness,
+            scale_score=scale_score,
+            custom_query=custom_query,
+        )
+
         try:
-            docs = self._document_store._bm25_retrieval(
-                query=query,
-                filters=filters,
-                fuzziness=fuzziness,
-                top_k=top_k,
-                scale_score=scale_score,
-                all_terms_must_match=all_terms_must_match,
-                custom_query=custom_query,
-            )
+            docs = self._document_store._bm25_retrieval(**bm25_args)
         except Exception as e:
             if self._raise_on_failure:
                 raise e
             else:
                 logger.warning(
-                    "An error during BM25 retrieval occurred and will be ignored by returning empty results: %s",
-                    str(e),
+                    "An error during BM25 retrieval occurred and will be ignored by returning empty results: {error}",
+                    error=str(e),
                     exc_info=True,
                 )
+
+        return {"documents": docs}
+
+    @component.output_types(documents=List[Document])
+    async def run_async(  # pylint: disable=too-many-positional-arguments
+        self,
+        query: str,
+        filters: Optional[Dict[str, Any]] = None,
+        all_terms_must_match: Optional[bool] = None,
+        top_k: Optional[int] = None,
+        fuzziness: Optional[Union[int, str]] = None,
+        scale_score: Optional[bool] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Asynchronously retrieve documents using BM25 retrieval.
+
+        :param query: The query string.
+        :param filters: Filters applied to the retrieved documents. The way runtime filters are applied depends on
+                        the `filter_policy` specified at Retriever's initialization.
+        :param all_terms_must_match: If `True`, all terms in the query string must be present in the
+        retrieved documents.
+        :param top_k: Maximum number of documents to return.
+        :param fuzziness: Fuzziness parameter for full-text queries to apply approximate string matching.
+        For more information, see [OpenSearch fuzzy query](https://opensearch.org/docs/latest/query-dsl/term/fuzzy/).
+        :param scale_score: If `True`, scales the score of retrieved documents to a range between 0 and 1.
+            This is useful when comparing documents across different indexes.
+        :param custom_query: A custom OpenSearch query. It must include a `$query` and may optionally
+        include a `$filters` placeholder.
+
+        :returns:
+            A dictionary containing the retrieved documents with the following structure:
+            - documents: List of retrieved Documents.
+
+        """
+        docs: List[Document] = []
+        bm25_args = self._prepare_bm25_args(
+            query=query,
+            filters=filters,
+            all_terms_must_match=all_terms_must_match,
+            top_k=top_k,
+            fuzziness=fuzziness,
+            scale_score=scale_score,
+            custom_query=custom_query,
+        )
+        try:
+            docs = await self._document_store._bm25_retrieval_async(**bm25_args)
+        except Exception as e:
+            if self._raise_on_failure:
+                raise e
+            logger.warning(
+                "An error during BM25 retrieval occurred and will be ignored by returning empty results: {error}",
+                error=str(e),
+                exc_info=True,
+            )
 
         return {"documents": docs}

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import logging
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import component, default_from_dict, default_to_dict
+from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
 from haystack.document_stores.types import FilterPolicy
 from haystack.document_stores.types.filter_policy import apply_filter_policy
@@ -235,9 +234,107 @@ class OpenSearchEmbeddingRetriever:
                 raise e
             else:
                 logger.warning(
-                    "An error during embedding retrieval occurred and will be ignored by returning empty results: %s",
-                    str(e),
+                    "An error during embedding retrieval occurred and will be ignored by returning empty results:"
+                    "{error}",
+                    error=str(e),
                     exc_info=True,
                 )
+
+        return {"documents": docs}
+
+    @component.output_types(documents=List[Document])
+    async def run_async(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        custom_query: Optional[Dict[str, Any]] = None,
+        efficient_filtering: Optional[bool] = None,
+    ):
+        """
+        Asynchronously retrieve documents using a vector similarity metric.
+
+        :param query_embedding: Embedding of the query.
+        :param filters: Filters applied when fetching documents from the Document Store.
+            Filters are applied during the approximate kNN search to ensure the Retriever
+              returns `top_k` matching documents.
+            The way runtime filters are applied depends on the `filter_policy` selected when initializing the Retriever.
+        :param top_k: Maximum number of documents to return.
+        :param custom_query: A custom OpenSearch query containing a mandatory `$query_embedding` and an
+          optional `$filters` placeholder.
+
+            **An example custom_query:**
+
+            ```python
+            {
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "knn": {
+                                    "embedding": {
+                                        "vector": "$query_embedding",   // mandatory query placeholder
+                                        "k": 10000,
+                                    }
+                                }
+                            }
+                        ],
+                        "filter": "$filters"                            // optional filter placeholder
+                    }
+                }
+            }
+            ```
+
+        For this `custom_query`, an example `run()` could be:
+
+        ```python
+        retriever.run(
+            query_embedding=embedding,
+            filters={
+                "operator": "AND",
+                "conditions": [
+                    {"field": "meta.years", "operator": "==", "value": "2019"},
+                    {"field": "meta.quarters", "operator": "in", "value": ["Q1", "Q2"]},
+                ],
+            },
+        )
+        ```
+
+        :param efficient_filtering: If `True`, the filter will be applied during the approximate kNN search.
+            This is only supported for knn engines "faiss" and "lucene" and does not work with the default "nmslib".
+
+        :returns:
+            Dictionary with key "documents" containing the retrieved Documents.
+            - documents: List of Document similar to `query_embedding`.
+        """
+        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
+        top_k = top_k or self._top_k
+        if filters is None:
+            filters = self._filters
+        if top_k is None:
+            top_k = self._top_k
+        if custom_query is None:
+            custom_query = self._custom_query
+        if efficient_filtering is None:
+            efficient_filtering = self._efficient_filtering
+
+        docs: List[Document] = []
+
+        try:
+            docs = await self._document_store._embedding_retrieval_async(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                custom_query=custom_query,
+                efficient_filtering=efficient_filtering,
+            )
+        except Exception as e:
+            if self._raise_on_failure:
+                raise e
+            logger.warning(
+                "An error during embedding retrieval occurred and will be ignored by returning empty results: {error}",
+                error=str(e),
+                exc_info=True,
+            )
 
         return {"documents": docs}

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -169,6 +169,26 @@ def test_run():
     assert res["documents"][0].content == "Test doc"
 
 
+@pytest.mark.asyncio
+async def test_run_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc")]
+    retriever = OpenSearchBM25Retriever(document_store=mock_store)
+    res = await retriever.run_async(query="some query")
+    mock_store._bm25_retrieval_async.assert_called_once_with(
+        query="some query",
+        filters={},
+        fuzziness="AUTO",
+        top_k=10,
+        scale_score=False,
+        all_terms_must_match=False,
+        custom_query=None,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+
+
 def test_run_init_params():
     mock_store = Mock(spec=OpenSearchDocumentStore)
     mock_store._bm25_retrieval.return_value = [Document(content="Test doc")]
@@ -183,6 +203,34 @@ def test_run_init_params():
     )
     res = retriever.run(query="some query")
     mock_store._bm25_retrieval.assert_called_once_with(
+        query="some query",
+        filters={"from": "init"},
+        fuzziness="1",
+        top_k=11,
+        scale_score=True,
+        all_terms_must_match=True,
+        custom_query={"some": "custom query"},
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+
+
+@pytest.mark.asyncio
+async def test_run_init_params_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc")]
+    retriever = OpenSearchBM25Retriever(
+        document_store=mock_store,
+        filters={"from": "init"},
+        all_terms_must_match=True,
+        scale_score=True,
+        top_k=11,
+        fuzziness="1",
+        custom_query={"some": "custom query"},
+    )
+    res = await retriever.run_async(query="some query")
+    mock_store._bm25_retrieval_async.assert_called_once_with(
         query="some query",
         filters={"from": "init"},
         fuzziness="1",
@@ -216,6 +264,40 @@ def test_run_time_params():
         fuzziness="2",
     )
     mock_store._bm25_retrieval.assert_called_once_with(
+        query="some query",
+        filters={"from": "run"},
+        fuzziness="2",
+        top_k=9,
+        scale_score=False,
+        all_terms_must_match=False,
+        custom_query=None,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+
+
+@pytest.mark.asyncio
+async def test_run_time_params_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc")]
+    retriever = OpenSearchBM25Retriever(
+        document_store=mock_store,
+        filters={"from": "init"},
+        all_terms_must_match=True,
+        scale_score=True,
+        top_k=11,
+        fuzziness="1",
+    )
+    res = await retriever.run_async(
+        query="some query",
+        filters={"from": "run"},
+        all_terms_must_match=False,
+        scale_score=False,
+        top_k=9,
+        fuzziness="2",
+    )
+    mock_store._bm25_retrieval_async.assert_called_once_with(
         query="some query",
         filters={"from": "run"},
         fuzziness="2",

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -964,3 +964,501 @@ class TestDocumentStore(DocumentStoreBaseTests):
         results = document_store_no_embbding_returned._bm25_retrieval("document", top_k=2)
         assert len(results) == 2
         assert results[0].embedding is None
+
+
+@pytest.mark.integration
+class TestDocumentStoreAsync:
+
+    @pytest.fixture
+    async def document_store(self, request):
+        """
+        This is the most basic requirement for the child class: provide
+        an instance of this document store so the base class can use it.
+        """
+        hosts = ["https://localhost:9200"]
+        # Use a different index for each test so we can run them in parallel
+        index = f"{request.node.name}"
+
+        store = OpenSearchDocumentStore(
+            hosts=hosts,
+            index=index,
+            http_auth=("admin", "admin"),
+            verify_certs=False,
+            embedding_dim=768,
+            method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
+        )
+        yield store
+        store._ensure_initialized()
+        assert store._client
+        store._client.indices.delete(index=index, params={"ignore": [400, 404]})
+        await store._async_client.close()
+
+    @pytest.fixture
+    async def document_store_readonly(self, request):
+        """
+        This is the most basic requirement for the child class: provide
+        an instance of this document store so the base class can use it.
+        """
+        hosts = ["https://localhost:9200"]
+        # Use a different index for each test so we can run them in parallel
+        index = f"{request.node.name}"
+
+        store = OpenSearchDocumentStore(
+            hosts=hosts,
+            index=index,
+            http_auth=("admin", "admin"),
+            verify_certs=False,
+            embedding_dim=768,
+            method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
+            create_index=False,
+        )
+        store._ensure_initialized()
+        assert store._client
+        store._client.cluster.put_settings(body={"transient": {"action.auto_create_index": False}})
+        yield store
+        store._client.cluster.put_settings(body={"transient": {"action.auto_create_index": True}})
+        store._client.indices.delete(index=index, params={"ignore": [400, 404]})
+        await store._async_client.close()
+
+    @pytest.fixture
+    async def document_store_embedding_dim_4(self, request):
+        """
+        This is the most basic requirement for the child class: provide
+        an instance of this document store so the base class can use it.
+        """
+        hosts = ["https://localhost:9200"]
+        # Use a different index for each test so we can run them in parallel
+        index = f"{request.node.name}"
+
+        store = OpenSearchDocumentStore(
+            hosts=hosts,
+            index=index,
+            http_auth=("admin", "admin"),
+            verify_certs=False,
+            embedding_dim=4,
+            method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
+        )
+        yield store
+        store._ensure_initialized()
+        assert store._client
+        store._client.indices.delete(index=index, params={"ignore": [400, 404]})
+        await store._async_client.close()
+
+    @pytest.fixture
+    async def document_store_no_embbding_returned(self, request):
+        """
+        This is the most basic requirement for the child class: provide
+        an instance of this document store so the base class can use it.
+        """
+        hosts = ["https://localhost:9200"]
+        # Use a different index for each test so we can run them in parallel
+        index = f"{request.node.name}"
+
+        store = OpenSearchDocumentStore(
+            hosts=hosts,
+            index=index,
+            http_auth=("admin", "admin"),
+            verify_certs=False,
+            embedding_dim=4,
+            return_embedding=False,
+            method={"space_type": "cosinesimil", "engine": "nmslib", "name": "hnsw"},
+        )
+        store._ensure_initialized()
+        yield store
+        store._client.indices.delete(index=index, params={"ignore": [400, 404]})
+
+    @pytest.mark.asyncio
+    async def test_write_documents(self, document_store: OpenSearchDocumentStore):
+        assert await document_store.write_documents_async([Document(id="1")]) == 1
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval(self, document_store: OpenSearchDocumentStore):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language"),
+                Document(content="Lisp is a functional programming language"),
+                Document(content="Exilir is a functional programming language"),
+                Document(content="F# is a functional programming language"),
+                Document(content="C# is a functional programming language"),
+                Document(content="C++ is an object oriented programming language"),
+                Document(content="Dart is an object oriented programming language"),
+                Document(content="Go is an object oriented programming language"),
+                Document(content="Python is a object oriented programming language"),
+                Document(content="Ruby is a object oriented programming language"),
+                Document(content="PHP is a object oriented programming language"),
+            ]
+        )
+        res = await document_store._bm25_retrieval_async("functional", top_k=3)
+        assert len(res) == 3
+        assert "functional" in res[0].content
+        assert "functional" in res[1].content
+        assert "functional" in res[2].content
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval_pagination(self, document_store: OpenSearchDocumentStore):
+        """
+        Test that handling of pagination works as expected, when the matching documents are > 10.
+        """
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language"),
+                Document(content="Lisp is a functional programming language"),
+                Document(content="Exilir is a functional programming language"),
+                Document(content="F# is a functional programming language"),
+                Document(content="C# is a functional programming language"),
+                Document(content="C++ is an object oriented programming language"),
+                Document(content="Dart is an object oriented programming language"),
+                Document(content="Go is an object oriented programming language"),
+                Document(content="Python is a object oriented programming language"),
+                Document(content="Ruby is a object oriented programming language"),
+                Document(content="PHP is a object oriented programming language"),
+                Document(content="Java is an object oriented programming language"),
+                Document(content="Javascript is a programming language"),
+                Document(content="Typescript is a programming language"),
+                Document(content="C is a programming language"),
+            ]
+        )
+
+        res = await document_store._bm25_retrieval_async("programming", top_k=11)
+        assert len(res) == 11
+        assert all("programming" in doc.content for doc in res)
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval_all_terms_must_match(self, document_store: OpenSearchDocumentStore):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language"),
+                Document(content="Lisp is a functional programming language"),
+                Document(content="Exilir is a functional programming language"),
+                Document(content="F# is a functional programming language"),
+                Document(content="C# is a functional programming language"),
+                Document(content="C++ is an object oriented programming language"),
+                Document(content="Dart is an object oriented programming language"),
+                Document(content="Go is an object oriented programming language"),
+                Document(content="Python is a object oriented programming language"),
+                Document(content="Ruby is a object oriented programming language"),
+                Document(content="PHP is a object oriented programming language"),
+            ]
+        )
+
+        res = await document_store._bm25_retrieval_async("functional Haskell", top_k=3, all_terms_must_match=True)
+        assert len(res) == 1
+        assert "Haskell is a functional programming language" in res[0].content
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval_all_terms_must_match_false(self, document_store: OpenSearchDocumentStore):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language"),
+                Document(content="Lisp is a functional programming language"),
+                Document(content="Exilir is a functional programming language"),
+                Document(content="F# is a functional programming language"),
+                Document(content="C# is a functional programming language"),
+                Document(content="C++ is an object oriented programming language"),
+                Document(content="Dart is an object oriented programming language"),
+                Document(content="Go is an object oriented programming language"),
+                Document(content="Python is a object oriented programming language"),
+                Document(content="Ruby is a object oriented programming language"),
+                Document(content="PHP is a object oriented programming language"),
+            ]
+        )
+
+        res = await document_store._bm25_retrieval_async("functional Haskell", top_k=10, all_terms_must_match=False)
+        assert len(res) == 5
+        assert "functional" in res[0].content
+        assert "functional" in res[1].content
+        assert "functional" in res[2].content
+        assert "functional" in res[3].content
+        assert "functional" in res[4].content
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval_with_filters(self, document_store: OpenSearchDocumentStore):
+        document_store.write_documents(
+            [
+                Document(
+                    content="Haskell is a functional programming language",
+                    meta={"likes": 100000, "language_type": "functional"},
+                    id="1",
+                ),
+                Document(
+                    content="Lisp is a functional programming language",
+                    meta={"likes": 10000, "language_type": "functional"},
+                    id="2",
+                ),
+                Document(
+                    content="Exilir is a functional programming language",
+                    meta={"likes": 1000, "language_type": "functional"},
+                    id="3",
+                ),
+                Document(
+                    content="F# is a functional programming language",
+                    meta={"likes": 100, "language_type": "functional"},
+                    id="4",
+                ),
+                Document(
+                    content="C# is a functional programming language",
+                    meta={"likes": 10, "language_type": "functional"},
+                    id="5",
+                ),
+                Document(
+                    content="C++ is an object oriented programming language",
+                    meta={"likes": 100000, "language_type": "object_oriented"},
+                    id="6",
+                ),
+                Document(
+                    content="Dart is an object oriented programming language",
+                    meta={"likes": 10000, "language_type": "object_oriented"},
+                    id="7",
+                ),
+                Document(
+                    content="Go is an object oriented programming language",
+                    meta={"likes": 1000, "language_type": "object_oriented"},
+                    id="8",
+                ),
+                Document(
+                    content="Python is a object oriented programming language",
+                    meta={"likes": 100, "language_type": "object_oriented"},
+                    id="9",
+                ),
+                Document(
+                    content="Ruby is a object oriented programming language",
+                    meta={"likes": 10, "language_type": "object_oriented"},
+                    id="10",
+                ),
+                Document(
+                    content="PHP is a object oriented programming language",
+                    meta={"likes": 1, "language_type": "object_oriented"},
+                    id="11",
+                ),
+            ]
+        )
+        res = await document_store._bm25_retrieval_async(
+            "programming",
+            top_k=10,
+            filters={"field": "language_type", "operator": "==", "value": "functional"},
+        )
+        assert len(res) == 5
+        retrieved_ids = sorted([doc.id for doc in res])
+        assert retrieved_ids == ["1", "2", "3", "4", "5"]
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval_with_custom_query(self, document_store: OpenSearchDocumentStore):
+        document_store.write_documents(
+            [
+                Document(
+                    content="Haskell is a functional programming language",
+                    meta={"likes": 100000, "language_type": "functional"},
+                    id="1",
+                ),
+                Document(
+                    content="Lisp is a functional programming language",
+                    meta={"likes": 10000, "language_type": "functional"},
+                    id="2",
+                ),
+                Document(
+                    content="Exilir is a functional programming language",
+                    meta={"likes": 1000, "language_type": "functional"},
+                    id="3",
+                ),
+                Document(
+                    content="F# is a functional programming language",
+                    meta={"likes": 100, "language_type": "functional"},
+                    id="4",
+                ),
+                Document(
+                    content="C# is a functional programming language",
+                    meta={"likes": 10, "language_type": "functional"},
+                    id="5",
+                ),
+                Document(
+                    content="C++ is an object oriented programming language",
+                    meta={"likes": 100000, "language_type": "object_oriented"},
+                    id="6",
+                ),
+                Document(
+                    content="Dart is an object oriented programming language",
+                    meta={"likes": 10000, "language_type": "object_oriented"},
+                    id="7",
+                ),
+                Document(
+                    content="Go is an object oriented programming language",
+                    meta={"likes": 1000, "language_type": "object_oriented"},
+                    id="8",
+                ),
+                Document(
+                    content="Python is a object oriented programming language",
+                    meta={"likes": 100, "language_type": "object_oriented"},
+                    id="9",
+                ),
+                Document(
+                    content="Ruby is a object oriented programming language",
+                    meta={"likes": 10, "language_type": "object_oriented"},
+                    id="10",
+                ),
+                Document(
+                    content="PHP is a object oriented programming language",
+                    meta={"likes": 1, "language_type": "object_oriented"},
+                    id="11",
+                ),
+            ]
+        )
+
+        custom_query = {
+            "query": {
+                "function_score": {
+                    "query": {
+                        "bool": {
+                            "must": {"match": {"content": "$query"}},
+                            "filter": "$filters",
+                        }
+                    },
+                    "field_value_factor": {
+                        "field": "likes",
+                        "factor": 0.1,
+                        "modifier": "log1p",
+                        "missing": 0,
+                    },
+                }
+            }
+        }
+        res = await document_store._bm25_retrieval_async(
+            "functional",
+            top_k=3,
+            custom_query=custom_query,
+            filters={"field": "language_type", "operator": "==", "value": "functional"},
+        )
+        assert len(res) == 3
+        assert "1" == res[0].id
+        assert "2" == res[1].id
+        assert "3" == res[2].id
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
+        docs = [
+            Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
+            Document(content="Not very similar document", embedding=[0.0, 0.8, 0.3, 0.9]),
+        ]
+        document_store_embedding_dim_4.write_documents(docs)
+
+        results = await document_store_embedding_dim_4._embedding_retrieval_async(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=2, filters={}
+        )
+        assert len(results) == 2
+        assert results[0].content == "Most similar document"
+        assert results[1].content == "2nd best document"
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval_with_filters(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
+        docs = [
+            Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
+            Document(
+                content="Not very similar document with meta field",
+                embedding=[0.0, 0.8, 0.3, 0.9],
+                meta={"meta_field": "custom_value"},
+            ),
+        ]
+        document_store_embedding_dim_4.write_documents(docs)
+
+        filters = {"field": "meta_field", "operator": "==", "value": "custom_value"}
+
+        results = await document_store_embedding_dim_4._embedding_retrieval_async(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=3, filters=filters
+        )
+        assert len(results) == 1
+        assert results[0].content == "Not very similar document with meta field"
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval_with_custom_query(self, document_store_embedding_dim_4: OpenSearchDocumentStore):
+        docs = [
+            Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
+            Document(
+                content="Not very similar document with meta field",
+                embedding=[0.0, 0.8, 0.3, 0.9],
+                meta={"meta_field": "custom_value"},
+            ),
+        ]
+        document_store_embedding_dim_4.write_documents(docs)
+
+        custom_query = {
+            "query": {
+                "bool": {
+                    "must": [{"knn": {"embedding": {"vector": "$query_embedding", "k": 3}}}],
+                    "filter": "$filters",
+                }
+            }
+        }
+
+        filters = {"field": "meta_field", "operator": "==", "value": "custom_value"}
+
+        results = await document_store_embedding_dim_4._embedding_retrieval_async(
+            query_embedding=[0.1, 0.1, 0.1, 0.1],
+            top_k=1,
+            filters=filters,
+            custom_query=custom_query,
+        )
+        assert len(results) == 1
+        assert results[0].content == "Not very similar document with meta field"
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval_but_dont_return_embeddings_for_embedding_retrieval(
+        self, document_store_no_embbding_returned: OpenSearchDocumentStore
+    ):
+        docs = [
+            Document(content="Most similar document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="2nd best document", embedding=[0.8, 0.8, 0.8, 1.0]),
+            Document(content="Not very similar document", embedding=[0.0, 0.8, 0.3, 0.9]),
+        ]
+        document_store_no_embbding_returned.write_documents(docs)
+
+        results = await document_store_no_embbding_returned._embedding_retrieval_async(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=2, filters={}
+        )
+        assert len(results) == 2
+        assert results[0].embedding is None
+
+    @pytest.mark.asyncio
+    async def test_count_documents(self, document_store: OpenSearchDocumentStore):
+        document_store.write_documents(
+            [
+                Document(content="test doc 1"),
+                Document(content="test doc 2"),
+                Document(content="test doc 3"),
+            ]
+        )
+        assert await document_store.count_documents_async() == 3
+
+    @pytest.mark.asyncio
+    async def test_filter_documents(self, document_store: OpenSearchDocumentStore):
+        filterable_docs = [
+            Document(
+                content="1",
+                meta={
+                    "number": -10,
+                },
+            ),
+            Document(
+                content="2",
+                meta={
+                    "number": 100,
+                },
+            ),
+        ]
+        await document_store.write_documents_async(filterable_docs)
+        result = await document_store.filter_documents_async(
+            filters={"field": "meta.number", "operator": "==", "value": 100}
+        )
+        TestDocumentStore().assert_documents_are_equal(
+            result, [d for d in filterable_docs if d.meta.get("number") == 100]
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_documents(self, document_store: OpenSearchDocumentStore):
+        doc = Document(content="test doc")
+        await document_store.write_documents_async([doc])
+        assert document_store.count_documents() == 1
+
+        await document_store.delete_documents_async([doc.id])
+        assert await document_store.count_documents_async() == 0

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -151,6 +151,25 @@ def test_run():
     assert res["documents"][0].embedding == [0.1, 0.2]
 
 
+@pytest.mark.asyncio
+async def test_run_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store)
+    res = await retriever.run_async(query_embedding=[0.5, 0.7])
+    mock_store._embedding_retrieval_async.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={},
+        top_k=10,
+        custom_query=None,
+        efficient_filtering=False,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
 def test_run_init_params():
     mock_store = Mock(spec=OpenSearchDocumentStore)
     mock_store._embedding_retrieval.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]
@@ -175,6 +194,30 @@ def test_run_init_params():
     assert res["documents"][0].embedding == [0.1, 0.2]
 
 
+@pytest.mark.asyncio
+async def test_run_async_init_params():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]
+    retriever = OpenSearchEmbeddingRetriever(
+        document_store=mock_store,
+        filters={"from": "init"},
+        top_k=11,
+        custom_query="custom_query",
+    )
+    res = await retriever.run_async(query_embedding=[0.5, 0.7])
+    mock_store._embedding_retrieval_async.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={"from": "init"},
+        top_k=11,
+        custom_query="custom_query",
+        efficient_filtering=False,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
 def test_run_time_params():
     mock_store = Mock(spec=OpenSearchDocumentStore)
     mock_store._embedding_retrieval.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]
@@ -186,6 +229,25 @@ def test_run_time_params():
         top_k=9,
         custom_query=None,
         efficient_filtering=True,
+    )
+    assert len(res) == 1
+    assert len(res["documents"]) == 1
+    assert res["documents"][0].content == "Test doc"
+    assert res["documents"][0].embedding == [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_run_async_time_params():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc", embedding=[0.1, 0.2])]
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store, filters={"from": "init"}, top_k=11)
+    res = await retriever.run_async(query_embedding=[0.5, 0.7], filters={"from": "run"}, top_k=9)
+    mock_store._embedding_retrieval_async.assert_called_once_with(
+        query_embedding=[0.5, 0.7],
+        filters={"from": "run"},
+        top_k=9,
+        custom_query=None,
+        efficient_filtering=False,
     )
     assert len(res) == 1
     assert len(res["documents"]) == 1


### PR DESCRIPTION
### Related Issues

- fixes #1392

### Proposed Changes:
- Async support for `OpenSearchDocumentStore` and its retrievers.
- This is mostly a migration of work done in https://github.com/deepset-ai/haystack-experimental/pull/96 and other PRs approved in experimental.
- I took care of fixing some errors and integrating async with small features/changes merged in this integration and absent in the original experiment.
- (I also took the opportunity to adopt Haystack logging in OpenSearch - see #1409)

### How did you test it?
CI; migrated many new tests.

### Notes for the reviewer
Even if this is a large PR, this is not a breaking change (original tests pass without requiring significant modifications).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
