### PR TITLE
chore: qdrant - pin haystack and remove dataframe checks

### DIFF
--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "qdrant-client>=1.10.0"]
+dependencies = ["haystack-ai>=2.11.0", "qdrant-client>=1.10.0"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/converters.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/converters.py
@@ -23,14 +23,6 @@ def convert_haystack_documents_to_qdrant_points(
     for document in documents:
         payload = document.to_dict(flatten=False)
 
-        if payload.pop("dataframe", None):
-            logger.warning(
-                "Document {doc_id} has the `dataframe` field set, "
-                "QdrantDocumentStore no longer supports dataframes and this field will be ignored. "
-                "The `dataframe` field will soon be removed from Haystack Document.",
-                doc_id=document.id,
-            )
-
         if use_sparse_embeddings:
             vector = {}
 
@@ -72,14 +64,6 @@ QdrantPoint = Union[rest.ScoredPoint, rest.Record]
 def convert_qdrant_point_to_haystack_document(point: QdrantPoint, use_sparse_embeddings: bool) -> Document:
     payload = {**point.payload}
     payload["score"] = point.score if hasattr(point, "score") else None
-
-    if payload.pop("dataframe", None):
-        logger.warning(
-            "Document {doc_id} has the `dataframe` field set, "
-            "QdrantDocumentStore no longer supports dataframes and this field will be ignored. "
-            "The `dataframe` field will soon be removed from Haystack Document.",
-            doc_id=payload["id"],
-        )
 
     if not use_sparse_embeddings:
         payload["embedding"] = point.vector if hasattr(point, "vector") else None

--- a/integrations/qdrant/tests/test_converters.py
+++ b/integrations/qdrant/tests/test_converters.py
@@ -1,10 +1,7 @@
 import numpy as np
-from haystack import Document
-from pandas import DataFrame
 from qdrant_client.http import models as rest
 
 from haystack_integrations.document_stores.qdrant.converters import (
-    convert_haystack_documents_to_qdrant_points,
     convert_id,
     convert_qdrant_point_to_haystack_document,
 )
@@ -65,44 +62,3 @@ def test_point_to_document_reverts_proper_structure_from_record_without_sparse()
     assert document.sparse_embedding is None
     assert {"test_field": 1} == document.meta
     assert 0.0 == np.sum(np.array([1.0, 0.0, 0.0, 0.0]) - document.embedding)
-
-
-def test_point_to_document_skips_dataframe():
-
-    point = rest.Record(
-        id="c7c62e8e-02b9-4ec6-9f88-46bd97b628b7",
-        payload={
-            "id": "my-id",
-            "content": "Lorem ipsum",
-            "content_type": "text",
-            "meta": {
-                "test_field": 1,
-            },
-            "dataframe": {"a": [1, 2, 3]},
-        },
-        vector=[1.0, 0.0, 0.0, 0.0],
-    )
-    document = convert_qdrant_point_to_haystack_document(point, use_sparse_embeddings=False)
-    assert "my-id" == document.id
-    assert "Lorem ipsum" == document.content
-    assert "text" == document.content_type
-    assert {"test_field": 1} == document.meta
-    assert 0.0 == np.sum(np.array([1.0, 0.0, 0.0, 0.0]) - document.embedding)
-    assert not hasattr(document, "dataframe") or document.dataframe is None
-
-
-def test_documents_to_points_skips_dataframe():
-    doc = Document(
-        id="my-id",
-        content="Lorem ipsum",
-        embedding=[1.0, 0.0, 0.0, 0.0],
-    )
-
-    doc.dataframe = DataFrame([[1, 2], [3, 4]])
-
-    points = convert_haystack_documents_to_qdrant_points([doc], use_sparse_embeddings=False)
-    assert len(points) == 1
-
-    assert points[0].payload["content"] == "Lorem ipsum"
-    assert points[0].vector == [1.0, 0.0, 0.0, 0.0]
-    assert "dataframe" not in points[0].payload


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks and tests

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.