### PR TITLE
chore: AmazonBedrock - remove max length 

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 from haystack.dataclasses import StreamingChunk
 
@@ -13,9 +13,8 @@ class BedrockModelAdapter(ABC):
     focusing on preparing the requests and extracting the responses from the Amazon Bedrock hosted LLMs.
     """
 
-    def __init__(self, model_kwargs: Dict[str, Any], max_length: Optional[int]) -> None:
+    def __init__(self, model_kwargs: Dict[str, Any]) -> None:
         self.model_kwargs = model_kwargs
-        self.max_length = max_length
 
     @abstractmethod
     def prepare_body(self, prompt: str, **inference_kwargs) -> Dict[str, Any]:
@@ -106,13 +105,13 @@ class AnthropicClaudeAdapter(BedrockModelAdapter):
     :param max_length: Maximum length of generated text
     """
 
-    def __init__(self, model_kwargs: Dict[str, Any], max_length: Optional[int]) -> None:
+    def __init__(self, model_kwargs: Dict[str, Any]) -> None:
         self.use_messages_api = model_kwargs.get("use_messages_api", True)
         self.include_thinking = model_kwargs.get("include_thinking", True)
         self.thinking_tag = model_kwargs.get("thinking_tag", "thinking")
         self.thinking_tag_start = f"<{self.thinking_tag}>" if self.thinking_tag else ""
         self.thinking_tag_end = f"</{self.thinking_tag}>\n\n" if self.thinking_tag else "\n\n"
-        super().__init__(model_kwargs, max_length)
+        super().__init__(model_kwargs)
 
     def prepare_body(self, prompt: str, **inference_kwargs) -> Dict[str, Any]:
         """
@@ -139,7 +138,6 @@ class AnthropicClaudeAdapter(BedrockModelAdapter):
             body = {"messages": [{"role": "user", "content": prompt}], **params}
         else:
             default_params = {
-                "max_tokens_to_sample": self.max_length,
                 "stop_sequences": ["\n\nHuman:"],
                 "temperature": None,
                 "top_p": None,

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
@@ -127,7 +127,6 @@ class AnthropicClaudeAdapter(BedrockModelAdapter):
         if self.use_messages_api:
             default_params: Dict[str, Any] = {
                 "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": self.max_length,
                 "system": None,
                 "stop_sequences": None,
                 "temperature": None,
@@ -213,7 +212,6 @@ class MistralAdapter(BedrockModelAdapter):
             - specified inference parameters.
         """
         default_params: Dict[str, Any] = {
-            "max_tokens": self.max_length,
             "stop": [],
             "temperature": None,
             "top_p": None,
@@ -263,7 +261,6 @@ class CohereCommandAdapter(BedrockModelAdapter):
             - specified inference parameters.
         """
         default_params = {
-            "max_tokens": self.max_length,
             "stop_sequences": None,
             "temperature": None,
             "p": None,
@@ -319,7 +316,6 @@ class CohereCommandRAdapter(BedrockModelAdapter):
             "documents": None,
             "search_query_only": None,
             "preamble": None,
-            "max_tokens": self.max_length,
             "temperature": None,
             "p": None,
             "k": None,
@@ -374,7 +370,6 @@ class AI21LabsJurassic2Adapter(BedrockModelAdapter):
             - specified inference parameters.
         """
         default_params = {
-            "maxTokens": self.max_length,
             "stopSequences": None,
             "temperature": None,
             "topP": None,
@@ -413,7 +408,6 @@ class AmazonTitanAdapter(BedrockModelAdapter):
             - specified inference parameters.
         """
         default_params = {
-            "maxTokenCount": self.max_length,
             "stopSequences": None,
             "temperature": None,
             "topP": None,
@@ -459,7 +453,6 @@ class MetaLlamaAdapter(BedrockModelAdapter):
             - specified inference parameters.
         """
         default_params = {
-            "max_gen_len": self.max_length,
             "temperature": None,
             "top_p": None,
         }

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -142,7 +142,8 @@ class AmazonBedrockGenerator:
         if max_length is not None or truncate is not None:
             warnings.warn(
                 "The 'max_length' and 'truncate' parameters have been removed and no longer have any effect. "
-                "No truncation will be performed.",
+                "No truncation will be performed. To control the length of the generated text, use "
+                "the 'max_tokens' (or the model-specific variant) in the generation_kwargs of the run method.",
                 stacklevel=2,
             )
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -182,7 +182,7 @@ class AmazonBedrockGenerator:
         model_input_kwargs = kwargs
 
         model_adapter_cls = self.get_model_adapter(model=model, model_family=model_family)
-        self.model_adapter = model_adapter_cls(model_kwargs=model_input_kwargs, max_length=self.max_length)
+        self.model_adapter = model_adapter_cls(model_kwargs=model_input_kwargs)
 
     @component.output_types(replies=List[str])
     def run(

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -250,7 +250,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         prompt = "Hello, how are you?"
         expected_body = {
             "messages": [{"role": "user", "content": "Hello, how are you?"}],
-            "max_tokens": 99,
             "anthropic_version": "bedrock-2023-05-31",
         }
 
@@ -263,7 +262,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         prompt = "Hello, how are you?"
         expected_body = {
             "messages": [{"role": "user", "content": "Hello, how are you?"}],
-            "max_tokens": 50,
             "stop_sequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "top_p": 0.8,
@@ -278,7 +276,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             temperature=0.7,
             top_p=0.8,
             top_k=5,
-            max_tokens=50,
             stop_sequences=["CUSTOM_STOP"],
             system="system prompt",
             anthropic_version="custom_version",
@@ -294,7 +291,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
                 "temperature": 0.7,
                 "top_p": 0.8,
                 "top_k": 5,
-                "max_tokens": 50,
                 "stop_sequences": ["CUSTOM_STOP"],
                 "system": "system prompt",
                 "anthropic_version": "custom_version",
@@ -306,7 +302,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         prompt = "Hello, how are you?"
         expected_body = {
             "messages": [{"role": "user", "content": "Hello, how are you?"}],
-            "max_tokens": 50,
             "stop_sequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "top_p": 0.8,
@@ -326,7 +321,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
                 "temperature": 0.6,
                 "top_p": 0.7,
                 "top_k": 4,
-                "max_tokens": 49,
                 "stop_sequences": ["CUSTOM_STOP_MODEL_KWARGS"],
                 "system": "system prompt",
                 "anthropic_version": "custom_version",
@@ -337,7 +331,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         prompt = "Hello, how are you?"
         expected_body = {
             "messages": [{"role": "user", "content": "Hello, how are you?"}],
-            "max_tokens": 50,
             "stop_sequences": ["CUSTOM_STOP_MODEL_KWARGS"],
             "temperature": 0.7,
             "top_p": 0.8,
@@ -352,7 +345,6 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             temperature=0.7,
             top_p=0.8,
             top_k=5,
-            max_tokens=50,
             system="new system prompt",
             anthropic_version="new_custom_version",
             thinking={"type": "enabled", "budget_tokens": 2048},
@@ -854,7 +846,7 @@ class TestMistralAdapter:
     def test_prepare_body_with_default_params(self) -> None:
         layer = MistralAdapter(model_kwargs={}, max_length=99)
         prompt = "Hello, how are you?"
-        expected_body = {"prompt": "<s>[INST] Hello, how are you? [/INST]", "max_tokens": 99, "stop": []}
+        expected_body = {"prompt": "<s>[INST] Hello, how are you? [/INST]", "stop": []}
 
         body = layer.prepare_body(prompt)
         assert body == expected_body
@@ -864,7 +856,6 @@ class TestMistralAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "<s>[INST] Hello, how are you? [/INST]",
-            "max_tokens": 50,
             "stop": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "top_p": 0.8,
@@ -876,7 +867,6 @@ class TestMistralAdapter:
             temperature=0.7,
             top_p=0.8,
             top_k=5,
-            max_tokens=50,
             stop=["CUSTOM_STOP"],
             unknown_arg="unknown_value",
         )
@@ -889,7 +879,6 @@ class TestMistralAdapter:
                 "temperature": 0.7,
                 "top_p": 0.8,
                 "top_k": 5,
-                "max_tokens": 50,
                 "stop": ["CUSTOM_STOP"],
                 "unknown_arg": "unknown_value",
             },
@@ -898,7 +887,6 @@ class TestMistralAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "<s>[INST] Hello, how are you? [/INST]",
-            "max_tokens": 50,
             "stop": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "top_p": 0.8,
@@ -915,7 +903,6 @@ class TestMistralAdapter:
                 "temperature": 0.6,
                 "top_p": 0.7,
                 "top_k": 4,
-                "max_tokens": 49,
                 "stop": ["CUSTOM_STOP_MODEL_KWARGS"],
             },
             max_length=99,
@@ -923,14 +910,13 @@ class TestMistralAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "<s>[INST] Hello, how are you? [/INST]",
-            "max_tokens": 50,
             "stop": ["CUSTOM_STOP_MODEL_KWARGS"],
             "temperature": 0.7,
             "top_p": 0.8,
             "top_k": 5,
         }
 
-        body = layer.prepare_body(prompt, temperature=0.7, top_p=0.8, top_k=5, max_tokens=50)
+        body = layer.prepare_body(prompt, temperature=0.7, top_p=0.8, top_k=5)
 
         assert body == expected_body
 
@@ -972,8 +958,6 @@ class TestMistralAdapter:
 
         stream_mock.__iter__.return_value = []
 
-        streaming_callback_mock.side_effect = lambda token_received, **kwargs: token_received
-
         adapter = MistralAdapter(model_kwargs={}, max_length=99)
         expected_responses = [""]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
@@ -985,7 +969,7 @@ class TestCohereCommandAdapter:
     def test_prepare_body_with_default_params(self) -> None:
         layer = CohereCommandAdapter(model_kwargs={}, max_length=99)
         prompt = "Hello, how are you?"
-        expected_body = {"prompt": "Hello, how are you?", "max_tokens": 99}
+        expected_body = {"prompt": "Hello, how are you?"}
 
         body = layer.prepare_body(prompt)
 
@@ -996,7 +980,6 @@ class TestCohereCommandAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "max_tokens": 50,
             "stop_sequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "p": 0.8,
@@ -1013,7 +996,6 @@ class TestCohereCommandAdapter:
             temperature=0.7,
             p=0.8,
             k=5,
-            max_tokens=50,
             stop_sequences=["CUSTOM_STOP"],
             return_likelihoods="GENERATION",
             stream=True,
@@ -1031,7 +1013,6 @@ class TestCohereCommandAdapter:
                 "temperature": 0.7,
                 "p": 0.8,
                 "k": 5,
-                "max_tokens": 50,
                 "stop_sequences": ["CUSTOM_STOP"],
                 "return_likelihoods": "GENERATION",
                 "stream": True,
@@ -1045,7 +1026,6 @@ class TestCohereCommandAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "max_tokens": 50,
             "stop_sequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "p": 0.8,
@@ -1067,7 +1047,6 @@ class TestCohereCommandAdapter:
                 "temperature": 0.6,
                 "p": 0.7,
                 "k": 4,
-                "max_tokens": 49,
                 "stop_sequences": ["CUSTOM_STOP_MODEL_KWARGS"],
                 "return_likelihoods": "ALL",
                 "stream": False,
@@ -1080,7 +1059,6 @@ class TestCohereCommandAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "max_tokens": 50,
             "stop_sequences": ["CUSTOM_STOP_MODEL_KWARGS"],
             "temperature": 0.7,
             "p": 0.8,
@@ -1097,7 +1075,6 @@ class TestCohereCommandAdapter:
             temperature=0.7,
             p=0.8,
             k=5,
-            max_tokens=50,
             return_likelihoods="GENERATION",
             stream=True,
             logit_bias={"token_id": 10.0},
@@ -1236,7 +1213,6 @@ class TestCohereCommandRAdapter:
             ],
             "search_query_only": False,
             "preamble": "preamble",
-            "max_tokens": 100,
             "temperature": 0,
             "p": 0.9,
             "k": 50,
@@ -1286,7 +1262,7 @@ class TestAI21LabsJurassic2Adapter:
     def test_prepare_body_with_default_params(self) -> None:
         layer = AI21LabsJurassic2Adapter(model_kwargs={}, max_length=99)
         prompt = "Hello, how are you?"
-        expected_body = {"prompt": "Hello, how are you?", "maxTokens": 99}
+        expected_body = {"prompt": "Hello, how are you?"}
 
         body = layer.prepare_body(prompt)
 
@@ -1297,7 +1273,6 @@ class TestAI21LabsJurassic2Adapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "maxTokens": 50,
             "stopSequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "topP": 0.8,
@@ -1309,7 +1284,6 @@ class TestAI21LabsJurassic2Adapter:
 
         body = layer.prepare_body(
             prompt,
-            maxTokens=50,
             stopSequences=["CUSTOM_STOP"],
             temperature=0.7,
             topP=0.8,
@@ -1325,7 +1299,6 @@ class TestAI21LabsJurassic2Adapter:
     def test_prepare_body_with_model_kwargs(self) -> None:
         layer = AI21LabsJurassic2Adapter(
             model_kwargs={
-                "maxTokens": 50,
                 "stopSequences": ["CUSTOM_STOP"],
                 "temperature": 0.7,
                 "topP": 0.8,
@@ -1340,7 +1313,6 @@ class TestAI21LabsJurassic2Adapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "maxTokens": 50,
             "stopSequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "topP": 0.8,
@@ -1357,7 +1329,6 @@ class TestAI21LabsJurassic2Adapter:
     def test_prepare_body_with_model_kwargs_and_custom_inference_params(self) -> None:
         layer = AI21LabsJurassic2Adapter(
             model_kwargs={
-                "maxTokens": 49,
                 "stopSequences": ["CUSTOM_STOP_MODEL_KWARGS"],
                 "temperature": 0.6,
                 "topP": 0.7,
@@ -1372,7 +1343,6 @@ class TestAI21LabsJurassic2Adapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "maxTokens": 50,
             "stopSequences": ["CUSTOM_STOP_MODEL_KWARGS"],
             "temperature": 0.7,
             "topP": 0.8,
@@ -1386,7 +1356,6 @@ class TestAI21LabsJurassic2Adapter:
             prompt,
             temperature=0.7,
             topP=0.8,
-            maxTokens=50,
             countPenalty={"scale": 1.0},
             presencePenalty={"scale": 5.0},
             frequencyPenalty={"scale": 500.0},
@@ -1428,7 +1397,7 @@ class TestAmazonTitanAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "inputText": "Hello, how are you?",
-            "textGenerationConfig": {"maxTokenCount": 99},
+            "textGenerationConfig": {},
         }
 
         body = layer.prepare_body(prompt)
@@ -1441,7 +1410,6 @@ class TestAmazonTitanAdapter:
         expected_body = {
             "inputText": "Hello, how are you?",
             "textGenerationConfig": {
-                "maxTokenCount": 50,
                 "stopSequences": ["CUSTOM_STOP"],
                 "temperature": 0.7,
                 "topP": 0.8,
@@ -1450,7 +1418,6 @@ class TestAmazonTitanAdapter:
 
         body = layer.prepare_body(
             prompt,
-            maxTokenCount=50,
             stopSequences=["CUSTOM_STOP"],
             temperature=0.7,
             topP=0.8,
@@ -1462,7 +1429,6 @@ class TestAmazonTitanAdapter:
     def test_prepare_body_with_model_kwargs(self) -> None:
         layer = AmazonTitanAdapter(
             model_kwargs={
-                "maxTokenCount": 50,
                 "stopSequences": ["CUSTOM_STOP"],
                 "temperature": 0.7,
                 "topP": 0.8,
@@ -1474,7 +1440,6 @@ class TestAmazonTitanAdapter:
         expected_body = {
             "inputText": "Hello, how are you?",
             "textGenerationConfig": {
-                "maxTokenCount": 50,
                 "stopSequences": ["CUSTOM_STOP"],
                 "temperature": 0.7,
                 "topP": 0.8,
@@ -1488,7 +1453,6 @@ class TestAmazonTitanAdapter:
     def test_prepare_body_with_model_kwargs_and_custom_inference_params(self) -> None:
         layer = AmazonTitanAdapter(
             model_kwargs={
-                "maxTokenCount": 49,
                 "stopSequences": ["CUSTOM_STOP_MODEL_KWARGS"],
                 "temperature": 0.6,
                 "topP": 0.7,
@@ -1499,14 +1463,13 @@ class TestAmazonTitanAdapter:
         expected_body = {
             "inputText": "Hello, how are you?",
             "textGenerationConfig": {
-                "maxTokenCount": 50,
                 "stopSequences": ["CUSTOM_STOP_MODEL_KWARGS"],
                 "temperature": 0.7,
                 "topP": 0.8,
             },
         }
 
-        body = layer.prepare_body(prompt, temperature=0.7, topP=0.8, maxTokenCount=50)
+        body = layer.prepare_body(prompt, temperature=0.7, topP=0.8)
 
         assert body == expected_body
 
@@ -1579,7 +1542,7 @@ class TestMetaLlamaAdapter:
     def test_prepare_body_with_default_params(self) -> None:
         layer = MetaLlamaAdapter(model_kwargs={}, max_length=99)
         prompt = "Hello, how are you?"
-        expected_body = {"prompt": "Hello, how are you?", "max_gen_len": 99}
+        expected_body = {"prompt": "Hello, how are you?"}
 
         body = layer.prepare_body(prompt)
 
@@ -1590,7 +1553,6 @@ class TestMetaLlamaAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "max_gen_len": 50,
             "temperature": 0.7,
             "top_p": 0.8,
         }
@@ -1599,7 +1561,6 @@ class TestMetaLlamaAdapter:
             prompt,
             temperature=0.7,
             top_p=0.8,
-            max_gen_len=50,
             unknown_arg="unknown_value",
         )
 
@@ -1610,7 +1571,6 @@ class TestMetaLlamaAdapter:
             model_kwargs={
                 "temperature": 0.7,
                 "top_p": 0.8,
-                "max_gen_len": 50,
                 "unknown_arg": "unknown_value",
             },
             max_length=99,
@@ -1618,7 +1578,6 @@ class TestMetaLlamaAdapter:
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "max_gen_len": 50,
             "temperature": 0.7,
             "top_p": 0.8,
         }
@@ -1633,19 +1592,17 @@ class TestMetaLlamaAdapter:
                 "temperature": 0.6,
                 "top_p": 0.7,
                 "top_k": 4,
-                "max_gen_len": 49,
             },
             max_length=99,
         )
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
-            "max_gen_len": 50,
             "temperature": 0.7,
             "top_p": 0.7,
         }
 
-        body = layer.prepare_body(prompt, temperature=0.7, max_gen_len=50)
+        body = layer.prepare_body(prompt, temperature=0.7)
 
         assert body == expected_body
 

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -236,17 +236,17 @@ def test_get_model_adapter_model_family_over_auto_detection():
 
 class TestAnthropicClaudeAdapter:
     def test_default_init(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=100)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         assert adapter.use_messages_api is True
 
     def test_use_messages_api_false(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False}, max_length=100)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False})
         assert adapter.use_messages_api is False
 
 
 class TestAnthropicClaudeAdapterMessagesAPI:
     def test_prepare_body_with_default_params(self) -> None:
-        layer = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        layer = AnthropicClaudeAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "messages": [{"role": "user", "content": "Hello, how are you?"}],
@@ -258,7 +258,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         assert body == expected_body
 
     def test_prepare_body_with_custom_inference_params(self) -> None:
-        layer = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        layer = AnthropicClaudeAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "messages": [{"role": "user", "content": "Hello, how are you?"}],
@@ -296,8 +296,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
                 "anthropic_version": "custom_version",
                 "unknown_arg": "unknown_value",
                 "thinking": {"type": "enabled", "budget_tokens": 1024},
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -325,8 +324,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
                 "system": "system prompt",
                 "anthropic_version": "custom_version",
                 "thinking": {"type": "enabled", "budget_tokens": 1024},
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -353,19 +351,19 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         assert body == expected_body
 
     def test_get_responses(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         response_body = {"content": [{"text": "This is a single response."}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_leading_whitespace(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         response_body = {"content": [{"text": "\n\t This is a single response."}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_with_thinking(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         response_body = {
             "content": [
                 {"thinking": "This is a thinking part.", "type": "thinking"},
@@ -376,7 +374,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_with_thinking_include_thinking_false(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={"include_thinking": False}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"include_thinking": False})
         response_body = {
             "content": [
                 {"thinking": "This is a thinking part.", "type": "thinking"},
@@ -387,7 +385,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_with_thinking_custom_thinking_tag(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": "custom"}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": "custom"})
         response_body = {
             "content": [
                 {"thinking": "This is a thinking part.", "type": "thinking"},
@@ -398,7 +396,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_with_thinking_no_thinking_tag(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": None}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": None})
         response_body = {
             "content": [
                 {"thinking": "This is a thinking part.", "type": "thinking"},
@@ -409,7 +407,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_with_thinking_redacted_thinking_is_ignored(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         response_body = {
             "content": [
                 {"thinking": "This is a thinking part.", "type": "thinking"},
@@ -433,7 +431,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             {"chunk": {"bytes": b'{"delta": {"text": " response."}}'}},
         ]
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         expected_responses = ["This is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -453,7 +451,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
 
         stream_mock.__iter__.return_value = []
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         expected_responses = [""]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -478,7 +476,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             {"chunk": {"bytes": b'{"delta": {"text": " response."}}'}},
         ]
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         expected_responses = ["<thinking>This is a thinking part.</thinking>\n\nThis is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -528,7 +526,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             {"chunk": {"bytes": b'{"delta": {"text": " response."}}'}},
         ]
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={"include_thinking": False}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"include_thinking": False})
         expected_responses = ["This is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -561,7 +559,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             {"chunk": {"bytes": b'{"delta": {"text": " response."}}'}},
         ]
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": "custom"}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": "custom"})
         expected_responses = ["<custom>This is a thinking part.</custom>\n\nThis is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -611,7 +609,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             {"chunk": {"bytes": b'{"delta": {"text": " response."}}'}},
         ]
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": None}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"thinking_tag": None})
         expected_responses = ["This is a thinking part.\n\nThis is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -668,7 +666,7 @@ class TestAnthropicClaudeAdapterMessagesAPI:
             {"chunk": {"bytes": b'{"delta": {"text": " response."}}'}},
         ]
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={})
         expected_responses = ["<thinking>This is a thinking part.</thinking>\n\nThis is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -702,11 +700,10 @@ class TestAnthropicClaudeAdapterMessagesAPI:
 
 class TestAnthropicClaudeAdapterNoMessagesAPI:
     def test_prepare_body_with_default_params(self) -> None:
-        layer = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False}, max_length=99)
+        layer = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False})
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "\n\nHuman: Hello, how are you?\n\nAssistant:",
-            "max_tokens_to_sample": 99,
             "stop_sequences": ["\n\nHuman:"],
         }
 
@@ -715,11 +712,10 @@ class TestAnthropicClaudeAdapterNoMessagesAPI:
         assert body == expected_body
 
     def test_prepare_body_with_custom_inference_params(self) -> None:
-        layer = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False}, max_length=99)
+        layer = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False})
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "\n\nHuman: Hello, how are you?\n\nAssistant:",
-            "max_tokens_to_sample": 50,
             "stop_sequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "top_p": 0.8,
@@ -745,16 +741,13 @@ class TestAnthropicClaudeAdapterNoMessagesAPI:
                 "temperature": 0.7,
                 "top_p": 0.8,
                 "top_k": 5,
-                "max_tokens_to_sample": 50,
                 "stop_sequences": ["CUSTOM_STOP"],
                 "unknown_arg": "unknown_value",
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "\n\nHuman: Hello, how are you?\n\nAssistant:",
-            "max_tokens_to_sample": 50,
             "stop_sequences": ["CUSTOM_STOP"],
             "temperature": 0.7,
             "top_p": 0.8,
@@ -772,33 +765,30 @@ class TestAnthropicClaudeAdapterNoMessagesAPI:
                 "temperature": 0.6,
                 "top_p": 0.7,
                 "top_k": 4,
-                "max_tokens_to_sample": 49,
                 "stop_sequences": ["CUSTOM_STOP_MODEL_KWARGS"],
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "\n\nHuman: Hello, how are you?\n\nAssistant:",
-            "max_tokens_to_sample": 50,
             "stop_sequences": ["CUSTOM_STOP_MODEL_KWARGS"],
             "temperature": 0.7,
             "top_p": 0.8,
             "top_k": 5,
         }
 
-        body = layer.prepare_body(prompt, temperature=0.7, top_p=0.8, top_k=5, max_tokens_to_sample=50)
+        body = layer.prepare_body(prompt, temperature=0.7, top_p=0.8, top_k=5)
 
         assert body == expected_body
 
     def test_get_responses(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False})
         response_body = {"completion": "This is a single response."}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_leading_whitespace(self) -> None:
-        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False})
         response_body = {"completion": "\n\t This is a single response."}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
@@ -815,7 +805,7 @@ class TestAnthropicClaudeAdapterNoMessagesAPI:
             {"chunk": {"bytes": b'{"completion": " response."}'}},
         ]
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False})
         expected_responses = ["This is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -835,7 +825,7 @@ class TestAnthropicClaudeAdapterNoMessagesAPI:
 
         stream_mock.__iter__.return_value = []
 
-        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False}, max_length=99)
+        adapter = AnthropicClaudeAdapter(model_kwargs={"use_messages_api": False})
         expected_responses = [""]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -844,7 +834,7 @@ class TestAnthropicClaudeAdapterNoMessagesAPI:
 
 class TestMistralAdapter:
     def test_prepare_body_with_default_params(self) -> None:
-        layer = MistralAdapter(model_kwargs={}, max_length=99)
+        layer = MistralAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {"prompt": "<s>[INST] Hello, how are you? [/INST]", "stop": []}
 
@@ -852,7 +842,7 @@ class TestMistralAdapter:
         assert body == expected_body
 
     def test_prepare_body_with_custom_inference_params(self) -> None:
-        layer = MistralAdapter(model_kwargs={}, max_length=99)
+        layer = MistralAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "<s>[INST] Hello, how are you? [/INST]",
@@ -881,8 +871,7 @@ class TestMistralAdapter:
                 "top_k": 5,
                 "stop": ["CUSTOM_STOP"],
                 "unknown_arg": "unknown_value",
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -904,8 +893,7 @@ class TestMistralAdapter:
                 "top_p": 0.7,
                 "top_k": 4,
                 "stop": ["CUSTOM_STOP_MODEL_KWARGS"],
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -921,7 +909,7 @@ class TestMistralAdapter:
         assert body == expected_body
 
     def test_get_responses(self) -> None:
-        adapter = MistralAdapter(model_kwargs={}, max_length=99)
+        adapter = MistralAdapter(model_kwargs={})
         response_body = {"outputs": [{"text": "This is a single response."}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
@@ -938,7 +926,7 @@ class TestMistralAdapter:
             {"chunk": {"bytes": b'{"outputs": [{"text": " response."}]}'}},
         ]
 
-        adapter = MistralAdapter(model_kwargs={}, max_length=99)
+        adapter = MistralAdapter(model_kwargs={})
         expected_responses = ["This is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -958,7 +946,7 @@ class TestMistralAdapter:
 
         stream_mock.__iter__.return_value = []
 
-        adapter = MistralAdapter(model_kwargs={}, max_length=99)
+        adapter = MistralAdapter(model_kwargs={})
         expected_responses = [""]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -967,7 +955,7 @@ class TestMistralAdapter:
 
 class TestCohereCommandAdapter:
     def test_prepare_body_with_default_params(self) -> None:
-        layer = CohereCommandAdapter(model_kwargs={}, max_length=99)
+        layer = CohereCommandAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {"prompt": "Hello, how are you?"}
 
@@ -976,7 +964,7 @@ class TestCohereCommandAdapter:
         assert body == expected_body
 
     def test_prepare_body_with_custom_inference_params(self) -> None:
-        layer = CohereCommandAdapter(model_kwargs={}, max_length=99)
+        layer = CohereCommandAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
@@ -1020,8 +1008,7 @@ class TestCohereCommandAdapter:
                 "num_generations": 1,
                 "truncate": "START",
                 "unknown_arg": "unknown_value",
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1053,8 +1040,7 @@ class TestCohereCommandAdapter:
                 "logit_bias": {"token_id": 9.0},
                 "num_generations": 2,
                 "truncate": "NONE",
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1085,19 +1071,19 @@ class TestCohereCommandAdapter:
         assert body == expected_body
 
     def test_get_responses(self) -> None:
-        adapter = CohereCommandAdapter(model_kwargs={}, max_length=99)
+        adapter = CohereCommandAdapter(model_kwargs={})
         response_body = {"generations": [{"text": "This is a single response."}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_leading_whitespace(self) -> None:
-        adapter = CohereCommandAdapter(model_kwargs={}, max_length=99)
+        adapter = CohereCommandAdapter(model_kwargs={})
         response_body = {"generations": [{"text": "\n\t This is a single response."}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_multiple_responses(self) -> None:
-        adapter = CohereCommandAdapter(model_kwargs={}, max_length=99)
+        adapter = CohereCommandAdapter(model_kwargs={})
         response_body = {
             "generations": [
                 {"text": "This is a single response."},
@@ -1123,7 +1109,7 @@ class TestCohereCommandAdapter:
             {"chunk": {"bytes": b'{"finish_reason": "MAX_TOKENS", "is_finished": true}'}},
         ]
 
-        adapter = CohereCommandAdapter(model_kwargs={}, max_length=99)
+        adapter = CohereCommandAdapter(model_kwargs={})
         expected_responses = ["This is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -1144,7 +1130,7 @@ class TestCohereCommandAdapter:
 
         stream_mock.__iter__.return_value = []
 
-        adapter = CohereCommandAdapter(model_kwargs={}, max_length=99)
+        adapter = CohereCommandAdapter(model_kwargs={})
         expected_responses = [""]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -1198,8 +1184,7 @@ class TestCohereCommandRAdapter:
                 "raw_prompting": True,
                 "stream": True,
                 "unknown_arg": "unknown_arg",
-            },
-            max_length=100,
+            }
         )
         body = adapter.prepare_body(prompt="test")
         assert body == {
@@ -1246,13 +1231,13 @@ class TestCohereCommandRAdapter:
         }
 
     def test_extract_completions_from_response(self) -> None:
-        adapter = CohereCommandRAdapter(model_kwargs={}, max_length=100)
+        adapter = CohereCommandRAdapter(model_kwargs={})
         response_body = {"text": "response"}
         completions = adapter._extract_completions_from_response(response_body=response_body)
         assert completions == ["response"]
 
     def test_build_chunk(self) -> None:
-        adapter = CohereCommandRAdapter(model_kwargs={}, max_length=100)
+        adapter = CohereCommandRAdapter(model_kwargs={})
         chunk = {"text": "response_token"}
         streaming_chunk = adapter._build_streaming_chunk(chunk=chunk)
         assert streaming_chunk == StreamingChunk(content="response_token", meta=chunk)
@@ -1260,7 +1245,7 @@ class TestCohereCommandRAdapter:
 
 class TestAI21LabsJurassic2Adapter:
     def test_prepare_body_with_default_params(self) -> None:
-        layer = AI21LabsJurassic2Adapter(model_kwargs={}, max_length=99)
+        layer = AI21LabsJurassic2Adapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {"prompt": "Hello, how are you?"}
 
@@ -1269,7 +1254,7 @@ class TestAI21LabsJurassic2Adapter:
         assert body == expected_body
 
     def test_prepare_body_with_custom_inference_params(self) -> None:
-        layer = AI21LabsJurassic2Adapter(model_kwargs={}, max_length=99)
+        layer = AI21LabsJurassic2Adapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
@@ -1307,8 +1292,7 @@ class TestAI21LabsJurassic2Adapter:
                 "frequencyPenalty": {"scale": 500.0},
                 "numResults": 1,
                 "unknown_arg": "unknown_value",
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1337,8 +1321,7 @@ class TestAI21LabsJurassic2Adapter:
                 "frequencyPenalty": {"scale": 499.0},
                 "numResults": 2,
                 "unknown_arg": "unknown_value",
-            },
-            max_length=99,
+            }
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1365,19 +1348,19 @@ class TestAI21LabsJurassic2Adapter:
         assert body == expected_body
 
     def test_get_responses(self) -> None:
-        adapter = AI21LabsJurassic2Adapter(model_kwargs={}, max_length=99)
+        adapter = AI21LabsJurassic2Adapter(model_kwargs={})
         response_body = {"completions": [{"data": {"text": "This is a single response."}}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_leading_whitespace(self) -> None:
-        adapter = AI21LabsJurassic2Adapter(model_kwargs={}, max_length=99)
+        adapter = AI21LabsJurassic2Adapter(model_kwargs={})
         response_body = {"completions": [{"data": {"text": "\n\t This is a single response."}}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_multiple_responses(self) -> None:
-        adapter = AI21LabsJurassic2Adapter(model_kwargs={}, max_length=99)
+        adapter = AI21LabsJurassic2Adapter(model_kwargs={})
         response_body = {
             "completions": [
                 {"data": {"text": "This is a single response."}},
@@ -1393,7 +1376,7 @@ class TestAI21LabsJurassic2Adapter:
 
 class TestAmazonTitanAdapter:
     def test_prepare_body_with_default_params(self) -> None:
-        layer = AmazonTitanAdapter(model_kwargs={}, max_length=99)
+        layer = AmazonTitanAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "inputText": "Hello, how are you?",
@@ -1405,7 +1388,7 @@ class TestAmazonTitanAdapter:
         assert body == expected_body
 
     def test_prepare_body_with_custom_inference_params(self) -> None:
-        layer = AmazonTitanAdapter(model_kwargs={}, max_length=99)
+        layer = AmazonTitanAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "inputText": "Hello, how are you?",
@@ -1434,7 +1417,6 @@ class TestAmazonTitanAdapter:
                 "topP": 0.8,
                 "unknown_arg": "unknown_value",
             },
-            max_length=99,
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1457,7 +1439,6 @@ class TestAmazonTitanAdapter:
                 "temperature": 0.6,
                 "topP": 0.7,
             },
-            max_length=99,
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1474,19 +1455,19 @@ class TestAmazonTitanAdapter:
         assert body == expected_body
 
     def test_get_responses(self) -> None:
-        adapter = AmazonTitanAdapter(model_kwargs={}, max_length=99)
+        adapter = AmazonTitanAdapter(model_kwargs={})
         response_body = {"results": [{"outputText": "This is a single response."}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_leading_whitespace(self) -> None:
-        adapter = AmazonTitanAdapter(model_kwargs={}, max_length=99)
+        adapter = AmazonTitanAdapter(model_kwargs={})
         response_body = {"results": [{"outputText": "\n\t This is a single response."}]}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_multiple_responses(self) -> None:
-        adapter = AmazonTitanAdapter(model_kwargs={}, max_length=99)
+        adapter = AmazonTitanAdapter(model_kwargs={})
         response_body = {
             "results": [
                 {"outputText": "This is a single response."},
@@ -1511,7 +1492,7 @@ class TestAmazonTitanAdapter:
             {"chunk": {"bytes": b'{"outputText": " response."}'}},
         ]
 
-        adapter = AmazonTitanAdapter(model_kwargs={}, max_length=99)
+        adapter = AmazonTitanAdapter(model_kwargs={})
         expected_responses = ["This is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -1531,7 +1512,7 @@ class TestAmazonTitanAdapter:
 
         stream_mock.__iter__.return_value = []
 
-        adapter = AmazonTitanAdapter(model_kwargs={}, max_length=99)
+        adapter = AmazonTitanAdapter(model_kwargs={})
         expected_responses = [""]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -1540,7 +1521,7 @@ class TestAmazonTitanAdapter:
 
 class TestMetaLlamaAdapter:
     def test_prepare_body_with_default_params(self) -> None:
-        layer = MetaLlamaAdapter(model_kwargs={}, max_length=99)
+        layer = MetaLlamaAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {"prompt": "Hello, how are you?"}
 
@@ -1549,7 +1530,7 @@ class TestMetaLlamaAdapter:
         assert body == expected_body
 
     def test_prepare_body_with_custom_inference_params(self) -> None:
-        layer = MetaLlamaAdapter(model_kwargs={}, max_length=99)
+        layer = MetaLlamaAdapter(model_kwargs={})
         prompt = "Hello, how are you?"
         expected_body = {
             "prompt": "Hello, how are you?",
@@ -1573,7 +1554,6 @@ class TestMetaLlamaAdapter:
                 "top_p": 0.8,
                 "unknown_arg": "unknown_value",
             },
-            max_length=99,
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1593,7 +1573,6 @@ class TestMetaLlamaAdapter:
                 "top_p": 0.7,
                 "top_k": 4,
             },
-            max_length=99,
         )
         prompt = "Hello, how are you?"
         expected_body = {
@@ -1607,13 +1586,13 @@ class TestMetaLlamaAdapter:
         assert body == expected_body
 
     def test_get_responses(self) -> None:
-        adapter = MetaLlamaAdapter(model_kwargs={}, max_length=99)
+        adapter = MetaLlamaAdapter(model_kwargs={})
         response_body = {"generation": "This is a single response."}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
 
     def test_get_responses_leading_whitespace(self) -> None:
-        adapter = MetaLlamaAdapter(model_kwargs={}, max_length=99)
+        adapter = MetaLlamaAdapter(model_kwargs={})
         response_body = {"generation": "\n\t This is a single response."}
         expected_responses = ["This is a single response."]
         assert adapter.get_responses(response_body) == expected_responses
@@ -1630,7 +1609,7 @@ class TestMetaLlamaAdapter:
             {"chunk": {"bytes": b'{"generation": " response."}'}},
         ]
 
-        adapter = MetaLlamaAdapter(model_kwargs={}, max_length=99)
+        adapter = MetaLlamaAdapter(model_kwargs={})
         expected_responses = ["This is a single response."]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 
@@ -1650,7 +1629,7 @@ class TestMetaLlamaAdapter:
 
         stream_mock.__iter__.return_value = []
 
-        adapter = MetaLlamaAdapter(model_kwargs={}, max_length=99)
+        adapter = MetaLlamaAdapter(model_kwargs={})
         expected_responses = [""]
         assert adapter.get_stream_responses(stream_mock, streaming_callback_mock) == expected_responses
 


### PR DESCRIPTION
This is one builds on previous [PR](https://github.com/deepset-ai/haystack-core-integrations/pull/1314/files) to completely remove max_length. User can as instructed in warning [message](https://github.com/deepset-ai/haystack-core-integrations/compare/remove_max_length?expand=1#diff-a86cb08c5c494f659efd55cf141082f799fa96c282aee145832a3eb962942381R146) pass the `generation_kwargs` parameter to control the generation length. 