### PR TITLE
build: Snowflake - add pandas depenency

### DIFF
--- a/integrations/snowflake/pyproject.toml
+++ b/integrations/snowflake/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "snowflake-connector-python>=3.10.1", "tabulate>=0.9.0"]
+dependencies = ["haystack-ai", "pandas", "snowflake-connector-python>=3.10.1", "tabulate>=0.9.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/snowflake#readme"


### PR DESCRIPTION
### Related Issues

Nightly failures due to missing pandas dependency: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13777255521/job/38528856377

### Proposed Changes:
- add pandas dependency

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
