### PR TITLE
feat: Add MCP tooling integration

### DIFF
--- a/integrations/mcp/CHANGELOG.md
+++ b/integrations/mcp/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-04-30
+
+### Added
+- Initial release of the MCP integration
+- Support for HTTP and stdio transports
+- Basic MCP tool implementation 

--- a/integrations/mcp/LICENSE.txt
+++ b/integrations/mcp/LICENSE.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -1,0 +1,26 @@
+# MCP Haystack Integration
+
+This integration adds support for the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) to Haystack. MCP is an open protocol that standardizes how applications provide context to LLMs, similar to how USB-C provides a standardized way to connect devices.
+
+## Installation
+
+```bash
+pip install mcp-haystack
+```
+
+## Usage
+
+```python
+from haystack_integrations.components.tools.mcp import MCPTool, HttpMCPServerInfo
+
+# Create an MCP tool that connects to an HTTP server
+server_info = HttpMCPServerInfo(base_url="http://localhost:8000")
+tool = MCPTool(name="my_tool", server_info=server_info)
+
+# Use the tool
+result = tool.invoke(param1="value1", param2="value2")
+```
+
+## License
+
+Apache 2.0 

--- a/integrations/mcp/examples/mcp_http_client.py
+++ b/integrations/mcp/examples/mcp_http_client.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack_integrations.tools.mcp import MCPTool, HttpMCPServerInfo
+
+# run this client after running the server mcp_http_server.py
+# it shows how easy it is to use the MCPTool with HTTP transport
+
+
+def main():
+    """Example of synchronous usage of MCPTool with HTTP transport."""
+
+    server_info = HttpMCPServerInfo(
+        base_url="http://localhost:8000",
+    )
+
+    tool = MCPTool(name="add", server_info=server_info)
+
+    tool_subtract = MCPTool(name="subtract", server_info=server_info)
+
+    try:
+        print(f"Tool spec: {tool.tool_spec}")
+
+        result = tool.invoke(a=7, b=3)
+        print(f"7 + 3 = {result}")
+
+        result = tool_subtract.invoke(a=5, b=3)
+        print(f"5 - 3 = {result}")
+
+        result = tool.invoke(a=10, b=20)
+        print(f"10 + 20 = {result}")
+
+    except Exception as e:
+        print(f"Error in sync example: {e}")
+    finally:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/mcp/examples/mcp_http_server.py
+++ b/integrations/mcp/examples/mcp_http_server.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from mcp.server.fastmcp import FastMCP
+
+# run this server first before running the client mcp_http_client.py
+# it shows how easy it is to create a MCP server in just a few lines of code
+# then we'll use the MCPTool to invoke the server
+
+
+mcp = FastMCP("MCP Calculator")
+
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers"""
+    return a + b
+
+
+@mcp.tool()
+def subtract(a: int, b: int) -> int:
+    """Subtract two numbers"""
+    return a - b
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport="sse")

--- a/integrations/mcp/examples/mcp_stdio_client.py
+++ b/integrations/mcp/examples/mcp_stdio_client.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack_integrations.tools.mcp import MCPTool, StdioMCPServerInfo
+
+# For stdio MCPTool we don't need to run a server, we can just use the MCPTool directly
+# Here we use the mcp-server-time server
+# See https://github.com/modelcontextprotocol/servers/tree/main/src/time for more details
+# prior to running this script, pip install mcp-server-time
+
+
+def main():
+    """Example of using the MCPTool implementation with stdio transport."""
+
+    try:
+
+        stdio_tool = MCPTool(
+            name="get_current_time",
+            server_info=StdioMCPServerInfo(
+                command="python", args=["-m", "mcp_server_time", "--local-timezone=Europe/Berlin"]
+            ),
+        )
+
+        print(f"Tool spec: {stdio_tool.tool_spec}")
+
+        result = stdio_tool.invoke(timezone="America/New_York")
+        print(f"Current time in New York: {result}")
+
+        result = stdio_tool.invoke(timezone="America/San_Francisco")
+        print(f"Current time in San Francisco: {result}")
+    except Exception as e:
+        print(f"Error in stdio example: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/mcp/examples/time_pipeline.py
+++ b/integrations/mcp/examples/time_pipeline.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Full example of a pipeline that uses MCPTool to get the current time
+# and then uses the time to answer a user question.
+
+from haystack import Pipeline
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.tools import ToolInvoker
+from haystack.components.converters import OutputAdapter
+from haystack.dataclasses import ChatMessage, ChatRole
+from haystack_integrations.tools.mcp.mcp_tool import MCPTool, StdioMCPServerInfo
+
+
+def main():
+    time_tool = MCPTool(
+        name="get_current_time",
+        server_info=StdioMCPServerInfo(command="python", args=["-m", "mcp_server_time", "--local-timezone=Europe/Berlin"]),
+    )
+    pipeline = Pipeline()
+    pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[time_tool]))
+    pipeline.add_component("tool_invoker", ToolInvoker(tools=[time_tool]))
+    pipeline.add_component("adapter", OutputAdapter(template="{{ initial_msg + initial_tool_messages + tool_messages }}", output_type=list[ChatMessage], unsafe=True))
+    pipeline.add_component("response_llm", OpenAIChatGenerator(model="gpt-4o-mini"))
+    pipeline.connect("llm.replies", "tool_invoker.messages")
+    pipeline.connect("llm.replies", "adapter.initial_tool_messages")
+    pipeline.connect("tool_invoker.tool_messages", "adapter.tool_messages")
+    pipeline.connect("adapter.output", "response_llm.messages")
+
+
+    user_input = "What is the time in Berlin? Be brief."
+    user_input_msg = ChatMessage.from_user(text=user_input)
+
+    result = pipeline.run(
+        {
+            "llm": {
+                "messages": [user_input_msg]
+            },
+            "adapter": {
+                "initial_msg": [user_input_msg]
+            }
+        }
+    )
+
+    print(result["response_llm"]["replies"][0].text)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -1,0 +1,181 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mcp-haystack"
+dynamic = ["version"]
+description = "Haystack integration for Model Context Protocol (MCP)"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+keywords = [
+    "MCP",
+    "Haystack",
+    "Model Context Protocol",
+]
+authors = [
+    { name = "deepset GmbH", email = "info@deepset.ai" },
+]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
+dependencies = ["mcp", "haystack-ai>=2.9.0"]
+
+[project.urls]
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mcp#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mcp"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/haystack_integrations"]
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = 'integrations\/mcp-v(?P<version>.*)'
+
+[tool.hatch.version.raw-options]
+root = "../.."
+git_describe_command = 'git describe --tags --match="integrations/mcp-v[0-9]*"'
+
+[tool.hatch.envs.default]
+installer = "uv"
+dependencies = [
+    "coverage[toml]>=6.5",
+    "haystack-pydoc-tools",
+    "pytest",
+    "anyio", 
+    "pytest-asyncio",    
+    "pytest-tornasync",
+    "pytest-rerunfailures",
+    "pytest-pythonpath",
+    "mcp_server_time" ## time server for tests
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+test-cov-retry = "test-cov --reruns 3 --reruns-delay 30 -x"
+cov-report = ["- coverage combine", "coverage report"]
+cov = ["test-cov", "cov-report"]
+docs = ["pydoc-markdown pydoc/config.yml"]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.10", "3.11", "3.12"]
+
+[tool.hatch.envs.lint]
+installer = "uv"
+detached = true
+dependencies = [
+    "pip",
+    "black>=23.1.0",
+    "mypy>=1.0.0",
+    "ruff>=0.0.243",
+]
+
+[tool.hatch.envs.lint.scripts]
+typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+style = ["ruff check {args:.}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff check --fix {args:.}", "style"]
+all = ["style", "typing"]
+
+[tool.black]
+target-version = ["py310"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ARG",
+    "B",
+    "C",
+    "DTZ",
+    "E",
+    "EM",
+    "F",
+    "I",
+    "ICN",
+    "ISC",
+    "N",
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    "Q",
+    "RUF",
+    "S",
+    "T",
+    "TID",
+    "UP",
+    "W",
+    "YTT",
+]
+ignore = [
+    # Allow non-abstract empty methods in abstract base classes
+    "B027",
+    # Ignore checks for possible passwords
+    "S105",
+    "S106",
+    "S107",
+    # Ignore complexity
+    "C901",
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+]
+unfixable = [
+    # Don't touch unused imports
+    "F401",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["haystack_integrations"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "parents"
+
+[tool.ruff.lint.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+source = ["haystack_integrations"]
+branch = true
+parallel = false
+
+[tool.coverage.report]
+omit = ["*/tests/*", "*/__init__.py"]
+show_missing = true
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
+
+[[tool.mypy.overrides]]
+module = [
+    "haystack.*",
+    "haystack_integrations.*",
+    "pytest.*",
+]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+    "unit: unit tests",
+    "integration: integration tests",
+]
+log_cli = true
+asyncio_default_fixture_loop_scope = "function"
+
+[tool.hatch.metadata]
+allow-direct-references = true 

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/__init__.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/__init__.py
@@ -1,0 +1,27 @@
+from .mcp_tool import (
+    HttpMCPClient,
+    HttpMCPServerInfo,
+    MCPClient,
+    MCPConnectionError,
+    MCPError,
+    MCPInvocationError,
+    MCPServerInfo,
+    MCPTool,
+    MCPToolNotFoundError,
+    StdioMCPClient,
+    StdioMCPServerInfo,
+)
+
+__all__ = [
+    "HttpMCPClient",
+    "HttpMCPServerInfo",
+    "MCPClient",
+    "MCPConnectionError",
+    "MCPError",
+    "MCPInvocationError",
+    "MCPServerInfo",
+    "MCPTool",
+    "MCPToolNotFoundError",
+    "StdioMCPClient",
+    "StdioMCPServerInfo",
+]

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -1,0 +1,625 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from abc import ABC, abstractmethod
+from collections.abc import Coroutine
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, fields
+from typing import Any, cast
+
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream  # type: ignore [import-not-found]
+from haystack import logging
+from haystack.core.serialization import generate_qualified_class_name, import_class_by_name
+from haystack.tools import Tool
+from haystack.tools.errors import ToolInvocationError
+
+from mcp import ClientSession, StdioServerParameters, types  # type: ignore [import-not-found]
+from mcp.client.sse import sse_client  # type: ignore [import-not-found]
+from mcp.client.stdio import stdio_client  # type: ignore [import-not-found]
+
+logger = logging.getLogger(__name__)
+
+
+class MCPError(Exception):
+    """Base class for MCP-related errors."""
+
+    pass
+
+
+class MCPConnectionError(MCPError):
+    """Error connecting to MCP server."""
+
+    pass
+
+
+class MCPToolNotFoundError(MCPError):
+    """Error when a tool is not found on the server."""
+
+    pass
+
+
+class MCPResponseTypeError(MCPError):
+    """Error when response content type is not supported."""
+
+    pass
+
+
+class MCPInvocationError(ToolInvocationError):
+    """Error during tool invocation."""
+
+    pass
+
+
+class MCPClient(ABC):
+    """
+    Abstract base class for MCP clients.
+
+    This class defines the common interface and shared functionality for all MCP clients,
+    regardless of the transport mechanism used.
+    """
+
+    def __init__(self) -> None:
+        self.session: ClientSession | None = None
+        self.exit_stack: AsyncExitStack = AsyncExitStack()
+        self.stdio: MemoryObjectReceiveStream[types.JSONRPCMessage | Exception] | None = None
+        self.write: MemoryObjectSendStream[types.JSONRPCMessage] | None = None
+
+    @abstractmethod
+    async def connect(self) -> list[Tool]:
+        """
+        Connect to an MCP server.
+
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        pass
+
+    async def call_tool(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+        """
+        Call a tool on the connected MCP server.
+
+        :param tool_name: Name of the tool to call
+        :param tool_args: Arguments to pass to the tool
+        :returns: Result of the tool invocation
+        :raises MCPError: If not connected to an MCP server
+        :raises MCPInvocationError: If the tool invocation fails
+        :raises MCPResponseTypeError: If response type is not TextContent
+        """
+        if not self.session:
+            message = "Not connected to an MCP server"
+            raise MCPError(message)
+
+        try:
+            result = await self.session.call_tool(tool_name, tool_args)
+
+            # Process and validate the response content
+            processed_result = self._process_response_content(result, tool_name)
+            return processed_result
+
+        except Exception as e:
+            if isinstance(e, MCPError):
+                # Re-raise specific MCP errors
+                raise
+            message = f"Failed to invoke tool '{tool_name}': {e!s}"
+            raise MCPInvocationError(message) from e
+
+    def _process_response_content(self, result, tool_name: str) -> Any:
+        """
+        Process response content from an MCP tool call, accepting only TextContent.
+
+        :param result: CallToolResult from MCP tool call
+        :param tool_name: Name of the called tool (for error messages)
+        :returns: The original CallToolResult object
+        :raises MCPResponseTypeError: If content type is not TextContent
+        :raises MCPInvocationError: If the tool call resulted in an error
+        """
+        # Return the result directly if it's not a CallToolResult structure
+        if not hasattr(result, "content"):
+            return result
+
+        # Check for error response
+        if hasattr(result, "isError") and result.isError:
+            error_msg = "Tool execution failed"
+            if result.content and isinstance(result.content, list) and len(result.content) > 0:
+                first_item = result.content[0]
+                if hasattr(first_item, "text"):
+                    error_msg = first_item.text
+                else:
+                    error_msg = str(first_item)
+            message = f"Tool '{tool_name}' returned an error: {error_msg}"
+            raise MCPInvocationError(message)
+
+        # Validate content types - only allow TextContent
+        if result.content and isinstance(result.content, list):
+            for item in result.content:
+                if not (hasattr(item, "type") and item.type == "text" and hasattr(item, "text")):
+                    # Reject any non-TextContent
+                    message = (
+                        f"Unsupported content type in response from tool '{tool_name}'. "
+                        f"Only TextContent is currently supported."
+                    )
+                    raise MCPResponseTypeError(message)
+
+        # Return the original result object
+        return result
+
+    async def close(self) -> None:
+        """
+        Close the connection and clean up resources.
+
+        This method ensures all resources are properly released, even if errors occur.
+        """
+        if not self.exit_stack:
+            return
+
+        try:
+            await self.exit_stack.aclose()
+        except Exception as e:
+            logger.warning(f"Error during MCP client cleanup: {e}")
+        finally:
+            # Ensure all references are cleared even if cleanup fails
+            self.session = None
+            self.stdio = None
+            self.write = None
+
+    async def _initialize_session_with_transport(
+        self,
+        transport_tuple: tuple[
+            MemoryObjectReceiveStream[types.JSONRPCMessage | Exception], MemoryObjectSendStream[types.JSONRPCMessage]
+        ],
+        connection_type: str,
+    ) -> list[Tool]:
+        """
+        Common session initialization logic for all transports.
+
+        :param transport_tuple: Tuple containing (stdio, write) from the transport
+        :param connection_type: String describing the connection type for error messages
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        try:
+            self.stdio, self.write = transport_tuple
+            self.session = await self.exit_stack.enter_async_context(ClientSession(self.stdio, self.write))
+
+            # Now session is guaranteed to be a ClientSession, not None
+            session = cast(ClientSession, self.session)  # Tell mypy the type is now known
+            await session.initialize()
+
+            # List available tools
+            response = await session.list_tools()
+            return response.tools
+
+        except Exception as e:
+            await self.close()
+            message = f"Failed to connect to {connection_type}: {e}"
+            raise MCPConnectionError(message) from e
+
+
+class StdioMCPClient(MCPClient):
+    """
+    MCP client that connects to servers using stdio transport.
+    """
+
+    def __init__(self, command: str, args: list[str] | None = None, env: dict[str, str] | None = None) -> None:
+        """
+        Initialize a stdio MCP client.
+
+        :param command: Command to run (e.g., "python", "node")
+        :param args: Arguments to pass to the command
+        :param env: Environment variables for the command
+        """
+        super().__init__()
+        self.command: str = command
+        self.args: list[str] = args or []
+        self.env: dict[str, str] | None = env
+
+    async def connect(self) -> list[Tool]:
+        """
+        Connect to an MCP server using stdio transport.
+
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env)
+        stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
+        return await self._initialize_session_with_transport(stdio_transport, f"stdio server (command: {self.command})")
+
+
+class HttpMCPClient(MCPClient):
+    """
+    MCP client that connects to servers using HTTP transport.
+    """
+
+    def __init__(self, base_url: str, token: str | None = None, timeout: int = 5) -> None:
+        """
+        Initialize an HTTP MCP client.
+
+        :param base_url: Base URL of the server
+        :param token: Authentication token for the server (optional)
+        :param timeout: Connection timeout in seconds
+        """
+        super().__init__()
+        self.base_url: str = base_url.rstrip("/")  # Remove any trailing slashes
+        self.token: str | None = token
+        self.timeout: int = timeout
+
+    async def connect(self) -> list[Tool]:
+        """
+        Connect to an MCP server using HTTP transport.
+
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        sse_url = f"{self.base_url}/sse"
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else None
+        sse_transport = await self.exit_stack.enter_async_context(
+            sse_client(sse_url, headers=headers, timeout=self.timeout)
+        )
+        return await self._initialize_session_with_transport(sse_transport, f"HTTP server at {self.base_url}")
+
+
+@dataclass
+class MCPServerInfo(ABC):
+    """
+    Abstract base class for MCP server connection parameters.
+
+    This class defines the common interface for all MCP server connection types.
+    """
+
+    @abstractmethod
+    def create_client(self) -> MCPClient:
+        """
+        Create an appropriate MCP client for this server info.
+
+        :returns: An instance of MCPClient configured with this server info
+        """
+        pass
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize this server info to a dictionary.
+
+        :returns: Dictionary representation of this server info
+        """
+        # Store the fully qualified class name for deserialization
+        result = {"type": generate_qualified_class_name(type(self))}
+
+        # Add all fields from the dataclass
+        for field in fields(self):
+            result[field.name] = getattr(self, field.name)
+
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MCPServerInfo":
+        """
+        Deserialize server info from a dictionary.
+
+        :param data: Dictionary containing serialized server info
+        :returns: Instance of the appropriate server info class
+        """
+        # Remove the type field as it's not a constructor parameter
+        data_copy = data.copy()
+        data_copy.pop("type", None)
+
+        # Create an instance of the class with the remaining fields
+        return cls(**data_copy)
+
+
+@dataclass
+class HttpMCPServerInfo(MCPServerInfo):
+    """
+    Data class that encapsulates HTTP MCP server connection parameters.
+
+    :param base_url: Base URL of the MCP server
+    :param token: Authentication token for the server (optional)
+    :param timeout: Connection timeout in seconds
+    """
+
+    base_url: str
+    token: str | None = None
+    timeout: int = 30
+
+    def create_client(self) -> MCPClient:
+        """
+        Create an HTTP MCP client.
+
+        :returns: Configured HttpMCPClient instance
+        """
+        return HttpMCPClient(self.base_url, self.token, self.timeout)
+
+
+@dataclass
+class StdioMCPServerInfo(MCPServerInfo):
+    """
+    Data class that encapsulates stdio MCP server connection parameters.
+
+    :param command: Command to run (e.g., "python", "node")
+    :param args: Arguments to pass to the command
+    :param env: Environment variables for the command
+    """
+
+    command: str
+    args: list[str] | None = None
+    env: dict[str, str] | None = None
+
+    def create_client(self) -> MCPClient:
+        """
+        Create a stdio MCP client.
+
+        :returns: Configured StdioMCPClient instance
+        """
+        return StdioMCPClient(self.command, self.args, self.env)
+
+
+class MCPTool(Tool):
+    """
+    A Tool that represents a single tool from an MCP server.
+
+    This implementation uses the official MCP SDK for protocol handling while maintaining
+    compatibility with the Haystack tool ecosystem.
+
+    Response handling:
+    - Text content is supported and returned as strings
+    - Unsupported content types (like binary/images) will raise MCPResponseTypeError
+
+    Example using HTTP:
+    ```python
+    from haystack.tools import MCPTool, HttpMCPServerInfo
+
+    # Create tool instance
+    tool = MCPTool(
+        name="add",
+        server_info=HttpMCPServerInfo(base_url="http://localhost:8000")
+    )
+
+    # Use the tool
+    result = tool.invoke(a=5, b=3)
+    ```
+
+    Example using stdio:
+    ```python
+    from haystack.tools import MCPTool, StdioMCPServerInfo
+
+    # Create tool instance
+    tool = MCPTool(
+        name="get_current_time",
+        server_info=StdioMCPServerInfo(command="python", args=["path/to/server.py"])
+    )
+
+    # Use the tool
+    result = tool.invoke(timezone="America/New_York")
+    ```
+    """
+
+    def __init__(
+        self,
+        name: str,
+        server_info: MCPServerInfo,
+        description: str | None = None,
+        connection_timeout: int = 30,
+        invocation_timeout: int = 30,
+    ):
+        """
+        Initialize the MCP tool.
+
+        :param name: Name of the tool to use
+        :param server_info: Server connection information
+        :param description: Custom description (if None, server description will be used)
+        :param connection_timeout: Timeout in seconds for server connection
+        :param invocation_timeout: Default timeout in seconds for tool invocations
+        :raises MCPConnectionError: If connection to the server fails
+        :raises MCPToolNotFoundError: If no tools are available or the requested tool is not found
+        :raises TimeoutError: If connection times out
+        """
+
+        # Store connection parameters for serialization
+        self._server_info = server_info
+        self._connection_timeout = connection_timeout
+        self._invocation_timeout = invocation_timeout
+        client = None
+
+        # Initialize the connection
+        try:
+            # Create the appropriate client using the factory method
+            client = server_info.create_client()
+
+            # Connect and get available tools with timeout
+            tools = self._run_sync(client.connect(), timeout=connection_timeout)
+
+            # Handle no tools case
+            if not tools:
+                message = "No tools available on server"
+                raise MCPToolNotFoundError(message)
+
+            # Find the specified tool
+            tool_info = next((t for t in tools if t.name == name), None)
+            if not tool_info:
+                available_tools = ", ".join(t.name for t in tools)
+                message = f"Tool '{name}' not found on server. Available tools: {available_tools}"
+                raise MCPToolNotFoundError(message)
+
+            # Store the client for later use
+            self._client = client
+
+            # Initialize the parent class with the final values
+            logger.debug(f"Initializing MCPTool with name: {name}")
+
+            # Hook into the Tool base class
+            super().__init__(
+                name=name,
+                description=description or tool_info.description,
+                parameters=tool_info.inputSchema,
+                function=self._invoke_tool,
+            )
+
+        except Exception as e:
+            # Ensure proper cleanup of resources on initialization failure
+            if client is not None:
+                try:
+                    self._run_sync(client.close(), timeout=10)  # Short timeout for cleanup
+                except Exception as cleanup_error:
+                    logger.warning(f"Error during cleanup after initialization failure: {cleanup_error}")
+
+            # Enhance the error message with more context
+            if isinstance(e, (MCPError | TimeoutError)):
+                raise
+            message = f"Failed to initialize MCPTool '{name}': {e}"
+            raise MCPError(message) from e
+
+    def _invoke_tool(self, **kwargs: Any) -> Any:
+        """
+        Synchronous tool invocation.
+
+        This method is called by the Tool base class's invoke() method.
+
+        :param kwargs: Arguments to pass to the tool
+        :returns: Result of the tool invocation, processed based on content type
+        :raises MCPInvocationError: If the tool invocation fails
+        :raises MCPResponseTypeError: If response type is not supported
+        :raises TimeoutError: If the operation times out
+        """
+        try:
+            # Use the configured invocation timeout
+            return self._run_sync(self._client.call_tool(self.name, kwargs), timeout=self._invocation_timeout)
+        except Exception as e:
+            # Add context to the error message for better debugging
+            if isinstance(e, (MCPError | TimeoutError)):
+                # Re-raise specific errors
+                raise
+            # Wrap other exceptions
+            message = f"Error invoking tool '{self.name}': {e}"
+            raise MCPInvocationError(message) from e
+
+    async def ainvoke(self, **kwargs: Any) -> Any:
+        """
+        Asynchronous tool invocation.
+
+        :param kwargs: Arguments to pass to the tool
+        :returns: Result of the tool invocation, processed based on content type
+        :raises MCPInvocationError: If the tool invocation fails
+        :raises MCPResponseTypeError: If response type is not supported
+        :raises TimeoutError: If the operation times out
+        """
+        try:
+            # Use asyncio.wait_for with the configured timeout
+            return await asyncio.wait_for(self._client.call_tool(self.name, kwargs), timeout=self._invocation_timeout)
+        except asyncio.TimeoutError as e:
+            message = f"Tool invocation timed out after {self._invocation_timeout} seconds"
+            raise TimeoutError(message) from e
+        except Exception as e:
+            if isinstance(e, MCPError):
+                raise
+            message = f"Error invoking tool '{self.name}': {e}"
+            raise MCPInvocationError(message) from e
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the MCPTool to a dictionary.
+
+        The serialization preserves all information needed to recreate the tool,
+        including server connection parameters and timeout settings. Note that the
+        active connection is not maintained.
+
+        :returns: Dictionary with serialized data in the format:
+                  {"type": fully_qualified_class_name, "data": {parameters}}
+        """
+        serialized = {
+            "name": self.name,
+            "description": self.description,
+            "server_info": self._server_info.to_dict(),
+            "connection_timeout": self._connection_timeout,
+            "invocation_timeout": self._invocation_timeout,
+        }
+        return {
+            "type": generate_qualified_class_name(type(self)),
+            "data": serialized,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Tool":
+        """
+        Deserializes the MCPTool from a dictionary.
+
+        This method reconstructs an MCPTool instance from a serialized dictionary,
+        including recreating the server_info object. A new connection will be established
+        to the MCP server during initialization.
+
+        :param data: Dictionary containing serialized tool data
+        :returns: A fully initialized MCPTool instance
+        :raises: Various exceptions if connection fails
+        """
+        # Extract the tool parameters from the data dictionary
+        inner_data = data["data"]
+        server_info_dict = inner_data.get("server_info", {})
+
+        # Reconstruct the server_info object
+        # First get the appropriate class by name
+        server_info_class = import_class_by_name(server_info_dict["type"])
+        # Then deserialize using that class's from_dict method
+        server_info = server_info_class.from_dict(server_info_dict)
+
+        # Handle backward compatibility for timeout parameters
+        connection_timeout = inner_data.get("connection_timeout", 30)
+        invocation_timeout = inner_data.get("invocation_timeout", 30)
+
+        # Create a new MCPTool instance with the deserialized parameters
+        # This will establish a new connection to the MCP server
+        return cls(
+            name=inner_data["name"],
+            description=inner_data.get("description"),
+            server_info=server_info,
+            connection_timeout=connection_timeout,
+            invocation_timeout=invocation_timeout,
+        )
+
+    def _run_sync(self, coro: Coroutine, timeout: float | None = 30) -> Any:
+        """
+        Run a coroutine in a synchronous context with improved handling.
+
+        This implementation is optimized for use with AsyncExitStack by ensuring
+        that coroutines run in the same event loop where AsyncExitStack resources
+        were initialized.
+
+        :param coro: Coroutine to run
+        :param timeout: Optional timeout in seconds
+        :returns: Result of the coroutine
+        :raises TimeoutError: If the operation times out
+        :raises Exception: Any exception that might occur during execution
+        """
+        try:
+            # Apply timeout if specified
+            if timeout is not None:
+                coro = asyncio.wait_for(coro, timeout)
+
+            # Try to get a running loop first (modern approach)
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                # No running loop, so we need to get or create one.
+                # The important part for AsyncExitStack compatibility is that
+                # we must use the SAME loop that was used to create the stack.
+
+                # IMPORTANT: Using get_event_loop() is necessary for AsyncExitStack compatibility
+                # but it generates a "There is no current event loop" deprecation warning in
+                # Python 3.10, 3.11, and 3.12.
+                #
+                # This is unavoidable because:
+                # 1. AsyncExitStack binds its resources to the loop where it was created
+                # 2. That loop was created using get_event_loop() internally
+                # 3. To access those resources, we must use the same loop
+                # 4. The only way to get that same loop is with get_event_loop()
+                loop = asyncio.get_event_loop_policy().get_event_loop()
+
+            # Run the coroutine in the loop but don't close it
+            # AsyncExitStack depends on this loop staying open
+            return loop.run_until_complete(coro)
+
+        except asyncio.TimeoutError:
+            message = f"Operation timed out after {timeout} seconds"
+            raise TimeoutError(message) from None
+        except Exception:
+            # Preserve the original exception
+            raise

--- a/integrations/mcp/tests/__init__.py
+++ b/integrations/mcp/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -1,0 +1,471 @@
+import os
+import subprocess
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from haystack import Pipeline
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.tools import ToolInvoker
+from haystack.dataclasses import ChatMessage, ChatRole
+from haystack.tools.errors import ToolInvocationError
+from haystack.tools.from_function import tool
+from haystack.utils.auth import TokenSecret
+
+from haystack_integrations.tools.mcp import (
+    HttpMCPServerInfo,
+    MCPError,
+    MCPTool,
+    StdioMCPServerInfo,
+)
+
+
+@tool
+def echo(name: str) -> str:
+    """Echo a name"""
+    return f"Hello, {name}!"
+
+
+# Create mocking fixtures for MCPTool tests
+@pytest.fixture
+def mock_mcp_tool():
+    """
+    Fixture to create a pre-configured MCPTool for testing without server connection.
+    This approach uses patching to avoid actual server connections.
+    """
+    # Create patch for connection methods
+    with (
+        patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool._run_sync") as mock_run_sync,
+        patch("haystack_integrations.tools.mcp.mcp_tool.MCPServerInfo.create_client") as mock_create_client,
+    ):
+
+        # Configure mock client
+        mock_client = MagicMock()
+
+        async def mock_invoke(*_args, **_kwargs):
+            return {"result": "mock_result"}
+
+        mock_client.invoke = mock_invoke
+        mock_create_client.return_value = mock_client
+
+        # Configure _run_sync to return a tool
+        mock_tool_info = MagicMock()
+        mock_tool_info.name = "test_tool"
+        mock_tool_info.description = "A test tool"
+        mock_tool_info.inputSchema = {"type": "object", "properties": {}}
+        mock_run_sync.return_value = [mock_tool_info]
+
+        # Create the MCPTool
+        tool = MCPTool(
+            name="test_tool",
+            server_info=HttpMCPServerInfo(
+                base_url="http://example.com", token=TokenSecret.from_token("MCP_TEST_TOKEN")
+            ),
+            description="A test MCP tool",
+        )
+
+        # Override the invoke method for testing
+        original_invoke = tool._invoke_tool
+
+        def mock_invoke_tool(**kwargs):
+            if "error" in kwargs:
+                error_message = "Mock error for testing"
+                raise ToolInvocationError(error_message)
+            return {"result": "mock_result"}
+
+        tool._invoke_tool = mock_invoke_tool
+        tool.function = mock_invoke_tool
+
+        # Add run method (alias for invoke) for testing
+        tool.run = tool.invoke = lambda **kwargs: mock_invoke_tool(**kwargs)
+
+        # Override to_dict method to match expected format
+        original_to_dict = tool.to_dict
+
+        def mock_to_dict():
+            return {
+                "type": "haystack_integrations.tools.mcp.mcp_tool.MCPTool",
+                "data": {
+                    "name": "test_tool",
+                    "description": "A test MCP tool",
+                    "server_info": {
+                        "type": "haystack_integrations.tools.mcp.mcp_tool.HttpMCPServerInfo",
+                        "base_url": "http://example.com",
+                        "token": {
+                            "type": "haystack.utils.auth.EnvVarSecret",
+                            "init_parameters": {"env_var": "MOCK_TOKEN"},
+                        },
+                        "timeout": 30,
+                    },
+                    "connection_timeout": 30,
+                    "invocation_timeout": 30,
+                },
+            }
+
+        tool.to_dict = mock_to_dict
+
+        yield tool
+
+        # Restore original methods if needed
+        tool._invoke_tool = original_invoke
+        tool.to_dict = original_to_dict
+
+
+class TestMCPServerInfo:
+    """Unit tests for MCPServerInfo classes."""
+
+    def test_http_server_info_serde(self):
+        """Test serialization/deserialization of HttpMCPServerInfo."""
+        server_info = HttpMCPServerInfo(base_url="http://example.com", token="test-token", timeout=45)
+
+        # Test to_dict
+        info_dict = server_info.to_dict()
+        assert info_dict["type"] == "haystack_integrations.tools.mcp.mcp_tool.HttpMCPServerInfo"
+        assert info_dict["base_url"] == "http://example.com"
+        assert info_dict["token"] == "test-token"
+        assert info_dict["timeout"] == 45
+
+        # Test from_dict
+        new_info = HttpMCPServerInfo.from_dict(info_dict)
+        assert new_info.base_url == "http://example.com"
+        assert new_info.token == "test-token"
+        assert new_info.timeout == 45
+
+    def test_stdio_server_info_serde(self):
+        """Test serialization/deserialization of StdioMCPServerInfo."""
+        server_info = StdioMCPServerInfo(command="python", args=["-m", "mcp_server_time"], env={"TEST_ENV": "value"})
+
+        # Test to_dict
+        info_dict = server_info.to_dict()
+        assert info_dict["type"] == "haystack_integrations.tools.mcp.mcp_tool.StdioMCPServerInfo"
+        assert info_dict["command"] == "python"
+        assert info_dict["args"] == ["-m", "mcp_server_time"]
+        assert info_dict["env"] == {"TEST_ENV": "value"}
+
+        # Test from_dict
+        new_info = StdioMCPServerInfo.from_dict(info_dict)
+        assert new_info.command == "python"
+        assert new_info.args == ["-m", "mcp_server_time"]
+        assert new_info.env == {"TEST_ENV": "value"}
+
+    def test_create_client(self):
+        """Test client creation from server info."""
+        http_info = HttpMCPServerInfo(base_url="http://example.com")
+        stdio_info = StdioMCPServerInfo(command="python")
+
+        http_client = http_info.create_client()
+        stdio_client = stdio_info.create_client()
+
+        assert http_client.base_url == "http://example.com"
+        assert stdio_client.command == "python"
+
+
+class TestMCPTool:
+    """Tests for the MCPTool class."""
+
+    def test_mcp_tool_initialization(self, mock_mcp_tool):
+        """Test if the MCPTool can be initialized correctly."""
+        # Get the pre-configured mock tool from the fixture
+        tool = mock_mcp_tool
+
+        # Check if the tool has all expected attributes
+        assert tool.name == "test_tool"
+        assert "A test MCP tool" == tool.description
+        assert isinstance(tool._server_info, HttpMCPServerInfo)
+        assert tool._connection_timeout == 30
+        assert tool._invocation_timeout == 30
+
+    def test_mcp_tool_direct_serde(self, mock_mcp_tool, monkeypatch):
+        """Test direct serialization and deserialization of the MCPTool."""
+        # Set environment variables for secrets
+        monkeypatch.setenv("MOCK_TOKEN", "test-token")
+        monkeypatch.setenv("MCP_TEST_TOKEN", "test-token")
+
+        # Get the pre-configured mock tool
+        tool = mock_mcp_tool
+
+        tool_dict = tool.to_dict()
+
+        # Verify serialization format
+        assert tool_dict["type"] == "haystack_integrations.tools.mcp.mcp_tool.MCPTool"
+        assert tool_dict["data"]["name"] == "test_tool"
+        assert tool_dict["data"]["description"] == "A test MCP tool"
+        assert tool_dict["data"]["server_info"]["type"] == "haystack_integrations.tools.mcp.mcp_tool.HttpMCPServerInfo"
+        assert tool_dict["data"]["server_info"]["base_url"] == "http://example.com"
+
+        # The token should be stored as a secret in serialized format
+        token_secret = tool_dict["data"]["server_info"]["token"]
+        assert isinstance(token_secret, dict)
+        assert token_secret["type"] == "haystack.utils.auth.EnvVarSecret"
+        assert "env_var" in token_secret["init_parameters"]
+
+        # Test deserialization with patched environment
+        with patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool.__init__", return_value=None) as mock_init:
+            # Call from_dict but use mock_init to verify arguments
+            MCPTool.from_dict(tool_dict)
+            # Verify that __init__ was called with correct parameters
+            mock_init.assert_called_once()
+            args, kwargs = mock_init.call_args
+            assert kwargs["name"] == "test_tool"
+            assert kwargs["description"] == "A test MCP tool"
+            assert isinstance(kwargs["server_info"], HttpMCPServerInfo)
+            assert kwargs["server_info"].base_url == "http://example.com"
+
+    def test_serde_in_pipeline(self, monkeypatch):
+        """Test serialization and deserialization of MCPTool within a Pipeline."""
+        # Set environment variables for testing
+        monkeypatch.setenv("MOCK_TOKEN", "test-token")
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with (
+            patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool.__init__", return_value=None) as mock_init,
+            patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool._run_sync"),
+            patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool.to_dict") as mock_to_dict,
+        ):
+
+            # Configure to_dict to return the same format as our mock
+            mock_to_dict.return_value = {
+                "type": "haystack_integrations.tools.mcp.mcp_tool.MCPTool",
+                "data": {
+                    "name": "test_tool",
+                    "description": "A test MCP tool",
+                    "server_info": {
+                        "type": "haystack_integrations.tools.mcp.mcp_tool.HttpMCPServerInfo",
+                        "base_url": "http://example.com",
+                        "token": {
+                            "type": "haystack.utils.auth.EnvVarSecret",
+                            "init_parameters": {"env_var": "MOCK_TOKEN"},
+                        },
+                        "timeout": 30,
+                    },
+                    "connection_timeout": 30,
+                    "invocation_timeout": 30,
+                },
+            }
+
+            # Create a tool instance with mocked initialization
+            mock_init.return_value = None
+            tool = MCPTool(
+                name="test_tool",
+                server_info=HttpMCPServerInfo(
+                    base_url="http://example.com", token=TokenSecret.from_env_var("MCP_TEST_TOKEN")
+                ),
+            )
+
+            # Set required attributes that would normally be set in __init__
+            tool.name = "test_tool"
+            tool.description = "A test MCP tool"
+            tool.parameters = {"type": "object", "properties": {}}
+            tool.function = lambda **_kwargs: {"result": "mock_result"}
+
+            pipeline = Pipeline()
+            pipeline.add_component("tool_invoker", ToolInvoker(tools=[tool]))
+            pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[tool]))
+            pipeline.connect("tool_invoker.tool_messages", "llm.messages")
+
+            # Serialize to dict and verify structure
+            pipeline_dict = pipeline.to_dict()
+
+            # Verify the tool is properly serialized in the pipeline
+            assert (
+                pipeline_dict["components"]["tool_invoker"]["type"]
+                == "haystack.components.tools.tool_invoker.ToolInvoker"
+            )
+            assert len(pipeline_dict["components"]["tool_invoker"]["init_parameters"]["tools"]) == 1
+
+            tool_dict = pipeline_dict["components"]["tool_invoker"]["init_parameters"]["tools"][0]
+            assert tool_dict["type"] == "haystack_integrations.tools.mcp.mcp_tool.MCPTool"
+            assert tool_dict["data"]["name"] == "test_tool"
+            assert tool_dict["data"]["description"] == "A test MCP tool"
+            assert (
+                tool_dict["data"]["server_info"]["type"] == "haystack_integrations.tools.mcp.mcp_tool.HttpMCPServerInfo"
+            )
+
+            # Test round-trip serialization (dumps/loads) with a patched from_dict
+            with patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool.from_dict", return_value=tool):
+                pipeline_yaml = pipeline.dumps()
+                # Just verify we can serialize to YAML without errors
+                assert isinstance(pipeline_yaml, str)
+                assert "MCPTool" in pipeline_yaml
+
+    def test_mcp_tool_error_handling(self, mock_mcp_tool):
+        """Test error handling during tool invocation."""
+        # Get the pre-configured mock tool
+        tool = mock_mcp_tool
+
+        # Test error handling
+        with pytest.raises(ToolInvocationError):
+            tool.run(error=True)  # This should trigger our mock error
+
+
+@pytest.mark.integration
+class TestMCPToolInPipelineWithOpenAI:
+    """Integration tests for MCPTool in Haystack pipelines with OpenAI."""
+
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_mcp_tool_with_http_server(self):
+        """Test using an MCPTool with a real HTTP server."""
+        import os
+        import socket
+        import tempfile
+
+        # Find an available port
+        def find_free_port():
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                return s.getsockname()[1]
+
+        port = find_free_port()
+
+        # Create a temporary file for the server script
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
+            temp_file.write(
+                f"""
+from mcp.server.fastmcp import FastMCP
+mcp = FastMCP("MCP Calculator", host="127.0.0.1", port={port})
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    \"\"\"Add two numbers\"\"\"
+    return a + b
+
+# Add a subtraction tool
+@mcp.tool()
+def subtract(a: int, b: int) -> int:
+    \"\"\"Subtract b from a\"\"\"
+    return a - b
+
+if __name__ == "__main__":
+    try:
+        mcp.run(transport="sse")
+    except Exception as e:
+        sys.exit(1)
+""".encode()
+            )
+            server_script_path = temp_file.name
+
+        server_process = None
+        try:
+            # Start the server in a separate process
+            server_process = subprocess.Popen(  # noqa: S603
+                ["python", server_script_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True  # noqa: S607
+            )
+
+            # Give the server a moment to start
+            time.sleep(2)
+            # Create an MCPTool that connects to the HTTP server
+            server_info = HttpMCPServerInfo(base_url=f"http://127.0.0.1:{port}")
+
+            # Create the tool
+            tool = MCPTool(name="add", server_info=server_info)
+
+            # Invoke the tool
+            result = tool.invoke(a=5, b=3)
+
+            # Verify the result
+            assert not result.isError
+            assert len(result.content) == 1
+            assert result.content[0].text == "8"
+
+            # Try another tool from the same server
+            subtract_tool = MCPTool(name="subtract", server_info=server_info)
+            result = subtract_tool.invoke(a=10, b=4)
+
+            # Verify the result
+            assert not result.isError
+            assert len(result.content) == 1
+            assert result.content[0].text == "6"
+
+        except Exception:
+            # Check server output for clues
+            if server_process and server_process.poll() is None:
+                server_process.terminate()
+            raise
+
+        finally:
+            # Clean up
+            if server_process:
+                if server_process.poll() is None:  # Process is still running
+                    server_process.terminate()
+                    try:
+                        server_process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        server_process.kill()
+                        server_process.wait(timeout=5)
+
+            # Remove the temporary file
+            if os.path.exists(server_script_path):
+                os.remove(server_script_path)
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY") and not os.environ.get("BRAVE_API_KEY"),
+        reason="OPENAI_API_KEY or BRAVE_API_KEY not set",
+    )
+    def test_mcp_brave_search(self):
+        """Test using an MCPTool in a pipeline with OpenAI."""
+
+        # Create an MCPTool for the brave_web_search operation
+        server_info = StdioMCPServerInfo(
+            command="docker",
+            args=["run", "-i", "--rm", "-e", f"BRAVE_API_KEY={os.environ.get('BRAVE_API_KEY')}", "mcp/brave-search"],
+            env=None,
+        )
+        tool = MCPTool(name="brave_web_search", server_info=server_info)
+        # Create pipeline with OpenAIChatGenerator and ToolInvoker
+        pipeline = Pipeline()
+        pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[tool]))
+        pipeline.add_component("tool_invoker", ToolInvoker(tools=[tool]))
+
+        # Connect components
+        pipeline.connect("llm.replies", "tool_invoker.messages")
+
+        # Create a message that should trigger tool use
+        message = ChatMessage.from_user(text="Use brave_web_search to search for the latest German elections news")
+
+        result = pipeline.run({"llm": {"messages": [message]}})
+
+        tool_messages = result["tool_invoker"]["tool_messages"]
+        assert len(tool_messages) == 1
+
+        tool_message = tool_messages[0]
+        assert tool_message.is_from(ChatRole.TOOL)
+        assert any(term in tool_message.tool_call_result.result for term in ["Bundestag", "elections"])
+
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_mcp_tool_in_pipeline_with_multiple_tools(self):
+        """Test using multiple MCPTools in a pipeline with OpenAI."""
+
+        # Mix mcp tool with a simple echo tool
+        time_server_info = StdioMCPServerInfo(
+            command="python", args=["-m", "mcp_server_time", "--local-timezone=America/New_York"]
+        )
+        time_tool = MCPTool(name="get_current_time", server_info=time_server_info)
+
+        # Create pipeline with OpenAIChatGenerator and ToolInvoker
+        pipeline = Pipeline()
+        pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[echo, time_tool]))
+        pipeline.add_component("tool_invoker", ToolInvoker(tools=[echo, time_tool]))
+
+        pipeline.connect("llm.replies", "tool_invoker.messages")
+
+        # Create a message that should trigger tool use
+        message = ChatMessage.from_user(text="What is the current time in New York?")
+
+        result = pipeline.run({"llm": {"messages": [message]}})
+
+        tool_messages = result["tool_invoker"]["tool_messages"]
+        assert len(tool_messages) == 1
+
+        tool_message = tool_messages[0]
+        assert tool_message.is_from(ChatRole.TOOL)
+        assert "timezone" in tool_message.tool_call_result.result
+        assert "datetime" in tool_message.tool_call_result.result
+        assert "New_York" in tool_message.tool_call_result.result
+
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_mcp_tool_error_handling(self):
+        """Test error handling with MCPTool in a pipeline."""
+
+        # Create a custom server info for a server that might return errors
+        server_info = HttpMCPServerInfo(base_url="http://localhost:8000")
+        with pytest.raises(MCPError):
+            MCPTool(name="divide", server_info=server_info)


### PR DESCRIPTION
### Why:
Introduces an initial integration of the Model Context Protocol (MCP) tool support

### What:
- Added MCP integration providing support for HTTP and stdio transport.
- Introduced the `MCPTool` tool to ease communication with MCP servers.
- Implemented new examples and test suites to demonstrate usage and validity.

### How can it be used:
An example of using the `MCPTool` class to connect with an HTTP server:
```python
from haystack_integrations.tools.mcp import MCPTool, HttpMCPServerInfo

server_info = HttpMCPServerInfo(base_url="http://localhost:8000")
tool = MCPTool(name="add", server_info=server_info)
result = tool.invoke(a=5, b=3)
```

### How did you test it:
Integrated tests were written, including both unit and integration tests, using pytest to validate tool operations and connectivity. MCP clients were mocked to simulate real server interactions, along with actual server-client integration tests using subprocesses.

### Notes for the reviewer:
Note that we don't use typing package as we are basing this package on 3.10+
Please focus on reviewing the `MCPTool` initialization and error handling logic, ensuring compatibility with various server types. Also, verify the completeness of the transport protocol handling in `mcp_tool.py`, and pay attention to the test coverage for potential integration pitfalls.