### PR TITLE
feat: pgvector - make error messages more informative

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ GitHub. The GitHub Actions workflow will take care of the rest.
     ```
 3. Wait for the CI to do its magic
 4. Review the changelog PR
+
     If the release is successful, the HaystackBot will open a pull request to generate the changelog. 
     Add yourself as the reviewer. If there are any issues, edit the changelog manually.
 

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -276,7 +276,7 @@ class PgvectorDocumentStore:
             result = cursor.execute(sql_query, params)
         except Error as e:
             self._connection.rollback()
-            detailed_error_msg = f"{error_msg}.\nYou can find the SQL query and the parameters in the debug logs."
+            detailed_error_msg = f"{error_msg}: {e}.\nYou can find the SQL query and the parameters in the debug logs."
             raise DocumentStoreError(detailed_error_msg) from e
 
         return result
@@ -314,7 +314,7 @@ class PgvectorDocumentStore:
             result = await cursor.execute(sql_query, params)
         except Error as e:
             await self._async_connection.rollback()
-            detailed_error_msg = f"{error_msg}.\nYou can find the SQL query and the parameters in the debug logs."
+            detailed_error_msg = f"{error_msg}: {e}.\nYou can find the SQL query and the parameters in the debug logs."
             raise DocumentStoreError(detailed_error_msg) from e
 
         return result
@@ -795,7 +795,7 @@ class PgvectorDocumentStore:
         except Error as e:
             self._connection.rollback()
             error_msg = (
-                "Could not write documents to PgvectorDocumentStore. \n"
+                "Could not write documents to PgvectorDocumentStore: {e}. \n"
                 "You can find the SQL query and the parameters in the debug logs."
             )
             raise DocumentStoreError(error_msg) from e
@@ -852,7 +852,7 @@ class PgvectorDocumentStore:
         except Error as e:
             await self._async_connection.rollback()
             error_msg = (
-                "Could not write documents to PgvectorDocumentStore. \n"
+                "Could not write documents to PgvectorDocumentStore: {e}. \n"
                 "You can find the SQL query and the parameters in the debug logs."
             )
             raise DocumentStoreError(error_msg) from e

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -276,7 +276,9 @@ class PgvectorDocumentStore:
             result = cursor.execute(sql_query, params)
         except Error as e:
             self._connection.rollback()
-            detailed_error_msg = f"{error_msg}: {e}.\nYou can find the SQL query and the parameters in the debug logs."
+            detailed_error_msg = (
+                f"{error_msg}. Error: {e!r}. \nYou can find the SQL query and the parameters in the debug logs."
+            )
             raise DocumentStoreError(detailed_error_msg) from e
 
         return result
@@ -314,7 +316,9 @@ class PgvectorDocumentStore:
             result = await cursor.execute(sql_query, params)
         except Error as e:
             await self._async_connection.rollback()
-            detailed_error_msg = f"{error_msg}: {e}.\nYou can find the SQL query and the parameters in the debug logs."
+            detailed_error_msg = (
+                f"{error_msg}. Error: {e!r}. \nYou can find the SQL query and the parameters in the debug logs."
+            )
             raise DocumentStoreError(detailed_error_msg) from e
 
         return result
@@ -795,7 +799,7 @@ class PgvectorDocumentStore:
         except Error as e:
             self._connection.rollback()
             error_msg = (
-                "Could not write documents to PgvectorDocumentStore: {e}. \n"
+                f"Could not write documents to PgvectorDocumentStore. Error: {e!r}. \n"
                 "You can find the SQL query and the parameters in the debug logs."
             )
             raise DocumentStoreError(error_msg) from e
@@ -852,7 +856,7 @@ class PgvectorDocumentStore:
         except Error as e:
             await self._async_connection.rollback()
             error_msg = (
-                "Could not write documents to PgvectorDocumentStore: {e}. \n"
+                f"Could not write documents to PgvectorDocumentStore. Error: {e!r}. \n"
                 "You can find the SQL query and the parameters in the debug logs."
             )
             raise DocumentStoreError(error_msg) from e


### PR DESCRIPTION
The pgvector document store does not currently report SQL exceptions, which makes debugging difficult. 

Using hayhooks, for example, with this patch, the error goes from this:
```
│ Server error: Pipeline execution failed: The following component failed to run: │
│ Component name: 'indexing:writer'                                               │
│ Component type: 'DocumentWriter'                                                │
│ Error: Could not write documents to PgvectorDocumentStore.                      │
│ You can find the SQL query and the parameters in the debug logs.                │
```
to this:
```
│ Server error: Pipeline execution failed: The following component failed to run:
│ Component name: 'indexing:writer'
│ Component type: 'DocumentWriter'
│ Error: Could not write documents to PgvectorDocumentStore:         │
│ expected 768 dimensions, not 384 
│You can find the SQL query and the parameters in the debug logs."}                   │
```

### Proposed Changes:
Include the SQL exception in the reporting message.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
