### PR TITLE
chore: Pinecone - pin haystack and remove dataframe checks

### DIFF
--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai",
+  "haystack-ai>=2.11.0",
   "pinecone>=3", # our implementation is not compatible with pinecone <3
 ]
 

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -288,15 +288,6 @@ class PineconeDocumentStore:
         for pinecone_doc in pinecone_docs:
             content = pinecone_doc["metadata"].pop("content", None)
 
-            dataframe = pinecone_doc["metadata"].pop("dataframe", None)
-            if dataframe:
-                logger.warning(
-                    "Document %s has the `dataframe` field set. "
-                    "PineconeDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    pinecone_doc["id"],
-                )
-
             # we always store vectors during writing but we don't want to return them if they are dummy vectors
             embedding = None
             if pinecone_doc["values"] != self._dummy_vector:
@@ -363,13 +354,7 @@ class PineconeDocumentStore:
             # we save content as metadata
             if document.content is not None:
                 doc_for_pinecone["metadata"]["content"] = document.content
-            if document.dataframe is not None:
-                logger.warning(
-                    "Document %s has the `dataframe` field set. "
-                    "PineconeDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    document.id,
-                )
+
             # currently, storing blob in Pinecone is not supported
             if document.blob is not None:
                 logger.warning(


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks (no tests)

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.