### PR TITLE
test: pinecone - increase sleep time in tests

### DIFF
--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
 # This is the approximate time in seconds it takes for the documents to be available
-SLEEP_TIME_IN_SECONDS = 18
+SLEEP_TIME_IN_SECONDS = 25
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Related Issues

Pinecone nightly tests have been failing intermittently for several days: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13688201316/job/38276265885

It seems that Pinecone servers got slower recently

### Proposed Changes:
- increase the sleep time: tests take longer, but hopefully we will get less failures

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
