### PR TITLE
fix: Make chroma backwards compatible

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0", "chromadb>=0.6.0"]
+dependencies = ["haystack-ai>=2.11.0", "chromadb>=1.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma#readme"

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -117,13 +117,7 @@ class ChromaDocumentStore:
             if "hnsw:space" not in self._metadata:
                 self._metadata["hnsw:space"] = self._distance_function
 
-            existing_collections = client.list_collections()
-            if len(existing_collections) > 0 and isinstance(existing_collections[0], str):
-                # Chroma >= 0.6.0,< 1.0.0
-                existing_collection_names = existing_collections
-            else:
-                # Chroma >= 1.0.0
-                existing_collection_names = [c.name for c in existing_collections]
+            existing_collection_names = [c.name for c in client.list_collections()]
             if self._collection_name in existing_collection_names:
                 self._collection = client.get_collection(self._collection_name, embedding_function=self._embedding_func)
 

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -117,7 +117,13 @@ class ChromaDocumentStore:
             if "hnsw:space" not in self._metadata:
                 self._metadata["hnsw:space"] = self._distance_function
 
-            existing_collection_names = [c.name for c in client.list_collections()]
+            existing_collections = client.list_collections()
+            if len(existing_collections) > 0 and isinstance(existing_collections[0], str):
+                # Chroma >= 0.6.0,< 1.0.0
+                existing_collection_names = existing_collections
+            else:
+                # Chroma >= 1.0.0
+                existing_collection_names = [c.name for c in existing_collections]
             if self._collection_name in existing_collection_names:
                 self._collection = client.get_collection(self._collection_name, embedding_function=self._embedding_func)
 


### PR DESCRIPTION
### Related Issues

Follow up of https://github.com/deepset-ai/haystack-core-integrations/pull/1618

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Make it so the integration works with older versions of chroma

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
