### PR TITLE
fix: replace `pinecone-client` dependency with `pinecone`

### DIFF
--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "pinecone-client>=3", # our implementation is not compatible with pinecone-client <3
+  "pinecone-client>=3,<6.0.0", # our implementation is not compatible with pinecone-client <3, #1430
 ]
 
 [project.urls]

--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai",
-  "pinecone-client>=3,<6.0.0", # our implementation is not compatible with pinecone-client <3, #1430
+  "pinecone>=3", # our implementation is not compatible with pinecone <3
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- Fixes #1430

### Proposed Changes:

Replace `pinecone-client` dependency with `pinecone`

### How did you test it?

CI only

### Notes for the reviewer

Alternative would be to pin version of `pinecone-client` to >=3,<6.0.0

6.0.0 includes some breaking changes listed at the bottom of the release notes: https://github.com/pinecone-io/pinecone-python-client/releases/tag/v6.0.0
We should therefore release a new major version of the integration after this PR got merged.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
