### PR TITLE
refactor: Qdrant - raise error if existing collection is not compatible with Haystack

### DIFF
--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.12"]
 
     steps:
       - name: Support longpaths

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -866,10 +866,18 @@ class QdrantDocumentStore:
 
         collection_info = self.client.get_collection(collection_name)
 
-        has_named_vectors = (
-            isinstance(collection_info.config.params.vectors, dict)
-            and DENSE_VECTORS_NAME in collection_info.config.params.vectors
-        )
+        has_named_vectors = isinstance(collection_info.config.params.vectors, dict)
+
+        if has_named_vectors and DENSE_VECTORS_NAME not in collection_info.config.params.vectors:
+            msg = (
+                f"Collection '{collection_name}' already exists in Qdrant, "
+                f"but it has been originally created outside of Haystack and is not supported. "
+                f"If possible, you should create a new Document Store with Haystack. "
+                f"In case you want to migrate the existing collection, see an example script in "
+                f"https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/qdrant/src/"
+                f"haystack_integrations/document_stores/qdrant/migrate_to_sparse.py."
+            )
+            raise QdrantStoreError(msg)
 
         if self.use_sparse_embeddings and not has_named_vectors:
             msg = (
@@ -882,7 +890,7 @@ class QdrantDocumentStore:
             )
             raise QdrantStoreError(msg)
 
-        elif not self.use_sparse_embeddings and has_named_vectors:
+        if not self.use_sparse_embeddings and has_named_vectors:
             msg = (
                 f"Collection '{collection_name}' already exists in Qdrant, "
                 f"but it has been originally created with sparse embedding vectors."

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -1,5 +1,5 @@
 from typing import List
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from haystack import Document
@@ -15,6 +15,7 @@ from haystack.testing.document_store import (
 from qdrant_client.http import models as rest
 
 from haystack_integrations.document_stores.qdrant.document_store import (
+    DENSE_VECTORS_NAME,
     SPARSE_VECTORS_NAME,
     QdrantDocumentStore,
     QdrantStoreError,
@@ -151,3 +152,79 @@ class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocu
 
             with pytest.raises(QdrantStoreError):
                 document_store._query_hybrid(query_sparse_embedding=sparse_embedding, query_embedding=embedding)
+
+    def test_set_up_collection_with_existing_incompatible_collection(self):
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True)
+
+        # Mock collection info with named vectors but missing DENSE_VECTORS_NAME
+        mock_collection_info = MagicMock()
+        mock_collection_info.config.params.vectors = {"some_other_vector": MagicMock()}
+
+        with patch.object(document_store.client, "collection_exists", return_value=True), patch.object(
+            document_store.client, "get_collection", return_value=mock_collection_info
+        ):
+
+            with pytest.raises(QdrantStoreError, match="created outside of Haystack"):
+                document_store._set_up_collection("test_collection", 768, False, "cosine", True, False)
+
+    def test_set_up_collection_use_sparse_embeddings_true_without_named_vectors(self):
+        """Test that an error is raised when use_sparse_embeddings is True but collection doesn't have named vectors"""
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True)
+
+        # Mock collection info without named vectors
+        mock_collection_info = MagicMock()
+        mock_collection_info.config.params.vectors = MagicMock(spec=rest.VectorsConfig)
+
+        with patch.object(document_store.client, "collection_exists", return_value=True), patch.object(
+            document_store.client, "get_collection", return_value=mock_collection_info
+        ):
+
+            with pytest.raises(QdrantStoreError, match="without sparse embedding vectors"):
+                document_store._set_up_collection("test_collection", 768, False, "cosine", True, False)
+
+    def test_set_up_collection_use_sparse_embeddings_false_with_named_vectors(self):
+        """Test that an error is raised when use_sparse_embeddings is False but collection has named vectors"""
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=False)
+
+        # Mock collection info with named vectors
+        mock_collection_info = MagicMock()
+        mock_collection_info.config.params.vectors = {DENSE_VECTORS_NAME: MagicMock()}
+
+        with patch.object(document_store.client, "collection_exists", return_value=True), patch.object(
+            document_store.client, "get_collection", return_value=mock_collection_info
+        ):
+
+            with pytest.raises(QdrantStoreError, match="with sparse embedding vectors"):
+                document_store._set_up_collection("test_collection", 768, False, "cosine", False, False)
+
+    def test_set_up_collection_with_distance_mismatch(self):
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=False, similarity="cosine")
+
+        # Mock collection info with different distance
+        mock_collection_info = MagicMock()
+        mock_collection_info.config.params.vectors = MagicMock()
+        mock_collection_info.config.params.vectors.distance = rest.Distance.DOT
+        mock_collection_info.config.params.vectors.size = 768
+
+        with patch.object(document_store.client, "collection_exists", return_value=True), patch.object(
+            document_store.client, "get_collection", return_value=mock_collection_info
+        ):
+
+            with pytest.raises(ValueError, match="different similarity"):
+                document_store._set_up_collection("test_collection", 768, False, "cosine", False, False)
+
+    def test_set_up_collection_with_dimension_mismatch(self):
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=False, similarity="cosine")
+
+        # Mock collection info with different vector size
+        mock_collection_info = MagicMock()
+        mock_collection_info.config.params.vectors = MagicMock()
+        mock_collection_info.config.params.vectors.distance = rest.Distance.COSINE
+        mock_collection_info.config.params.vectors.size = 512
+
+        with patch.object(document_store.client, "collection_exists", return_value=True), patch.object(
+            document_store.client, "get_collection", return_value=mock_collection_info
+        ):
+
+            with pytest.raises(ValueError, match="different vector size"):
+                document_store._set_up_collection("test_collection", 768, False, "cosine", False, False)


### PR DESCRIPTION
### Related Issues

- related to #1434 (and #729)
- It happened several times that users try to use an existing Qdrant collection with Haystack and get errors

### Proposed Changes:
- when we are sure that the existing collection was created without Haystack and is not compatible, raise an informative error

### How did you test it?
CI; added several tests 

### Notes for the reviewer
I will also take care of updating docs

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
