### PR TITLE
chore: Chroma - pin haystack and remove dataframe checks

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai",
+  "haystack-ai>=2.11.0",
   "chromadb>=0.6.0",
   ]
 

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -253,13 +253,11 @@ class ChromaDocumentStore:
                     doc_id=doc.id,
                 )
                 continue
-            elif (hasattr(doc, "dataframe") and doc.dataframe is not None) or (
-                hasattr(doc, "blob") and doc.blob is not None
-            ):
+            elif hasattr(doc, "blob") and doc.blob is not None:
                 logger.warning(
-                    "Document with id {doc_id} contains `dataframe` or `blob` fields. "
-                    "ChromaDocumentStore cannot store `dataframe` or `blob` fields. "
-                    "These fields will be ignored.",
+                    "Document with id {doc_id} contains the `blob` field. "
+                    "ChromaDocumentStore cannot store `blob` fields. "
+                    "This field will be ignored.",
                     doc_id=doc.id,
                 )
             data = {"ids": [doc.id], "documents": [doc.content]}

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -237,17 +237,15 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, FilterDocuments
         document_store.write_documents([Document(content=None)])
         assert document_store.filter_documents() == []
 
-    def test_dataframe_and_blob_are_not_stored(self, document_store: ChromaDocumentStore):
+    def test_blob_not_stored(self, document_store: ChromaDocumentStore):
         bs = ByteStream(data=b"test")
         doc_mixed = Document(content="test", blob=bs)
-        doc_mixed.dataframe = "non null content"  # just a placeholder
 
         document_store.write_documents([doc_mixed])
 
         retrieved_doc = document_store.filter_documents()[0]
         assert retrieved_doc.content == "test"
         assert retrieved_doc.blob is None
-        assert not hasattr(retrieved_doc, "dataframe") or retrieved_doc.dataframe is None
 
     @pytest.mark.integration
     def test_to_dict(self, request):


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks and tests

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.