### PR TITLE
test: Reduce Nvidia API calls in integration tests

### DIFF
--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -4,7 +4,7 @@ name: Test / nvidia
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 0"
   pull_request:
     paths:
       - "integrations/nvidia/**"

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9"]
 
     steps:
       - name: Support longpaths

--- a/integrations/nvidia/tests/test_document_embedder.py
+++ b/integrations/nvidia/tests/test_document_embedder.py
@@ -431,19 +431,11 @@ class TestNvidiaDocumentEmbedder:
         "model, api_url",
         [
             ("NV-Embed-QA", None),
-            ("snowflake/arctic-embed-l", "https://integrate.api.nvidia.com/v1"),
-            ("nvidia/nv-embed-v1", "https://integrate.api.nvidia.com/v1"),
-            ("nvidia/nv-embedqa-mistral-7b-v2", "https://integrate.api.nvidia.com/v1"),
             ("nvidia/nv-embedqa-e5-v5", "https://integrate.api.nvidia.com/v1"),
-            ("baai/bge-m3", "https://integrate.api.nvidia.com/v1"),
         ],
         ids=[
             "NV-Embed-QA",
-            "snowflake/arctic-embed-l",
-            "nvidia/nv-embed-v1",
-            "nvidia/nv-embedqa-mistral-7b-v2",
             "nvidia/nv-embedqa-e5-v5",
-            "baai/bge-m3",
         ],
     )
     @pytest.mark.skipif(

--- a/integrations/nvidia/tests/test_text_embedder.py
+++ b/integrations/nvidia/tests/test_text_embedder.py
@@ -223,19 +223,11 @@ class TestNvidiaTextEmbedder:
         "model, api_url",
         [
             ("NV-Embed-QA", None),
-            ("snowflake/arctic-embed-l", "https://integrate.api.nvidia.com/v1"),
-            ("nvidia/nv-embed-v1", "https://integrate.api.nvidia.com/v1"),
-            ("nvidia/nv-embedqa-mistral-7b-v2", "https://integrate.api.nvidia.com/v1"),
             ("nvidia/nv-embedqa-e5-v5", "https://integrate.api.nvidia.com/v1"),
-            ("baai/bge-m3", "https://integrate.api.nvidia.com/v1"),
         ],
         ids=[
             "NV-Embed-QA",
-            "snowflake/arctic-embed-l",
-            "nvidia/nv-embed-v1",
-            "nvidia/nv-embedqa-mistral-7b-v2",
             "nvidia/nv-embedqa-e5-v5",
-            "baai/bge-m3",
         ],
     )
     @pytest.mark.skipif(


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/105

### Proposed Changes:

- We run the integration tests weekly on Sundays instead of nightly
- We run the tests only with Python version 3.9 instead of 3.9 and 3.10
- For the parameterized embedder integration tests, we only use two models instead of six. I suggest NV-Embed-QA as it is also used in the example code snippet and nvidia/nv-embedqa-e5-v5 because support for it was most recently added in https://github.com/deepset-ai/haystack-core-integrations/pull/1015 .

### How did you test it?

Only CI

### Notes for the reviewer

Integration tests won't run before we add more credits to Nvidia API account.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
