### PR TITLE
test: Mistral - remove unneeded `tool_choice` parameter from `test_live_run_streaming`

### DIFF
--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -276,9 +276,7 @@ class TestMistralChatGenerator:
 
         callback = Callback()
         component = MistralChatGenerator(streaming_callback=callback)
-        results = component.run(
-            [ChatMessage.from_user("What's the capital of France?")], generation_kwargs={"tool_choice": "any"}
-        )
+        results = component.run([ChatMessage.from_user("What's the capital of France?")])
 
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]


### PR DESCRIPTION
### Related Issues

- Nightly tests failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/14434845695/job/40474230283
- In this test, we initialize `MistralChatGenerator` with `generation_kwargs={"tool_choice": "any"}`, even if we don't provide tools. In the past, this parameter was ignored and everything worked. Now there have probably been updates to OpenAI (which we use for calling Mistral) and we are getting errors.

### Proposed Changes:
- remove `tool_choice` parameter from `test_live_run_streaming`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
