### PR TITLE
fix: amazon-bedrock-haystack remove init files to make them namespace packages

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/common/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/common/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Remove inits in folders that should be treated as namespace packages instead of regular packages.

More info [here](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) but basically for package names that are shared across integrations e.g. haystack_integrations, components, retrievers, etc. we want to make sure these are treated as namespace packages so the namespaces are shareable when installing multiple integrations at once.

Additional info:
- in this [comment](https://github.com/deepset-ai/haystack-core-integrations/pull/1591#issuecomment-2774902527)
- and original [PR](https://github.com/deepset-ai/haystack-core-integrations/pull/1591) 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
