### PR TITLE
feat: Add trace_id to output of LangfuseConnector

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Dict, Optional
 
 import httpx
@@ -159,7 +163,7 @@ class LangfuseConnector:
         )
         tracing.enable_tracing(self.tracer)
 
-    @component.output_types(name=str, trace_url=str)
+    @component.output_types(name=str, trace_url=str, trace_id=str)
     def run(self, invocation_context: Optional[Dict[str, Any]] = None):
         """
         Runs the LangfuseConnector component.
@@ -176,7 +180,7 @@ class LangfuseConnector:
             "Langfuse tracer invoked with the following context: '{invocation_context}'",
             invocation_context=invocation_context,
         )
-        return {"name": self.name, "trace_url": self.tracer.get_trace_url()}
+        return {"name": self.name, "trace_url": self.tracer.get_trace_url(), "trace_id": self.tracer.get_trace_id()}
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 import os
 from abc import ABC, abstractmethod
@@ -43,6 +47,8 @@ _ALL_SUPPORTED_GENERATORS = _SUPPORTED_GENERATORS + _SUPPORTED_CHAT_GENERATORS
 
 # These are the keys used by Haystack for traces and span.
 # We keep them here to avoid making typos when using them.
+_PIPELINE_INPUT_KEY = "haystack.pipeline.input_data"
+_PIPELINE_OUTPUT_KEY = "haystack.pipeline.output_data"
 _PIPELINE_RUN_KEY = "haystack.pipeline.run"
 _COMPONENT_NAME_KEY = "haystack.component.name"
 _COMPONENT_TYPE_KEY = "haystack.component.type"
@@ -234,9 +240,10 @@ class DefaultSpanHandler(SpanHandler):
     """DefaultSpanHandler provides the default Langfuse tracing behavior for Haystack."""
 
     def create_span(self, context: SpanContext) -> LangfuseSpan:
-        message = "Tracer is not initialized"
         if self.tracer is None:
+            message = "Tracer is not initialized"
             raise RuntimeError(message)
+
         tracing_ctx = tracing_context_var.get({})
         if not context.parent_span:
             if context.operation_name != _PIPELINE_RUN_KEY:
@@ -262,6 +269,10 @@ class DefaultSpanHandler(SpanHandler):
             return LangfuseSpan(context.parent_span.raw_span().span(name=context.name))
 
     def handle(self, span: LangfuseSpan, component_type: Optional[str]) -> None:
+        # Means we are at the pipeline level
+        if component_type is None:
+            span._span.update(input=span._data.get(_PIPELINE_INPUT_KEY), output=span._data.get(_PIPELINE_OUTPUT_KEY))
+
         if component_type in _SUPPORTED_GENERATORS:
             meta = span._data.get(_COMPONENT_OUTPUT_KEY, {}).get("meta")
             if meta:
@@ -380,3 +391,10 @@ class LangfuseTracer(Tracer):
         :return: The URL to the tracing data.
         """
         return self._tracer.get_trace_url()
+
+    def get_trace_id(self) -> str:
+        """
+        Return the trace ID.
+        :return: The trace ID.
+        """
+        return self._tracer.get_trace_id()

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -127,6 +127,7 @@ def test_tracing_integration(llm_class, env_var, expected_trace, pipeline_fixtur
     )
     assert "Berlin" in response["llm"]["replies"][0].text
     assert response["tracer"]["trace_url"]
+    assert response["tracer"]["trace_id"]
 
     trace_url = response["tracer"]["trace_url"]
     uuid = os.path.basename(urlparse(trace_url).path)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1263

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds trace id to output of langfuse connector

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
updated existing test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
