### PR TITLE
fix: fix changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,17 +25,19 @@ body = """
         If we don't do this we get an empty section since we don't show
         commits that update the changelog
     #}\
-    {% if commits | length == 1 and 'update changelog for' in commits[0].message | lower %}\
+    {% set first_commit_message_low = commits[0].message | lower %}
+    {% if commits | length == 1 and 'update changelog for' in first_commit_message_low %}\
         {% continue %}\
-    {% elif commits | length == 1 and commits[0].message == 'update the changelog' | lower %}\
+    {% elif commits | length == 1 and first_commit_message_low == 'update the changelog' %}\
         {% continue %}\
     {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}\
+        {% set commit_message_low = commit.message | lower %}
         {#
             Skip commits that update the changelog, they're not useful to the user
         #}\
-        {% if 'update changelog for' in commit.message | lower or commit.message | lower == 'update the changelog' %}\
+        {% if 'update changelog for' in commit_message_low or commit_message_low == 'update the changelog' %}\
             {% continue %}\
         {% endif %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\


### PR DESCRIPTION
### Related Issues

- errors in changelog generation: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/14259834586/job/39968917378

### Proposed Changes:

- fix the cliff.toml configuration

### How did you test it?
I finally found a simple way to test it locally:
- installation: `brew install git-cliff`
- run: `git-cliff --config=cliff.toml --include-path "integrations/nvidia/**/*" --tag-pattern "integrations/nvidia-v*"`

Seems to work correctly now.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
