### PR TITLE
docs: add MCPToolset to do pydoc

### DIFF
--- a/integrations/mcp/pydoc/config.yml
+++ b/integrations/mcp/pydoc/config.yml
@@ -3,6 +3,7 @@ loaders:
     search_path: [../src]
     modules: [
       "haystack_integrations.tools.mcp.mcp_tool",
+      "haystack_integrations.tools.mcp.mcp_toolset",
     ]
     ignore_when_discovered: ["__init__"]
 processors:
@@ -17,7 +18,7 @@ renderer:
   type: haystack_pydoc_tools.renderers.ReadmeIntegrationRenderer
   excerpt: MCP integration for Haystack
   category_slug: integrations-api
-  title: mcp
+  title: MCP
   slug: integrations-mcp
   order: 145
   markdown:


### PR DESCRIPTION
### Proposed Changes:

Adding MCPToolset to do pydoc.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
