### PR TITLE
fix: do not include changelog update commits in changelog - legacy format support

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -27,13 +27,15 @@ body = """
     #}\
     {% if commits | length == 1 and 'Update changelog for' in commits[0].message %}\
         {% continue %}\
+    {% if commits | length == 1 and commits[0].message == 'Update the changelog' %}\
+        {% continue %}\        
     {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}\
         {#
             Skip commits that update the changelog, they're not useful to the user
         #}\
-        {% if 'Update changelog for' in commit.message %}\
+        {% if 'Update changelog for' in commit.message or commit.message == 'Update the changelog' %}\
             {% continue %}\
         {% endif %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\

--- a/cliff.toml
+++ b/cliff.toml
@@ -28,7 +28,7 @@ body = """
     {% if commits | length == 1 and 'Update changelog for' in commits[0].message %}\
         {% continue %}\
     {% if commits | length == 1 and commits[0].message == 'Update the changelog' %}\
-        {% continue %}\        
+        {% continue %}\
     {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}\


### PR DESCRIPTION
### Related Issues

- follow up of #1566
- the changes in #1566 were effective, but now some commits with the legacy message ("Update the changelog") appear in the changelog (see #1586 for example)

### Proposed Changes:
- skip also commit messages with the legacy format

### How did you test it?
No easy ways to test it.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
