### PR TITLE
chore: Astra - pin `haystack-ai>=2.11.0` and remove dataframe checks

### DIFF
--- a/integrations/astra/pyproject.toml
+++ b/integrations/astra/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "pydantic", "typing_extensions", "astrapy>=1.5.0,<2.0"]
+dependencies = ["haystack-ai>=2.11.0", "pydantic", "typing_extensions", "astrapy>=1.5.0,<2.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/astra#readme"

--- a/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
@@ -329,14 +329,6 @@ class AstraDocumentStore:
     def _get_result_to_documents(results) -> List[Document]:
         documents = []
         for match in results.matches:
-            dataframe = match.metadata.pop("dataframe", None)
-            if dataframe is not None:
-                logger.warning(
-                    "Document %s has the `dataframe` field set. "
-                    "AstraDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    match.document_id,
-                )
             document = Document(
                 content=match.text,
                 id=match.document_id,

--- a/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
@@ -202,16 +202,6 @@ class AstraDocumentStore:
             if embedding := document_dict.pop("embedding", []):
                 document_dict["$vector"] = embedding
 
-            if "dataframe" in document_dict:
-                dataframe = document_dict.pop("dataframe", None)
-                if dataframe:
-                    logger.warning(
-                        "Document {id} has the `dataframe` field set. "
-                        "AstraDocumentStore no longer supports dataframes and this field will be ignored. "
-                        "The `dataframe` field will soon be removed from Haystack Document.",
-                        id=document_dict["_id"],
-                    )
-
             if "sparse_embedding" in document_dict:
                 sparse_embedding = document_dict.pop("sparse_embedding", None)
                 if sparse_embedding:

--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -10,7 +10,6 @@ from haystack import Document
 from haystack.document_stores.errors import MissingDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
-from pandas import DataFrame
 
 from haystack_integrations.document_stores.astra import AstraDocumentStore
 
@@ -110,20 +109,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
             Document(id="1", content="test doc 2"),
         ]
         assert document_store.write_documents(docs, policy=DuplicatePolicy.SKIP) == 1
-
-    def test_write_documents_dataframe_ignored(self, document_store: AstraDocumentStore):
-        doc = Document(id="1", content="test")
-        doc.dataframe = DataFrame({"a": [1, 2, 3]})
-
-        document_store.write_documents([doc])
-
-        res = document_store.filter_documents()
-        assert len(res) == 1
-
-        assert res[0].id == "1"
-        assert res[0].content == "test"
-
-        assert not hasattr(res[0], "dataframe") or res[0].dataframe is None
 
     def test_delete_documents_non_existing_document(self, document_store: AstraDocumentStore):
         """


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks and tests

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
