### PR TITLE
feat!: OpenSearch - apply `return_embedding` to `filter_documents`

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -72,7 +72,8 @@ class OpenSearchDocumentStore:
         :param max_chunk_bytes: Maximum size of the requests in bytes. Defaults to 100MB
         :param embedding_dim: Dimension of the embeddings. Defaults to 768
         :param return_embedding:
-            Whether to return the embedding of the retrieved Documents.
+            Whether to return the embedding of the retrieved Documents. This parameter also applies to the
+            `filter_documents` and `filter_documents_async` methods.
         :param method: The method definition of the underlying configuration of the approximate k-NN algorithm. Please
             see the [official OpenSearch docs](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#method-definitions)
             for more information. Defaults to None
@@ -309,6 +310,11 @@ class OpenSearchDocumentStore:
         search_kwargs: Dict[str, Any] = {"size": 10_000}
         if filters:
             search_kwargs["query"] = {"bool": {"filter": normalize_filters(filters)}}
+
+        # For some applications not returning the embedding can save a lot of bandwidth
+        # if you don't need this data not retrieving it can be a good idea
+        if not self._return_embedding:
+            search_kwargs["_source"] = {"excludes": ["embedding"]}
         return search_kwargs
 
     def _search_documents(self, request_body: Dict[str, Any]) -> List[Document]:


### PR DESCRIPTION
### Related Issues

- fixes #1559

### Proposed Changes:
- take into consideration `self._return_embedding` in `filter_documents` method: if `False`, do not return embedding
- (unrelated: fix typo in fixture)

### How did you test it?
CI; new test

### Notes for the reviewer
I'm convinced that `filter_documents` always returned embeddings since the introduction of the integration.
So, while #1559 seems to make sense, I would treat as a breaking change (it changes the default behavior of the Document Store) -> I will release a major version

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
