### PR TITLE
feat: adding async run to `AnthropicChatGenerator`

### DIFF
--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -164,5 +164,5 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
-markers = ["unit: unit tests", "integration: integration tests"]
+markers = ["unit: unit tests", "integration: integration tests", "asyncio: mark a test as an asyncio coroutine"]
 log_cli = true

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -44,9 +44,10 @@ git_describe_command = 'git describe --tags --match="integrations/anthropic-v[0-
 installer = "uv"
 dependencies = [
   "coverage[toml]>=6.5",
-  "pytest",
-  "pytest-rerunfailures",
   "haystack-pydoc-tools",
+  "pytest",
+  "pytest-asyncio",
+  "pytest-rerunfailures",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
@@ -166,3 +167,4 @@ ignore_missing_imports = true
 addopts = "--strict-markers"
 markers = ["unit: unit tests", "integration: integration tests", "asyncio: mark a test as an asyncio coroutine"]
 log_cli = true
+asyncio_default_fixture_loop_scope = "class"

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -165,6 +165,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
-markers = ["unit: unit tests", "integration: integration tests", "asyncio: mark a test as an asyncio coroutine"]
-log_cli = true
 asyncio_default_fixture_loop_scope = "class"
+asyncio_mode = "auto"
+log_cli = true
+markers = ["unit: unit tests", "integration: integration tests", "asyncio: mark a test as an asyncio coroutine"]

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -543,7 +543,7 @@ class AnthropicChatGenerator:
             messages, generation_kwargs, tools
         )
 
-        # ToDO: change to haystack.dataclasses.select_streaming_callback once it is available
+        # ToDO: use haystack.dataclasses.select_streaming_callback once it is available
         streaming_callback = streaming_callback or self.streaming_callback
 
         response = self.client.messages.create(
@@ -581,7 +581,7 @@ class AnthropicChatGenerator:
             messages, generation_kwargs, tools
         )
 
-        # ToDO: change to haystack.dataclasses.select_streaming_callback once it is available
+        # ToDO: use haystack.dataclasses.select_streaming_callback once it is available
         streaming_callback = streaming_callback or self.streaming_callback
 
         response = await self.async_client.messages.create(

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -2,14 +2,8 @@ import json
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.dataclasses import (
-    ChatMessage,
-    ChatRole,
-    StreamingChunk,
-    ToolCall,
-    ToolCallResult,
-    select_streaming_callback,
-)
+from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall, ToolCallResult, \
+    select_streaming_callback
 from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
@@ -550,10 +544,8 @@ class AnthropicChatGenerator:
             messages, generation_kwargs, tools
         )
 
-        # validate and select the streaming callback
-        streaming_callback = select_streaming_callback(
-            self.streaming_callback, streaming_callback, requires_async=False
-        )  # type: ignore
+        # ToDO: change to haystack.dataclasses.select_streaming_callback once it is available
+        streaming_callback = streaming_callback or self.streaming_callback
 
         response = self.client.messages.create(
             model=self.model,
@@ -590,10 +582,8 @@ class AnthropicChatGenerator:
             messages, generation_kwargs, tools
         )
 
-        # validate and select the streaming callback
-        streaming_callback = select_streaming_callback(
-            self.streaming_callback, streaming_callback, requires_async=False
-        )  # type: ignore
+        # ToDO: change to haystack.dataclasses.select_streaming_callback once it is available
+        streaming_callback = streaming_callback or self.streaming_callback
 
         response = await self.async_client.messages.create(
             model=self.model,

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -2,8 +2,7 @@ import json
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall, ToolCallResult, \
-    select_streaming_callback
+from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall, ToolCallResult
 from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -6,7 +6,7 @@ from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
 from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
-from anthropic import Anthropic, AsyncAnthropic, Stream
+from anthropic import Anthropic, AsyncAnthropic, Stream, AsyncStream
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +135,8 @@ class AnthropicChatGenerator:
 
     Usage example:
     ```python
-    from haystack_experimental.components.generators.anthropic import AnthropicChatGenerator
-    from haystack_experimental.dataclasses import ChatMessage
+    from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
+    from haystack.dataclasses import ChatMessage
 
     generator = AnthropicChatGenerator(model="claude-3-5-sonnet-20240620",
                                        generation_kwargs={
@@ -493,9 +493,11 @@ class AnthropicChatGenerator:
 
         :param response: The response from the Anthropic API.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :returns: A dictionary containing the processed response as a list of ChatMessage objects.
+
+        :returns:
+            A dictionary containing the processed response as a list of ChatMessage objects.
         """
-        if isinstance(response, Stream):
+        if isinstance(response, AsyncStream):
             chunks: List[StreamingChunk] = []
             model: Optional[str] = None
             async for chunk in response:

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -2,11 +2,18 @@ import json
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall, ToolCallResult
+from haystack.dataclasses import (
+    ChatMessage,
+    ChatRole,
+    StreamingChunk,
+    ToolCall,
+    ToolCallResult,
+    select_streaming_callback,
+)
 from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
-from anthropic import Anthropic
+from anthropic import Anthropic, AsyncAnthropic, Stream
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +214,7 @@ class AnthropicChatGenerator:
         self.generation_kwargs = generation_kwargs or {}
         self.streaming_callback = streaming_callback
         self.client = Anthropic(api_key=self.api_key.resolve_value())
+        self.async_client = AsyncAnthropic(api_key=self.api_key.resolve_value())
         self.ignore_tools_thinking_messages = ignore_tools_thinking_messages
         self.tools = tools
 
@@ -299,7 +307,8 @@ class AnthropicChatGenerator:
         )
         return message
 
-    def _convert_anthropic_chunk_to_streaming_chunk(self, chunk: Any) -> StreamingChunk:
+    @staticmethod
+    def _convert_anthropic_chunk_to_streaming_chunk(chunk: Any) -> StreamingChunk:
         """
         Converts an Anthropic StreamEvent to a StreamingChunk.
         """
@@ -370,7 +379,8 @@ class AnthropicChatGenerator:
 
         return message
 
-    def _remove_cache_control(self, message: Dict[str, Any]) -> Dict[str, Any]:
+    @staticmethod
+    def _remove_cache_control(message: Dict[str, Any]) -> Dict[str, Any]:
         """
         Removes the cache_control key from the message.
         :param message: The message to remove the cache_control key from.
@@ -378,24 +388,23 @@ class AnthropicChatGenerator:
         """
         return {k: v for k, v in message.items() if k != "cache_control"}
 
-    @component.output_types(replies=List[ChatMessage])
-    def run(
+    def _prepare_request_params(
         self,
         messages: List[ChatMessage],
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         tools: Optional[List[Tool]] = None,
-    ):
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, Any], List[Dict[str, Any]]]:
         """
-        Invokes the Anthropic API with the given messages and generation kwargs.
+        Prepare the parameters for the Anthropic API request.
 
         :param messages: A list of ChatMessage instances representing the input messages.
-        :param streaming_callback: A callback function that is called when a new token is received from the stream.
         :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
-        :param tools: A list of tools for which the model can prepare calls. If set, it will override
-        the `tools` parameter set during component initialization.
-        :returns: A dictionary with the following keys:
-            - `replies`: The responses from the model
+        :param tools: A list of tools for which the model can prepare calls.
+        :returns: A tuple containing:
+            - system_messages: List of system messages in Anthropic format
+            - non_system_messages: List of non-system messages in Anthropic format
+            - generation_kwargs: Processed generation kwargs
+            - anthropic_tools: List of tools in Anthropic format
         """
         # update generation kwargs by merging with the generation kwargs passed to the run method
         generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
@@ -442,21 +451,21 @@ class AnthropicChatGenerator:
             else []
         )
 
-        streaming_callback = streaming_callback or self.streaming_callback
-        stream = streaming_callback is not None
+        return system_messages, non_system_messages, generation_kwargs, anthropic_tools
 
-        response = self.client.messages.create(
-            model=self.model,
-            messages=non_system_messages,
-            system=system_messages,
-            tools=anthropic_tools,
-            stream=stream,
-            max_tokens=generation_kwargs.pop("max_tokens", 1024),
-            **generation_kwargs,
-        )
+    def _process_response(
+        self,
+        response: Any,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+    ) -> Dict[str, List[ChatMessage]]:
+        """
+        Process the response from the Anthropic API.
 
-        # workaround for https://github.com/DataDog/dd-trace-py/issues/12562
-        if stream:
+        :param response: The response from the Anthropic API.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :returns: A dictionary containing the processed response as a list of ChatMessage objects.
+        """
+        if isinstance(response, Stream):
             chunks: List[StreamingChunk] = []
             model: Optional[str] = None
             for chunk in response:
@@ -480,3 +489,120 @@ class AnthropicChatGenerator:
                     self._convert_chat_completion_to_chat_message(response, self.ignore_tools_thinking_messages)
                 ]
             }
+
+    async def _process_response_async(
+        self,
+        response: Any,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+    ) -> Dict[str, List[ChatMessage]]:
+        """
+        Process the response from the Anthropic API asynchronously.
+
+        :param response: The response from the Anthropic API.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :returns: A dictionary containing the processed response as a list of ChatMessage objects.
+        """
+        if isinstance(response, Stream):
+            chunks: List[StreamingChunk] = []
+            model: Optional[str] = None
+            async for chunk in response:
+                if chunk.type == "message_start":
+                    model = chunk.message.model
+                elif chunk.type in [
+                    "content_block_start",
+                    "content_block_delta",
+                    "message_delta",
+                ]:
+                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk)
+                    chunks.append(streaming_chunk)
+                    if streaming_callback:
+                        streaming_callback(streaming_chunk)
+
+            completion = self._convert_streaming_chunks_to_chat_message(chunks, model)
+            return {"replies": [completion]}
+        else:
+            return {
+                "replies": [
+                    self._convert_chat_completion_to_chat_message(response, self.ignore_tools_thinking_messages)
+                ]
+            }
+
+    @component.output_types(replies=List[ChatMessage])
+    def run(
+        self,
+        messages: List[ChatMessage],
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        tools: Optional[List[Tool]] = None,
+    ):
+        """
+        Invokes the Anthropic API with the given messages and generation kwargs.
+
+        :param messages: A list of ChatMessage instances representing the input messages.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param tools: A list of tools for which the model can prepare calls. If set, it will override
+        the `tools` parameter set during component initialization.
+        :returns: A dictionary with the following keys:
+            - `replies`: The responses from the model
+        """
+        system_messages, non_system_messages, generation_kwargs, anthropic_tools = self._prepare_request_params(
+            messages, generation_kwargs, tools
+        )
+
+        # validate and select the streaming callback
+        streaming_callback = select_streaming_callback(
+            self.streaming_callback, streaming_callback, requires_async=False
+        )  # type: ignore
+
+        response = self.client.messages.create(
+            model=self.model,
+            messages=non_system_messages,
+            system=system_messages,
+            tools=anthropic_tools,
+            stream=streaming_callback is not None,
+            max_tokens=generation_kwargs.pop("max_tokens", 1024),
+            **generation_kwargs,
+        )
+
+        return self._process_response(response, streaming_callback)
+
+    @component.output_types(replies=List[ChatMessage])
+    async def run_async(
+        self,
+        messages: List[ChatMessage],
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        tools: Optional[List[Tool]] = None,
+    ):
+        """
+        Async version of the run method. Invokes the Anthropic API with the given messages and generation kwargs.
+
+        :param messages: A list of ChatMessage instances representing the input messages.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param tools: A list of tools for which the model can prepare calls. If set, it will override
+        the `tools` parameter set during component initialization.
+        :returns: A dictionary with the following keys:
+            - `replies`: The responses from the model
+        """
+        system_messages, non_system_messages, generation_kwargs, anthropic_tools = self._prepare_request_params(
+            messages, generation_kwargs, tools
+        )
+
+        # validate and select the streaming callback
+        streaming_callback = select_streaming_callback(
+            self.streaming_callback, streaming_callback, requires_async=False
+        )  # type: ignore
+
+        response = await self.async_client.messages.create(
+            model=self.model,
+            messages=non_system_messages,
+            system=system_messages,
+            tools=anthropic_tools,
+            stream=streaming_callback is not None,
+            max_tokens=generation_kwargs.pop("max_tokens", 1024),
+            **generation_kwargs,
+        )
+
+        return await self._process_response_async(response, streaming_callback)

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -6,7 +6,7 @@ from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
 from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
-from anthropic import Anthropic, AsyncAnthropic, Stream, AsyncStream
+from anthropic import Anthropic, AsyncAnthropic, AsyncStream, Stream
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import anthropic
 import pytest
-import pytest_asyncio
+import pytest_asyncio  # type: ignore[import]
 from anthropic.types import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -13,7 +13,9 @@ import pytest_asyncio  # type: ignore[import]
 from anthropic.types import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
+    ContentBlockStopEvent,
     Message,
+    MessageDeltaEvent,
     MessageStartEvent,
     TextBlockParam,
     TextDelta,
@@ -853,7 +855,7 @@ class TestAnthropicChatGenerator:
         assert len(results["replies"]) == 1
         message = results["replies"][0]
 
-        # this is Antropic thinking message prior to tool call
+        # this is Anthropic thinking message prior to tool call
         assert message.text is not None
         assert "weather" in message.text.lower()
         assert "paris" in message.text.lower()
@@ -1137,67 +1139,41 @@ class TestAnthropicChatGeneratorAsync:
         assert response["replies"][0].meta["model"] == "claude-3-5-sonnet-20240620"
         assert response["replies"][0].meta["finish_reason"] == "end_turn"
 
-    @pytest.mark.asyncio
-    async def test_run_async_with_tools(self, tools, mock_anthropic_completion_async_with_tool):
-        """
-        Test that the async run method of AnthropicChatGenerator works with tools.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = AnthropicChatGenerator(tools=tools)
-        results = await component.run_async(messages=initial_messages)
-
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.id is not None
-        assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
-        assert message.meta["finish_reason"] == "tool_use"
-
-        new_messages = [
-            *initial_messages,
-            message,
-            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-        ]
-        # the model tends to make tool calls if provided with tools, so we don't pass them here
-        results = await component.run_async(new_messages, generation_kwargs={"max_tokens": 50})
-
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
-
-    # async def test_run_async_with_streaming(self, chat_messages, mock_anthropic_completion_async):
+    # @pytest.mark.asyncio
+    # async def test_run_async_with_tools(self, tools, mock_anthropic_completion_async_with_tool):
     #     """
-    #     Test that the async run method of AnthropicChatGenerator works with streaming.
+    #     Test that the async run method of AnthropicChatGenerator works with tools.
     #     """
-    #
-    #     class Callback:
-    #         def __init__(self):
-    #             self.responses = ""
-    #             self.counter = 0
-    #
-    #         def __call__(self, chunk: StreamingChunk) -> None:
-    #             self.counter += 1
-    #             self.responses += chunk.content if chunk.content else ""
-    #
-    #     callback = Callback()
-    #     component = AnthropicChatGenerator(streaming_callback=callback)
-    #     results = await component.run_async([ChatMessage.from_user("What's the capital of France?")])
+    #     initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+    #     component = AnthropicChatGenerator(tools=tools)
+    #     results = await component.run_async(messages=initial_messages)
     #
     #     assert len(results["replies"]) == 1
-    #     message: ChatMessage = results["replies"][0]
-    #     assert "Paris" in message.text
+    #     message = results["replies"][0]
     #
-    #     assert "claude-3-5-sonnet-20240620" in message.meta["model"]
-    #     assert message.meta["finish_reason"] == "end_turn"
+    #     assert message.tool_calls
+    #     tool_call = message.tool_call
+    #     assert isinstance(tool_call, ToolCall)
+    #     assert tool_call.id is not None
+    #     assert tool_call.tool_name == "weather"
+    #     assert tool_call.arguments == {"city": "Paris"}
+    #     assert message.meta["finish_reason"] == "tool_use"
     #
-    #     assert callback.counter > 1
-    #     assert "Paris" in callback.responses
+    #     new_messages = [
+    #         *initial_messages,
+    #         message,
+    #         ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+    #     ]
+    #     # the model tends to make tool calls if provided with tools, so we don't pass them here
+    #     results = await component.run_async(new_messages, generation_kwargs={"max_tokens": 50})
+    #
+    #     assert len(results["replies"]) == 1
+    #     final_message = results["replies"][0]
+    #     assert not final_message.tool_calls
+    #     assert len(final_message.text) > 0
+    #     assert "paris" in final_message.text.lower()
+
+
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -1216,6 +1192,46 @@ class TestAnthropicChatGeneratorAsync:
         assert "Paris" in message.text
         assert "claude-3-5-sonnet-20240620" in message.meta["model"]
         assert message.meta["finish_reason"] == "end_turn"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY", None),
+        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_live_run_async_with_streaming(self):
+        """
+        Test that the async run method of AnthropicChatGenerator works with streaming.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator(streaming_callback=print_streaming_chunk)
+
+        # Create a callback to capture streaming chunks
+        class Callback:
+            def __init__(self):
+                self.responses = ""
+                self.counter = 0
+
+            def __call__(self, chunk: StreamingChunk) -> None:
+                self.counter += 1
+                self.responses += chunk.content if chunk.content else ""
+
+        callback = Callback()
+        component.streaming_callback = callback
+
+        # Run the async streaming test
+        results = await component.run_async(messages=initial_messages)
+
+        # Verify the results
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+        assert "paris" in message.text.lower()
+        assert "claude-3-5-sonnet-20240620" in message.meta["model"]
+        assert message.meta["finish_reason"] == "end_turn"
+
+        # Verify streaming behavior
+        assert callback.counter > 1  # Should have received multiple chunks
+        assert "paris" in callback.responses.lower()  # Should have received the response in chunks
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -1301,3 +1317,4 @@ class TestAnthropicChatGeneratorAsync:
     #     assert "22°" in message.text
     #     assert "12°" in message.text
     #     assert message.meta["finish_reason"] == "end_turn"
+

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -1144,40 +1144,6 @@ class TestAnthropicChatGeneratorAsync:
         assert response["replies"][0].meta["model"] == "claude-3-5-sonnet-20240620"
         assert response["replies"][0].meta["finish_reason"] == "end_turn"
 
-    # @pytest.mark.asyncio
-    # async def test_run_async_with_tools(self, tools, mock_anthropic_completion_async_with_tool):
-    #     """
-    #     Test that the async run method of AnthropicChatGenerator works with tools.
-    #     """
-    #     initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-    #     component = AnthropicChatGenerator(tools=tools)
-    #     results = await component.run_async(messages=initial_messages)
-    #
-    #     assert len(results["replies"]) == 1
-    #     message = results["replies"][0]
-    #
-    #     assert message.tool_calls
-    #     tool_call = message.tool_call
-    #     assert isinstance(tool_call, ToolCall)
-    #     assert tool_call.id is not None
-    #     assert tool_call.tool_name == "weather"
-    #     assert tool_call.arguments == {"city": "Paris"}
-    #     assert message.meta["finish_reason"] == "tool_use"
-    #
-    #     new_messages = [
-    #         *initial_messages,
-    #         message,
-    #         ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-    #     ]
-    #     # the model tends to make tool calls if provided with tools, so we don't pass them here
-    #     results = await component.run_async(new_messages, generation_kwargs={"max_tokens": 50})
-    #
-    #     assert len(results["replies"]) == 1
-    #     final_message = results["replies"][0]
-    #     assert not final_message.tool_calls
-    #     assert len(final_message.text) > 0
-    #     assert "paris" in final_message.text.lower()
-
     @pytest.mark.asyncio
     @pytest.mark.skipif(
         not os.environ.get("ANTHROPIC_API_KEY", None),
@@ -1272,51 +1238,3 @@ class TestAnthropicChatGeneratorAsync:
         assert not final_message.tool_calls
         assert len(final_message.text) > 0
         assert "paris" in final_message.text.lower()
-
-    # @pytest.mark.asyncio
-    # @pytest.mark.skipif(
-    #     not os.environ.get("ANTHROPIC_API_KEY", None),
-    #     reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    # )
-    # @pytest.mark.integration
-    # async def test_live_run_async_with_parallel_tools(self, tools):
-    #     """
-    #     Integration test that the async run method works with parallel tools.
-    #     """
-    #     initial_messages = [ChatMessage.from_user("What's the weather like in Paris and Berlin?")]
-    #     component = AnthropicChatGenerator(tools=tools)
-    #     results = await component.run_async(messages=initial_messages)
-    #
-    #     assert len(results["replies"]) == 1
-    #     message = results["replies"][0]
-    #
-    #     assert len(message.tool_calls) == 2
-    #     tool_call_paris = message.tool_calls[0]
-    #     assert isinstance(tool_call_paris, ToolCall)
-    #     assert tool_call_paris.id is not None
-    #     assert tool_call_paris.tool_name == "weather"
-    #     assert tool_call_paris.arguments["city"] in {"Paris", "Berlin"}
-    #     assert message.meta["finish_reason"] == "tool_use"
-    #
-    #     tool_call_berlin = message.tool_calls[1]
-    #     assert isinstance(tool_call_berlin, ToolCall)
-    #     assert tool_call_berlin.id is not None
-    #     assert tool_call_berlin.tool_name == "weather"
-    #     assert tool_call_berlin.arguments["city"] in {"Berlin", "Paris"}
-    #
-    #     new_messages = [
-    #         *initial_messages,
-    #         message,
-    #         ChatMessage.from_tool(tool_result="22° C", origin=tool_call_paris, error=False),
-    #         ChatMessage.from_tool(tool_result="12° C", origin=tool_call_berlin, error=False),
-    #     ]
-    #
-    #     results = await component.run_async(new_messages)
-    #     message = results["replies"][0]
-    #     assert not message.tool_calls
-    #     assert len(message.text) > 0
-    #     assert "paris" in message.text.lower()
-    #     assert "berlin" in message.text.lower()
-    #     assert "22°" in message.text
-    #     assert "12°" in message.text
-    #     assert message.meta["finish_reason"] == "end_turn"

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -9,14 +9,13 @@ from unittest.mock import AsyncMock, patch
 
 import anthropic
 import pytest
-import pytest_asyncio  # type: ignore[import]
 from anthropic.types import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
     Message,
     MessageStartEvent,
     TextBlockParam,
-    TextDelta,
+    TextDelta, Usage,
 )
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
@@ -1068,7 +1067,7 @@ class TestAnthropicChatGenerator:
 
 class TestAnthropicChatGeneratorAsync:
 
-    @pytest_asyncio.fixture
+    @pytest.fixture
     async def mock_anthropic_completion_async(self):
         with patch("anthropic.resources.messages.AsyncMessages.create") as mock_anthropic:
             completion = Message(
@@ -1078,13 +1077,13 @@ class TestAnthropicChatGeneratorAsync:
                 role="assistant",
                 content=[TextBlockParam(type="text", text="Hello! I'm Claude.")],
                 stop_reason="end_turn",
-                usage={"input_tokens": 10, "output_tokens": 20},
+                usage=Usage(input_tokens=10, output_tokens=20),
             )
             # Make the mock return an awaitable
             mock_anthropic.return_value = AsyncMock(return_value=completion)()
             yield mock_anthropic
 
-    @pytest_asyncio.fixture
+    @pytest.fixture
     async def mock_anthropic_completion_async_with_tool(self):
         with patch("anthropic.resources.messages.AsyncMessages.create") as mock_anthropic:
             completion = Message(
@@ -1097,7 +1096,7 @@ class TestAnthropicChatGeneratorAsync:
                     {"type": "tool_use", "id": "tool_123", "name": "weather", "input": {"city": "Paris"}},
                 ],
                 stop_reason="tool_use",
-                usage={"input_tokens": 10, "output_tokens": 20},
+                usage=Usage(input_tokens=10, output_tokens=20),
             )
             # Make the mock return an awaitable
             mock_anthropic.return_value = AsyncMock(return_value=completion)()

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -1151,6 +1151,7 @@ class TestAnthropicChatGeneratorAsync:
         """
         Test that the async run method of AnthropicChatGenerator works with streaming.
         """
+
         class Callback:
             def __init__(self):
                 self.responses = ""

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -1077,6 +1077,30 @@ class TestAnthropicChatGeneratorAsync:
             mock_anthropic.return_value = AsyncMock(return_value=completion)()
             yield mock_anthropic
 
+    @pytest_asyncio.fixture
+    async def mock_anthropic_completion_async_with_tool(self):
+        with patch("anthropic.resources.messages.AsyncMessages.create") as mock_anthropic:
+            completion = Message(
+                id="foo",
+                type="message",
+                model="claude-3-5-sonnet-20240620",
+                role="assistant",
+                content=[
+                    TextBlockParam(type="text", text="Let me check the weather for you."),
+                    {
+                        "type": "tool_use",
+                        "id": "tool_123",
+                        "name": "weather",
+                        "input": {"city": "Paris"}
+                    }
+                ],
+                stop_reason="tool_use",
+                usage={"input_tokens": 10, "output_tokens": 20},
+            )
+            # Make the mock return an awaitable
+            mock_anthropic.return_value = AsyncMock(return_value=completion)()
+            yield mock_anthropic
+
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_anthropic_completion_async, monkeypatch):
         """
@@ -1118,67 +1142,67 @@ class TestAnthropicChatGeneratorAsync:
         assert response["replies"][0].meta["model"] == "claude-3-5-sonnet-20240620"
         assert response["replies"][0].meta["finish_reason"] == "end_turn"
 
-    @pytest.mark.asyncio
-    async def test_run_async_with_tools(self, tools, mock_anthropic_completion_async):
-        """
-        Test that the async run method of AnthropicChatGenerator works with tools.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = AnthropicChatGenerator(tools=tools)
-        results = await component.run_async(messages=initial_messages)
+    # @pytest.mark.asyncio
+    # async def test_run_async_with_tools(self, tools, mock_anthropic_completion_async_with_tool):
+    #     """
+    #     Test that the async run method of AnthropicChatGenerator works with tools.
+    #     """
+    #     initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+    #     component = AnthropicChatGenerator(tools=tools)
+    #     results = await component.run_async(messages=initial_messages)
+    #
+    #     assert len(results["replies"]) == 1
+    #     message = results["replies"][0]
+    #
+    #     assert message.tool_calls
+    #     tool_call = message.tool_call
+    #     assert isinstance(tool_call, ToolCall)
+    #     assert tool_call.id is not None
+    #     assert tool_call.tool_name == "weather"
+    #     assert tool_call.arguments == {"city": "Paris"}
+    #     assert message.meta["finish_reason"] == "tool_use"
+    #
+    #     new_messages = [
+    #         *initial_messages,
+    #         message,
+    #         ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+    #     ]
+    #     # the model tends to make tool calls if provided with tools, so we don't pass them here
+    #     results = await component.run_async(new_messages, generation_kwargs={"max_tokens": 50})
+    #
+    #     assert len(results["replies"]) == 1
+    #     final_message = results["replies"][0]
+    #     assert not final_message.tool_calls
+    #     assert len(final_message.text) > 0
+    #     assert "paris" in final_message.text.lower()
 
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.id is not None
-        assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
-        assert message.meta["finish_reason"] == "tool_use"
-
-        new_messages = [
-            *initial_messages,
-            message,
-            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-        ]
-        # the model tends to make tool calls if provided with tools, so we don't pass them here
-        results = await component.run_async(new_messages, generation_kwargs={"max_tokens": 50})
-
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
-
-    async def test_run_async_with_streaming(self, chat_messages, mock_anthropic_completion_async):
-        """
-        Test that the async run method of AnthropicChatGenerator works with streaming.
-        """
-
-        class Callback:
-            def __init__(self):
-                self.responses = ""
-                self.counter = 0
-
-            def __call__(self, chunk: StreamingChunk) -> None:
-                self.counter += 1
-                self.responses += chunk.content if chunk.content else ""
-
-        callback = Callback()
-        component = AnthropicChatGenerator(streaming_callback=callback)
-        results = await component.run_async([ChatMessage.from_user("What's the capital of France?")])
-
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-
-        assert "claude-3-5-sonnet-20240620" in message.meta["model"]
-        assert message.meta["finish_reason"] == "end_turn"
-
-        assert callback.counter > 1
-        assert "Paris" in callback.responses
+    # async def test_run_async_with_streaming(self, chat_messages, mock_anthropic_completion_async):
+    #     """
+    #     Test that the async run method of AnthropicChatGenerator works with streaming.
+    #     """
+    #
+    #     class Callback:
+    #         def __init__(self):
+    #             self.responses = ""
+    #             self.counter = 0
+    #
+    #         def __call__(self, chunk: StreamingChunk) -> None:
+    #             self.counter += 1
+    #             self.responses += chunk.content if chunk.content else ""
+    #
+    #     callback = Callback()
+    #     component = AnthropicChatGenerator(streaming_callback=callback)
+    #     results = await component.run_async([ChatMessage.from_user("What's the capital of France?")])
+    #
+    #     assert len(results["replies"]) == 1
+    #     message: ChatMessage = results["replies"][0]
+    #     assert "Paris" in message.text
+    #
+    #     assert "claude-3-5-sonnet-20240620" in message.meta["model"]
+    #     assert message.meta["finish_reason"] == "end_turn"
+    #
+    #     assert callback.counter > 1
+    #     assert "Paris" in callback.responses
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -1198,19 +1222,6 @@ class TestAnthropicChatGeneratorAsync:
         assert "claude-3-5-sonnet-20240620" in message.meta["model"]
         assert message.meta["finish_reason"] == "end_turn"
 
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    async def test_live_run_async_wrong_model(self, chat_messages):
-        """
-        Integration test that the async run method fails with wrong model.
-        """
-        component = AnthropicChatGenerator(model="something-obviously-wrong")
-        with pytest.raises(anthropic.NotFoundError):
-            await component.run_async(chat_messages)
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -1249,50 +1260,50 @@ class TestAnthropicChatGeneratorAsync:
         assert len(final_message.text) > 0
         assert "paris" in final_message.text.lower()
 
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    async def test_live_run_async_with_parallel_tools(self, tools):
-        """
-        Integration test that the async run method works with parallel tools.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris and Berlin?")]
-        component = AnthropicChatGenerator(tools=tools)
-        results = await component.run_async(messages=initial_messages)
-
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert len(message.tool_calls) == 2
-        tool_call_paris = message.tool_calls[0]
-        assert isinstance(tool_call_paris, ToolCall)
-        assert tool_call_paris.id is not None
-        assert tool_call_paris.tool_name == "weather"
-        assert tool_call_paris.arguments["city"] in {"Paris", "Berlin"}
-        assert message.meta["finish_reason"] == "tool_use"
-
-        tool_call_berlin = message.tool_calls[1]
-        assert isinstance(tool_call_berlin, ToolCall)
-        assert tool_call_berlin.id is not None
-        assert tool_call_berlin.tool_name == "weather"
-        assert tool_call_berlin.arguments["city"] in {"Berlin", "Paris"}
-
-        new_messages = [
-            *initial_messages,
-            message,
-            ChatMessage.from_tool(tool_result="22° C", origin=tool_call_paris, error=False),
-            ChatMessage.from_tool(tool_result="12° C", origin=tool_call_berlin, error=False),
-        ]
-
-        results = await component.run_async(new_messages)
-        message = results["replies"][0]
-        assert not message.tool_calls
-        assert len(message.text) > 0
-        assert "paris" in message.text.lower()
-        assert "berlin" in message.text.lower()
-        assert "22°" in message.text
-        assert "12°" in message.text
-        assert message.meta["finish_reason"] == "end_turn"
+    # @pytest.mark.asyncio
+    # @pytest.mark.skipif(
+    #     not os.environ.get("ANTHROPIC_API_KEY", None),
+    #     reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+    # )
+    # @pytest.mark.integration
+    # async def test_live_run_async_with_parallel_tools(self, tools):
+    #     """
+    #     Integration test that the async run method works with parallel tools.
+    #     """
+    #     initial_messages = [ChatMessage.from_user("What's the weather like in Paris and Berlin?")]
+    #     component = AnthropicChatGenerator(tools=tools)
+    #     results = await component.run_async(messages=initial_messages)
+    #
+    #     assert len(results["replies"]) == 1
+    #     message = results["replies"][0]
+    #
+    #     assert len(message.tool_calls) == 2
+    #     tool_call_paris = message.tool_calls[0]
+    #     assert isinstance(tool_call_paris, ToolCall)
+    #     assert tool_call_paris.id is not None
+    #     assert tool_call_paris.tool_name == "weather"
+    #     assert tool_call_paris.arguments["city"] in {"Paris", "Berlin"}
+    #     assert message.meta["finish_reason"] == "tool_use"
+    #
+    #     tool_call_berlin = message.tool_calls[1]
+    #     assert isinstance(tool_call_berlin, ToolCall)
+    #     assert tool_call_berlin.id is not None
+    #     assert tool_call_berlin.tool_name == "weather"
+    #     assert tool_call_berlin.arguments["city"] in {"Berlin", "Paris"}
+    #
+    #     new_messages = [
+    #         *initial_messages,
+    #         message,
+    #         ChatMessage.from_tool(tool_result="22° C", origin=tool_call_paris, error=False),
+    #         ChatMessage.from_tool(tool_result="12° C", origin=tool_call_berlin, error=False),
+    #     ]
+    #
+    #     results = await component.run_async(new_messages)
+    #     message = results["replies"][0]
+    #     assert not message.tool_calls
+    #     assert len(message.text) > 0
+    #     assert "paris" in message.text.lower()
+    #     assert "berlin" in message.text.lower()
+    #     assert "22°" in message.text
+    #     assert "12°" in message.text
+    #     assert message.meta["finish_reason"] == "end_turn"

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -13,9 +13,7 @@ import pytest_asyncio  # type: ignore[import]
 from anthropic.types import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
-    ContentBlockStopEvent,
     Message,
-    MessageDeltaEvent,
     MessageStartEvent,
     TextBlockParam,
     TextDelta,
@@ -1173,8 +1171,6 @@ class TestAnthropicChatGeneratorAsync:
     #     assert len(final_message.text) > 0
     #     assert "paris" in final_message.text.lower()
 
-
-
     @pytest.mark.asyncio
     @pytest.mark.skipif(
         not os.environ.get("ANTHROPIC_API_KEY", None),
@@ -1317,4 +1313,3 @@ class TestAnthropicChatGeneratorAsync:
     #     assert "22°" in message.text
     #     assert "12°" in message.text
     #     assert message.meta["finish_reason"] == "end_turn"
-

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -15,7 +15,8 @@ from anthropic.types import (
     Message,
     MessageStartEvent,
     TextBlockParam,
-    TextDelta, Usage,
+    TextDelta,
+    Usage,
 )
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -1087,12 +1087,7 @@ class TestAnthropicChatGeneratorAsync:
                 role="assistant",
                 content=[
                     TextBlockParam(type="text", text="Let me check the weather for you."),
-                    {
-                        "type": "tool_use",
-                        "id": "tool_123",
-                        "name": "weather",
-                        "input": {"city": "Paris"}
-                    }
+                    {"type": "tool_use", "id": "tool_123", "name": "weather", "input": {"city": "Paris"}},
                 ],
                 stop_reason="tool_use",
                 usage={"input_tokens": 10, "output_tokens": 20},
@@ -1221,7 +1216,6 @@ class TestAnthropicChatGeneratorAsync:
         assert "Paris" in message.text
         assert "claude-3-5-sonnet-20240620" in message.meta["model"]
         assert message.meta["finish_reason"] == "end_turn"
-
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -5,7 +5,7 @@
 import json
 import logging
 import os
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import anthropic
 import pytest
@@ -1077,7 +1077,6 @@ class TestAnthropicChatGeneratorAsync:
             mock_anthropic.return_value = AsyncMock(return_value=completion)()
             yield mock_anthropic
 
-
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_anthropic_completion_async, monkeypatch):
         """
@@ -1093,7 +1092,6 @@ class TestAnthropicChatGeneratorAsync:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-
 
     @pytest.mark.asyncio
     async def test_run_async_with_params(self, chat_messages, mock_anthropic_completion_async):

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -1137,39 +1137,39 @@ class TestAnthropicChatGeneratorAsync:
         assert response["replies"][0].meta["model"] == "claude-3-5-sonnet-20240620"
         assert response["replies"][0].meta["finish_reason"] == "end_turn"
 
-    # @pytest.mark.asyncio
-    # async def test_run_async_with_tools(self, tools, mock_anthropic_completion_async_with_tool):
-    #     """
-    #     Test that the async run method of AnthropicChatGenerator works with tools.
-    #     """
-    #     initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-    #     component = AnthropicChatGenerator(tools=tools)
-    #     results = await component.run_async(messages=initial_messages)
-    #
-    #     assert len(results["replies"]) == 1
-    #     message = results["replies"][0]
-    #
-    #     assert message.tool_calls
-    #     tool_call = message.tool_call
-    #     assert isinstance(tool_call, ToolCall)
-    #     assert tool_call.id is not None
-    #     assert tool_call.tool_name == "weather"
-    #     assert tool_call.arguments == {"city": "Paris"}
-    #     assert message.meta["finish_reason"] == "tool_use"
-    #
-    #     new_messages = [
-    #         *initial_messages,
-    #         message,
-    #         ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-    #     ]
-    #     # the model tends to make tool calls if provided with tools, so we don't pass them here
-    #     results = await component.run_async(new_messages, generation_kwargs={"max_tokens": 50})
-    #
-    #     assert len(results["replies"]) == 1
-    #     final_message = results["replies"][0]
-    #     assert not final_message.tool_calls
-    #     assert len(final_message.text) > 0
-    #     assert "paris" in final_message.text.lower()
+    @pytest.mark.asyncio
+    async def test_run_async_with_tools(self, tools, mock_anthropic_completion_async_with_tool):
+        """
+        Test that the async run method of AnthropicChatGenerator works with tools.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator(tools=tools)
+        results = await component.run_async(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.id is not None
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_use"
+
+        new_messages = [
+            *initial_messages,
+            message,
+            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+        ]
+        # the model tends to make tool calls if provided with tools, so we don't pass them here
+        results = await component.run_async(new_messages, generation_kwargs={"max_tokens": 50})
+
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
 
     # async def test_run_async_with_streaming(self, chat_messages, mock_anthropic_completion_async):
     #     """


### PR DESCRIPTION
### Related Issues

- fixes #1380 

### Proposed Changes:

• Added async support to `AnthropicChatGenerator` with new `run_async` method
• Introduced `AsyncAnthropic` client initialization alongside existing sync client
• Refactored code to extract common functionality into `prepare_messages_and_tools`
• Added `_process_response` and `_process_response_async` methods to handle API responses
• Added async tests :
  - Basic async functionality tests
  - Live integration tests

• Made `convert_anthropic_chunk_to_streaming_chunk` and `_remove_cache_control static` methods
• Fixed usage metadata handling with proper Anthropic `Usage` type
• Maintained backward compatibility with existing sync functionality

### How did you test it?

- unit tests, integration tests, CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
