### PR TITLE
fix: Update serialization/deserialization tests to add new parameter `connection_type_validation`

### DIFF
--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -606,7 +606,8 @@ class TestAmazonBedrockChatGeneratorInference:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
-        assert pipeline_dict == {
+
+        expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
             "connection_type_validation": True,
@@ -644,6 +645,11 @@ class TestAmazonBedrockChatGeneratorInference:
             },
             "connections": [],
         }
+
+        if not hasattr(pipeline, "_connection_type_validation"):
+            expected_dict.pop("connection_type_validation")
+
+        assert pipeline_dict == expected_dict
 
         # Test YAML serialization/deserialization
         pipeline_yaml = pipeline.dumps()

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -609,6 +609,7 @@ class TestAmazonBedrockChatGeneratorInference:
         assert pipeline_dict == {
             "metadata": {},
             "max_runs_per_component": 100,
+            "connection_type_validation": True,
             "components": {
                 "generator": {
                     "type": KLASS,

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -532,6 +532,7 @@ class TestAnthropicChatGenerator:
         assert pipeline_dict == {
             "metadata": {},
             "max_runs_per_component": 100,
+            "connection_type_validation": True,
             "components": {
                 "generator": {
                     "type": type_,

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -7,6 +7,7 @@ import os
 from unittest.mock import patch
 
 import anthropic
+import haystack
 import pytest
 from anthropic.types import (
     ContentBlockDeltaEvent,
@@ -529,7 +530,8 @@ class TestAnthropicChatGenerator:
 
         pipeline_dict = pipeline.to_dict()
         type_ = "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator"
-        assert pipeline_dict == {
+
+        expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
             "connection_type_validation": True,
@@ -558,6 +560,16 @@ class TestAnthropicChatGenerator:
             },
             "connections": [],
         }
+
+        try:
+            version = haystack.version.__version__
+        except AttributeError:
+            version = haystack.__version__
+
+        if version < "2.11.0":
+            expected_dict.pop("connection_type_validation")
+
+        assert pipeline_dict == expected_dict
 
         pipeline_yaml = pipeline.dumps()
 

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -7,7 +7,6 @@ import os
 from unittest.mock import patch
 
 import anthropic
-import haystack
 import pytest
 from anthropic.types import (
     ContentBlockDeltaEvent,
@@ -561,12 +560,7 @@ class TestAnthropicChatGenerator:
             "connections": [],
         }
 
-        try:
-            version = haystack.version.__version__
-        except AttributeError:
-            version = haystack.__version__
-
-        if version < "2.11.0":
+        if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
 
         assert pipeline_dict == expected_dict

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -431,6 +431,7 @@ class TestCohereChatGenerator:
         assert pipeline_dict == {
             "metadata": {},
             "max_runs_per_component": 100,
+            "connection_type_validation": True,
             "components": {
                 "generator": {
                     "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",  # noqa: E501

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -428,7 +428,8 @@ class TestCohereChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
-        assert pipeline_dict == {
+
+        expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
             "connection_type_validation": True,
@@ -457,6 +458,11 @@ class TestCohereChatGenerator:
             },
             "connections": [],
         }
+
+        if not hasattr(pipeline, "_connection_type_validation"):
+            expected_dict.pop("connection_type_validation")
+
+        assert pipeline_dict == expected_dict
 
         # Test YAML serialization/deserialization
         pipeline_yaml = pipeline.dumps()

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -290,6 +290,7 @@ class TestGoogleAIGeminiChatGenerator:
         assert pipeline_dict == {
             "metadata": {},
             "max_runs_per_component": 100,
+            "connection_type_validation": True,
             "components": {
                 "generator": {
                     "type": TYPE,

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -287,7 +287,8 @@ class TestGoogleAIGeminiChatGenerator:
         pipeline.add_component("generator", generator)
 
         pipeline_dict = pipeline.to_dict()
-        assert pipeline_dict == {
+
+        expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
             "connection_type_validation": True,
@@ -320,6 +321,11 @@ class TestGoogleAIGeminiChatGenerator:
             },
             "connections": [],
         }
+
+        if not hasattr(pipeline, "_connection_type_validation"):
+            expected_dict.pop("connection_type_validation")
+
+        assert pipeline_dict == expected_dict
 
         pipeline_yaml = pipeline.dumps()
 

--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -522,6 +522,7 @@ class TestVertexAIGeminiChatGenerator:
         assert pipeline_dict == {
             "metadata": {},
             "max_runs_per_component": 100,
+            "connection_type_validation": True,
             "components": {
                 "generator": {
                     "type": (

--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -519,7 +519,8 @@ class TestVertexAIGeminiChatGenerator:
         pipeline.add_component("generator", generator)
 
         pipeline_dict = pipeline.to_dict()
-        assert pipeline_dict == {
+
+        expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
             "connection_type_validation": True,
@@ -556,6 +557,11 @@ class TestVertexAIGeminiChatGenerator:
             },
             "connections": [],
         }
+
+        if not hasattr(pipeline, "_connection_type_validation"):
+            expected_dict.pop("connection_type_validation")
+
+        assert pipeline_dict == expected_dict
 
         pipeline_yaml = pipeline.dumps()
 

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -468,6 +468,7 @@ class TestMistralChatGenerator:
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
+            "connection_type_validation": True,
             "components": {
                 "generator": {
                     "type": "haystack_integrations.components.generators.mistral.chat.chat_generator.MistralChatGenerator",  # noqa: E501

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -494,6 +494,10 @@ class TestMistralChatGenerator:
             },
             "connections": [],
         }
+
+        if not hasattr(pipeline, "_connection_type_validation"):
+            expected_dict.pop("connection_type_validation")
+
         assert pipeline_dict == expected_dict
 
         # Test YAML serialization/deserialization


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds `connection_type_validation` to the expected dicts when converting a pipeline to a dict.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Only updated tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
