### PR TITLE
feat: support extended thinking mode with AnthropicGenerator

### DIFF
--- a/integrations/anthropic/tests/conftest.py
+++ b/integrations/anthropic/tests/conftest.py
@@ -21,3 +21,25 @@ def mock_chat_completion():
 
         mock_chat_completion_create.return_value = completion
         yield mock_chat_completion_create
+
+
+@pytest.fixture
+def mock_chat_completion_extended_thinking():
+    """
+    Mock the OpenAI API completion response and reuse it for tests
+    """
+    with patch("anthropic.resources.messages.Messages.create") as mock_chat_completion_create:
+        completion = Message(
+            id="foo",
+            content=[
+                {"type": "thinking", "thinking": "This is a thinking part!", "signature": ""},
+                {"type": "text", "text": "Hello, world!"},
+            ],
+            model="claude-3-sonnet-20240229",
+            role="assistant",
+            type="message",
+            usage={"input_tokens": 57, "output_tokens": 40},
+        )
+
+        mock_chat_completion_create.return_value = completion
+        yield mock_chat_completion_create


### PR DESCRIPTION
### Related Issues

With [Claude 3.7](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#implementing-extended-thinking) the API supports the `thinking` parameter to enable extended thinking mode, e.g.:
```
"thinking": {
    "type": "enabled",
    "budget_tokens": 1024
}
```

Example:
https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#implementing-extended-thinking

Note that thinking output is separated from normal text output, other than for example for Deepseek-R1. So we have to decide how to incorporate thinking output into the reply. Per default we include it using <thinking></thinking> tags, whereas this behavior is fully controllable via parameters:
- `include_thinking`: if `False` no thinking output is incorporated into the reply (default: `True`)
- `thinking_tag`: the name of the thinking tag, defaults to `thinking`. If `None`, the thinking part of the reply won't be encapsulated within tags.

This is the same approach as in https://github.com/deepset-ai/haystack-core-integrations/pull/1439

This also contains a fix for https://github.com/deepset-ai/haystack-core-integrations/issues/1454 in `AnthropicGenerator`

### Proposed Changes:
- support parameter `thinking`
- add options for how to incorporate the thinking response into the reply
- add `streaming_callback` run param

### How did you test it?
- tested against Anthropic API

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
