### PR TITLE
chore: skip `typing_extensions` license check

### DIFF
--- a/.github/workflows/CI_license_compliance.yml
+++ b/.github/workflows/CI_license_compliance.yml
@@ -12,7 +12,7 @@ on:
 env:
   CORE_DATADOG_API_KEY: ${{ secrets.CORE_DATADOG_API_KEY }}
   PYTHON_VERSION: "3.10"
-  EXCLUDE_PACKAGES: "(?i)^(deepeval|cohere|fastembed|ragas|tqdm|psycopg).*"
+  EXCLUDE_PACKAGES: "(?i)^(deepeval|cohere|fastembed|ragas|tqdm|psycopg|typing_extensions).*"
 
   # Exclusions must be explicitly motivated
   #
@@ -20,6 +20,8 @@ env:
   # - cohere is MIT but the license is not available on PyPI
   # - fastembed is Apache 2.0 but the license on PyPI is unclear ("Other/Proprietary License (Apache License)")
   # - ragas is Apache 2.0 but the license is not available on PyPI
+  # - typing_extensions>=4.13.0 has a Python Software Foundation License 2.0 but pip-license-checker does not recognize it
+  #   (https://github.com/pilosus/pip-license-checker/issues/143)
 
   # - tqdm is MLP but there are no better alternatives
   # - psycopg is LGPL-3.0 but FOSSA is fine with it


### PR DESCRIPTION
### Related Issues

- failing license compliance workflow: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/14095898343/job/39498550832

- this happens because `typing-extensions==4.13.0` was released yesterday with Python Software Foundation License 2.0 and the GitHub action that checks licenses does not recognize it (see https://github.com/pilosus/pip-license-checker/issues/143)


### Proposed Changes:

- add `typing_extensions` to excluded packages

### How did you test it?
Tested locally using the docker image:
```bash
docker run -it -v `pwd`:/volume \
    --rm pilosus/pip-license-checker \
    java -jar app.jar --exclude 'typing_extensions.*' \
    --requirements '/volume/requirements.txt' \
    --verbose
```


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
