### PR TITLE
fix: `TypeError` in `QdrantDocumentStore` when handling duplicate documents

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -1511,9 +1511,9 @@ class QdrantDocumentStore:
         for document in documents:
             if document.id in _hash_ids:
                 logger.info(
-                    "Duplicate Documents: Document with id '%s' already exists in index '%s'",
-                    document.id,
-                    self.index,
+                    "Duplicate Documents: Document with id '{document_id}' already exists in index '{index}'",
+                    document_id=document.id,
+                    index=self.index,
                 )
                 continue
             _documents.append(document)


### PR DESCRIPTION
### Related Issues

- fixes #1550

### Proposed Changes:

Bug was introduced in https://github.com/deepset-ai/haystack-core-integrations/pull/1484 and I solved it by passing kwargs just like in similar cases in mentioned PR.

### How did you test it?

unit tests, manual verification

### Notes for the reviewer

none

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
