### PR TITLE
chore: update label name for stalebot

### DIFF
--- a/.github/workflows/CI_stale.yml
+++ b/.github/workflows/CI_stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          any-of-labels: 'community-triage'
+          any-of-labels: 'information-needed'
           stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           days-before-stale: 30
           days-before-close: 10


### PR DESCRIPTION
### Related Issues

We renamed the `community-triage` label to `information-needed` to better communicate its purpose. This label can be applied to issues that need additional information from the user.

### Proposed Changes:
Modify stalebot configuration to reflect the new label name.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
