### PR TITLE
test: skip tests that require credentials on PRs from forks for some integrations

### DIFF
--- a/integrations/azure_ai_search/tests/conftest.py
+++ b/integrations/azure_ai_search/tests/conftest.py
@@ -83,26 +83,19 @@ def document_store(request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def cleanup_indexes(request):
+def cleanup_indexes():
     """
     Fixture to clean up all remaining indexes at the end of the test session.
-    Only runs if in the session there is at least one test marked with 'integration'.
+    Only runs if Azure credentials are available.
     Automatically runs after all tests.
     """
-    # Check if any test in the session is marked as integration
-    has_integration_test = False
-    for item in request.session.items:
-        if item.get_closest_marker("integration"):
-            has_integration_test = True
-            break
-
-    if not has_integration_test:
-        yield
-        return
-
-    # the following happens only if there is at least one integration test in the session
     azure_endpoint = os.getenv("AZURE_SEARCH_SERVICE_ENDPOINT")
     api_key = os.getenv("AZURE_SEARCH_API_KEY")
+
+    # Skip cleanup if credentials aren't available
+    if not azure_endpoint or not api_key:
+        yield
+        return
 
     client = SearchIndexClient(azure_endpoint, AzureKeyCredential(api_key))
 

--- a/integrations/deepeval/tests/test_evaluator.py
+++ b/integrations/deepeval/tests/test_evaluator.py
@@ -269,7 +269,7 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params, monk
 # This integration test validates the evaluator by running it against the
 # OpenAI API. It is parameterized by the metric, the inputs to the evalutor
 # and the metric parameters.
-@pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "metric, inputs, metric_params",

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -31,7 +31,7 @@ def test_init_is_lazy(_mock_client):
 
 
 @pytest.mark.skipif(
-    "MONGO_CONNECTION_STRING" not in os.environ,
+    not os.environ.get("MONGO_CONNECTION_STRING"),
     reason="No MongoDB Atlas connection string provided",
 )
 @pytest.mark.integration

--- a/integrations/mongodb_atlas/tests/test_embedding_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_embedding_retrieval.py
@@ -11,7 +11,7 @@ from haystack_integrations.document_stores.mongodb_atlas import MongoDBAtlasDocu
 
 
 @pytest.mark.skipif(
-    "MONGO_CONNECTION_STRING" not in os.environ,
+    not os.environ.get("MONGO_CONNECTION_STRING"),
     reason="No MongoDB Atlas connection string provided",
 )
 @pytest.mark.integration

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -24,7 +24,7 @@ def get_document_store():
 
 
 @pytest.mark.skipif(
-    "MONGO_CONNECTION_STRING_2" not in os.environ,
+    not os.environ.get("MONGO_CONNECTION_STRING_2"),
     reason="No MongoDB Atlas connection string provided",
 )
 @pytest.mark.integration

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -212,7 +212,7 @@ def test_convert_meta_to_int():
 
 
 @pytest.mark.integration
-@pytest.mark.skipif("PINECONE_API_KEY" not in os.environ, reason="PINECONE_API_KEY not set")
+@pytest.mark.skipif(not os.environ.get("PINECONE_API_KEY"), reason="PINECONE_API_KEY not set")
 def test_serverless_index_creation_from_scratch(sleep_time):
     # we use a fixed index name to avoid hitting the limit of Pinecone's free tier (max 5 indexes)
     # the index name is defined in the test matrix of the GitHub Actions workflow
@@ -252,7 +252,7 @@ def test_serverless_index_creation_from_scratch(sleep_time):
 
 
 @pytest.mark.integration
-@pytest.mark.skipif("PINECONE_API_KEY" not in os.environ, reason="PINECONE_API_KEY not set")
+@pytest.mark.skipif(not os.environ.get("PINECONE_API_KEY"), reason="PINECONE_API_KEY not set")
 class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, WriteDocumentsTest):
     def test_write_documents(self, document_store: PineconeDocumentStore):
         docs = [Document(id="1")]

--- a/integrations/pinecone/tests/test_filters.py
+++ b/integrations/pinecone/tests/test_filters.py
@@ -9,7 +9,7 @@ from haystack.testing.document_store import (
 
 
 @pytest.mark.integration
-@pytest.mark.skipif("PINECONE_API_KEY" not in os.environ, reason="PINECONE_API_KEY not set")
+@pytest.mark.skipif(not os.environ.get("PINECONE_API_KEY"), reason="PINECONE_API_KEY not set")
 class TestFilters(FilterDocumentsTest):
     def assert_documents_are_equal(self, received: List[Document], expected: List[Document]):
         for doc in received:


### PR DESCRIPTION
### Related Issues

Reviewing https://github.com/deepset-ai/haystack-core-integrations/pull/1450 (community PR), I understood that some tests requiring API keys or other credentials were failing instead of being skipped (we don't pass Secrets in PRs from forks).

### Proposed Changes:
- Mongo: check more robustly if the credentials are set; credentials should be present and not empty. If not, skip tests.
- Azure AI Search: the conditions introduced in #1425 to clean up indexes after the test session are too complex and don't work properly. I implemented a simpler approach: if the API keys are present and not empty, just clean up the indexes.

### How did you test it?
CI; this PR is created from a fork.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
