### PR TITLE
test: Azure AI Search - improvements to the test suite

### DIFF
--- a/integrations/azure_ai_search/tests/conftest.py
+++ b/integrations/azure_ai_search/tests/conftest.py
@@ -86,7 +86,7 @@ def document_store(request):
 def cleanup_indexes(request):
     """
     Fixture to clean up all remaining indexes at the end of the test session.
-    Only runs for tests marked with 'integration'.
+    Only runs if in the session there is at least one test marked with 'integration'.
     Automatically runs after all tests.
     """
     # Check if any test in the session is marked as integration

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -100,6 +100,7 @@ def test_init(_mock_azure_search_client):
     assert document_store._vector_search_configuration == DEFAULT_VECTOR_SEARCH
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(
     not os.environ.get("AZURE_SEARCH_SERVICE_ENDPOINT", None) and not os.environ.get("AZURE_SEARCH_API_KEY", None),
     reason="Missing AZURE_SEARCH_SERVICE_ENDPOINT or AZURE_SEARCH_API_KEY.",
@@ -155,6 +156,7 @@ TEST_EMBEDDING_1 = _random_embeddings(768)
 TEST_EMBEDDING_2 = _random_embeddings(768)
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(
     not os.environ.get("AZURE_SEARCH_SERVICE_ENDPOINT", None) and not os.environ.get("AZURE_SEARCH_API_KEY", None),
     reason="Missing AZURE_SEARCH_SERVICE_ENDPOINT or AZURE_SEARCH_API_KEY.",


### PR DESCRIPTION
### Related Issues

While running unit tests locally with `hatch run test -m "not integration"`,
I encountered several errors due to the fact that the test suite tries to clean up Azure indexes at the end of session, even if I only run local unit tests.

I should be able to locally run the unit tests without worrying about API keys or encountering errors.

### Proposed Changes:
- refactor the `cleanup_indexes` fixture to only clean up indexes when we execute integration tests
- add some missing integration markers

### How did you test it?
Local runs; CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
