### PR TITLE
test: update tool serialization in tests to include `inputs_from_state` and `outputs_to_state`

### DIFF
--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -649,6 +649,16 @@ class TestAmazonBedrockChatGeneratorInference:
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
 
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "inputs_from_state"
+            ] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "outputs_to_state"
+            ] = tool.outputs_to_state
+
         assert pipeline_dict == expected_dict
 
         # Test YAML serialization/deserialization

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -171,7 +171,7 @@ class TestAnthropicChatGenerator:
         )
         data = component.to_dict()
 
-        assert data == {
+        expected_dict = {
             "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
             "init_parameters": {
                 "api_key": {"env_vars": ["ENV_VAR"], "type": "env_var", "strict": True},
@@ -196,6 +196,14 @@ class TestAnthropicChatGenerator:
                 ],
             },
         }
+
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = tool.outputs_to_state
+
+        assert data == expected_dict
 
     def test_from_dict(self, monkeypatch):
         """
@@ -565,6 +573,16 @@ class TestAnthropicChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
+
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "inputs_from_state"
+            ] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "outputs_to_state"
+            ] = tool.outputs_to_state
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -462,6 +462,16 @@ class TestCohereChatGenerator:
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
 
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "inputs_from_state"
+            ] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "outputs_to_state"
+            ] = tool.outputs_to_state
+
         assert pipeline_dict == expected_dict
 
         # Test YAML serialization/deserialization

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -157,7 +157,7 @@ class TestGoogleAIGeminiChatGenerator:
                 tools=tools,
                 tool_config=tool_config,
             )
-        assert gemini.to_dict() == {
+        expected_dict = {
             "type": TYPE,
             "init_parameters": {
                 "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
@@ -191,6 +191,14 @@ class TestGoogleAIGeminiChatGenerator:
                 },
             },
         }
+
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tools[0], "inputs_from_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = tools[0].inputs_from_state
+        if hasattr(tools[0], "outputs_to_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = tools[0].outputs_to_state
+
+        assert gemini.to_dict() == expected_dict
 
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "test")
@@ -324,6 +332,16 @@ class TestGoogleAIGeminiChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
+
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "inputs_from_state"
+            ] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "outputs_to_state"
+            ] = tool.outputs_to_state
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -171,7 +171,7 @@ class TestVertexAIGeminiChatGenerator:
             tool_config=tool_config,
         )
 
-        assert gemini.to_dict() == {
+        expected_dict = {
             "type": "haystack_integrations.components.generators.google_vertex.chat.gemini.VertexAIGeminiChatGenerator",
             "init_parameters": {
                 "model": "gemini-1.5-flash",
@@ -206,6 +206,14 @@ class TestVertexAIGeminiChatGenerator:
                 },
             },
         }
+
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tools[0], "inputs_from_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = tools[0].inputs_from_state
+        if hasattr(tools[0], "outputs_to_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = tools[0].outputs_to_state
+
+        assert gemini.to_dict() == expected_dict
 
     @patch("haystack_integrations.components.generators.google_vertex.chat.gemini.vertexai_init")
     @patch("haystack_integrations.components.generators.google_vertex.chat.gemini.GenerativeModel")
@@ -560,6 +568,16 @@ class TestVertexAIGeminiChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
+
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "inputs_from_state"
+            ] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "outputs_to_state"
+            ] = tool.outputs_to_state
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -498,6 +498,16 @@ class TestMistralChatGenerator:
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
 
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "inputs_from_state"
+            ] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"][
+                "outputs_to_state"
+            ] = tool.outputs_to_state
+
         assert pipeline_dict == expected_dict
 
         # Test YAML serialization/deserialization

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -215,7 +215,8 @@ class TestOllamaChatGenerator:
             response_format={"type": "object", "properties": {"name": {"type": "string"}, "age": {"type": "number"}}},
         )
         data = component.to_dict()
-        assert data == {
+
+        expected_dict = {
             "type": "haystack_integrations.components.generators.ollama.chat.chat_generator.OllamaChatGenerator",
             "init_parameters": {
                 "timeout": 120,
@@ -248,6 +249,14 @@ class TestOllamaChatGenerator:
                 },
             },
         }
+
+        # add inputs_from_state and outputs_to_state tool parameters for compatibility with haystack-ai>=2.12.0
+        if hasattr(tool, "inputs_from_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = tool.inputs_from_state
+        if hasattr(tool, "outputs_to_state"):
+            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = tool.outputs_to_state
+
+        assert data == expected_dict
 
     def test_from_dict(self):
         tool = Tool(


### PR DESCRIPTION
### Related Issues

- fixes #1580

### Proposed Changes:
- in serialization tests, take into account `inputs_from_state` and `outputs_to_state` tool parameters if they exist (they will be introduced in Haystack 2.12.0)

### How did you test it?
CI.
For each integration, I also locally ran the unit tests with Haystack main branch, similarly to what our nightly tests do.
*Bedrock test failures seems unrelated to this PR.*

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
