### PR TITLE
refactor: Update AWS Bedrock with improved docstrings and warning message

### DIFF
--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -60,7 +61,7 @@ cov-retry = ["test-cov-retry", "cov-report"]
 docs = ["pydoc-markdown pydoc/config.yml"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.13"]
 
 [tool.hatch.envs.lint]
 installer = "uv"

--- a/integrations/amazon_bedrock/src/haystack_integrations/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/common/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/common/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
@@ -11,6 +11,11 @@ class BedrockModelAdapter(ABC):
 
     Each subclass of this class is designed to address the unique specificities of a particular LLM it adapts,
     focusing on preparing the requests and extracting the responses from the Amazon Bedrock hosted LLMs.
+
+    :param model_kwargs: Keyword arguments for the model. You can find the full list of parameters in the
+        Amazon Bedrock API [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html).
+    :param max_length: Maximum length of generated text. This is mapped to the correct parameter for each model.
+        It will be overridden by the corresponding parameter in the `model_kwargs` if it is present.
     """
 
     def __init__(self, model_kwargs: Dict[str, Any], max_length: Optional[int]) -> None:
@@ -99,7 +104,10 @@ class AnthropicClaudeAdapter(BedrockModelAdapter):
     """
     Adapter for the Anthropic Claude models.
 
-    :param model_kwargs: model configuration:
+    :param model_kwargs: Keyword arguments for the model. You can find the full list of parameters in the
+        Amazon Bedrock API documentation for the Claude model
+        [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html).
+        Some example parameters are:
         - use_messages_api: Whether to use the messages API, default: True
         - include_thinking: Whether to include thinking output, default: True
         - thinking_tag: XML tag for thinking content, default: "thinking"

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -147,26 +147,24 @@ class AmazonBedrockChatGenerator:
         and `aws_region_name`.
 
         :param model: The model to use for text generation. The model must be available in Amazon Bedrock and must
-        be specified in the format outlined in the [Amazon Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html).
+            be specified in the format outlined in the [Amazon Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html).
         :param aws_access_key_id: AWS access key ID.
         :param aws_secret_access_key: AWS secret access key.
         :param aws_session_token: AWS session token.
         :param aws_region_name: AWS region name. Make sure the region you set supports Amazon Bedrock.
         :param aws_profile_name: AWS profile name.
-        :param generation_kwargs: Keyword arguments sent to the model. These
-        parameters are specific to a model. You can find them in the model's documentation.
-          For example, you can find the
-        Anthropic Claude generation parameters in [Anthropic documentation](https://docs.anthropic.com/claude/reference/complete_post).
+        :param generation_kwargs: Keyword arguments sent to the model. These parameters are specific to a model.
+            You can find the model specific arguments in the AWS Bedrock API
+            [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html).
         :param stop_words: A list of stop words that stop the model from generating more text
-          when encountered. You can provide them using
-        this parameter or using the model's `generation_kwargs` under a model's specific key for stop words.
-          For example, you can provide
-        stop words for Anthropic Claude in the `stop_sequences` key.
+            when encountered. You can provide them using this parameter or using the model's `generation_kwargs`
+            under a model's specific key for stop words.
+            For example, you can provide stop words for Anthropic Claude in the `stop_sequences` key.
         :param streaming_callback: A callback function called when a new token is received from the stream.
-        By default, the model is not set up for streaming. To enable streaming, set this parameter to a callback
-        function that handles the streaming chunks. The callback function receives a
-          [StreamingChunk](https://docs.haystack.deepset.ai/docs/data-classes#streamingchunk) object and
-        switches the streaming mode on.
+            By default, the model is not set up for streaming. To enable streaming, set this parameter to a callback
+            function that handles the streaming chunks. The callback function receives a
+            [StreamingChunk](https://docs.haystack.deepset.ai/docs/data-classes#streamingchunk) object and switches
+            the streaming mode on.
         :param boto3_config: The configuration for the boto3 client.
         :param tools: A list of Tool objects that the model can use. Each tool should have a unique name.
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -118,7 +118,8 @@ class AmazonBedrockGenerator:
         :param aws_session_token: The AWS session token.
         :param aws_region_name: The AWS region name. Make sure the region you set supports Amazon Bedrock.
         :param aws_profile_name: The AWS profile name.
-        :param max_length: Deprecated. This parameter no longer has any effect.
+        :param max_length: The maximum length of the generated text. This can also be set in the `kwargs` parameter
+            by using the model specific parameter name.
         :param truncate: Deprecated. This parameter no longer has any effect.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
@@ -126,6 +127,8 @@ class AmazonBedrockGenerator:
         :param model_family: The model family to use. If not provided, the model adapter is selected based on the model
             name.
         :param kwargs: Additional keyword arguments to be passed to the model.
+            You can find the model specific arguments in AWS Bedrock's
+            [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html).
         These arguments are specific to the model. You can find them in the model's documentation.
         :raises ValueError: If the model name is empty or None.
         :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly or the model is

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -140,7 +140,7 @@ class AmazonBedrockGenerator:
         self.model = model
 
         if truncate is not None:
-            msg = "The 'truncate' parameter no longer have any effect. No truncation will be performed."
+            msg = "The 'truncate' parameter no longer has any effect. No truncation will be performed."
             logger.warning(msg)
             warnings.warn(msg, stacklevel=2)
         self.truncate = truncate

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -135,16 +135,14 @@ class AmazonBedrockGenerator:
             msg = "'model' cannot be None or empty string"
             raise ValueError(msg)
         self.model = model
-        self.max_length = max_length
+
+        if truncate is not None:
+            msg = "The 'truncate' parameter no longer have any effect. No truncation will be performed."
+            logger.warning(msg)
+            warnings.warn(msg, stacklevel=2)
         self.truncate = truncate
 
-        if max_length is not None or truncate is not None:
-            warnings.warn(
-                "The 'max_length' and 'truncate' parameters have been removed and no longer have any effect. "
-                "No truncation will be performed.",
-                stacklevel=2,
-            )
-
+        self.max_length = max_length
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_session_token = aws_session_token
@@ -285,7 +283,6 @@ class AmazonBedrockGenerator:
             aws_profile_name=self.aws_profile_name.to_dict() if self.aws_profile_name else None,
             model=self.model,
             max_length=self.max_length,
-            truncate=self.truncate,
             streaming_callback=callback_name,
             boto3_config=self.boto3_config,
             model_family=self.model_family,

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -34,7 +34,7 @@ def test_to_dict(mock_boto3_session: Any, boto3_config: Optional[Dict[str, Any]]
     Test that the to_dict method returns the correct dictionary without aws credentials
     """
     generator = AmazonBedrockGenerator(
-        model="anthropic.claude-v2", max_length=99, truncate=False, temperature=10, boto3_config=boto3_config
+        model="anthropic.claude-v2", max_length=99, temperature=10, boto3_config=boto3_config
     )
 
     expected_dict = {
@@ -47,7 +47,6 @@ def test_to_dict(mock_boto3_session: Any, boto3_config: Optional[Dict[str, Any]]
             "aws_profile_name": {"type": "env_var", "env_vars": ["AWS_PROFILE"], "strict": False},
             "model": "anthropic.claude-v2",
             "max_length": 99,
-            "truncate": False,
             "temperature": 10,
             "streaming_callback": None,
             "boto3_config": boto3_config,


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Removed `truncate` from `to_dict` since it's no longer supported
- Updated warning message to reflect that only `truncate` is deprecated. `max_length` still performs a function we would like to keep
- Updated docstrings to make it easier to find the model specific parameters

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
