### PR TITLE
chore: reduce line breaks in changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,7 +25,7 @@ body = """
         If we don't do this we get an empty section since we don't show
         commits that update the changelog
     #}\
-    {% set first_commit_message_low = commits[0].message | lower %}
+    {% set first_commit_message_low = commits[0].message | lower %}\
     {% if commits | length == 1 and 'update changelog for' in first_commit_message_low %}\
         {% continue %}\
     {% elif commits | length == 1 and first_commit_message_low == 'update the changelog' %}\
@@ -33,7 +33,7 @@ body = """
     {% endif %}\
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}\
-        {% set commit_message_low = commit.message | lower %}
+        {% set commit_message_low = commit.message | lower %}\
         {#
             Skip commits that update the changelog, they're not useful to the user
         #}\


### PR DESCRIPTION
### Related Issues

After #1610, changelog is correctly generated but contains many line breaks

### Proposed Changes:
Reduce them

### How did you test it?
Tested locally


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
