### PR TITLE
feat: use HaystackLLMWrapper instead of LangChain in Ragas evaluators

### DIFF
--- a/integrations/ragas/example/evaluation_from_pipeline_example.py
+++ b/integrations/ragas/example/evaluation_from_pipeline_example.py
@@ -12,11 +12,11 @@ from haystack.components.embedders import OpenAITextEmbedder, OpenAIDocumentEmbe
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
 from haystack.components.builders import ChatPromptBuilder
 from haystack.dataclasses import ChatMessage
+from haystack.components.generators import OpenAIGenerator
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.builders import AnswerBuilder
 
-from langchain_openai import ChatOpenAI
-from ragas.llms import LangchainLLMWrapper
+from ragas.llms import HaystackLLMWrapper
 from ragas.metrics import AnswerRelevancy, ContextPrecision, Faithfulness
 from ragas import evaluate
 from ragas.dataset_schema import EvaluationDataset
@@ -126,8 +126,8 @@ for que_idx in range(len(questions)):
 
 evaluation_dataset = EvaluationDataset.from_list(evals_list)
 
-llm = ChatOpenAI(model="gpt-4o-mini")
-evaluator_llm = LangchainLLMWrapper(llm)
+llm = OpenAIGenerator(model="gpt-4o-mini")
+evaluator_llm = HaystackLLMWrapper(llm)
 
 result = evaluate(
     dataset=evaluation_dataset,

--- a/integrations/ragas/example/evaluation_with_components_example.py
+++ b/integrations/ragas/example/evaluation_with_components_example.py
@@ -13,12 +13,12 @@ from haystack.components.embedders import OpenAITextEmbedder, OpenAIDocumentEmbe
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
 from haystack.components.builders import ChatPromptBuilder
 from haystack.dataclasses import ChatMessage
+from haystack.components.generators import OpenAIGenerator
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.builders import AnswerBuilder
 from haystack_integrations.components.evaluators.ragas import RagasEvaluator
 
-from langchain_openai import ChatOpenAI
-from ragas.llms import LangchainLLMWrapper
+from ragas.llms import HaystackLLMWrapper
 from ragas.metrics import AnswerRelevancy, ContextPrecision, Faithfulness
 
 
@@ -67,8 +67,8 @@ prompt_builder = ChatPromptBuilder(template=template)
 chat_generator = OpenAIChatGenerator(model="gpt-4o-mini")
 
 # Setting the RagasEvaluator Component
-llm = ChatOpenAI(model="gpt-4o-mini")
-evaluator_llm = LangchainLLMWrapper(llm)
+llm = OpenAIGenerator(model="gpt-4o-mini")
+evaluator_llm = HaystackLLMWrapper(llm)
 
 ragas_evaluator = RagasEvaluator(
     ragas_metrics=[AnswerRelevancy(), ContextPrecision(), Faithfulness()], evaluator_llm=evaluator_llm

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "ragas>=0.2.0,<0.3.0", "langchain_openai"]
+dependencies = ["haystack-ai", "ragas>=0.2.0,<0.3.0"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ragas"

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -88,14 +88,12 @@ class RagasEvaluator:
             error_message = "All items in ragas_metrics must be instances of Metric class."
             raise TypeError(error_message)
 
-        if llm is not None and not isinstance(llm, (BaseRagasLLM)):
+        if llm is not None and not isinstance(llm, BaseRagasLLM):
             error_message = f"Expected evaluator_llm to be BaseRagasLLM, got {type(llm).__name__}"
             raise TypeError(error_message)
 
-        if embedding is not None and not isinstance(embedding, (BaseRagasEmbeddings)):
-            error_message = (
-                f"Expected evaluator_embedding to be BaseRagasEmbeddings, got {type(embedding).__name__}"
-            )
+        if embedding is not None and not isinstance(embedding, BaseRagasEmbeddings):
+            error_message = f"Expected evaluator_embedding to be BaseRagasEmbeddings, got {type(embedding).__name__}"
             raise TypeError(error_message)
 
     @component.output_types(result=EvaluationResult)

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -94,8 +94,7 @@ class RagasEvaluator:
 
         if embedding is not None and not isinstance(embedding, (BaseRagasEmbeddings)):
             error_message = (
-                f"Expected evaluator_embedding to be BaseRagasEmbeddings, "
-                f"got {type(embedding).__name__}"
+                f"Expected evaluator_embedding to be BaseRagasEmbeddings, got {type(embedding).__name__}"
             )
             raise TypeError(error_message)
 

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -24,13 +24,13 @@ class RagasEvaluator:
 
     Usage example:
     ```python
+    from haystack.components.generators import OpenAIGenerator
     from haystack_integrations.components.evaluators.ragas import RagasEvaluator
     from ragas.metrics import ContextPrecision
-    from ragas.llms import LangchainLLMWrapper
-    from langchain_openai import ChatOpenAI
+    from ragas.llms import HaystackLLMWrapper
 
-    llm = ChatOpenAI(model="gpt-4o-mini")
-    evaluator_llm = LangchainLLMWrapper(llm)
+    llm = OpenAIGenerator(model="gpt-4o-mini")
+    evaluator_llm = HaystackLLMWrapper(llm)
 
     evaluator = RagasEvaluator(
         ragas_metrics=[ContextPrecision()],
@@ -89,13 +89,13 @@ class RagasEvaluator:
             raise TypeError(error_message)
 
         if llm is not None and not isinstance(llm, (BaseRagasLLM)):
-            error_message = f"Expected evaluator_llm to be BaseRagasLLM or LangchainLLM, got {type(llm).__name__}"
+            error_message = f"Expected evaluator_llm to be BaseRagasLLM, got {type(llm).__name__}"
             raise TypeError(error_message)
 
         if embedding is not None and not isinstance(embedding, (BaseRagasEmbeddings)):
             error_message = (
-                f"Expected evaluator_embedding to be BaseRagasEmbeddings or "
-                f"LangchainEmbeddings, got {type(embedding).__name__}"
+                f"Expected evaluator_embedding to be BaseRagasEmbeddings, "
+                f"got {type(embedding).__name__}"
             )
             raise TypeError(error_message)
 

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -3,8 +3,6 @@ from typing import Any, Dict, List, Optional, Union, get_args, get_origin
 
 from haystack import Document, component
 from haystack.dataclasses import ChatMessage
-from langchain_core.embeddings import Embeddings as LangchainEmbeddings  # type: ignore
-from langchain_core.language_models import BaseLanguageModel as LangchainLLM  # type: ignore
 from pydantic import ValidationError  # type: ignore
 
 from ragas import evaluate  # type: ignore
@@ -57,8 +55,8 @@ class RagasEvaluator:
     def __init__(
         self,
         ragas_metrics: List[Metric],
-        evaluator_llm: Optional[Union[BaseRagasLLM, LangchainLLM]] = None,
-        evaluator_embedding: Optional[Union[BaseRagasEmbeddings, LangchainEmbeddings]] = None,
+        evaluator_llm: Optional[BaseRagasLLM] = None,
+        evaluator_embedding: Optional[BaseRagasEmbeddings] = None,
     ):
         """
         Constructs a new Ragas evaluator.
@@ -75,8 +73,8 @@ class RagasEvaluator:
     def _validate_inputs(
         self,
         metrics: List[Metric],
-        llm: Optional[Union[BaseRagasLLM, LangchainLLM]],
-        embedding: Optional[Union[BaseRagasEmbeddings, LangchainEmbeddings]],
+        llm: Optional[BaseRagasLLM],
+        embedding: Optional[BaseRagasEmbeddings],
     ) -> None:
         """Validate input parameters.
 
@@ -90,11 +88,11 @@ class RagasEvaluator:
             error_message = "All items in ragas_metrics must be instances of Metric class."
             raise TypeError(error_message)
 
-        if llm is not None and not isinstance(llm, (BaseRagasLLM, LangchainLLM)):
+        if llm is not None and not isinstance(llm, (BaseRagasLLM)):
             error_message = f"Expected evaluator_llm to be BaseRagasLLM or LangchainLLM, got {type(llm).__name__}"
             raise TypeError(error_message)
 
-        if embedding is not None and not isinstance(embedding, (BaseRagasEmbeddings, LangchainEmbeddings)):
+        if embedding is not None and not isinstance(embedding, (BaseRagasEmbeddings)):
             error_message = (
                 f"Expected evaluator_embedding to be BaseRagasEmbeddings or "
                 f"LangchainEmbeddings, got {type(embedding).__name__}"

--- a/integrations/ragas/tests/test_evaluator.py
+++ b/integrations/ragas/tests/test_evaluator.py
@@ -51,7 +51,7 @@ def test_invalid_llm():
     valid_metric = MagicMock(spec=Metric)
     invalid_llm = "not_a_llm"
 
-    with pytest.raises(TypeError, match="Expected evaluator_llm to be BaseRagasLLM or LangchainLLM"):
+    with pytest.raises(TypeError, match="Expected evaluator_llm to be BaseRagasLLM"):
         RagasEvaluator(ragas_metrics=[valid_metric], evaluator_llm=invalid_llm)
 
 
@@ -60,9 +60,7 @@ def test_invalid_embedding():
     valid_metric = MagicMock(spec=Metric)
     invalid_embedding = "not_an_embedding"
 
-    with pytest.raises(
-        TypeError, match="Expected evaluator_embedding to be BaseRagasEmbeddings or LangchainEmbeddings"
-    ):
+    with pytest.raises(TypeError, match="Expected evaluator_embedding to be BaseRagasEmbeddings"):
         RagasEvaluator(ragas_metrics=[valid_metric], evaluator_embedding=invalid_embedding)
 
 


### PR DESCRIPTION
- Ragas now has HaystackLLMWrapper which will allow users to use Haystack LLMs as evaluators