### PR TITLE
feat: Add `streaming_callback` to run methods of OllamaGenerator and OllamaChatGenerator

### DIFF
--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -459,7 +459,9 @@ class TestOllamaChatGenerator:
         assert isinstance(response, dict)
         assert isinstance(response["replies"], list)
 
-        assert any(city in response["replies"][-1].text for city in ["Manchester", "Birmingham", "Glasgow"])
+        assert any(
+            city.lower() in response["replies"][-1].text.lower() for city in ["Manchester", "Birmingham", "Glasgow"]
+        )
 
     @pytest.mark.integration
     def test_run_model_unavailable(self):
@@ -486,7 +488,9 @@ class TestOllamaChatGenerator:
 
         assert isinstance(response, dict)
         assert isinstance(response["replies"], list)
-        assert any(city in response["replies"][-1].text for city in ["Manchester", "Birmingham", "Glasgow"])
+        assert any(
+            city.lower() in response["replies"][-1].text.lower() for city in ["Manchester", "Birmingham", "Glasgow"]
+        )
 
     @pytest.mark.integration
     def test_run_with_tools(self, tools):
@@ -525,7 +529,7 @@ class TestOllamaChatGenerator:
         assert isinstance(response_data["capital"], str)
         assert "population" in response_data
         assert isinstance(response_data["population"], (int, float))
-        assert response_data["capital"] == "Paris"
+        assert response_data["capital"].lower() == "paris"
 
     def test_run_with_streaming_and_format(self):
         response_format = {

--- a/integrations/ollama/tests/test_generator.py
+++ b/integrations/ollama/tests/test_generator.py
@@ -151,7 +151,7 @@ class TestOllamaGenerator:
         results = component.run(prompt="What's the capital of Netherlands?")
 
         assert len(results["replies"]) == 1
-        assert "Amsterdam" in results["replies"][0]
+        assert "amsterdam" in results["replies"][0].lower()
         assert len(results["meta"]) == 1
         assert callback.responses == results["replies"][0]
         assert callback.count_calls > 1


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/hayhooks/issues/104

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add streaming_callback to run method of OllamaGenerator and OllamaChatGenerator so streaming works in hayhooks

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
added tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
