### PR TITLE
chore: Azure AI - pin haystack and remove dataframe checks

### DIFF
--- a/integrations/azure_ai_search/pyproject.toml
+++ b/integrations/azure_ai_search/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "azure-search-documents>=11.5", "azure-identity"]
+dependencies = ["haystack-ai>=2.11.0ß", "azure-search-documents>=11.5", "azure-identity"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/azure_ai_search#readme"

--- a/integrations/azure_ai_search/pyproject.toml
+++ b/integrations/azure_ai_search/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0ß", "azure-search-documents>=11.5", "azure-identity"]
+dependencies = ["haystack-ai>=2.11.0", "azure-search-documents>=11.5", "azure-identity"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/azure_ai_search#readme"

--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -365,16 +365,6 @@ class AzureAISearchDocumentStore:
 
         doc_dict = document.to_dict(flatten=False)
 
-        if "dataframe" in doc_dict:
-            dataframe = doc_dict.pop("dataframe")
-            if dataframe:
-                logger.warning(
-                    "Document {doc_id} has the `dataframe` field set. "
-                    "AzureAISearchDocumentStore does not support dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    doc_id=doc_dict["id"],
-                )
-
         # Because Azure Search does not allow dynamic fields, we only include fields that are part of the schema
         index_document = {k: v for k, v in {**doc_dict, **doc_dict.get("meta", {})}.items() if k in self._index_fields}
         if index_document["embedding"] is None:

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -17,7 +17,6 @@ from haystack.testing.document_store import (
     WriteDocumentsTest,
 )
 from haystack.utils.auth import EnvVarSecret, Secret
-from pandas import DataFrame
 
 from haystack_integrations.document_stores.azure_ai_search import DEFAULT_VECTOR_SEARCH, AzureAISearchDocumentStore
 
@@ -130,16 +129,6 @@ class TestDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsT
         document_store.write_documents(docs)
         doc = document_store.get_documents_by_id(["1"])
         assert doc[0] == docs[0]
-
-    def test_write_documents_skips_dataframe(self, document_store: AzureAISearchDocumentStore):
-        doc = Document(id="1", content="test")
-        doc.dataframe = DataFrame({"a": [1, 2, 3]})
-
-        assert document_store.write_documents([doc]) == 1
-        retrieved_docs = document_store.get_documents_by_id(["1"])
-        assert retrieved_docs[0].id == "1"
-        assert retrieved_docs[0].content == "test"
-        assert not hasattr(retrieved_docs[0], "dataframe") or retrieved_docs[0].dataframe is None
 
     @pytest.mark.skip(reason="Azure AI search index overwrites duplicate documents by default")
     def test_write_documents_duplicate_fail(self, document_store: AzureAISearchDocumentStore): ...


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks and tests

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.
