### PR TITLE
test: test llama.cpp with python 3.12

### DIFF
--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -31,7 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest] # we don't test on windows because of issues on llama-cpp-python
-        python-version: ["3.9", "3.13"]
+        # we test with 3.12 since sentencepiece has issues with 3.13: https://github.com/google/sentencepiece/issues/1103
+        python-version: ["3.9", "3.12"]  
 
     steps:
       - name: Support longpaths

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -51,6 +51,9 @@ dependencies = [
     "pytest",
     "pytest-rerunfailures",
     "haystack-pydoc-tools",
+    # "transformers[sentencepiece]" is required for models using a custom HF tokenizer.  
+    # We exclude it from dependencies since some use cases don't need it.  
+    # If missing when required, llama-cpp-python will provide a clear error message. 
     "transformers[sentencepiece]",
 ]
 [tool.hatch.envs.default.scripts]

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -468,6 +468,7 @@ class TestLlamaCppChatGeneratorFunctionary:
         assert tool_calls[0].tool_name == "get_user_info"
         assert tool_calls[0].arguments == {"username": "john_doe"}
 
+    @pytest.mark.integration
     def test_function_call_and_execute(self, generator):
         temperature_tool = create_tool_from_function(self.get_current_temperature)
 


### PR DESCRIPTION
### Related Issues

- nightly failures: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/14232191293
- our test environment depends on `sentencepiece`, which has installation issues with python 3.13: https://github.com/google/sentencepiece/issues/1103

### Proposed Changes:
- test with python 3.12 instead
- clarify in pyproject.toml why we install `transformers[sentencepiece]`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
