### PR TITLE
fix: perform case-insensitive check on changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,9 +25,9 @@ body = """
         If we don't do this we get an empty section since we don't show
         commits that update the changelog
     #}\
-    {% if commits | length == 1 and 'Update changelog for' in commits[0].message | lower %}\
+    {% if commits | length == 1 and 'update changelog for' in commits[0].message | lower %}\
         {% continue %}\
-    {% elif commits | length == 1 and commits[0].message == 'Update the changelog' | lower %}\
+    {% elif commits | length == 1 and commits[0].message == 'update the changelog' | lower %}\
         {% continue %}\
     {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
@@ -35,7 +35,7 @@ body = """
         {#
             Skip commits that update the changelog, they're not useful to the user
         #}\
-        {% if 'Update changelog for' in commit.message | lower or commit.message | lower == 'Update the changelog' %}\
+        {% if 'update changelog for' in commit.message | lower or commit.message | lower == 'update the changelog' %}\
             {% continue %}\
         {% endif %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,10 +25,9 @@ body = """
         If we don't do this we get an empty section since we don't show
         commits that update the changelog
     #}\
-    {% if commits | length == 1 and 'Update changelog for' in commits[0].message %}\
+    {% if commits | length == 1 and 'Update changelog for' in commits[0].message | lower %}\
         {% continue %}\
-    {% endif %}\
-    {% if commits | length == 1 and commits[0].message == 'Update the changelog' %}\
+    {% elif commits | length == 1 and commits[0].message == 'Update the changelog' | lower %}\
         {% continue %}\
     {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
@@ -36,7 +35,7 @@ body = """
         {#
             Skip commits that update the changelog, they're not useful to the user
         #}\
-        {% if 'Update changelog for' in commit.message or commit.message == 'Update the changelog' %}\
+        {% if 'Update changelog for' in commit.message | lower or commit.message | lower == 'Update the changelog' %}\
             {% continue %}\
         {% endif %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\


### PR DESCRIPTION
### Related Issues
We recently improved changelog generation to exclude commits that only perform changelog updates
However, some of these commits are still included: see https://github.com/deepset-ai/haystack-core-integrations/pull/1599 for an example.

After investigation, I discovered that in this case, there have been manual edits and the commit message is different: see https://github.com/deepset-ai/haystack-core-integrations/commit/63738bddfd795edc7b3608ef6290ddfe24be6e38. It includes "update changelog for" (lowercase).

### Proposed Changes:
- update cliff.toml to perform a case-insensitive check using [`lower` filter](https://keats.github.io/tera/docs/#lower).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
