### PR TITLE
test: llama.cpp - do not test on Windows

### DIFF
--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        os: [ubuntu-latest, macos-latest] # we don't test on windows becaus of issues on llama-cpp-python
+        python-version: ["3.9", "3.12"]
 
     steps:
       - name: Support longpaths


### PR DESCRIPTION
### Related Issues
Windows test have been failing for several days.
The issue is on llama-cpp-python, even if I cannot find a single GitHub issue that tracks this problem; there are several ones related to compilation problems.
I tried several approaches in #1466 (pinning to a previous version, using pre-built wheels...), but none of them worked.

### Proposed Changes:
Do not test on Windows. (We can change that in the future)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
