### PR TITLE
fix: do not include changelog update commits in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,7 +25,7 @@ body = """
         If we don't do this we get an empty section since we don't show
         commits that update the changelog
     #}\
-    {% if commits | length == 1 and commits[0].message == 'Update the changelog' %}\
+    {% if commits | length == 1 and 'Update changelog for' in commits[0].message %}\
         {% continue %}\
     {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
@@ -33,7 +33,7 @@ body = """
         {#
             Skip commits that update the changelog, they're not useful to the user
         #}\
-        {% if commit.message == 'Update the changelog' %}\
+        {% if 'Update changelog for' in commit.message %}\
             {% continue %}\
         {% endif %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\


### PR DESCRIPTION
### Related Issues
- During the release of an integration, the changelog is generated, including previous commits to update the changelog ("Update changelog for..."). This information is not useful and makes the changelog chaotic.
- There is a mechanism in place to avoid this, but it was not updated after https://github.com/deepset-ai/haystack-core-integrations/pull/1328 (where the commit message was changed)

### Proposed Changes:
- Update the Git cliff template to account for the new commit message format for changelog updates ([Tera templating syntax](https://keats.github.io/tera/docs/#in-checking))

### How did you test it?
I can't find a quick way to test this.
I suggest we just try...

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
