### PR TITLE
chore: OpenSearch - pin haystack and remove dataframe checks

### DIFF
--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "opensearch-py[async]>=2,<3"]
+dependencies = ["haystack-ai>=2.11.0", "opensearch-py[async]>=2,<3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/opensearch#readme"

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -357,15 +357,6 @@ class OpenSearchDocumentStore:
         opensearch_actions = []
         for doc in documents:
             doc_dict = doc.to_dict()
-            if "dataframe" in doc_dict:
-                dataframe = doc_dict.pop("dataframe")
-                if dataframe:
-                    logger.warning(
-                        "Document {id} has the `dataframe` field set,"
-                        "OpenSearchDocumentStore no longer supports dataframes and this field will be ignored. "
-                        "The `dataframe` field will soon be removed from Haystack Document.",
-                        id=doc.id,
-                    )
             if "sparse_embedding" in doc_dict:
                 sparse_embedding = doc_dict.pop("sparse_embedding", None)
                 if sparse_embedding:
@@ -464,16 +455,6 @@ class OpenSearchDocumentStore:
         if "highlight" in hit:
             data["metadata"]["highlighted"] = hit["highlight"]
         data["score"] = hit["_score"]
-
-        if "dataframe" in data:
-            dataframe = data.pop("dataframe")
-            if dataframe:
-                logger.warning(
-                    "Document {id} has the `dataframe` field set,"
-                    "OpenSearchDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    id=data["id"],
-                )
 
         return Document.from_dict(data)
 

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -12,7 +12,6 @@ from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
 from haystack.utils.auth import Secret
 from opensearchpy.exceptions import RequestError
-from pandas import DataFrame
 
 from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 from haystack_integrations.document_stores.opensearch.auth import AWSAuth
@@ -470,31 +469,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
     def test_create_index(self, document_store_readonly: OpenSearchDocumentStore):
         document_store_readonly.create_index()
         assert document_store_readonly._client.indices.exists(index=document_store_readonly._index)
-
-    def test_write_documents_dataframe_ignored(self, document_store: OpenSearchDocumentStore):
-        doc = Document(id="1", content="test")
-        doc.dataframe = DataFrame({"a": [1, 2, 3]})
-
-        document_store.write_documents([doc])
-
-        res = document_store.filter_documents()
-        assert len(res) == 1
-
-        assert res[0].id == "1"
-        assert res[0].content == "test"
-
-        assert not hasattr(res[0], "dataframe") or res[0].dataframe is None
-
-    def test_deserialize_document_dataframe_ignored(self, document_store: OpenSearchDocumentStore):
-        hit = {
-            "_source": {"id": "1", "content": "test", "dataframe": {"a": [1, 2, 3]}},
-            "_score": 1.0,
-        }
-        doc = document_store._deserialize_document(hit)
-        assert doc.id == "1"
-        assert doc.content == "test"
-        assert doc.score == 1.0
-        assert not hasattr(doc, "dataframe") or doc.dataframe is None
 
     def test_bm25_retrieval(self, document_store: OpenSearchDocumentStore):
         document_store.write_documents(


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks and tests

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.