### PR TITLE
feat: Enhance Langfuse ToolInvoker span naming

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -56,6 +56,7 @@ _PIPELINE_RUN_KEY = "haystack.pipeline.run"
 _COMPONENT_NAME_KEY = "haystack.component.name"
 _COMPONENT_TYPE_KEY = "haystack.component.type"
 _COMPONENT_OUTPUT_KEY = "haystack.component.output"
+_COMPONENT_INPUT_KEY = "haystack.component.input"
 
 # Context var used to keep track of tracing related info.
 # This mainly useful for parents spans.
@@ -290,37 +291,18 @@ class DefaultSpanHandler(SpanHandler):
 
         # special case for ToolInvoker (to update the span name to be: `original_component_name - [tool_names]`)
         if component_type == "ToolInvoker":
-            tool_input_data = span.get_data().get("haystack.component.input")
-
-            tool_names = []
-            if tool_input_data and isinstance(tool_input_data.get("messages"), list):
-                for message in tool_input_data["messages"]:
-                    # should be true for all tool calls
-                    if isinstance(message, ChatMessage) and message.tool_calls:
-                        for tool_call in message.tool_calls:
-                            tool_names.append(tool_call.tool_name)
+            tool_names: List[str] = []
+            messages = span.get_data().get(_COMPONENT_INPUT_KEY, {}).get("messages", [])
+            for message in messages:
+                if isinstance(message, ChatMessage) and message.tool_calls:
+                    tool_names.extend(call.tool_name for call in message.tool_calls)
 
             if tool_names:
-                try:
-                    original_name = span.get_data().get(_COMPONENT_NAME_KEY)
-                    if original_name:
-                        tool_counts = Counter(tool_names)
-                        formatted_tool_names = []
-                        for name, count in tool_counts.items():
-                            if count > 1:
-                                formatted_tool_names.append(f"{name} (x{count})")
-                            else:
-                                formatted_tool_names.append(name)
-
-                        new_name = f"{original_name} - {sorted(formatted_tool_names)}"
-                        span.raw_span().update(name=new_name)
-                    else:
-                        logger.warning(
-                            f"Could not retrieve original component "
-                            f"name ({_COMPONENT_NAME_KEY}) from span data to update ToolInvoker span name."
-                        )
-                except Exception as e:
-                    logger.error(f"Failed to update ToolInvoker span name: {e}")
+                # Fallback to "ToolInvoker" if we can't retrieve component name
+                tool_invoker_name = span.get_data().get(_COMPONENT_NAME_KEY, "ToolInvoker")
+                tool_counts = Counter(tool_names)  # how many times each tool was called
+                formatted_names = [f"{name} (x{count})" if count > 1 else name for name, count in tool_counts.items()]
+                span.raw_span().update(name=f"{tool_invoker_name} - {sorted(formatted_names)}")
 
         if component_type in _SUPPORTED_GENERATORS:
             meta = span.get_data().get(_COMPONENT_OUTPUT_KEY, {}).get("meta")

--- a/integrations/langfuse/tests/test_tracer.py
+++ b/integrations/langfuse/tests/test_tracer.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 from typing import Optional
 
 import pytest
-from haystack.dataclasses import ChatMessage
+from haystack.dataclasses import ChatMessage, ToolCall, ToolCallResult
 from haystack_integrations.tracing.langfuse.tracer import LangfuseTracer, LangfuseSpan, SpanContext, DefaultSpanHandler
 from haystack_integrations.tracing.langfuse.tracer import _COMPONENT_OUTPUT_KEY
 
@@ -287,6 +287,56 @@ class TestLangfuseTracer:
         assert span.raw_span()._data["usage"] is None
         assert span.raw_span()._data["model"] == "test_model"
         assert span.raw_span()._data["completion_start_time"] == datetime.datetime(2021, 7, 27, 16, 2, 8, 12345)
+
+    def test_handle_tool_invoker(self):
+        """
+        Test that the ToolInvoker span name is updated correctly with the tool names invoked for better UI/UX
+        """
+        mock_span = Mock()
+        mock_span.raw_span.return_value = mock_span
+
+        # Simulate data for the ToolInvoker component
+        span_data = {
+            "haystack.component.name": "tool_invoker",
+            "haystack.component.type": "ToolInvoker",
+            "haystack.component.input": {
+                "messages": [
+                    # Create a chat message with tool calls
+                    ChatMessage.from_assistant(
+                        text="Calling tools",
+                        tool_calls=[
+                            ToolCall(tool_name="search_tool", arguments={"query": "test"}),
+                            ToolCall(tool_name="search_tool", arguments={"query": "another test"}),
+                            ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"}),
+                        ],
+                    )
+                ]
+            },
+        }
+
+        mock_span.get_data.return_value = span_data
+
+        handler = DefaultSpanHandler()
+        handler.handle(mock_span, component_type="ToolInvoker")
+
+        assert mock_span.update.call_count >= 1
+        name_update_call = None
+        for call in mock_span.update.call_args_list:
+            if 'name' in call[1]:
+                name_update_call = call
+                break
+
+        assert name_update_call is not None, "No call to update the span name was made"
+        updated_name = name_update_call[1]['name']
+
+        # verify the format of the updated span name to be: `original_component_name - [list_of_tool_names]`
+        assert updated_name != "tool_invoker", f"Expected 'tool_invoker` to be upddated with tool names"
+        assert " - " in updated_name, f"Expected ' - ' in {updated_name}"
+        assert "[" in updated_name, f"Expected '[' in {updated_name}"
+        assert "]" in updated_name, f"Expected ']' in {updated_name}"
+        assert "tool_invoker" in updated_name, f"Expected 'tool_invoker' in {updated_name}"
+        assert "search_tool (x2)" in updated_name, f"Expected 'search_tool (x2)' in {updated_name}"
+        assert "weather_tool" in updated_name, f"Expected 'weather_tool' in {updated_name}"
 
     def test_trace_generation_invalid_start_time(self):
         tracer = LangfuseTracer(tracer=MockTracer(), name="Haystack", public=False)


### PR DESCRIPTION
### Why:

This PR enhances the Langfuse tracing integration for Haystack's `ToolInvoker` component. Previously, the Langfuse span for a `ToolInvoker` step was named after its register pipeline name (e.g., "tool_invoker"). This change updates the span name *after* execution to include the specific tools called and their invocation counts, making traces significantly more informative and aiding observability, especially in complex agentic pipelines.

Here is the trace before:

<img width="743" alt="Screenshot 2025-04-30 at 15 06 27" src="https://github.com/user-attachments/assets/0e0e341b-3577-416a-b7a0-305c91dcb0ff" />

Here is the trace after:

<img width="781" alt="Screenshot 2025-04-30 at 15 07 04" src="https://github.com/user-attachments/assets/d9f4ed84-1111-40ad-a1ed-11c857cbc24c" />


### What:
- Modified `DefaultSpanHandler.handle` in `integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py`.
- Added logic to extract tool names and invocation counts from the `ToolInvoker`'s input `ChatMessage.tool_calls`.
- Utilized `collections.Counter` to aggregate tool counts.
- Updated the Langfuse span's name dynamically to reflect the called tools, e.g., `tool_invoker - ['get_weather (x2)', 'search_web']`.

### How can it be used:
This change automatically improves the tracing experience for any Haystack pipeline using the `ToolInvoker` component when the Langfuse integration is enabled. Users will see more descriptive span names in the Langfuse UI without any changes to their pipeline code.

### How did you test it:
- Manually tested by running Haystack pipelines containing `ToolInvoker` with various tools (including repeated calls) and the Langfuse tracer enabled.
- Verified in the Langfuse UI that the `ToolInvoker` span names were correctly updated to include the specific tool names and their invocation counts (e.g., `tool_invoker - ['tool_name (xN)', ...]`).

### Notes for the reviewer:
- Please review the logic within `DefaultSpanHandler.handle` for extracting, counting, and formatting tool names.
- Note the use of `span.get_data()` to retrieve necessary information (original name, input data) as it's available *after* the span is initially created.