### PR TITLE
chore: Weaviate - pin haystack and remove dataframe checks

### DIFF
--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai",
+  "haystack-ai>=2.11.0",
   "weaviate-client>=4.9",
   "python-dateutil",
 ]

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -293,16 +293,6 @@ class WeaviateDocumentStore:
                 id=data["_original_id"],
             )
 
-        if "dataframe" in data:
-            dataframe = data.pop("dataframe")
-            if dataframe:
-                logger.warning(
-                    "Document {id} has the `dataframe` field set. "
-                    "WeaviateDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    id=data["_original_id"],
-                )
-
         if "sparse_embedding" in data:
             sparse_embedding = data.pop("sparse_embedding", None)
             if sparse_embedding:
@@ -337,16 +327,6 @@ class WeaviateDocumentStore:
         # We always delete these fields as they're not part of the Document dataclass
         document_data.pop("blob_data", None)
         document_data.pop("blob_mime_type", None)
-
-        if "dataframe" in document_data:
-            dataframe = document_data.pop("dataframe")
-            if dataframe:
-                logger.warning(
-                    "Document {id} has the `dataframe` field set. "
-                    "WeaviateDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    id=document_data["id"],
-                )
 
         for key, value in document_data.items():
             if isinstance(value, datetime.datetime):

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -23,7 +23,6 @@ from haystack.utils.auth import Secret
 from numpy import array as np_array
 from numpy import array_equal as np_array_equal
 from numpy import float32 as np_float32
-from pandas import DataFrame
 from weaviate.collections.classes.data import DataObject
 from weaviate.config import AdditionalConfig, ConnectionConfig, Proxies, Timeout
 from weaviate.embedded import (
@@ -314,16 +313,6 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
             "key": "value",
         }
 
-    def test_to_data_object_skips_dataframe(self, document_store):
-        doc = Document(id="test_id", content="test content")
-        doc.dataframe = DataFrame([{"a": 1, "b": 2}, {"a": 3, "b": 4}])
-
-        data = document_store._to_data_object(doc)
-
-        assert data["_original_id"] == "test_id"
-        assert data["content"] == "test content"
-        assert "dataframe" not in data
-
     def test_to_document(self, document_store, test_files_path):
         image = ByteStream.from_file_path(test_files_path / "robot1.jpg", mime_type="image/jpeg")
         data = DataObject(
@@ -345,20 +334,6 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         assert doc.embedding == [1, 2, 3]
         assert doc.score is None
         assert doc.meta == {"key": "value"}
-
-    def test_to_document_skips_dataframe(self, document_store):
-        data = DataObject(
-            properties={
-                "_original_id": "test_id",
-                "content": "test content",
-                "dataframe": {"a": [1, 2, 3]},
-            }
-        )
-
-        doc = document_store._to_document(data)
-        assert doc.id == "test_id"
-        assert doc.content == "test content"
-        assert not hasattr(doc, "dataframe") or doc.dataframe is None
 
     def test_write_documents(self, document_store):
         """


### PR DESCRIPTION
### Related Issues

- part of #1462

### Proposed Changes:
- pin `haystack-ai>=2.11.0`
- remove dataframe checks and tests

### How did you test it?
CI

### Notes for the reviewer
I'll release a new major version since the pin can be considered a breaking change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.