### PR TITLE
test: change model from unsupported gemini-pro to gemini-1.5-pro

### DIFF
--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -25,7 +25,7 @@ class GoogleAIGeminiGenerator:
     from haystack.utils import Secret
     from haystack_integrations.components.generators.google_ai import GoogleAIGeminiGenerator
 
-    gemini = GoogleAIGeminiGenerator(model="gemini-pro", api_key=Secret.from_token("<MY_API_KEY>"))
+    gemini = GoogleAIGeminiGenerator(model="gemini-1.5-pro", api_key=Secret.from_token("<MY_API_KEY>"))
     res = gemini.run(parts = ["What is the most interesting thing you know?"])
     for answer in res["replies"]:
         print(answer)

--- a/integrations/google_ai/tests/generators/test_gemini.py
+++ b/integrations/google_ai/tests/generators/test_gemini.py
@@ -167,7 +167,7 @@ def test_from_dict(monkeypatch):
 
 @pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")
 def test_run():
-    gemini = GoogleAIGeminiGenerator(model="gemini-pro")
+    gemini = GoogleAIGeminiGenerator(model="gemini-1.5-pro")
     res = gemini.run("Tell me something cool")
     assert len(res["replies"]) > 0
 
@@ -180,7 +180,7 @@ def test_run_with_streaming_callback():
         nonlocal streaming_callback_called
         streaming_callback_called = True
 
-    gemini = GoogleAIGeminiGenerator(model="gemini-pro", streaming_callback=streaming_callback)
+    gemini = GoogleAIGeminiGenerator(model="gemini-1.5-pro", streaming_callback=streaming_callback)
     res = gemini.run("Tell me something cool")
     assert len(res["replies"]) > 0
     assert streaming_callback_called


### PR DESCRIPTION
### Related Issues

- failing nightly test https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13533769319/job/37821499273#step:8:112

`google.api_core.exceptions.NotFound: 404 models/gemini-pro is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.`

Support for gemini 1.0 pro ended on Feb 18, 2025: https://ai.google.dev/gemini-api/docs/changelog#02-18-2025

Related PR in haystack-integrations: https://github.com/deepset-ai/haystack-integrations/pull/304

### Proposed Changes:

- Changing the model in tests from gemini-pro to gemini-1.5-pro
- Changing the model also in the docstring code example

### How did you test it?

Only CI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
