### PR TITLE
fix: Unstructured - pin client version

### DIFF
--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "unstructured", "psutil"]
+dependencies = ["haystack-ai", "unstructured", "unstructured-client<0.30.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/unstructured#readme"


### PR DESCRIPTION
### Related Issues

- nightly tests failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13380658910/job/37368547644

### Proposed Changes:
- pin `unstructured-client` to the latest working version
- unrelated: remove `psutil` dependency (added in #854 and no longer required)

### How did you test it?
CI

### Notes for the reviewer
Unstructured is a complex ecosystem (library, clients, Docker image, free and paid APIs) and this is just a temporary fix to ensure that things work again.
I'll open an issue to track ideas for maintenance and refactoring of this integration.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
