### PR TITLE
test: Mistral/Stackit - add pytz test dependency

### DIFF
--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
+  "pytz",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/integrations/stackit/pyproject.toml
+++ b/integrations/stackit/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "haystack-pydoc-tools",
-]
+  "pytz",
+  ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"

--- a/integrations/stackit/pyproject.toml
+++ b/integrations/stackit/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
   "haystack-pydoc-tools",
   "pytz",
   ]
+  
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"


### PR DESCRIPTION
### Related Issues
Nightly failures: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13777505362/job/38529576009 
https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13777522873/job/38529623183

This likely happens because pytz was a dependency of pandas, removed in 2.11.0

### Proposed Changes:
- add pytz to test dependencies

### How did you test it?
- CI
- Mistral tests run but fail: this seems related to https://github.com/deepset-ai/haystack/pull/8968 and I won't fix it in this PR

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
