### PR TITLE
feat: add weave_init_kwargs to WeaveConnector

### DIFF
--- a/integrations/weights_bias/src/haystack_integrations/components/connectors/weave_connector.py
+++ b/integrations/weights_bias/src/haystack_integrations/components/connectors/weave_connector.py
@@ -71,7 +71,7 @@ class WeaveConnector:
 
     """
 
-    def __init__(self, pipeline_name: str, weave_init_kwargs: dict[str, Any] | None = None) -> None:
+    def __init__(self, pipeline_name: str, weave_init_kwargs: Optional[dict[str, Any]] = None) -> None:
         """
         Initialize WeaveConnector.
 

--- a/integrations/weights_bias/src/haystack_integrations/components/connectors/weave_connector.py
+++ b/integrations/weights_bias/src/haystack_integrations/components/connectors/weave_connector.py
@@ -76,7 +76,7 @@ class WeaveConnector:
         Initialize WeaveConnector.
 
         :param pipeline_name: The name of the pipeline you want to trace.
-        :param weave_init_kwargs: Additional arguments to pass to the Weave client.
+        :param weave_init_kwargs: Additional arguments to pass to the WeaveTracer client.
         """
         self.pipeline_name = pipeline_name
         self.weave_init_kwargs = weave_init_kwargs or {}

--- a/integrations/weights_bias/src/haystack_integrations/tracing/weave/tracer.py
+++ b/integrations/weights_bias/src/haystack_integrations/tracing/weave/tracer.py
@@ -68,11 +68,12 @@ class WeaveTracer(Tracer):
     to Weave spans. It creates spans for each Haystack component run.
     """
 
-    def __init__(self, project_name: str) -> None:
+    def __init__(self, project_name: str, **weave_init_kwargs: Any) -> None:
         """
         Initialize the WeaveTracer.
 
         :param project_name: The name of the project to trace, this is will be the name appearing in Weave project.
+        :param weave_init_kwargs: Additional arguments to pass to the Weave client.
         """
 
         content_tracing_enabled = os.getenv("HAYSTACK_CONTENT_TRACING_ENABLED", "false").lower()
@@ -84,7 +85,7 @@ class WeaveTracer(Tracer):
                 "before importing Haystack."
             )
 
-        self._client = weave.init(project_name)
+        self._client = weave.init(project_name, **weave_init_kwargs)
         self._current_span: Optional[WeaveSpan] = None
 
     @staticmethod

--- a/integrations/weights_bias/tests/test_tracer.py
+++ b/integrations/weights_bias/tests/test_tracer.py
@@ -1,6 +1,8 @@
 import logging
 from unittest.mock import patch
 
+from weave.trace.autopatch import AutopatchSettings
+
 from haystack_integrations.tracing.weave.tracer import WeaveSpan, WeaveTracer
 
 
@@ -33,6 +35,19 @@ class TestWeaveTracer:
             assert tracer._client is not None
             assert tracer._current_span is None
             mock_init.assert_called_once_with("test_project")
+
+    def test_initialization_with_weave_init_kwargs(self):
+        with patch("weave.init") as mock_init:
+            mock_init.return_value = MockWeaveClient()
+            tracer = WeaveTracer(
+                project_name="test_project",
+                autopatch_settings=AutopatchSettings(disable_autopatch=True),
+            )
+            assert tracer._client is not None
+            assert tracer._current_span is None
+            mock_init.assert_called_once_with(
+                "test_project", autopatch_settings=AutopatchSettings(disable_autopatch=True)
+            )
 
     def test_create_new_span(self):
         with patch("weave.init") as mock_init:


### PR DESCRIPTION
### Related Issues
- mitigates https://github.com/deepset-ai/haystack/issues/9014 by allowing to pass `autopatch_settings` to `weave.init`

### Proposed Changes:
- add `weave_init_kwargs` to `WeaveConnector`
- (de)serialize AutopatchSettings

### How did you test it?
- added tests

### Notes for the reviewer
Usage in yaml to disable autopatch:
```yaml
type: haystack_integrations.components.connectors.weave_connector.WeaveConnector
init_parameters:
  pipeline_name: test_pipeline
  weave_init_kwargs:
    autopatch_settings:
      disable_autopatch: true
```
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
