### PR TITLE
chore: Mongo - pin haystack and remove dataframe checks

### DIFF
--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "pymongo[srv]"]
+dependencies = ["haystack-ai>=2.11.0", "pymongo[srv]"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -204,15 +204,6 @@ class MongoDBAtlasDocumentStore:
                         "The `sparse_embedding` field will be ignored.",
                         id=doc.id,
                     )
-            if "dataframe" in doc_dict:
-                dataframe = doc_dict.pop("dataframe", None)
-                if dataframe:
-                    logger.warning(
-                        "Document {id} has the `dataframe` field set,"
-                        "MongoDBAtlasDocumentStore no longer supports dataframes and this field will be ignored. "
-                        "The `dataframe` field will soon be removed from Haystack Document.",
-                        id=doc.id,
-                    )
             mongo_documents.append(doc_dict)
         operations: List[Union[UpdateOne, InsertOne, ReplaceOne]]
         written_docs = len(documents)
@@ -409,13 +400,4 @@ class MongoDBAtlasDocumentStore:
         :returns: A Haystack Document object
         """
         mongo_doc.pop("_id", None)
-        if "dataframe" in mongo_doc:
-            dataframe = mongo_doc.pop("dataframe", None)
-            if dataframe:
-                logger.warning(
-                    "Document {id} has the `dataframe` field set,"
-                    "MongoDBAtlasDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    id=mongo_doc["id"],
-                )
         return Document.from_dict(mongo_doc)

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -11,7 +11,6 @@ from haystack.document_stores.errors import DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
 from haystack.utils import Secret
-from pandas import DataFrame
 from pymongo import MongoClient
 from pymongo.driver_info import DriverInfo
 
@@ -71,17 +70,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
         document_store.write_documents(docs)
         retrieved_docs = document_store.filter_documents()
         assert retrieved_docs == docs
-
-    def test_write_documents_dataframe_ignored(self, document_store: MongoDBAtlasDocumentStore):
-        doc = Document(id="test_id", content="test content")
-        doc.dataframe = DataFrame({"col1": [1, 2], "col2": [3, 4]})
-
-        document_store.write_documents([doc])
-
-        retrieved_docs = document_store.filter_documents()
-        assert retrieved_docs[0].id == "test_id"
-        assert retrieved_docs[0].content == "test content"
-        assert not hasattr(retrieved_docs[0], "dataframe") or retrieved_docs[0].dataframe is None
 
     def test_to_dict(self, document_store):
         serialized_store = document_store.to_dict()


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks and tests

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.