### PR TITLE
feat: Add AsyncExecutor in MCPTool, ensure MCPTool works in hayhooks

### DIFF
--- a/integrations/mcp/examples/hayhooks/pipeline_wrapper.py
+++ b/integrations/mcp/examples/hayhooks/pipeline_wrapper.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Example of a Hayhooks PipelineWrapper for deploying an MCP Tool-based time pipeline as a REST API.
+
+To run this example:
+
+1. Install Hayhooks and dependencies:
+   $ pip install hayhooks haystack-ai
+
+2. Start the Hayhooks server:
+   $ hayhooks run
+
+3. Deploy this pipeline wrapper:
+   $ hayhooks pipeline deploy-files -n time_pipeline {root_dir_for_mcp_haystack_integration}/examples/hayhooks/
+
+4. Invoke via curl:
+   $ curl -X POST 'http://localhost:1416/time_pipeline/run' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"query":"What is the time in San Francisco? Be brief"}'
+
+For more information, see: https://github.com/deepset-ai/hayhooks
+"""
+
+from hayhooks import BasePipelineWrapper
+from haystack import Pipeline
+from haystack.components.converters import OutputAdapter
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.tools import ToolInvoker
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.tools.mcp.mcp_tool import MCPTool, StdioServerInfo
+
+
+class PipelineWrapper(BasePipelineWrapper):
+    def setup(self) -> None:
+        """
+        Setup the pipeline with MCP time tool.
+
+        This creates a pipeline that uses an MCP time tool to get the current time
+        and then uses the time to answer a user question.
+        """
+
+        time_tool = MCPTool(
+            name="get_current_time",
+            server_info=StdioServerInfo(command="uvx", args=["mcp-server-time", "--local-timezone=Europe/Berlin"]),
+        )
+
+        self.pipeline = Pipeline()
+        self.pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[time_tool]))
+        self.pipeline.add_component("tool_invoker", ToolInvoker(tools=[time_tool]))
+        self.pipeline.add_component(
+            "adapter",
+            OutputAdapter(
+                template="{{ initial_msg + initial_tool_messages + tool_messages }}",
+                output_type=list[ChatMessage],
+                unsafe=True,
+            ),
+        )
+        self.pipeline.add_component("response_llm", OpenAIChatGenerator(model="gpt-4o-mini"))
+        self.pipeline.connect("llm.replies", "tool_invoker.messages")
+        self.pipeline.connect("llm.replies", "adapter.initial_tool_messages")
+        self.pipeline.connect("tool_invoker.tool_messages", "adapter.tool_messages")
+        self.pipeline.connect("adapter.output", "response_llm.messages")
+
+    def run_api(self, query: str) -> str:
+        """
+        Run the pipeline with a user query.
+
+        :param query: The user query asking about time
+        :return: The response from the LLM
+        """
+        # Create a user message from the query
+        user_input_msg = ChatMessage.from_user(text=query)
+
+        # Run the pipeline
+        result = self.pipeline.run(
+            {"llm": {"messages": [user_input_msg]}, "adapter": {"initial_msg": [user_input_msg]}}
+        )
+
+        # Return the text of the first reply
+        return result["response_llm"]["replies"][0].text

--- a/integrations/mcp/examples/mcp_sse_client.py
+++ b/integrations/mcp/examples/mcp_sse_client.py
@@ -2,7 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from haystack_integrations.tools.mcp import MCPTool, SSEServerInfo
+
+# Setup targeted logging - only show debug logs from our package
+logging.basicConfig(level=logging.WARNING)  # Set root logger to WARNING
+mcp_logger = logging.getLogger("haystack_integrations.tools.mcp")
+mcp_logger.setLevel(logging.DEBUG)
+# Ensure we have at least one handler to avoid messages going to root logger
+if not mcp_logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    mcp_logger.addHandler(handler)
+    mcp_logger.propagate = False  # Prevent propagation to root logger
 
 # run this client after running the server mcp_sse_server.py
 # it shows how easy it is to use the MCPTool with SSE transport

--- a/integrations/mcp/examples/mcp_stdio_client.py
+++ b/integrations/mcp/examples/mcp_stdio_client.py
@@ -2,7 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from haystack_integrations.tools.mcp import MCPTool, StdioServerInfo
+
+# Setup logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("haystack_integrations.tools.mcp")
+logger.setLevel(logging.DEBUG)
 
 # For stdio MCPTool we don't need to run a server, we can just use the MCPTool directly
 # Here we use the mcp-server-time server

--- a/integrations/mcp/examples/time_pipeline.py
+++ b/integrations/mcp/examples/time_pipeline.py
@@ -8,6 +8,8 @@
 # See https://github.com/modelcontextprotocol/servers/tree/main/src/time for more details
 # prior to running this script, pip install mcp-server-time
 
+import logging
+
 from haystack import Pipeline
 from haystack.components.converters import OutputAdapter
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -15,6 +17,17 @@ from haystack.components.tools import ToolInvoker
 from haystack.dataclasses import ChatMessage
 
 from haystack_integrations.tools.mcp.mcp_tool import MCPTool, StdioServerInfo
+
+# Setup targeted logging - only show debug logs from our package
+logging.basicConfig(level=logging.WARNING)  # Set root logger to WARNING
+mcp_logger = logging.getLogger("haystack_integrations.tools.mcp")
+mcp_logger.setLevel(logging.DEBUG)
+# Ensure we have at least one handler to avoid messages going to root logger
+if not mcp_logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    mcp_logger.addHandler(handler)
+    mcp_logger.propagate = False  # Prevent propagation to root logger
 
 
 def main():

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -37,9 +37,17 @@ def mock_mcp_tool():
     """
     # Create patch for connection methods
     with (
-        patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool._run_sync") as mock_run_sync,
+        patch("haystack_integrations.tools.mcp.mcp_tool.AsyncExecutor.get_instance") as mock_get_instance,
         patch("haystack_integrations.tools.mcp.mcp_tool.MCPServerInfo.create_client") as mock_create_client,
     ):
+        # Configure mock executor
+        mock_executor = MagicMock()
+        mock_tool_info = MagicMock()
+        mock_tool_info.name = "test_tool"
+        mock_tool_info.description = "A test tool"
+        mock_tool_info.inputSchema = {"type": "object", "properties": {}}
+        mock_executor.run.return_value = [mock_tool_info]
+        mock_get_instance.return_value = mock_executor
 
         # Configure mock client
         mock_client = MagicMock()
@@ -49,13 +57,6 @@ def mock_mcp_tool():
 
         mock_client.invoke = mock_invoke
         mock_create_client.return_value = mock_client
-
-        # Configure _run_sync to return a tool
-        mock_tool_info = MagicMock()
-        mock_tool_info.name = "test_tool"
-        mock_tool_info.description = "A test tool"
-        mock_tool_info.inputSchema = {"type": "object", "properties": {}}
-        mock_run_sync.return_value = [mock_tool_info]
 
         # Create the MCPTool
         tool = MCPTool(
@@ -219,7 +220,7 @@ class TestMCPTool:
 
         with (
             patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool.__init__", return_value=None) as mock_init,
-            patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool._run_sync"),
+            patch("haystack_integrations.tools.mcp.mcp_tool.AsyncExecutor.get_instance"),
             patch("haystack_integrations.tools.mcp.mcp_tool.MCPTool.to_dict") as mock_to_dict,
         ):
 


### PR DESCRIPTION
### Why:
To simplify and standardize the use of MCPTool across different deployment contexts—whether in standalone scripts, sync/async environments, or Hayhooks-based REST deployments. This is achieved by introducing AsyncExecutor and using it for MCPTool invocation. 

- fixes https://github.com/deepset-ai/haystack/issues/9137

### What:
- Introduced `AsyncExecutor`: a utility for executing async code in sync contexts, enabling cleaner and safer integration of MCPTool.
- Added `PipelineWrapper` example: a concrete `examples/hayhooks/pipeline_wrapper.py` of deploying MCPTool in a Haystack pipeline using Hayhooks, exposing it as a REST API.
- Enhanced client-server communication and tool invocation with improved logging for easier debugging and observability.

### How it can be used:
Example hayhooks pipeline wrapper of a time tool in Hayhooks:
```python
class PipelineWrapper(BasePipelineWrapper):
    def setup(self) -> None:
        time_tool = MCPTool(
            name="get_current_time",
            server_info=StdioServerInfo(command="uvx", args=["mcp-server-time", "--local-timezone=Europe/Berlin"]),
        )
        self.pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[time_tool]))
```

Example invocation:
```bash
curl -X POST 'http://localhost:1416/time_pipeline/run' \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{"query":"What is the time in San Francisco? Be brief"}'
```

### How it was tested:
- Updated unit tests 
- Validated that the REST deployment works end-to-end with the time query example, see `examples/hayhooks/pipeline_wrapper.py`
- Validated all existing examples continue to work as well 

### Notes for the reviewer:
- Focus on `AsyncExecutor` and how it simplifies coroutine management across different environments.
- Review the logging enhancements which improve transparency during tool execution and aid in debugging issues across async boundaries.
