### PR TITLE
fix: OpenSearch - call `_ensure_index_exists` only at initialization

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -256,7 +256,7 @@ class OpenSearchDocumentStore:
 
             self._initialized = True
 
-        self._ensure_index_exists()
+            self._ensure_index_exists()
 
     def _ensure_index_exists(self):
         assert self._client is not None


### PR DESCRIPTION
### Related Issues
I noticed `_ensure_index_exists` was erroneously called for each invocation of the CRUD operations of the Document Store.
This should only happen once, at initialization.

### Proposed Changes:
- call `_ensure_index_exists` only at initialization

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
