### PR TITLE
tests: upgrade gemini models

### DIFF
--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -25,7 +25,7 @@ class GoogleAIGeminiGenerator:
     from haystack.utils import Secret
     from haystack_integrations.components.generators.google_ai import GoogleAIGeminiGenerator
 
-    gemini = GoogleAIGeminiGenerator(model="gemini-1.5-pro", api_key=Secret.from_token("<MY_API_KEY>"))
+    gemini = GoogleAIGeminiGenerator(model="gemini-2.0-flash", api_key=Secret.from_token("<MY_API_KEY>"))
     res = gemini.run(parts = ["What is the most interesting thing you know?"])
     for answer in res["replies"]:
         print(answer)
@@ -55,7 +55,7 @@ class GoogleAIGeminiGenerator:
         for url in URLS
     ]
 
-    gemini = GoogleAIGeminiGenerator(model="gemini-1.5-flash", api_key=Secret.from_token("<MY_API_KEY>"))
+    gemini = GoogleAIGeminiGenerator(model="gemini-2.0-flash", api_key=Secret.from_token("<MY_API_KEY>"))
     result = gemini.run(parts = ["What can you tell me about this robots?", *images])
     for answer in result["replies"]:
         print(answer)
@@ -76,7 +76,7 @@ class GoogleAIGeminiGenerator:
         self,
         *,
         api_key: Secret = Secret.from_env_var("GOOGLE_API_KEY"),  # noqa: B008
-        model: str = "gemini-1.5-flash",
+        model: str = "gemini-2.0-flash",
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,

--- a/integrations/google_ai/tests/generators/test_gemini.py
+++ b/integrations/google_ai/tests/generators/test_gemini.py
@@ -28,7 +28,7 @@ def test_init(monkeypatch):
             safety_settings=safety_settings,
         )
     mock_genai_configure.assert_called_once_with(api_key="test")
-    assert gemini.model_name == "gemini-1.5-flash"
+    assert gemini.model_name == "gemini-2.0-flash"
     assert gemini.generation_config == generation_config
     assert gemini.safety_settings == safety_settings
     assert isinstance(gemini._model, GenerativeModel)
@@ -47,7 +47,7 @@ def test_to_dict(monkeypatch):
     assert gemini.to_dict() == {
         "type": "haystack_integrations.components.generators.google_ai.gemini.GoogleAIGeminiGenerator",
         "init_parameters": {
-            "model": "gemini-1.5-flash",
+            "model": "gemini-2.0-flash",
             "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
             "generation_config": None,
             "safety_settings": None,
@@ -77,7 +77,7 @@ def test_to_dict_with_param(monkeypatch):
     assert gemini.to_dict() == {
         "type": "haystack_integrations.components.generators.google_ai.gemini.GoogleAIGeminiGenerator",
         "init_parameters": {
-            "model": "gemini-1.5-flash",
+            "model": "gemini-2.0-flash",
             "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
             "generation_config": {
                 "temperature": 0.5,
@@ -101,7 +101,7 @@ def test_from_dict_with_param(monkeypatch):
             {
                 "type": "haystack_integrations.components.generators.google_ai.gemini.GoogleAIGeminiGenerator",
                 "init_parameters": {
-                    "model": "gemini-1.5-flash",
+                    "model": "gemini-2.0-flash",
                     "generation_config": {
                         "temperature": 0.5,
                         "top_p": 0.5,
@@ -116,7 +116,7 @@ def test_from_dict_with_param(monkeypatch):
             }
         )
 
-    assert gemini.model_name == "gemini-1.5-flash"
+    assert gemini.model_name == "gemini-2.0-flash"
     assert gemini.generation_config == GenerationConfig(
         candidate_count=1,
         stop_sequences=["stop"],
@@ -137,7 +137,7 @@ def test_from_dict(monkeypatch):
             {
                 "type": "haystack_integrations.components.generators.google_ai.gemini.GoogleAIGeminiGenerator",
                 "init_parameters": {
-                    "model": "gemini-1.5-flash",
+                    "model": "gemini-2.0-flash",
                     "generation_config": {
                         "temperature": 0.5,
                         "top_p": 0.5,
@@ -152,7 +152,7 @@ def test_from_dict(monkeypatch):
             }
         )
 
-    assert gemini.model_name == "gemini-1.5-flash"
+    assert gemini.model_name == "gemini-2.0-flash"
     assert gemini.generation_config == GenerationConfig(
         candidate_count=1,
         stop_sequences=["stop"],

--- a/integrations/google_ai/tests/generators/test_gemini.py
+++ b/integrations/google_ai/tests/generators/test_gemini.py
@@ -167,7 +167,7 @@ def test_from_dict(monkeypatch):
 
 @pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY", None), reason="GOOGLE_API_KEY env var not set")
 def test_run():
-    gemini = GoogleAIGeminiGenerator(model="gemini-1.5-pro")
+    gemini = GoogleAIGeminiGenerator(model="gemini-2.0-flash")
     res = gemini.run("Tell me something cool")
     assert len(res["replies"]) > 0
 
@@ -180,7 +180,7 @@ def test_run_with_streaming_callback():
         nonlocal streaming_callback_called
         streaming_callback_called = True
 
-    gemini = GoogleAIGeminiGenerator(model="gemini-1.5-pro", streaming_callback=streaming_callback)
+    gemini = GoogleAIGeminiGenerator(model="gemini-2.0-flash", streaming_callback=streaming_callback)
     res = gemini.run("Tell me something cool")
     assert len(res["replies"]) > 0
     assert streaming_callback_called

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -61,7 +61,7 @@ class VertexAIGeminiGenerator:
     def __init__(
         self,
         *,
-        model: str = "gemini-1.5-flash",
+        model: str = "gemini-2.0-flash",
         project_id: Optional[str] = None,
         location: Optional[str] = None,
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,

--- a/integrations/google_vertex/tests/test_gemini.py
+++ b/integrations/google_vertex/tests/test_gemini.py
@@ -35,7 +35,7 @@ def test_init(mock_vertexai_init, _mock_generative_model):
         system_instruction="Please provide brief answers.",
     )
     mock_vertexai_init.assert_called()
-    assert gemini._model_name == "gemini-1.5-flash"
+    assert gemini._model_name == "gemini-2.0-flash"
     assert gemini._generation_config == generation_config
     assert gemini._safety_settings == safety_settings
     assert gemini._system_instruction == "Please provide brief answers."
@@ -57,7 +57,7 @@ def test_to_dict(_mock_vertexai_init, _mock_generative_model):
     assert gemini.to_dict() == {
         "type": "haystack_integrations.components.generators.google_vertex.gemini.VertexAIGeminiGenerator",
         "init_parameters": {
-            "model": "gemini-1.5-flash",
+            "model": "gemini-2.0-flash",
             "project_id": None,
             "location": None,
             "generation_config": None,
@@ -91,7 +91,7 @@ def test_to_dict_with_params(_mock_vertexai_init, _mock_generative_model):
     assert gemini.to_dict() == {
         "type": "haystack_integrations.components.generators.google_vertex.gemini.VertexAIGeminiGenerator",
         "init_parameters": {
-            "model": "gemini-1.5-flash",
+            "model": "gemini-2.0-flash",
             "project_id": "TestID123",
             "location": "TestLocation",
             "generation_config": {
@@ -118,7 +118,7 @@ def test_from_dict(_mock_vertexai_init, _mock_generative_model):
             "init_parameters": {
                 "project_id": None,
                 "location": None,
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.0-flash",
                 "generation_config": None,
                 "safety_settings": None,
                 "streaming_callback": None,
@@ -127,7 +127,7 @@ def test_from_dict(_mock_vertexai_init, _mock_generative_model):
         }
     )
 
-    assert gemini._model_name == "gemini-1.5-flash"
+    assert gemini._model_name == "gemini-2.0-flash"
     assert gemini._project_id is None
     assert gemini._location is None
     assert gemini._safety_settings is None
@@ -144,7 +144,7 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
             "init_parameters": {
                 "project_id": "TestID123",
                 "location": "TestLocation",
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.0-flash",
                 "generation_config": {
                     "temperature": 0.5,
                     "top_p": 0.5,
@@ -160,7 +160,7 @@ def test_from_dict_with_param(_mock_vertexai_init, _mock_generative_model):
         }
     )
 
-    assert gemini._model_name == "gemini-1.5-flash"
+    assert gemini._model_name == "gemini-2.0-flash"
     assert gemini._project_id == "TestID123"
     assert gemini._location == "TestLocation"
     assert gemini._safety_settings == {HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH}
@@ -200,7 +200,7 @@ def test_run_with_streaming_callback(mock_generative_model):
         nonlocal streaming_callback_called
         streaming_callback_called = True
 
-    gemini = VertexAIGeminiGenerator(model="gemini-pro", streaming_callback=streaming_callback)
+    gemini = VertexAIGeminiGenerator(model="gemini-2.0-flash", streaming_callback=streaming_callback)
     gemini.run(["Come on, stream!"])
     assert streaming_callback_called
 


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/haystack-core-integrations/issues/1440#issue-2881165596

### Proposed Changes:

- Replace gemini-pro by gemini-2.0-flash in tests
- Replace gemini-1.5-pro by gemini-2.0-flash in tests and code example
- Replace gemini-1.5-flash by gemini-2.0-flash in tests

The tests are mocking the model call so it doesn't really change the behavior of the test. Still gemini-pro support ends this month and gemini-1.5-flash in September.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
