### PR TITLE
feat: mongodb async

### DIFF
--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
   "pytest-rerunfailures",
+  "pytest-asyncio",
   "ipython",
   "haystack-pydoc-tools",
 ]
@@ -160,3 +161,5 @@ addopts = "--strict-markers"
 markers = [
   "integration: integration tests",
 ]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "class"

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -153,4 +153,12 @@ class MongoDBAtlasEmbeddingRetriever:
         :returns: A dictionary with the following keys:
             - `documents`: List of Documents most similar to the given `query_embedding`
         """
-        pass
+        filters = apply_filter_policy(self.filter_policy, self.filters, filters)
+        top_k = top_k or self.top_k
+
+        docs = await self.document_store._embedding_retrieval_async(
+            query_embedding=query_embedding,
+            filters=filters,
+            top_k=top_k,
+        )
+        return {"documents": docs}

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -133,3 +133,24 @@ class MongoDBAtlasEmbeddingRetriever:
             top_k=top_k,
         )
         return {"documents": docs}
+
+    @component.output_types(documents=List[Document])
+    async def run_async(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+    ) -> Dict[str, List[Document]]:
+        """
+        Asynchronously retrieve documents from the MongoDBAtlasDocumentStore, based on the provided embedding
+        similarity.
+
+        :param query_embedding: Embedding of the query.
+        :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
+                        details.
+        :param top_k: Maximum number of Documents to return. Overrides the value specified at initialization.
+        :returns: A dictionary with the following keys:
+            - `documents`: List of Documents most similar to the given `query_embedding`
+        """
+        pass

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
@@ -148,3 +148,40 @@ class MongoDBAtlasFullTextRetriever:
         )
 
         return {"documents": docs}
+
+    @component.output_types(documents=List[Document])
+    async def run_async(
+        self,
+        query: Union[str, List[str]],
+        fuzzy: Optional[Dict[str, int]] = None,
+        match_criteria: Optional[Literal["any", "all"]] = None,
+        score: Optional[Dict[str, Dict]] = None,
+        synonyms: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+    ) -> Dict[str, List[Document]]:
+        """
+        Asynchronously retrieve documents from the MongoDBAtlasDocumentStore by full-text search.
+
+        :param query: The query string or a list of query strings to search for.
+            If the query contains multiple terms, Atlas Search evaluates each term separately for matches.
+        :param fuzzy: Enables finding strings similar to the search term(s).
+            Note, `fuzzy` cannot be used with `synonyms`. Configurable options include `maxEdits`, `prefixLength`,
+            and `maxExpansions`. For more details refer to MongoDB Atlas
+            [documentation](https://www.mongodb.com/docs/atlas/atlas-search/text/#fields).
+        :param match_criteria: Defines how terms in the query are matched. Supported options are `"any"` and `"all"`.
+            For more details refer to MongoDB Atlas
+            [documentation](https://www.mongodb.com/docs/atlas/atlas-search/text/#fields).
+        :param score: Specifies the scoring method for matching results. Supported options include `boost`, `constant`,
+            and `function`. For more details refer to MongoDB Atlas
+            [documentation](https://www.mongodb.com/docs/atlas/atlas-search/text/#fields).
+        :param synonyms: The name of the synonym mapping definition in the index. This value cannot be an empty string.
+            Note, `synonyms` can not be used with `fuzzy`.
+        :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
+                        details.
+        :param top_k: Maximum number of Documents to return. Overrides the value specified at initialization.
+        :returns: A dictionary with the following keys:
+            - `documents`: List of Documents most similar to the given `query`
+        """
+        pass

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
@@ -184,4 +184,17 @@ class MongoDBAtlasFullTextRetriever:
         :returns: A dictionary with the following keys:
             - `documents`: List of Documents most similar to the given `query`
         """
-        pass
+        filters = apply_filter_policy(self.filter_policy, self.filters, filters)
+        top_k = top_k or self.top_k
+
+        docs = await self.document_store._fulltext_retrieval_async(
+            query=query,
+            fuzzy=fuzzy,
+            match_criteria=match_criteria,
+            score=score,
+            synonyms=synonyms,
+            filters=filters,
+            top_k=top_k,
+        )
+
+        return {"documents": docs}

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -736,7 +736,8 @@ class MongoDBAtlasDocumentStore:
 
         return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
-    def _mongo_doc_to_haystack_doc(self, mongo_doc: Dict[str, Any]) -> Document:
+    @staticmethod
+    def _mongo_doc_to_haystack_doc(mongo_doc: Dict[str, Any]) -> Document:
         """
         Converts the dictionary coming out of MongoDB into a Haystack document
 

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -259,7 +259,7 @@ class MongoDBAtlasDocumentStore:
         """
         self._ensure_connection_setup()
         filters = _normalize_filters(filters) if filters else None
-        documents = list(self.collection.find(filters))
+        documents = self._collection.find(filters).to_list()
         for doc in documents:
             doc.pop("_id", None)  # MongoDB's internal id doesn't belong into a Haystack document, so we remove it.
         return [Document.from_dict(doc) for doc in documents]
@@ -276,6 +276,7 @@ class MongoDBAtlasDocumentStore:
         """
         await self._ensure_connection_setup_async()
         filters = _normalize_filters(filters) if filters else None
+        documents = await self._collection_async.find(filters).to_list()
         for doc in documents:
             doc.pop("_id", None)
         return [Document.from_dict(doc) for doc in documents]
@@ -467,7 +468,7 @@ class MongoDBAtlasDocumentStore:
             },
         ]
         try:
-            documents = list(self.collection.aggregate(pipeline))
+            documents = self._collection.aggregate(pipeline).to_list()
         except Exception as e:
             msg = f"Retrieval of documents from MongoDB Atlas failed: {e}"
             if filters:
@@ -627,7 +628,7 @@ class MongoDBAtlasDocumentStore:
         ]
 
         try:
-            documents = list(self.collection.aggregate(pipeline))
+            documents = self._collection.aggregate(pipeline).to_list()
         except Exception as e:
             error_msg = f"Failed to retrieve documents from MongoDB Atlas: {e}"
             if filters:

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -98,7 +98,7 @@ class MongoDBAtlasDocumentStore:
         self.vector_search_index = vector_search_index
         self.full_text_search_index = full_text_search_index
         self._connection: Optional[MongoClient] = None
-        self._connection_async : Optional[AsyncMongoClient] = None
+        self._connection_async: Optional[AsyncMongoClient] = None
         self._collection: Optional[Collection] = None
         self._collection_async: Optional[AsyncCollection] = None
 
@@ -159,8 +159,7 @@ class MongoDBAtlasDocumentStore:
         """
         if not self._connection:
             self._connection = MongoClient(
-            self.mongo_connection_string.resolve_value(),
-            driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
+                self.mongo_connection_string.resolve_value(), driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
             )
 
         if not self._connection_is_valid():
@@ -184,8 +183,7 @@ class MongoDBAtlasDocumentStore:
         """
         if not self._connection_async:
             self._connection_async = AsyncMongoClient(
-                self.mongo_connection_string.resolve_value(),
-                driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
+                self.mongo_connection_string.resolve_value(), driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
             )
 
         if not await self._connection_is_valid_async():
@@ -259,7 +257,7 @@ class MongoDBAtlasDocumentStore:
         """
         self._ensure_connection_setup()
         filters = _normalize_filters(filters) if filters else None
-        documents = self._collection.find(filters).to_list()
+        documents = list(self._collection.find(filters))
         for doc in documents:
             doc.pop("_id", None)  # MongoDB's internal id doesn't belong into a Haystack document, so we remove it.
         return [Document.from_dict(doc) for doc in documents]
@@ -468,7 +466,7 @@ class MongoDBAtlasDocumentStore:
             },
         ]
         try:
-            documents = self._collection.aggregate(pipeline).to_list()
+            documents = list(self._collection.aggregate(pipeline))
         except Exception as e:
             msg = f"Retrieval of documents from MongoDB Atlas failed: {e}"
             if filters:
@@ -627,8 +625,9 @@ class MongoDBAtlasDocumentStore:
             },
         ]
 
+        self._ensure_connection_setup()
         try:
-            documents = self._collection.aggregate(pipeline).to_list()
+            documents = list(self._collection.aggregate(pipeline))
         except Exception as e:
             error_msg = f"Failed to retrieve documents from MongoDB Atlas: {e}"
             if filters:
@@ -726,6 +725,7 @@ class MongoDBAtlasDocumentStore:
             },
         ]
 
+        await self._ensure_connection_setup_async()
         try:
             documents = self._collection.aggregate(pipeline).to_list()
         except Exception as e:

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -109,7 +109,7 @@ class MongoDBAtlasDocumentStore:
         :returns: True if the connection is valid, False otherwise.
         """
         try:
-            self._connection.admin.command("ping")
+            self._connection.admin.command("ping")  # type: ignore[union-attr]
             return True
         except Exception as e:
             logger.error(f"Connection to MongoDB Atlas failed: {e}")
@@ -122,7 +122,7 @@ class MongoDBAtlasDocumentStore:
         :returns: True if the connection is valid, False otherwise.
         """
         try:
-            await self._connection_async.admin.command("ping")
+            await self._connection_async.admin.command("ping")  # type: ignore[union-attr]
             return True
         except Exception as e:
             logger.error(f"Connection to MongoDB Atlas failed: {e}")
@@ -134,7 +134,7 @@ class MongoDBAtlasDocumentStore:
 
         :returns: True if the collection exists, False otherwise.
         """
-        database = self._connection[self.database_name]
+        database = self._connection[self.database_name]  # type: ignore[index]
         if self.collection_name in database.list_collection_names():
             return True
         return False
@@ -145,7 +145,7 @@ class MongoDBAtlasDocumentStore:
 
         :returns: True if the collection exists, False otherwise.
         """
-        database = self._connection_async[self.database_name]
+        database = self._connection_async[self.database_name]  # type: ignore[index]
         if self.collection_name in await database.list_collection_names():
             return True
         return False
@@ -234,7 +234,7 @@ class MongoDBAtlasDocumentStore:
         :returns: The number of documents in the document store.
         """
         self._ensure_connection_setup()
-        return self._collection.count_documents({})
+        return self._collection.count_documents({})  # type: ignore[union-attr]
 
     async def count_documents_async(self) -> int:
         """
@@ -243,7 +243,7 @@ class MongoDBAtlasDocumentStore:
         :returns: The number of documents in the document store.
         """
         await self._ensure_connection_setup_async()
-        return await self._collection_async.count_documents({})
+        return await self._collection_async.count_documents({})  # type: ignore[union-attr]
 
     def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         """
@@ -257,7 +257,7 @@ class MongoDBAtlasDocumentStore:
         """
         self._ensure_connection_setup()
         filters = _normalize_filters(filters) if filters else None
-        documents = list(self._collection.find(filters))
+        documents = list(self._collection.find(filters))  # type: ignore[union-attr]
         for doc in documents:
             doc.pop("_id", None)  # MongoDB's internal id doesn't belong into a Haystack document, so we remove it.
         return [Document.from_dict(doc) for doc in documents]
@@ -274,7 +274,7 @@ class MongoDBAtlasDocumentStore:
         """
         await self._ensure_connection_setup_async()
         filters = _normalize_filters(filters) if filters else None
-        documents = await self._collection_async.find(filters).to_list()
+        documents = await self._collection_async.find(filters).to_list()  # type: ignore[union-attr]
         for doc in documents:
             doc.pop("_id", None)
         return [Document.from_dict(doc) for doc in documents]
@@ -318,7 +318,7 @@ class MongoDBAtlasDocumentStore:
 
         if policy == DuplicatePolicy.SKIP:
             operations = [UpdateOne({"id": doc["id"]}, {"$setOnInsert": doc}, upsert=True) for doc in mongo_documents]
-            existing_documents = self._collection.count_documents({"id": {"$in": [doc.id for doc in documents]}})
+            existing_documents = self._collection.count_documents({"id": {"$in": [doc.id for doc in documents]}})  # type: ignore[union-attr]
             written_docs -= existing_documents
         elif policy == DuplicatePolicy.FAIL:
             operations = [InsertOne(doc) for doc in mongo_documents]
@@ -326,7 +326,7 @@ class MongoDBAtlasDocumentStore:
             operations = [ReplaceOne({"id": doc["id"]}, upsert=True, replacement=doc) for doc in mongo_documents]
 
         try:
-            self._collection.bulk_write(operations)
+            self._collection.bulk_write(operations)  # type: ignore[union-attr]
         except BulkWriteError as e:
             msg = f"Duplicate documents found: {e.details['writeErrors']}"
             raise DuplicateDocumentError(msg) from e
@@ -383,7 +383,7 @@ class MongoDBAtlasDocumentStore:
 
         if policy == DuplicatePolicy.SKIP:
             operations = [UpdateOne({"id": doc["id"]}, {"$setOnInsert": doc}, upsert=True) for doc in mongo_documents]
-            existing_documents = self._collection.count_documents({"id": {"$in": [doc.id for doc in documents]}})
+            existing_documents = self._collection.count_documents({"id": {"$in": [doc.id for doc in documents]}})  # type: ignore[union-attr]
             written_docs -= existing_documents
         elif policy == DuplicatePolicy.FAIL:
             operations = [InsertOne(doc) for doc in mongo_documents]
@@ -391,7 +391,7 @@ class MongoDBAtlasDocumentStore:
             operations = [ReplaceOne({"id": doc["id"]}, upsert=True, replacement=doc) for doc in mongo_documents]
 
         try:
-            await self._collection_async.bulk_write(operations)
+            await self._collection_async.bulk_write(operations)  # type: ignore[union-attr]
         except BulkWriteError as e:
             msg = f"Duplicate documents found: {e.details['writeErrors']}"
             raise DuplicateDocumentError(msg) from e
@@ -407,7 +407,7 @@ class MongoDBAtlasDocumentStore:
         self._ensure_connection_setup()
         if not document_ids:
             return
-        self._collection.delete_many(filter={"id": {"$in": document_ids}})
+        self._collection.delete_many(filter={"id": {"$in": document_ids}})  # type: ignore[union-attr]
 
     async def delete_documents_async(self, document_ids: List[str]) -> None:
         """
@@ -418,7 +418,7 @@ class MongoDBAtlasDocumentStore:
         await self._ensure_connection_setup_async()
         if not document_ids:
             return
-        await self._collection_async.delete_many(filter={"id": {"$in": document_ids}})
+        await self._collection_async.delete_many(filter={"id": {"$in": document_ids}})  # type: ignore[union-attr]
 
     def _embedding_retrieval(
         self,
@@ -466,7 +466,7 @@ class MongoDBAtlasDocumentStore:
             },
         ]
         try:
-            documents = list(self._collection.aggregate(pipeline))
+            documents = list(self._collection.aggregate(pipeline))  # type: ignore[union-attr]
         except Exception as e:
             msg = f"Retrieval of documents from MongoDB Atlas failed: {e}"
             if filters:
@@ -523,7 +523,7 @@ class MongoDBAtlasDocumentStore:
             },
         ]
         try:
-            documents = await self._collection_async.aggregate(pipeline).to_list()
+            documents = await self._collection_async.aggregate(pipeline).to_list()  # type: ignore[union-attr]
         except Exception as e:
             msg = f"Retrieval of documents from MongoDB Atlas failed: {e}"
             if filters:
@@ -627,7 +627,7 @@ class MongoDBAtlasDocumentStore:
 
         self._ensure_connection_setup()
         try:
-            documents = list(self._collection.aggregate(pipeline))
+            documents = list(self._collection.aggregate(pipeline))  # type: ignore[union-attr]
         except Exception as e:
             error_msg = f"Failed to retrieve documents from MongoDB Atlas: {e}"
             if filters:
@@ -727,7 +727,7 @@ class MongoDBAtlasDocumentStore:
 
         await self._ensure_connection_setup_async()
         try:
-            documents = self._collection.aggregate(pipeline).to_list()
+            documents = self._collection.aggregate(pipeline).to_list()  # type: ignore[union-attr]
         except Exception as e:
             error_msg = f"Failed to retrieve documents from MongoDB Atlas: {e}"
             if filters:

--- a/integrations/mongodb_atlas/tests/test_document_store_async.py
+++ b/integrations/mongodb_atlas/tests/test_document_store_async.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from haystack.dataclasses.document import ByteStream, Document
+from haystack.document_stores.errors import DuplicateDocumentError
+from haystack.document_stores.types import DuplicatePolicy
+from haystack.testing.document_store import FilterableDocsFixtureMixin
+from haystack.utils import Secret
+from pymongo import MongoClient
+from pymongo.driver_info import DriverInfo
+
+from haystack_integrations.document_stores.mongodb_atlas import MongoDBAtlasDocumentStore
+
+
+@patch("haystack_integrations.document_stores.mongodb_atlas.document_store.AsyncMongoClient")
+def test_init_is_lazy(_mock_client):
+    MongoDBAtlasDocumentStore(
+        mongo_connection_string=Secret.from_token("test"),
+        database_name="database_name",
+        collection_name="collection_name",
+        vector_search_index="cosine_index",
+        full_text_search_index="full_text_index",
+    )
+
+    _mock_client.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MONGO_CONNECTION_STRING"),
+    reason="No MongoDB Atlas connection string provided",
+)
+@pytest.mark.integration
+class TestDocumentStoreAsync(FilterableDocsFixtureMixin):
+    @pytest.fixture
+    def document_store(self):
+        database_name = "haystack_integration_test"
+        collection_name = "test_collection_" + str(uuid4())
+
+        with MongoClient(
+            os.environ["MONGO_CONNECTION_STRING"], driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
+        ) as connection:
+            database = connection[database_name]
+            if collection_name in database.list_collection_names():
+                database[collection_name].drop()
+            database.create_collection(collection_name)
+            database[collection_name].create_index("id", unique=True)
+
+            store = MongoDBAtlasDocumentStore(
+                database_name=database_name,
+                collection_name=collection_name,
+                vector_search_index="cosine_index",
+                full_text_search_index="full_text_index",
+            )
+            yield store
+            database[collection_name].drop()
+
+    @pytest.mark.asyncio
+    async def test_write_documents_async(self, document_store: MongoDBAtlasDocumentStore):
+        docs = [Document(content="some text")]
+        assert await document_store.write_documents_async(docs) == 1
+        with pytest.raises(DuplicateDocumentError):
+            await document_store.write_documents_async(docs, DuplicatePolicy.FAIL)
+
+    @pytest.mark.asyncio
+    async def test_write_blob_async(self, document_store: MongoDBAtlasDocumentStore):
+        bytestream = ByteStream(b"test", meta={"meta_key": "meta_value"}, mime_type="mime_type")
+        docs = [Document(blob=bytestream)]
+        await document_store.write_documents_async(docs)
+        retrieved_docs = await document_store.filter_documents_async()
+        assert retrieved_docs == docs
+
+    @pytest.mark.asyncio
+    async def test_count_documents_async(self, document_store: MongoDBAtlasDocumentStore):
+        docs = [Document(content="some text")]
+        await document_store.write_documents_async(docs)
+        assert await document_store.count_documents_async() == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_documents_async(self, document_store: MongoDBAtlasDocumentStore, filterable_docs):
+        filters = {
+            "operator": "OR",
+            "conditions": [
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"field": "meta.number", "operator": "==", "value": 100},
+                        {"field": "meta.chapter", "operator": "==", "value": "intro"},
+                    ],
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"field": "meta.page", "operator": "==", "value": "90"},
+                        {"field": "meta.chapter", "operator": "==", "value": "conclusion"},
+                    ],
+                },
+            ],
+        }
+        await document_store.write_documents_async(filterable_docs)
+        result = await document_store.filter_documents_async(filters=filters)
+        expected = [
+            d
+            for d in filterable_docs
+            if (d.meta.get("number") == 100 and d.meta.get("chapter") == "intro")
+            or (d.meta.get("page") == "90" and d.meta.get("chapter") == "conclusion")
+        ]
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_delete_documents_async(self, document_store: MongoDBAtlasDocumentStore):
+        docs = [Document(id="1", content="some text")]
+        await document_store.write_documents_async(docs)
+        assert await document_store.count_documents_async() == 1
+        await document_store.delete_documents_async(document_ids=["1"])
+        assert await document_store.count_documents_async() == 0

--- a/integrations/mongodb_atlas/tests/test_embedding_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_embedding_retrieval.py
@@ -83,7 +83,7 @@ class TestEmbeddingRetrieval:
     def test_embedding_retrieval_with_filters(self):
         """
         Note: we can combine embedding retrieval with filters
-        becuse the `cosine_index` vector_search_index was created with the `content` field as the filter field.
+        because the `cosine_index` vector_search_index was created with the `content` field as the filter field.
         {
         "fields": [
             {


### PR DESCRIPTION
### Related Issues  
- Fixes #1390  

### Proposed Changes  
This PR adds the following asynchronous methods while adhering to the `DocumentStore` protocol referenced in #1386:  

- `MongoDBAtlasDocumentStore.count_documents_async`  
- `MongoDBAtlasDocumentStore.filter_documents_async`  
- `MongoDBAtlasDocumentStore.write_documents_async`  
- `MongoDBAtlasDocumentStore.delete_documents_async`  
- `MongoDBAtlasEmbeddingRetriever.run_async`  
- `MongoDBAtlasFullTextRetriever.run_async`  

### How Did You Test It?  
Added relevant unit and integration tests. Specifically:  
- `test_document_store_async.py` for new async methods  
- Additional async tests in `test_retriever.py` and `test_fulltext_retrieval.py`  

### Notes for the Reviewer  
- I did not modify `tests/test_embedding_retrieval.py` because I lack access to the database/collection needed to run the tests locally. These tests fail on my local machine due to missing access, so it would be helpful to verify that my changes do not break existing tests.  
- I followed the approach used in other recently approved async PRs for handling delayed connections.  
- `pymongo >= 4.0` does not allow reusing a client [after it is closed](https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient.close). Since connection closing was not handled previously, I did not attempt to address it in this PR. 
- Some test cli output show 'Task was destroyed but it is pending!', which I believe is due to pending asynchronous operations lingering in the event loop before test teardown—potentially related to the connection closing issue mentioned above. I'll be investigating this over the next few days, but any insights would be appreciated, as the root cause is still somewhat unclear to me.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
