### PR TITLE
fix: pgvector - improve `_create_table_if_not_exists` to be used without admin rights

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -23,7 +23,7 @@ from .filters import _convert_filters_to_where_clause_and_params
 logger = logging.getLogger(__name__)
 
 CREATE_TABLE_STATEMENT = """
-CREATE TABLE IF NOT EXISTS {schema_name}.{table_name} (
+CREATE TABLE {schema_name}.{table_name} (
 id VARCHAR(128) PRIMARY KEY,
 embedding VECTOR({embedding_dimension}),
 content TEXT,
@@ -310,13 +310,22 @@ class PgvectorDocumentStore:
         Creates the table to store Haystack documents if it doesn't exist yet.
         """
 
-        create_sql = SQL(CREATE_TABLE_STATEMENT).format(
-            schema_name=Identifier(self.schema_name),
-            table_name=Identifier(self.table_name),
-            embedding_dimension=SQLLiteral(self.embedding_dimension),
+        table_exists = bool(
+            self._execute_sql(
+                "SELECT 1 FROM pg_tables WHERE schemaname = %s AND tablename = %s",
+                (self.schema_name, self.table_name),
+                "Could not check if table exists",
+            ).fetchone()
         )
 
-        self._execute_sql(create_sql, error_msg="Could not create table in PgvectorDocumentStore")
+        if not table_exists:
+            create_sql = SQL(CREATE_TABLE_STATEMENT).format(
+                schema_name=Identifier(self.schema_name),
+                table_name=Identifier(self.table_name),
+                embedding_dimension=SQLLiteral(self.embedding_dimension),
+            )
+
+            self._execute_sql(create_sql, error_msg="Could not create table in PgvectorDocumentStore")
 
     def delete_table(self):
         """


### PR DESCRIPTION
### Related Issues

- fixes #1354

### Proposed Changes:
- modify the `_create_table_if_not_exists` method to be usable by non-admin users when the table already exists

### How did you test it?
CI; added a new test for the method

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
