### PR TITLE
feat: Support thinking parameter in Anthropic generators

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -353,7 +353,8 @@ class AnthropicChatGenerator:
                     except json.JSONDecodeError:
                         logger.warning(
                             "Anthropic returned a malformed JSON string for tool call arguments. "
-                            "This tool call will be skipped. Arguments: {current_arguments}", current_arguments=current_tool_call.get('arguments', '')
+                            "This tool call will be skipped. Arguments: {current_arguments}",
+                            current_arguments=current_tool_call.get("arguments", ""),
                         )
                     current_tool_call = None
 
@@ -405,7 +406,8 @@ class AnthropicChatGenerator:
         disallowed_params = set(generation_kwargs) - set(self.ALLOWED_PARAMS)
         if disallowed_params:
             logger.warning(
-                "Model parameters {disallowed_params} are not allowed and will be ignored. Allowed parameters are {allowed_params}.",
+                "Model parameters {disallowed_params} are not allowed and will be ignored. "
+                "Allowed parameters are {allowed_params}.",
                 disallowed_params=disallowed_params,
                 allowed_params=self.ALLOWED_PARAMS,
             )

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -161,6 +161,7 @@ class AnthropicChatGenerator:
         "top_p",
         "top_k",
         "extra_headers",
+        "thinking",
     ]
 
     def __init__(
@@ -352,7 +353,7 @@ class AnthropicChatGenerator:
                     except json.JSONDecodeError:
                         logger.warning(
                             "Anthropic returned a malformed JSON string for tool call arguments. "
-                            f"This tool call will be skipped. Arguments: {current_tool_call.get('arguments', '')}",
+                            "This tool call will be skipped. Arguments: {current_arguments}", current_arguments=current_tool_call.get('arguments', '')
                         )
                     current_tool_call = None
 
@@ -404,9 +405,9 @@ class AnthropicChatGenerator:
         disallowed_params = set(generation_kwargs) - set(self.ALLOWED_PARAMS)
         if disallowed_params:
             logger.warning(
-                "Model parameters %s are not allowed and will be ignored. Allowed parameters are %s.",
-                disallowed_params,
-                self.ALLOWED_PARAMS,
+                "Model parameters {disallowed_params} are not allowed and will be ignored. Allowed parameters are {allowed_params}.",
+                disallowed_params=disallowed_params,
+                allowed_params=self.ALLOWED_PARAMS,
             )
         generation_kwargs = {k: v for k, v in generation_kwargs.items() if k in self.ALLOWED_PARAMS}
 

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
@@ -48,6 +48,7 @@ class AnthropicGenerator:
         "temperature",
         "top_p",
         "top_k",
+        "thinking",
     ]
 
     def __init__(
@@ -138,8 +139,10 @@ class AnthropicGenerator:
         disallowed_params = set(generation_kwargs) - set(self.ALLOWED_PARAMS)
         if disallowed_params:
             logger.warning(
-                f"Model parameters {disallowed_params} are not allowed and will be ignored. "
-                f"Allowed parameters are {self.ALLOWED_PARAMS}."
+                "Model parameters {disallowed_params} are not allowed and will be ignored. "
+                "Allowed parameters are {allowed_params}.",
+                disallowed_params=disallowed_params,
+                allowed_params=self.ALLOWED_PARAMS
             )
 
         streaming_callback = streaming_callback or self.streaming_callback

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
@@ -142,7 +142,7 @@ class AnthropicGenerator:
                 "Model parameters {disallowed_params} are not allowed and will be ignored. "
                 "Allowed parameters are {allowed_params}.",
                 disallowed_params=disallowed_params,
-                allowed_params=self.ALLOWED_PARAMS
+                allowed_params=self.ALLOWED_PARAMS,
             )
 
         streaming_callback = streaming_callback or self.streaming_callback


### PR DESCRIPTION
### Related Issues

Fixes wrong use of the haystack logger and adds the thinking parameter to allowed params.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
