### PR TITLE
fix: Langfuse - remove warning "Creating a new trace without a parent span is not recommended ..."

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -52,7 +52,6 @@ _PIPELINE_INPUT_KEY = "haystack.pipeline.input_data"
 _PIPELINE_OUTPUT_KEY = "haystack.pipeline.output_data"
 _ASYNC_PIPELINE_RUN_KEY = "haystack.async_pipeline.run"
 _PIPELINE_RUN_KEY = "haystack.pipeline.run"
-_AGENT_RUN_KEY = "haystack.agent.run"
 _COMPONENT_NAME_KEY = "haystack.component.name"
 _COMPONENT_TYPE_KEY = "haystack.component.type"
 _COMPONENT_OUTPUT_KEY = "haystack.component.output"
@@ -263,12 +262,6 @@ class DefaultSpanHandler(SpanHandler):
 
         tracing_ctx = tracing_context_var.get({})
         if not context.parent_span:
-            allowed_span_roots = [_PIPELINE_RUN_KEY, _ASYNC_PIPELINE_RUN_KEY, _AGENT_RUN_KEY]
-            if context.operation_name not in allowed_span_roots:
-                logger.warning(
-                    "Creating a new trace without a parent span is not recommended for operation '{operation_name}'.",
-                    operation_name=context.operation_name,
-                )
             # Create a new trace when there's no parent span
             return LangfuseSpan(
                 self.tracer.trace(

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -263,8 +263,8 @@ class DefaultSpanHandler(SpanHandler):
 
         tracing_ctx = tracing_context_var.get({})
         if not context.parent_span:
-            _ALLOWED_SPAN_ROOTS = [_PIPELINE_RUN_KEY, _ASYNC_PIPELINE_RUN_KEY, _AGENT_RUN_KEY]
-            if context.operation_name not in _ALLOWED_SPAN_ROOTS:
+            allowed_span_roots = [_PIPELINE_RUN_KEY, _ASYNC_PIPELINE_RUN_KEY, _AGENT_RUN_KEY]
+            if context.operation_name not in allowed_span_roots:
                 logger.warning(
                     "Creating a new trace without a parent span is not recommended for operation '{operation_name}'.",
                     operation_name=context.operation_name,

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -52,6 +52,7 @@ _PIPELINE_INPUT_KEY = "haystack.pipeline.input_data"
 _PIPELINE_OUTPUT_KEY = "haystack.pipeline.output_data"
 _ASYNC_PIPELINE_RUN_KEY = "haystack.async_pipeline.run"
 _PIPELINE_RUN_KEY = "haystack.pipeline.run"
+_AGENT_RUN_KEY = "haystack.agent.run"
 _COMPONENT_NAME_KEY = "haystack.component.name"
 _COMPONENT_TYPE_KEY = "haystack.component.type"
 _COMPONENT_OUTPUT_KEY = "haystack.component.output"
@@ -262,7 +263,8 @@ class DefaultSpanHandler(SpanHandler):
 
         tracing_ctx = tracing_context_var.get({})
         if not context.parent_span:
-            if context.operation_name not in [_PIPELINE_RUN_KEY, _ASYNC_PIPELINE_RUN_KEY]:
+            _ALLOWED_SPAN_ROOTS = [_PIPELINE_RUN_KEY, _ASYNC_PIPELINE_RUN_KEY, _AGENT_RUN_KEY]
+            if context.operation_name not in _ALLOWED_SPAN_ROOTS:
                 logger.warning(
                     "Creating a new trace without a parent span is not recommended for operation '{operation_name}'.",
                     operation_name=context.operation_name,


### PR DESCRIPTION
We observed "Creating a new trace without a parent span is not recommended for operation `haystack.agent.run`" when running agent only examples - no pipeline. This warning is confusing to users. This fix removes it by adding it to allowed span roots.

### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1653

### Proposed Changes:

Allow `haystack.agent.run` to be span root 

### How did you test it?

Manual testing with agent only examples
