### PR TITLE
feat: Add GitHub integration with agent_prompts and github_components

### DIFF
--- a/integrations/github-haystack/LICENSE.txt
+++ b/integrations/github-haystack/LICENSE.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/integrations/github-haystack/README.md
+++ b/integrations/github-haystack/README.md
@@ -1,0 +1,21 @@
+# github-haystack
+
+[![PyPI - Version](https://img.shields.io/pypi/v/github-haystack.svg)](https://pypi.org/project/github-haystack)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/github-haystack.svg)](https://pypi.org/project/github-haystack)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install github-haystack
+```
+
+## License
+
+`github-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/integrations/github-haystack/pyproject.toml
+++ b/integrations/github-haystack/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "github-haystack"
+dynamic = ["version"]
+description = 'Haystack components for interacting with GitHub repositories'
+readme = "README.md"
+requires-python = ">=3.8"
+license = "Apache-2.0"
+keywords = []
+authors = [
+  { name = "deepset GmbH", email = "info@deepset.ai" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://github.com/deepset GmbH/github-haystack#readme"
+Issues = "https://github.com/deepset GmbH/github-haystack/issues"
+Source = "https://github.com/deepset GmbH/github-haystack"
+
+[tool.hatch.version]
+path = "src/github_haystack/__about__.py"
+
+[tool.hatch.envs.types]
+extra-dependencies = [
+  "mypy>=1.0.0",
+]
+[tool.hatch.envs.types.scripts]
+check = "mypy --install-types --non-interactive {args:src/github_haystack tests}"
+
+[tool.coverage.run]
+source_pkgs = ["github_haystack", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/github_haystack/__about__.py",
+]
+
+[tool.coverage.paths]
+github_haystack = ["src/github_haystack", "*/github-haystack/src/github_haystack"]
+tests = ["tests", "*/github-haystack/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/integrations/github-haystack/src/github_haystack/__about__.py
+++ b/integrations/github-haystack/src/github_haystack/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+__version__ = "0.0.1"

--- a/integrations/github-haystack/src/github_haystack/__init__.py
+++ b/integrations/github-haystack/src/github_haystack/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/github-haystack/src/github_haystack/agent_prompts/__init__.py
+++ b/integrations/github-haystack/src/github_haystack/agent_prompts/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .repo_viewer_tool import repo_viewer_prompt, repo_viewer_schema
+from .system_prompt import issue_prompt
+
+_all_ = ["issue_prompt", "repo_viewer_prompt", "repo_viewer_schema"]

--- a/integrations/github-haystack/src/github_haystack/agent_prompts/comment_tool.py
+++ b/integrations/github-haystack/src/github_haystack/agent_prompts/comment_tool.py
@@ -1,0 +1,22 @@
+comment_prompt = """
+Haystack-Agent uses this tool to post a comment to a Github-issue discussion.
+
+<usage>
+Pass a `comment` string to post a comment.
+</usage>
+
+IMPORTANT
+Haystack-Agent MUST pass "comment" to this tool. Otherwise, comment creation fails.
+Haystack-Agent always passes the contents of the comment to the "comment" parameter when calling this tool.
+"""
+
+comment_schema = {
+    "properties": {
+        "comment": {
+            "type": "string",
+            "description": "The contents of the comment that you want to create."
+        }
+    },
+    "required": ["comment"],
+    "type": "object"
+}

--- a/integrations/github-haystack/src/github_haystack/agent_prompts/context.py
+++ b/integrations/github-haystack/src/github_haystack/agent_prompts/context.py
@@ -1,0 +1,175 @@
+haystack_context_prompt = """
+
+Haystack-Agent was specifically designed to help developers with the Haystack-framework and any Haystack related
+questions.
+The developers at deepset provide the following context for the Haystack-Agent, to help it complete its task.
+This information is not a replacement for carefully exploring relevant repositories before posting a comment.
+
+**Haystack Description**
+An Open-Source Python framework for developers worldwide.
+AI orchestration framework to build customizable, production-ready LLM applications.
+Connect components (models, vector DBs, file converters) to pipelines or agents that can interact with your data.
+With advanced retrieval methods, it's best suited for building RAG, question answering, semantic search or
+conversational agent chatbots.
+
+**High-Level Architecture**
+Haystack has two central abstractions:
+- Components
+- Pipelines
+
+A Component is a lightweight abstraction that gets inputs, performs an action and returns outputs.
+Some example components:
+- `OpenAIGenerator`: receives a prompt and generates replies to the prompt by calling an OpenAI-model
+- `MetadataRouter`: routes documents to configurable outputs based on their metadata
+- `BM25Retriever`: retrieves documents from a 'DocumentStore' based on the 'query'-input
+
+A component is lightweight. It is easy to implement custom components. Here is some information from the docs:
+
+Requirements
+
+Here are the requirements for all custom components:
+
+- `@component`: This decorator marks a class as a component, allowing it to be used in a pipeline.
+- `run()`: This is a required method in every component. It accepts input arguments and returns a `dict`. The inputs can
+either come from the pipeline when it’s executed, or from the output of another component when connected using
+`connect()`. The `run()` method should be compatible with the input/output definitions declared for the component.
+See an [Extended Example](#extended-example) below to check how it works.
+
+## Inputs and Outputs
+
+Next, define the inputs and outputs for your component.
+
+### Inputs
+
+You can choose between three input options:
+
+- `set_input_type`: This method defines or updates a single input socket for a component instance. It’s ideal for adding
+or modifying a specific input at runtime without affecting others. Use this when you need to dynamically set or modify
+a single input based on specific conditions.
+- `set_input_types`: This method allows you to define multiple input sockets at once, replacing any existing inputs.
+It’s useful when you know all the inputs the component will need and want to configure them in bulk. Use this when you
+want to define multiple inputs during initialization.
+- Declaring arguments directly in the `run()` method. Use this method when the component’s inputs are static and known
+at the time of class definition.
+
+### Outputs
+
+You can choose between two output options:
+
+- `@component.output_types`: This decorator defines the output types and names at the time of class definition. The
+output names and types must match the `dict` returned by the `run()` method. Use this when the output types are static
+and known in advance. This decorator is cleaner and more readable for static components.
+- `set_output_types`: This method defines or updates multiple output sockets for a component instance at runtime.
+It’s useful when you need flexibility in configuring outputs dynamically. Use this when the output types need to be set
+at runtime for greater flexibility.
+
+# Short Example
+
+Here is an example of a simple minimal component setup:
+
+```python
+from haystack import component
+
+@component
+class WelcomeTextGenerator:
+  '''
+  A component generating personal welcome message and making it upper case
+  '''
+  @component.output_types(welcome_text=str, note=str)
+  def run(self, name:str):
+    return {"welcome_text": f'Hello {name}, welcome to Haystack!'.upper(), "note": "welcome message is ready"}
+
+```
+
+Here, the custom component `WelcomeTextGenerator` accepts one input: `name` string and returns two outputs:
+`welcome_text` and `note`.
+
+
+----------
+
+**Pipelines**
+The pipelines in Haystack 2.0 are directed multigraphs of different Haystack components and integrations.
+They give you the freedom to connect these components in various ways. This means that the
+pipeline doesn't need to be a continuous stream of information. With the flexibility of Haystack pipelines,
+you can have simultaneous flows, standalone components, loops, and other types of connections.
+
+# Steps to Create a Pipeline Explained
+
+Once all your components are created and ready to be combined in a pipeline, there are four steps to make it work:
+
+1. Create the pipeline with `Pipeline()`.
+   This creates the Pipeline object.
+2. Add components to the pipeline, one by one, with `.add_component(name, component)`.
+   This just adds components to the pipeline without connecting them yet. It's especially useful for loops as it allows
+   the smooth connection of the components in the next step because they all already exist in the pipeline.
+3. Connect components with `.connect("producer_component.output_name", "consumer_component.input_name")`.
+   At this step, you explicitly connect one of the outputs of a component to one of the inputs of the next component.
+   This is also when the pipeline validates the connection without running the components. It makes the validation fast.
+4. Run the pipeline with `.run({"component_1": {"mandatory_inputs": value}})`.
+   Finally, you run the Pipeline by specifying the first component in the pipeline and passing its mandatory inputs.
+
+   Optionally, you can pass inputs to other components, for example:
+   `.run({"component_1": {"mandatory_inputs": value}, "component_2": {"inputs": value}})`.
+
+The full pipeline [example](/docs/creating-pipelines#example) in [Creating Pipelines](/docs/creating-pipelines) shows
+how all the elements come together to create a working RAG pipeline.
+
+Once you create your pipeline, you can [visualize it in a graph](/docs/drawing-pipeline-graphs) to understand how the
+components are connected and make sure that's how you want them. You can use Mermaid graphs to do that.
+
+# Validation
+
+Validation happens when you connect pipeline components with `.connect()`, but before running the components to make it
+faster. The pipeline validates that:
+
+- The components exist in the pipeline.
+- The components' outputs and inputs match and are explicitly indicated. For example, if a component produces two
+outputs, when connecting it to another component, you must indicate which output connects to which input.
+- The components' types match.
+- For input types other than `Variadic`, checks if the input is already occupied by another connection.
+
+All of these checks produce detailed errors to help you quickly fix any issues identified.
+
+# Serialization
+
+Thanks to serialization, you can save and then load your pipelines. Serialization is converting a Haystack pipeline
+into a format you can store on disk or send over the wire. It's particularly useful for:
+
+- Editing, storing, and sharing pipelines.
+- Modifying existing pipelines in a format different than Python.
+
+Haystack pipelines delegate the serialization to its components, so serializing a pipeline simply means serializing
+each component in the pipeline one after the other, along with their connections. The pipeline is serialized into a
+dictionary format, which acts as an intermediate format that you can then convert into the final format you want.
+
+> 📘 Serialization formats
+>
+> Haystack 2.0 only supports YAML format at this time. We'll be rolling out more formats gradually.
+
+For serialization to be possible, components must support conversion from and to Python dictionaries. All Haystack
+components have two methods that make them serializable: `from_dict` and `to_dict`. The `Pipeline` class, in turn, has
+its own `from_dict` and `to_dict` methods that take care of serializing components and connections.
+
+
+---------
+
+**Haystack Repositories**
+
+1. "deepset-ai/haystack"
+
+Contains the core code for the Haystack framework and a few components.
+The components that are part of this repository typically don't have heavy dependencies.
+
+
+2. "deepset-ai/haystack-core-integrations"
+
+This is a mono-repo maintained by the deepset-Team that contains integrations for the Haystack framework.
+Typically, an integration consists of one or more components. Some integrations only contain document stores.
+Each integration is a standalone pypi-package but you can find all of them in the core integrations repo.
+
+
+3. "deepset-ai/haystack-experimental"
+
+Contains experimental features for the Haystack framework.
+
+"""

--- a/integrations/github-haystack/src/github_haystack/agent_prompts/file_editor_tool.py
+++ b/integrations/github-haystack/src/github_haystack/agent_prompts/file_editor_tool.py
@@ -1,0 +1,130 @@
+file_editor_prompt = """
+Use the file editor to edit an existing file in the repository.
+
+You must provide a 'command' for the action that you want to perform:
+- edit
+- create
+- delete
+- undo
+
+The 'payload' contains your options for each command.
+
+**Command 'edit'**
+
+To edit a file, you need to provide:
+1. The path to the file
+2. The original code snippet from the file
+3. Your replacement code
+4. A commit message
+
+The code will only be replaced if it is unique in the file. Pass a minimum of 2 consecutive lines that should
+be replaced. If the original is not unique, the editor will return an error.
+Pay attention to whitespace both for the original as well as the replacement.
+
+The commit message should be short and communicate your intention.
+Use the conventional commit style for your messages.
+
+Example:
+{
+    "command": "edit",
+    "payload": {
+        "path": "README.md",
+        "original": "This is a placeholder description!\\nIt should be updated.",
+        "replacement": "This project helps developers test AI applications.",
+        "message": "docs: README should mention project purpose."
+    }
+}
+
+
+**Command 'create'**
+
+To create a file, you need to provide:
+1. The path for the new file
+2. The content for the file
+3. A commit message
+
+The commit message should be short and communicate your intention.
+Use the conventional commit style for your messages.
+
+IMPORTANT:
+You MUST ALWAYS provide 'content' when creating a new file. File creation with empty content does not work.
+
+Example:
+{
+    "command": "create",
+    "payload": {
+        "path": "CONTRIBUTING.md",
+        "content": "Contributions are welcome, please write tests and follow our code style guidelines.",
+        "message": "chore: minimal instructions for contributors"
+    }
+}
+
+
+**Command 'delete'**
+
+To delete a file, you need to provide:
+1. The path to the file to delete
+2. A commit message
+
+The commit message should be short and communicate your intention.
+Use the conventional commit style for your messages.
+
+Example:
+{
+    "command": "delete",
+    "payload": {
+        "path": "tests/components/test_messaging",
+        "message": "chore: messaging feature was removed"
+    }
+}
+
+**Command 'undo'**
+
+This is how to undo your latest change.
+
+Important notes:
+- You can only undo your own changes
+- You can only undo one change at a time
+- You need to provide a message for the undo operation
+
+Example:
+{
+    "command": "undo",
+    "payload": {
+        "message": "revert: undo previous commit due to failing tests"
+    }
+}
+"""
+
+file_editor_schema = {
+  "type": "object",
+  "properties": {
+    "command": {
+      "type": "string",
+      "enum": ["edit", "create", "delete", "undo"],
+      "description": "The command to execute"
+    },
+    "payload": {
+      "type": "object",
+      "required": ["message"],
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "original": {
+          "type": "string"
+        },
+        "replacement": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "required": ["command", "payload"]
+}

--- a/integrations/github-haystack/src/github_haystack/agent_prompts/pr_system_prompt.py
+++ b/integrations/github-haystack/src/github_haystack/agent_prompts/pr_system_prompt.py
@@ -1,0 +1,53 @@
+system_prompt = """
+The assistant is Haystack-Agent, created by deepset.
+Haystack-Agent creates Pull Requests that resolve GitHub issues.
+
+Haystack-Agent receives a GitHub issue and all current comments.
+Haystack-Agent analyzes the issue, creates code changes, and submits a Pull Request.
+
+**Issue Analysis**
+Haystack-Agent reviews all implementation suggestions in the comments.
+Haystack-Agent evaluates each proposed approach and determines if it adequately solves the issue.
+Haystack-Agent uses the `repository_viewer` utility to examine repository files.
+Haystack-Agent views any files that are directly referenced in the issue, to understand the context of the issue.
+Haystack-Agent follows instructions that are provided in the comments, when they make sense.
+
+**Software Engineering**
+Haystack-Agent creates high-quality code that is easy to understand, performant, secure, easy to test, and maintainable.
+Haystack-Agent finds the right level of abstraction and complexity.
+When working with other developers on an issue, Haystack-Agent generally adapts to the code, architecture, and
+documentation patterns that are already being used in the codebase.
+Haystack-Agent may propose better code style, documentation, or architecture when appropriate.
+Haystack-Agent needs context on the code being discussed before starting to resolve the issue.
+Haystack-Agent produces code that can be merged without needing manual intervention from other developers.
+Haystack-Agent adapts to the comment style, that is already being used in the codebase.
+It avoids superfluous comments that point out the obvious. When Haystack-Agent wants to explain code changes,
+it uses the PR description for that.
+
+**Thinking Process**
+Haystack-Agent thinks thoroughly about each issue.
+Haystack-Agent takes time to consider all aspects of the implementation.
+A lengthy thought process is acceptable and often necessary for proper resolution.
+
+<scratchpad>
+Haystack-Agent notes down any thoughts and observations in the scratchpad, so that it can reference them later.
+</scratchpad>
+
+**Resolution Process**
+Haystack-Agent follows these steps to resolve issues:
+
+1. Analyze the issue and comments, noting all proposed implementations
+2. Explore the repository from the root (/) directory
+3. Examine files referenced in the issue or comments
+4. View additional files and test cases to understand intended behavior
+5. Create initial test cases to validate the planned solution
+6. Edit repository source code to resolve the issue
+7. Update test cases to match code changes
+8. Handle edge cases and ensure code matches repository style
+9. Create a Pull Request using the `create_pr` utility
+
+**Pull Request Creation**
+Haystack-Agent writes clear Pull Request descriptions.
+Each description explains what changes were made and why they were necessary.
+The description helps reviewers understand the implementation approach.
+"""

--- a/integrations/github-haystack/src/github_haystack/agent_prompts/repo_viewer_tool.py
+++ b/integrations/github-haystack/src/github_haystack/agent_prompts/repo_viewer_tool.py
@@ -1,0 +1,78 @@
+repo_viewer_prompt = """
+Haystack-Agent uses this tool to browse GitHub repositories.
+Haystack-Agent can view directories and files with this tool.
+
+<usage>
+Pass a `repo` string for the repository that you want to view.
+It is required to pass `repo` to use this tool.
+The structure is "owner/repo-name".
+
+Pass a `path` string for the directory or file that you want to view.
+If you pass an empty path, you will view the root directory of the repository.
+
+Examples:
+
+- {"repo": "pandas-dev/pandas", "path": ""}
+    - will show you the root of the pandas repository
+- {"repo": "pandas-dev/pandas", "path": "pyproject.toml"}
+    - will show you the "pyproject.toml"-file of the pandas repository
+- {"repo": "huggingface/transformers", "path": "src/transformers/models/albert"}
+    - will show you the "albert"-directory in the transformers repository
+- {"repo": "huggingface/transformers", "path": "src/transformers/models/albert/albert_modelling.py"}
+    - will show you the source code for the albert model in the transformers repository
+</usage>
+
+Haystack-Agent uses the `github_repository_viewer` to view relevant code.
+Haystack-Agent starts at the root of the repository.
+Haystack-Agent navigates one level at a time using directory listings.
+Haystack-Agent views all relevant code, testing, configuration, or documentation files on a level.
+It never skips a directory level or guesses full paths.
+
+Haystack-Agent thinks deeply about the content of a repository. Before Haystack-Agent uses the tool, it reasons about
+next steps:
+
+<thinking>
+- What am I looking for in this location?
+- Why is this path potentially relevant?
+- What specific files might help solve the issue?
+- What patterns or implementations should I look for?
+ </thinking>
+
+After viewing the contents of a file or directory, Haystack-Agent reflects on its observations before moving on:
+<thinking>
+- What did I learn from these files?
+- What else might be related?
+- Where should I look next and why?
+</thinking>
+
+IMPORTANT
+Haystack-Agent views the content of relevant files, it knows that it is not enough to explore the directory structure.
+Haystack-Agent needs to read the code to understand it properly.
+To view a file, Haystack-Agent passes the full path of the file to the `github_repository_viewer`.
+Haystack-Agent never guesses a file or directory path.
+
+Haystack-Agent takes notes after viewing code:
+<scratchpad>
+- extract important code snippets
+- document key functions, classes or configurations
+- note key architecture patterns
+- relate findings to the original issue
+- relate findings to other code that was already viewed
+- note down file paths as a reference
+</scratchpad>
+"""
+
+repo_viewer_schema = {
+    "properties": {
+        "repo": {
+            "type": "string",
+            "description": "The owner/repository_name that you want to view."
+        },
+        "path": {
+            "type": "string",
+            "description": "Path to directory or file to view. Defaults to repository root.",
+        }
+    },
+    "required": ["repo"],
+    "type": "object"
+}

--- a/integrations/github-haystack/src/github_haystack/agent_prompts/system_prompt.py
+++ b/integrations/github-haystack/src/github_haystack/agent_prompts/system_prompt.py
@@ -1,0 +1,61 @@
+issue_prompt = """
+The assistant is Haystack-Agent, created by deepset.
+Haystack-Agent helps developers to develop software by participating in GitHub issue discussions.
+
+Haystack-Agent receives a GitHub issue and all current comments.
+Haystack-Agent participates in the discussion by:
+- helping users find answers to their questions
+- analyzing bug reports and proposing a fix when necessary
+- analyzing feature requests and proposing an implementation
+- being a sounding board in architecture discussions and proposing alternative solutions
+
+**Style**
+Haystack-Agent uses Markdown formatting. When using Markdown, Haystack-Agent always follows best practices for clarity
+and consistency.
+It always uses a single space after hash symbols for headers (e.g., ”# Header 1”) and leaves a blank line before and
+after headers, lists, and code blocks. For emphasis, Haystack-Agent uses asterisks or underscores consistently
+(e.g., italic or bold). When creating lists, it aligns items properly and uses a single space after the list marker.
+For nested bullets in bullet point lists, Haystack-Agent uses two spaces before the asterisk (*) or hyphen (-) for each
+level of nesting. For nested bullets in numbered lists, Haystack-Agent uses three spaces before the number and period
+(e.g., “1.”) for each level of nesting. When writing code, Haystack-Agent uses Markdown-blocks with appropriate language
+annotation.
+
+**Software Engineering**
+Haystack-Agent creates high-quality code that is easy to understand, performant, secure, easy to test, and maintainable.
+Haystack-Agent finds the right level of abstraction and complexity.
+When working with other developers on an issue, Haystack-Agent generally adapts to the code, architecture, and
+documentation patterns that are already being used in the codebase.
+Haystack-Agent may propose better code style, documentation, or architecture when appropriate.
+Haystack-Agent needs context on the code being discussed before responding with a comment.
+Haystack-Agent does not craft any comments without knowing the code being discussed.
+Haystack-Agent can explore any repository on GitHub and view its contents.
+
+**Exploring Repositories**
+Haystack-Agent uses the `repository_viewer` to explore GitHub repositories before crafting a comment.
+Haystack-Agent explores more than one repository when the GitHub discussions mentions multiple relevant repositories.
+
+**Thinking**
+Haystack-Agent is a rigorous thinker. It uses <thinking></thinking>-blocks to gather thoughts, reflect on the issue at
+hand, and relate its learnings to it. It is not afraid of a lengthy thought process, because it knows that Software
+Engineering is a challenging discipline.
+Haystack-Agent takes notes on the <scratchpad></scratchpad>. The scratchpad holds important pieces of information that
+Haystack-Agent wants to reference later.
+
+**Comments**
+Haystack-Agent is friendly, uses accessible language and keeps comments as simple as possible.
+When developers address Haystack-Agent directly, it follows their instructions and finds the best response to their
+comment. Haystack-Agent is happy to revise its code when a developer asks for it.
+Haystack-Agent may disagree with a developer, when the changes being asked for clearly don't help to resolve the issue
+or when Haystack-Agent has found a better approach to solving it.
+Haystack-Agent uses the `create_comment`-tool to create a comment. Before creating a comment, Haystack-Agent reflects on
+the issue, and any learnings from the code analysis. Haystack-Agent only responds when ready.
+
+
+Haystack-Agent, this is IMPORTANT:
+- DO NOT START WRITING YOUR RESPONSE UNTIL YOU HAVE COMPLETED THE ENTIRE EXPLORATION PHASE
+- VIEWING DIRECTORY LISTINGS IS NOT ENOUGH - YOU MUST EXAMINE FILE CONTENTS
+- If you find yourself running out of context space during exploration, say: "I need to continue exploring the codebase
+before providing a complete response." Then continue exploration in the next interaction.
+
+Haystack-Agent will now receive its tools including instructions and will then participate in a Github-issue discussion.
+"""

--- a/integrations/github-haystack/src/github_haystack/github_components/file_editor.py
+++ b/integrations/github-haystack/src/github_haystack/github_components/file_editor.py
@@ -1,0 +1,299 @@
+from base64 import b64decode, b64encode
+from enum import StrEnum
+from typing import Any, Dict, Optional, Union
+
+import requests
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+logger = logging.getLogger(__name__)
+
+class Command(StrEnum):
+    """
+    Available commands for file operations in GitHub.
+
+    Attributes:
+        EDIT: Edit an existing file by replacing content
+        UNDO: Revert the last commit if made by the same user
+        CREATE: Create a new file
+        DELETE: Delete an existing file
+    """
+    EDIT = "edit"
+    UNDO = "undo"
+    CREATE = "create"
+    DELETE = "delete"
+
+@component
+class GithubFileEditor:
+    """
+    A Haystack component for editing files in GitHub repositories.
+
+    Supports editing, undoing changes, deleting files, and creating new files
+    through the GitHub API.
+
+    ### Usage example
+    ```python
+    from haystack.components.actions import GithubFileEditor
+    from haystack.utils import Secret
+
+    # Initialize with default repo and branch
+    editor = GithubFileEditor(
+        github_token=Secret.from_env_var("GITHUB_TOKEN"),
+        repo="owner/repo",
+        branch="main"
+    )
+
+    # Edit a file using default repo and branch
+    result = editor.run(
+        command=Command.EDIT,
+        payload={
+            "path": "path/to/file.py",
+            "original": "def old_function():",
+            "replacement": "def new_function():",
+            "message": "Renamed function for clarity"
+        }
+    )
+
+    # Edit a file in a different repo/branch
+    result = editor.run(
+        command=Command.EDIT,
+        repo="other-owner/other-repo",  # Override default repo
+        branch="feature",  # Override default branch
+        payload={
+            "path": "path/to/file.py",
+            "original": "def old_function():",
+            "replacement": "def new_function():",
+            "message": "Renamed function for clarity"
+        }
+    )
+    ```
+    """
+
+    def __init__(
+        self,
+        github_token: Secret = Secret.from_env_var("GITHUB_TOKEN"),
+        repo: Optional[str] = None,
+        branch: str = "main",
+        raise_on_failure: bool = True
+    ):
+        """
+        Initialize the component.
+
+        :param github_token: GitHub personal access token for API authentication
+        :param repo: Default repository in owner/repo format
+        :param branch: Default branch to work with
+        :param raise_on_failure: If True, raises exceptions on API errors
+        """
+        if not isinstance(github_token, Secret):
+            raise TypeError("github_token must be a Secret")
+
+        self.github_token = github_token
+        self.default_repo = repo
+        self.default_branch = branch
+        self.raise_on_failure = raise_on_failure
+
+        self.headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": f"Bearer {self.github_token.resolve_value()}",
+            "User-Agent": "Haystack/GithubFileEditor"
+        }
+
+    def _get_file_content(self, owner: str, repo: str, path: str, branch: str) -> tuple[str, str]:
+        """Get file content and SHA from GitHub."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+        response = requests.get(url, headers=self.headers, params={"ref": branch})
+        response.raise_for_status()
+        data = response.json()
+        content = b64decode(data["content"]).decode("utf-8")
+        return content, data["sha"]
+
+    def _update_file(
+        self,
+        owner: str,
+        repo: str,
+        path: str,
+        content: str,
+        message: str,
+        sha: str,
+        branch: str
+    ) -> bool:
+        """Update file content on GitHub."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+        payload = {
+            "message": message,
+            "content": b64encode(content.encode("utf-8")).decode("utf-8"),
+            "sha": sha,
+            "branch": branch
+        }
+        response = requests.put(url, headers=self.headers, json=payload)
+        response.raise_for_status()
+        return True
+
+    def _check_last_commit(self, owner: str, repo: str, branch: str) -> bool:
+        """Check if last commit was made by the current token user."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/commits"
+        response = requests.get(url, headers=self.headers, params={"per_page": 1, "sha": branch})
+        response.raise_for_status()
+        last_commit = response.json()[0]
+        commit_author = last_commit["author"]["login"]
+
+        # Get current user
+        user_response = requests.get("https://api.github.com/user", headers=self.headers)
+        user_response.raise_for_status()
+        current_user = user_response.json()["login"]
+
+        return commit_author == current_user
+
+    def _edit_file(self, owner: str, repo: str, payload: Dict[str, str], branch: str) -> str:
+        """Handle file editing."""
+        try:
+            content, sha = self._get_file_content(owner, repo, payload["path"], branch)
+
+            # Check if original string is unique
+            occurrences = content.count(payload["original"])
+            if occurrences == 0:
+                return "Error: Original string not found in file"
+            if occurrences > 1:
+                return "Error: Original string appears multiple times. Please provide more context"
+
+            # Perform the replacement
+            new_content = content.replace(payload["original"], payload["replacement"])
+            success = self._update_file(
+                owner, repo, payload["path"], new_content, payload["message"], sha, branch
+            )
+            return "Edit successful" if success else "Edit failed"
+
+        except requests.RequestException as e:
+            if self.raise_on_failure:
+                raise
+            return f"Error: {str(e)}"
+
+    def _undo_changes(self, owner: str, repo: str, payload: Dict[str, str], branch: str) -> str:
+        """Handle undoing changes."""
+        try:
+            if not self._check_last_commit(owner, repo, branch):
+                return "Error: Last commit was not made by the current user"
+
+            # Reset to previous commit
+            url = f"https://api.github.com/repos/{owner}/{repo}/git/refs/heads/{branch}"
+            commits_url = f"https://api.github.com/repos/{owner}/{repo}/commits"
+
+            # Get the previous commit SHA
+            commits = requests.get(
+                commits_url,
+                headers=self.headers,
+                params={"per_page": 2, "sha": branch}
+            ).json()
+            previous_sha = commits[1]["sha"]
+
+            # Update branch reference to previous commit
+            payload = {"sha": previous_sha, "force": True}
+            response = requests.patch(url, headers=self.headers, json=payload)
+            response.raise_for_status()
+
+            return "Successfully undid last change"
+
+        except requests.RequestException as e:
+            if self.raise_on_failure:
+                raise
+            return f"Error: {str(e)}"
+
+    def _create_file(self, owner: str, repo: str, payload: Dict[str, str], branch: str) -> str:
+        """Handle file creation."""
+        try:
+            url = f"https://api.github.com/repos/{owner}/{repo}/contents/{payload['path']}"
+            content = b64encode(payload["content"].encode("utf-8")).decode("utf-8")
+
+            data = {
+                "message": payload["message"],
+                "content": content,
+                "branch": branch
+            }
+
+            response = requests.put(url, headers=self.headers, json=data)
+            response.raise_for_status()
+            return "File created successfully"
+
+        except requests.RequestException as e:
+            if self.raise_on_failure:
+                raise
+            return f"Error: {str(e)}"
+
+    def _delete_file(self, owner: str, repo: str, payload: Dict[str, str], branch: str) -> str:
+        """Handle file deletion."""
+        try:
+            content, sha = self._get_file_content(owner, repo, payload["path"], branch)
+            url = f"https://api.github.com/repos/{owner}/{repo}/contents/{payload['path']}"
+
+            data = {
+                "message": payload["message"],
+                "sha": sha,
+                "branch": branch
+            }
+
+            response = requests.delete(url, headers=self.headers, json=data)
+            response.raise_for_status()
+            return "File deleted successfully"
+
+        except requests.RequestException as e:
+            if self.raise_on_failure:
+                raise
+            return f"Error: {str(e)}"
+
+    @component.output_types(result=str)
+    def run(
+        self,
+        command: Union[Command, str],
+        payload: Dict[str, Any],
+        repo: Optional[str] = None,
+        branch: Optional[str] = None
+    ) -> Dict[str, str]:
+        """
+        Process GitHub file operations.
+
+        :param command: Operation to perform ("edit", "undo", "create", "delete")
+        :param payload: Dictionary containing command-specific parameters
+        :param repo: Repository in owner/repo format (overrides default if provided)
+        :param branch: Branch to perform operations on (overrides default if provided)
+        :return: Dictionary containing operation result
+        """
+        if repo is None:
+            if self.default_repo is None:
+                return {
+                    "result": "Error: No repository specified. Either provide it in initialization or in run() method"
+                }
+            repo = self.default_repo
+
+        working_branch = branch if branch is not None else self.default_branch
+        owner, repo_name = repo.split("/")
+
+        command_handlers = {
+            Command.EDIT: self._edit_file,
+            Command.UNDO: self._undo_changes,
+            Command.CREATE: self._create_file,
+            Command.DELETE: self._delete_file
+        }
+
+        if command not in command_handlers:
+            return {"result": f"Error: Unknown command '{command}'"}
+
+        result = command_handlers[command](owner, repo_name, payload, working_branch)
+        return {"result": result}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the component to a dictionary."""
+        return default_to_dict(
+            self,
+            github_token=self.github_token.to_dict() if self.github_token else None,
+            repo=self.default_repo,
+            branch=self.default_branch,
+            raise_on_failure=self.raise_on_failure
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GithubFileEditor":
+        """Deserialize the component from a dictionary."""
+        init_params = data["init_parameters"]
+        deserialize_secrets_inplace(init_params, keys=["github_token"])
+        return default_from_dict(cls, data)
+

--- a/integrations/github-haystack/src/github_haystack/github_components/issue_commenter.py
+++ b/integrations/github-haystack/src/github_haystack/github_components/issue_commenter.py
@@ -1,0 +1,155 @@
+import re
+from typing import Any, Dict, Optional
+
+import requests
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.utils import deserialize_secrets_inplace
+from haystack.utils.auth import Secret
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class GithubIssueCommenter:
+    """
+    Posts comments to GitHub issues.
+
+    The component takes a GitHub issue URL and comment text, then posts the comment
+    to the specified issue using the GitHub API.
+
+    ### Usage example
+    ```python
+    from haystack.components.writers import GithubIssueCommenter
+
+    commenter = GithubIssueCommenter(github_token=Secret.from_env_var("GITHUB_TOKEN"))
+    result = commenter.run(
+        url="https://github.com/owner/repo/issues/123",
+        comment="Thanks for reporting this issue! We'll look into it."
+    )
+
+    assert result["success"] is True
+    ```
+    """
+
+    def __init__(
+            self,
+            github_token: Secret = Secret.from_env_var("GITHUB_TOKEN"),
+            raise_on_failure: bool = True,
+            retry_attempts: int = 2,
+    ):
+        """
+        Initialize the component.
+
+        :param github_token: GitHub personal access token for API authentication as a Secret
+        :param raise_on_failure: If True, raises exceptions on API errors
+        :param retry_attempts: Number of retry attempts for failed requests
+        """
+        self.github_token = github_token
+        self.raise_on_failure = raise_on_failure
+        self.retry_attempts = retry_attempts
+
+        # Set base headers during initialization
+        self.headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "Haystack/GithubIssueCommenter",
+        }
+
+    def _get_request_headers(self) -> dict:
+        """
+        Get headers with resolved token for the request.
+
+        :return: Dictionary of headers including authorization if token is present
+        """
+        headers = self.headers.copy()
+        if self.github_token is not None:
+            headers["Authorization"] = f"Bearer {self.github_token.resolve_value()}"
+        return headers
+
+    def _parse_github_url(self, url: str) -> tuple[str, str, int]:
+        """
+        Parse GitHub URL into owner, repo and issue number.
+
+        :param url: GitHub issue URL
+        :return: Tuple of (owner, repo, issue_number)
+        :raises ValueError: If URL format is invalid
+        """
+        pattern = r"https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)"
+        match = re.match(pattern, url)
+        if not match:
+            raise ValueError(f"Invalid GitHub issue URL format: {url}")
+
+        owner, repo, issue_number = match.groups()
+        return owner, repo, int(issue_number)
+
+    def _post_comment(self, owner: str, repo: str, issue_number: int, comment: str) -> bool:
+        """
+        Post a comment to a GitHub issue.
+
+        :param owner: Repository owner
+        :param repo: Repository name
+        :param issue_number: Issue number
+        :param comment: Comment text to post
+        :return: True if comment was posted successfully
+        :raises requests.exceptions.RequestException: If the API request fails
+        """
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments"
+        data = {"body": comment}
+
+        for attempt in range(self.retry_attempts):
+            try:
+                response = requests.post(url, headers=self._get_request_headers(), json=data)
+                response.raise_for_status()
+                return True
+            except requests.exceptions.RequestException as e:
+                if attempt == self.retry_attempts - 1:
+                    raise
+                logger.warning(f"Attempt {attempt + 1} failed: {str(e)}. Retrying...")
+
+        return False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            github_token=self.github_token.to_dict() if self.github_token else None,
+            raise_on_failure=self.raise_on_failure,
+            retry_attempts=self.retry_attempts,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GithubIssueCommenter":
+        """
+        Deserialize the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        init_params = data["init_parameters"]
+        deserialize_secrets_inplace(init_params, keys=["github_token"])
+        return default_from_dict(cls, data)
+
+    @component.output_types(success=bool)
+    def run(self, url: str, comment: str) -> dict:
+        """
+        Post a comment to a GitHub issue.
+
+        :param url: GitHub issue URL
+        :param comment: Comment text to post
+        :return: Dictionary containing success status
+        """
+        try:
+            owner, repo, issue_number = self._parse_github_url(url)
+            success = self._post_comment(owner, repo, issue_number, comment)
+            return {"success": success}
+
+        except Exception as e:
+            if self.raise_on_failure:
+                raise
+
+            error_message = f"Error posting comment to GitHub issue {url}: {str(e)}"
+            logger.warning(error_message)
+            return {"success": False}

--- a/integrations/github-haystack/src/github_haystack/github_components/issue_viewer.py
+++ b/integrations/github-haystack/src/github_haystack/github_components/issue_viewer.py
@@ -1,0 +1,218 @@
+import re
+from typing import Any, Dict, List, Optional
+
+import requests
+from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack.utils import deserialize_secrets_inplace
+from haystack.utils.auth import Secret
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class GithubIssueViewer:
+    """
+    Fetches and parses GitHub issues into Haystack documents.
+
+    The component takes a GitHub issue URL and returns a list of documents where:
+    - First document contains the main issue content
+    - Subsequent documents contain the issue comments
+
+    ### Usage example
+    ```python
+    from haystack.components.fetchers import GithubIssueViewer
+
+    viewer = GithubIssueViewer(github_token=Secret.from_env_var("GITHUB_TOKEN"))
+    docs = viewer.run(
+        url="https://github.com/owner/repo/issues/123"
+    )["documents"]
+
+    assert len(docs) >= 1  # At least the main issue
+    assert docs[0].meta["type"] == "issue"
+    ```
+    """
+
+    def __init__(
+        self,
+        github_token: Optional[Secret] = None,
+        raise_on_failure: bool = True,
+        retry_attempts: int = 2,
+    ):
+        """
+        Initialize the component.
+
+        :param github_token: GitHub personal access token for API authentication as a Secret
+        :param raise_on_failure: If True, raises exceptions on API errors
+        :param retry_attempts: Number of retry attempts for failed requests
+        """
+        self.github_token = github_token
+        self.raise_on_failure = raise_on_failure
+        self.retry_attempts = retry_attempts
+
+        # Only set the basic headers during initialization
+        self.headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "Haystack/GithubIssueViewer",
+        }
+
+    def _get_request_headers(self) -> dict:
+        """
+        Get headers with resolved token for the request.
+
+        :return: Dictionary of headers including authorization if token is present
+        """
+        headers = self.headers.copy()
+        if self.github_token:
+            headers["Authorization"] = f"Bearer {self.github_token.resolve_value()}"
+        return headers
+
+    def _parse_github_url(self, url: str) -> tuple[str, str, int]:
+        """
+        Parse GitHub URL into owner, repo and issue number.
+
+        :param url: GitHub issue URL
+        :return: Tuple of (owner, repo, issue_number)
+        :raises ValueError: If URL format is invalid
+        """
+        pattern = r"https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)"
+        match = re.match(pattern, url)
+        if not match:
+            raise ValueError(f"Invalid GitHub issue URL format: {url}")
+
+        owner, repo, issue_number = match.groups()
+        return owner, repo, int(issue_number)
+
+    def _fetch_issue(self, owner: str, repo: str, issue_number: int) -> Any:
+        """
+        Fetch issue data from GitHub API.
+
+        :param owner: Repository owner
+        :param repo: Repository name
+        :param issue_number: Issue number
+        :return: Issue data dictionary
+        """
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}"
+        response = requests.get(url, headers=self._get_request_headers())
+        response.raise_for_status()
+        return response.json()
+
+    def _fetch_comments(self, comments_url: str) -> Any:
+        """
+        Fetch issue comments from GitHub API.
+
+        :param comments_url: URL for issue comments
+        :return: List of comment dictionaries
+        """
+        response = requests.get(comments_url, headers=self._get_request_headers())
+        response.raise_for_status()
+        return response.json()
+
+    def _create_issue_document(self, issue_data: dict) -> Document:
+        """
+        Create a Document from issue data.
+
+        :param issue_data: Issue data from GitHub API
+        :return: Haystack Document
+        """
+        return Document(  # type: ignore
+            content=issue_data["body"],
+            meta={
+                "type": "issue",
+                "title": issue_data["title"],
+                "number": issue_data["number"],
+                "state": issue_data["state"],
+                "created_at": issue_data["created_at"],
+                "updated_at": issue_data["updated_at"],
+                "author": issue_data["user"]["login"],
+                "url": issue_data["html_url"],
+            },
+        )
+
+    def _create_comment_document(
+        self, comment_data: dict, issue_number: int
+    ) -> Document:
+        """
+        Create a Document from comment data.
+
+        :param comment_data: Comment data from GitHub API
+        :param issue_number: Parent issue number
+        :return: Haystack Document
+        """
+        return Document(
+            content=comment_data["body"],
+            meta={
+                "type": "comment",
+                "issue_number": issue_number,
+                "created_at": comment_data["created_at"],
+                "updated_at": comment_data["updated_at"],
+                "author": comment_data["user"]["login"],
+                "url": comment_data["html_url"],
+            },
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            github_token=self.github_token.to_dict() if self.github_token else None,
+            raise_on_failure=self.raise_on_failure,
+            retry_attempts=self.retry_attempts,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GithubIssueViewer":
+        """
+        Deserialize the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        init_params = data["init_parameters"]
+        deserialize_secrets_inplace(init_params, keys=["github_token"])
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=List[Document])
+    def run(self, url: str) -> dict:
+        """
+        Process a GitHub issue URL and return documents.
+
+        :param url: GitHub issue URL
+        :return: Dictionary containing list of documents
+        """
+        try:
+            owner, repo, issue_number = self._parse_github_url(url)
+
+            # Fetch issue data
+            issue_data = self._fetch_issue(owner, repo, issue_number)
+            documents = [self._create_issue_document(issue_data)]
+
+            # Fetch and process comments if they exist
+            if issue_data["comments"] > 0:
+                comments = self._fetch_comments(issue_data["comments_url"])
+                documents.extend(
+                    self._create_comment_document(comment, issue_number)
+                    for comment in comments
+                )
+
+            return {"documents": documents}
+
+        except Exception as e:
+            if self.raise_on_failure:
+                raise
+
+            error_message = f"Error processing GitHub issue {url}: {str(e)}"
+            logger.warning(error_message)
+            error_doc = Document(
+                content=error_message,
+                meta={
+                    "error": True,
+                    "type": "error",
+                    "url": url,
+                }
+            )
+            return {"documents": [error_doc]}
+

--- a/integrations/github-haystack/src/github_haystack/github_components/pr_creator.py
+++ b/integrations/github-haystack/src/github_haystack/github_components/pr_creator.py
@@ -1,0 +1,171 @@
+import re
+from typing import Any, Dict
+
+import requests
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class GithubPRCreator:
+    """
+    A Haystack component for creating pull requests from a fork back to the original repository.
+
+    Uses the authenticated user's fork to create the PR and links it to an existing issue.
+
+    ### Usage example
+    ```python
+    from haystack.components.actions import GithubPRCreator
+    from haystack.utils import Secret
+
+    pr_creator = GithubPRCreator(
+        github_token=Secret.from_env_var("GITHUB_TOKEN")  # Token from the fork owner
+    )
+
+    # Create a PR from your fork
+    result = pr_creator.run(
+        issue_url="https://github.com/owner/repo/issues/123",
+        title="Fix issue #123",
+        body="This PR addresses issue #123",
+        branch="feature-branch",     # The branch in your fork with the changes
+        base="main"                  # The branch in the original repo to merge into
+    )
+    ```
+    """
+
+    def __init__(
+            self,
+            github_token: Secret = Secret.from_env_var("GITHUB_TOKEN"),
+            raise_on_failure: bool = True
+    ):
+        """
+        Initialize the component.
+
+        :param github_token: GitHub personal access token for authentication (from the fork owner)
+        :param raise_on_failure: If True, raises exceptions on API errors
+        """
+        if not isinstance(github_token, Secret):
+            raise TypeError("github_token must be a Secret")
+
+        self.github_token = github_token
+        self.raise_on_failure = raise_on_failure
+
+    def _get_headers(self) -> Dict[str, str]:
+        """
+        Get headers for GitHub API requests with resolved token.
+
+        :return: Dictionary of request headers
+        """
+        return {
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": f"Bearer {self.github_token.resolve_value()}",
+            "User-Agent": "Haystack/GithubPRCreator"
+        }
+
+    def _parse_issue_url(self, issue_url: str) -> tuple[str, str, str]:
+        """
+        Parse owner, repo name, and issue number from GitHub issue URL.
+
+        :param issue_url: Full GitHub issue URL
+        :return: Tuple of (owner, repo_name, issue_number)
+        :raises ValueError: If URL format is invalid
+        """
+        pattern = r"https://github\.com/([^/]+)/([^/]+)/issues/(\d+)"
+        match = re.match(pattern, issue_url)
+        if not match:
+            raise ValueError("Invalid GitHub issue URL format")
+        return match.group(1), match.group(2), match.group(3)
+
+    def _get_authenticated_user(self) -> str:
+        """Get the username of the authenticated user (fork owner)."""
+        response = requests.get(
+            "https://api.github.com/user",
+            headers=self._get_headers()
+        )
+        response.raise_for_status()
+        return response.json()["login"]
+
+    def _check_fork_exists(self, owner: str, repo: str, fork_owner: str) -> bool:
+        """Check if the fork exists."""
+        url = f"https://api.github.com/repos/{fork_owner}/{repo}"
+        try:
+            response = requests.get(url, headers=self._get_headers())
+            response.raise_for_status()
+            fork_data = response.json()
+            return fork_data.get("fork", False)
+        except requests.RequestException:
+            return False
+
+    @component.output_types(result=str)
+    def run(
+            self,
+            issue_url: str,
+            title: str,
+            branch: str,
+            base: str,
+            body: str = "",
+            draft: bool = False
+    ) -> Dict[str, str]:
+        """
+        Create a new pull request from your fork to the original repository, linked to the specified issue.
+
+        :param issue_url: URL of the GitHub issue to link the PR to
+        :param title: Title of the pull request
+        :param branch: Name of the branch in your fork where changes are implemented
+        :param base: Name of the branch in the original repo you want to merge into
+        :param body: Additional content for the pull request description
+        :param draft: Whether to create a draft pull request
+        :return: Dictionary containing operation result
+        """
+        try:
+            # Parse repository information from issue URL
+            owner, repo_name, issue_number = self._parse_issue_url(issue_url)
+
+            # Get the authenticated user (fork owner)
+            fork_owner = self._get_authenticated_user()
+
+            # Check if the fork exists
+            if not self._check_fork_exists(owner, repo_name, fork_owner):
+                return {"result": f"Error: Fork not found at {fork_owner}/{repo_name}"}
+
+            url = f"https://api.github.com/repos/{owner}/{repo_name}/pulls"
+
+            # For cross-repository PRs, head must be in the format username:branch
+            head = f"{fork_owner}:{branch}"
+
+            pr_data = {
+                "title": title,
+                "body": body,
+                "head": head,
+                "base": base,
+                "draft": draft,
+                "maintainer_can_modify": True,  # Allow maintainers to modify the PR
+            }
+
+            response = requests.post(url, headers=self._get_headers(), json=pr_data)
+            response.raise_for_status()
+            pr_number = response.json()["number"]
+
+            return {"result": f"Pull request #{pr_number} created successfully and linked to issue #{issue_number}"}
+
+        except (requests.RequestException, ValueError) as e:
+            if self.raise_on_failure:
+                raise
+            return {"result": f"Error: {str(e)}"}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the component to a dictionary."""
+        return default_to_dict(
+            self,
+            github_token=self.github_token.to_dict() if self.github_token else None,
+            raise_on_failure=self.raise_on_failure
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GithubPRCreator":
+        """Deserialize the component from a dictionary."""
+        init_params = data["init_parameters"]
+        deserialize_secrets_inplace(init_params, keys=["github_token"])
+        return default_from_dict(cls, data)

--- a/integrations/github-haystack/src/github_haystack/github_components/repo_viewer.py
+++ b/integrations/github-haystack/src/github_haystack/github_components/repo_viewer.py
@@ -1,0 +1,263 @@
+import base64
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import requests
+from haystack import Document, component, logging
+from haystack.utils import Secret
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GitHubItem:
+    """Represents an item (file or directory) in a GitHub repository"""
+
+    name: str
+    type: str  # "file" or "dir"
+    path: str
+    size: int
+    url: str
+    content: Optional[str] = None
+
+
+@component
+class GithubRepositoryViewer:
+    """
+    Navigates and fetches content from GitHub repositories.
+
+    For directories:
+    - Returns a list of Documents, one for each item
+    - Each Document's content is the item name
+    - Full path and metadata in Document.meta
+
+    For files:
+    - Returns a single Document
+    - Document's content is the file content
+    - Full path and metadata in Document.meta
+
+    For errors:
+    - Returns a single Document
+    - Document's content is the error message
+    - Document's meta contains type="error"
+
+    ### Usage example
+    ```python
+    from haystack.components.fetchers import GithubRepositoryViewer
+    from haystack.utils import Secret
+
+    # Using token directly
+    viewer = GithubRepositoryViewer(github_token=Secret.from_token("your_token"))
+
+    # Using environment variable
+    viewer = GithubRepositoryViewer(github_token=Secret.from_env_var("GITHUB_TOKEN"))
+
+    # List directory contents - returns multiple documents
+    result = viewer.run(
+        repo="owner/repository",
+        path="docs/",
+        ref="main"
+    )
+
+    # Get specific file - returns single document
+    result = viewer.run(
+        repo="owner/repository",
+        path="README.md",
+        ref="main"
+    )
+    ```
+    """
+
+    def __init__(
+        self,
+        github_token: Optional[Secret] = None,
+        raise_on_failure: bool = True,
+        max_file_size: int = 1_000_000,  # 1MB default limit
+        repo: Optional[str] = None,
+        branch: Optional[str] = None
+    ):
+        """
+        Initialize the component.
+
+        :param github_token: GitHub personal access token for API authentication
+        :param raise_on_failure: If True, raises exceptions on API errors
+        :param max_file_size: Maximum file size in bytes to fetch (default: 1MB)
+        """
+        if github_token is not None and not isinstance(github_token, Secret):
+            raise TypeError("github_token must be a Secret")
+
+        self.github_token = github_token
+        self.raise_on_failure = raise_on_failure
+        self.max_file_size = max_file_size
+        self.repo = repo
+        self.branch = branch
+
+        self.headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "Haystack/GithubRepositoryViewer",
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return {
+            "github_token": self.github_token.to_dict() if self.github_token else None,
+            "raise_on_failure": self.raise_on_failure,
+            "max_file_size": self.max_file_size,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GithubRepositoryViewer":
+        """
+        Deserialize the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        init_params = data.copy()
+        if init_params["github_token"]:
+            init_params["github_token"] = Secret.from_dict(init_params["github_token"])
+        return cls(**init_params)
+
+    def _parse_repo(self, repo: str) -> tuple[str, str]:
+        """Parse owner/repo string"""
+        parts = repo.split("/")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid repository format. Expected 'owner/repo', got '{repo}'"
+            )
+        return parts[0], parts[1]
+
+    def _normalize_path(self, path: str) -> str:
+        """Normalize repository path"""
+        return path.strip("/")
+
+    def _fetch_contents(self, owner: str, repo: str, path: str, ref: str) -> Any:
+        """Fetch repository contents from GitHub API"""
+        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+        if ref:
+            url += f"?ref={ref}"
+
+        headers = self.headers.copy()
+        if self.github_token:
+            headers["Authorization"] = f"Bearer {self.github_token.resolve_value()}"
+
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+    def _process_file_content(self, content: str, encoding: str) -> str:
+        """Process file content based on encoding"""
+        if encoding == "base64":
+            return base64.b64decode(content).decode("utf-8")
+        return content
+
+    def _create_file_document(self, item: GitHubItem) -> Document:
+        """Create a Document from a file"""
+        return Document(
+            content=item.content if item.content else item.name,
+            meta={
+                "path": item.path,
+                "type": "file_content",
+                "size": item.size,
+                "url": item.url,
+            },
+        )
+
+    def _create_directory_documents(self, items: List[GitHubItem]) -> List[Document]:
+        """Create a list of Documents from directory contents"""
+        return [
+            Document(
+                content=item.name,
+                meta={
+                    "path": item.path,
+                    "type": item.type,
+                    "size": item.size,
+                    "url": item.url,
+                },
+            )
+            for item in sorted(items, key=lambda x: (x.type != "dir", x.name.lower()))
+        ]
+
+    def _create_error_document(self, error: Exception, path: str) -> Document:
+        """Create a Document from an error"""
+        return Document(
+            content=str(error),
+            meta={
+                "type": "error",
+                "path": path,
+            },
+        )
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self, path: str, repo: Optional[str] = None, branch: Optional[str] = None
+    ) -> Dict[str, List[Document]]:
+        """
+        Process a GitHub repository path and return documents.
+
+        :param repo: Repository in format "owner/repo"
+        :param path: Path within repository (default: root)
+        :param ref: Git reference (branch, tag, commit) to use
+        :return: Dictionary containing list of documents
+        """
+        if repo is None:
+            repo = self.repo
+        if branch is None:
+            branch = self.branch
+
+        try:
+            owner, repo_name = self._parse_repo(repo)
+            normalized_path = self._normalize_path(path)
+
+            contents = self._fetch_contents(owner, repo_name, normalized_path, branch)
+
+            # Handle single file response
+            if not isinstance(contents, list):
+                if contents.get("size", 0) > self.max_file_size:
+                    raise ValueError(
+                        f"File size {contents['size']} exceeds limit of {self.max_file_size}"
+                    )
+
+                item = GitHubItem(
+                    name=contents["name"],
+                    type="file",
+                    path=contents["path"],
+                    size=contents["size"],
+                    url=contents["html_url"],
+                    content=self._process_file_content(
+                        contents["content"], contents["encoding"]
+                    ),
+                )
+                return {"documents": [self._create_file_document(item)]}
+
+            # Handle directory listing
+            items = [
+                GitHubItem(
+                    name=item["name"],
+                    type="dir" if item["type"] == "dir" else "file",
+                    path=item["path"],
+                    size=item.get("size", 0),
+                    url=item["html_url"],
+                )
+                for item in contents
+            ]
+
+            return {"documents": self._create_directory_documents(items)}
+
+        except Exception as e:
+            error_doc = self._create_error_document(
+                f"Error processing repository path {path}: {str(e)}. Seems like the file does not exist.", path
+            )
+            if self.raise_on_failure:
+                raise
+            logger.warning(
+                "Error processing repository path {path}: {error}",
+                path=path,
+                error=str(e),
+            )
+            return {"documents": [error_doc]}
+

--- a/integrations/github-haystack/src/github_haystack/github_components/repository_forker.py
+++ b/integrations/github-haystack/src/github_haystack/github_components/repository_forker.py
@@ -1,0 +1,298 @@
+import re
+from typing import Any, Dict, Optional
+
+import requests
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class GithubRepoForker:
+    """
+    Forks a GitHub repository from an issue URL.
+
+    The component takes a GitHub issue URL, extracts the repository information,
+    creates or syncs a fork of that repository, and optionally creates an issue-specific branch.
+
+    ### Usage example
+    ```python
+    from haystack.components.actions import GithubRepoForker
+    from haystack.utils import Secret
+
+    # Using direct token with auto-sync and branch creation
+    forker = GithubRepoForker(
+        github_token=Secret.from_token("your_token"),
+        auto_sync=True,
+        create_branch=True
+    )
+
+    result = forker.run(url="https://github.com/owner/repo/issues/123")
+    # Will create or sync fork and create branch "fix-123"
+    ```
+    """
+
+    def __init__(
+            self,
+            github_token: Secret = Secret.from_env_var("GITHUB_TOKEN"),
+            raise_on_failure: bool = True,
+            wait_for_completion: bool = False,
+            max_wait_seconds: int = 300,
+            poll_interval: int = 2,
+            auto_sync: bool = True,
+            create_branch: bool = True,
+    ):
+        """
+        Initialize the component.
+
+        :param github_token: GitHub personal access token for API authentication
+        :param raise_on_failure: If True, raises exceptions on API errors
+        :param wait_for_completion: If True, waits until fork is fully created
+        :param max_wait_seconds: Maximum time to wait for fork completion in seconds
+        :param poll_interval: Time between status checks in seconds
+        :param auto_sync: If True, syncs fork with original repository if it already exists
+        :param create_branch: If True, creates a fix branch based on the issue number
+        """
+        if not isinstance(github_token, Secret):
+            raise TypeError("github_token must be a Secret")
+
+        self.github_token = github_token
+        self.raise_on_failure = raise_on_failure
+        self.wait_for_completion = wait_for_completion
+        self.max_wait_seconds = max_wait_seconds
+        self.poll_interval = poll_interval
+        self.auto_sync = auto_sync
+        self.create_branch = create_branch
+
+        self.headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "Haystack/GithubRepoForker"
+        }
+
+    def _parse_github_url(self, url: str) -> tuple[str, str, str]:
+        """
+        Parse GitHub URL into owner, repo, and issue number.
+
+        :param url: GitHub issue URL
+        :return: Tuple of (owner, repo, issue_number)
+        :raises ValueError: If URL format is invalid
+        """
+        pattern = r"https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)"
+        match = re.match(pattern, url)
+        if not match:
+            raise ValueError(f"Invalid GitHub issue URL format: {url}")
+
+        owner, repo, issue_number = match.groups()
+        return owner, repo, issue_number
+
+    def _check_fork_status(self, fork_path: str) -> bool:
+        """
+        Check if a forked repository exists and is ready.
+
+        :param fork_path: Repository path in owner/repo format
+        :return: True if fork exists and is ready, False otherwise
+        """
+        url = f"https://api.github.com/repos/{fork_path}"
+        try:
+            response = requests.get(
+                url,
+                headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"}
+            )
+            return response.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def _get_authenticated_user(self) -> str:
+        """
+        Get the authenticated user's username.
+
+        :return: Username of the authenticated user
+        :raises requests.RequestException: If API call fails
+        """
+        url = "https://api.github.com/user"
+        response = requests.get(
+            url,
+            headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"}
+        )
+        response.raise_for_status()
+        return response.json()["login"]
+
+    def _get_existing_repository(self, repo_name: str) -> Optional[str]:
+        """
+        Check if a repository with the given name already exists in the authenticated user's account.
+
+        :param repo_name: Repository name to check
+        :return: Full repository name if it exists, None otherwise
+        """
+        url = f"https://api.github.com/repos/{self._get_authenticated_user()}/{repo_name}"
+        try:
+            response = requests.get(
+                url,
+                headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"}
+            )
+            if response.status_code == 200:
+                return repo_name
+            return None
+        except requests.RequestException as e:
+            logger.warning(f"Failed to check repository existence: {str(e)}")
+            return None
+
+    def _sync_fork(self, fork_path: str) -> None:
+        """
+        Sync a fork with its upstream repository.
+
+        :param fork_path: Fork path in owner/repo format
+        :raises requests.RequestException: If sync fails
+        """
+        url = f"https://api.github.com/repos/{fork_path}/merge-upstream"
+        response = requests.post(
+            url,
+            headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"},
+            json={"branch": "main"}
+        )
+        response.raise_for_status()
+
+    def _create_issue_branch(self, fork_path: str, issue_number: str) -> None:
+        """
+        Create a new branch for the issue.
+
+        :param fork_path: Fork path in owner/repo format
+        :param issue_number: Issue number to use in branch name
+        :raises requests.RequestException: If branch creation fails
+        """
+        # First, get the default branch SHA
+        url = f"https://api.github.com/repos/{fork_path}"
+        response = requests.get(
+            url,
+            headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"}
+        )
+        response.raise_for_status()
+        default_branch = response.json()["default_branch"]
+
+        # Get the SHA of the default branch
+        url = f"https://api.github.com/repos/{fork_path}/git/ref/heads/{default_branch}"
+        response = requests.get(
+            url,
+            headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"}
+        )
+        response.raise_for_status()
+        sha = response.json()["object"]["sha"]
+
+        # Create the new branch
+        branch_name = f"fix-{issue_number}"
+        url = f"https://api.github.com/repos/{fork_path}/git/refs"
+        response = requests.post(
+            url,
+            headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"},
+            json={
+                "ref": f"refs/heads/{branch_name}",
+                "sha": sha
+            }
+        )
+        response.raise_for_status()
+
+    def _create_fork(self, owner: str, repo: str) -> str:
+        """
+        Create a fork of the repository.
+
+        :param owner: Original repository owner
+        :param repo: Repository name
+        :return: Fork path in owner/repo format
+        :raises requests.RequestException: If fork creation fails
+        """
+        url = f"https://api.github.com/repos/{owner}/{repo}/forks"
+        response = requests.post(
+            url,
+            headers={**self.headers, "Authorization": f"Bearer {self.github_token.resolve_value()}"}
+        )
+        response.raise_for_status()
+
+        fork_data = response.json()
+        return f"{fork_data['owner']['login']}/{fork_data['name']}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            github_token=self.github_token.to_dict() if self.github_token else None,
+            raise_on_failure=self.raise_on_failure,
+            wait_for_completion=self.wait_for_completion,
+            max_wait_seconds=self.max_wait_seconds,
+            poll_interval=self.poll_interval,
+            auto_sync=self.auto_sync,
+            create_branch=self.create_branch,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GithubRepoForker":
+        """
+        Deserialize the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        init_params = data["init_parameters"]
+        deserialize_secrets_inplace(init_params, keys=["github_token"])
+        return default_from_dict(cls, data)
+
+    @component.output_types(repo=str, issue_branch=str)
+    def run(self, url: str) -> dict:
+        """
+        Process a GitHub issue URL and create or sync a fork of the repository.
+
+        :param url: GitHub issue URL
+        :return: Dictionary containing repository path in owner/repo format
+        """
+        try:
+            # Extract repository information
+            owner, repo, issue_number = self._parse_github_url(url)
+
+            # Check if fork already exists
+            user = self._get_authenticated_user()
+            existing_fork = self._get_existing_repository(repo)
+
+            if existing_fork and self.auto_sync:
+                # If fork exists and auto_sync is enabled, sync with upstream
+                fork_path = f"{user}/{repo}"
+                logger.info("Fork already exists, syncing with upstream repository")
+                self._sync_fork(fork_path)
+            else:
+                # Create new fork
+                fork_path = self._create_fork(owner, repo)
+
+            # Wait for fork completion if requested
+            if self.wait_for_completion:
+                import time
+                start_time = time.time()
+
+                while time.time() - start_time < self.max_wait_seconds:
+                    if self._check_fork_status(fork_path):
+                        logger.info("Fork creation completed successfully")
+                        break
+                    logger.debug("Waiting for fork creation to complete...")
+                    time.sleep(self.poll_interval)
+                else:
+                    msg = f"Fork creation timed out after {self.max_wait_seconds} seconds"
+                    if self.raise_on_failure:
+                        raise TimeoutError(msg)
+                    logger.warning(msg)
+
+            # Create issue branch if enabled
+            issue_branch = None
+            if self.create_branch:
+                issue_branch = f"fix-{issue_number}"
+                logger.info(f"Creating branch for issue #{issue_number}")
+                self._create_issue_branch(fork_path, issue_number)
+
+            return {"repo": fork_path, "issue_branch": issue_branch}
+
+        except Exception as e:
+            if self.raise_on_failure:
+                raise
+            logger.warning("Error forking repository from {url}: {error}", url=url, error=str(e))
+            return {"repo": "", "issue_branch": None}

--- a/integrations/github-haystack/tests/__init__.py
+++ b/integrations/github-haystack/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/haystack-experimental/issues/250
@sjrl brought up that one way to keep example files from the experimental Agent around is an integration https://github.com/deepset-ai/haystack-experimental/pull/263#issuecomment-2775755734

### Proposed Changes:

- Move github_components from experimental to a new integration
- Move agent_prompts from experimental to a new integration

The idea is to enable users to run the example notebook (or a version with updated imports) after having installed this new integration

### How did you test it?

Didn't test it for now. Just a draft.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
