### PR TITLE
chore!: `CohereRanker` - change default model and remove `max_chunks_per_doc parameter`

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -20,7 +20,7 @@ class CohereRanker:
     Usage example:
     ```python
     from haystack import Document
-    from haystack.components.rankers import CohereRanker
+    from haystack_integrations.components.rankers.cohere import CohereRanker
 
     ranker = CohereRanker(model="rerank-v3.5", top_k=2)
 

--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -94,6 +94,11 @@ class CohereRanker:
         :returns:
             The deserialized component.
         """
+
+        # max_chunks_per_doc parameter was removed and we want to avoid deserialization errors if component
+        # was serialized with the old version
+        data["init_parameters"].pop("max_chunks_per_doc", None)
+
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 

--- a/integrations/cohere/tests/test_cohere_ranker.py
+++ b/integrations/cohere/tests/test_cohere_ranker.py
@@ -41,11 +41,10 @@ class TestCohereRanker:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
         component = CohereRanker()
-        assert component.model_name == "rerank-english-v2.0"
+        assert component.model_name == "rerank-v3.5"
         assert component.top_k == 10
         assert component.api_key == Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"])
         assert component.api_base_url == COHERE_API_URL
-        assert component.max_chunks_per_doc is None
         assert component.meta_fields_to_embed == []
         assert component.meta_data_separator == "\n"
         assert component.max_tokens_per_doc == 4096
@@ -59,20 +58,18 @@ class TestCohereRanker:
     def test_init_with_parameters(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
         component = CohereRanker(
-            model="rerank-multilingual-v2.0",
+            model="rerank-multilingual-v3.0",
             top_k=5,
             api_key=Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
             api_base_url="test-base-url",
-            max_chunks_per_doc=40,
             meta_fields_to_embed=["meta_field_1", "meta_field_2"],
             meta_data_separator=",",
             max_tokens_per_doc=100,
         )
-        assert component.model_name == "rerank-multilingual-v2.0"
+        assert component.model_name == "rerank-multilingual-v3.0"
         assert component.top_k == 5
         assert component.api_key == Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"])
         assert component.api_base_url == "test-base-url"
-        assert component.max_chunks_per_doc == 40
         assert component.meta_fields_to_embed == ["meta_field_1", "meta_field_2"]
         assert component.meta_data_separator == ","
         assert component.max_tokens_per_doc == 100
@@ -84,11 +81,10 @@ class TestCohereRanker:
         assert data == {
             "type": "haystack_integrations.components.rankers.cohere.ranker.CohereRanker",
             "init_parameters": {
-                "model": "rerank-english-v2.0",
+                "model": "rerank-v3.5",
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "api_base_url": COHERE_API_URL,
                 "top_k": 10,
-                "max_chunks_per_doc": None,
                 "meta_fields_to_embed": [],
                 "meta_data_separator": "\n",
                 "max_tokens_per_doc": 4096,
@@ -98,11 +94,10 @@ class TestCohereRanker:
     def test_to_dict_with_parameters(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
         component = CohereRanker(
-            model="rerank-multilingual-v2.0",
+            model="rerank-multilingual-v3.0",
             top_k=2,
             api_key=Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
             api_base_url="test-base-url",
-            max_chunks_per_doc=50,
             meta_fields_to_embed=["meta_field_1", "meta_field_2"],
             meta_data_separator=",",
             max_tokens_per_doc=100,
@@ -111,11 +106,10 @@ class TestCohereRanker:
         assert data == {
             "type": "haystack_integrations.components.rankers.cohere.ranker.CohereRanker",
             "init_parameters": {
-                "model": "rerank-multilingual-v2.0",
+                "model": "rerank-multilingual-v3.0",
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "api_base_url": "test-base-url",
                 "top_k": 2,
-                "max_chunks_per_doc": 50,
                 "meta_fields_to_embed": ["meta_field_1", "meta_field_2"],
                 "meta_data_separator": ",",
                 "max_tokens_per_doc": 100,
@@ -127,22 +121,20 @@ class TestCohereRanker:
         data = {
             "type": "haystack_integrations.components.rankers.cohere.ranker.CohereRanker",
             "init_parameters": {
-                "model": "rerank-multilingual-v2.0",
+                "model": "rerank-multilingual-v3.0",
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "api_base_url": "test-base-url",
                 "top_k": 2,
-                "max_chunks_per_doc": 50,
                 "meta_fields_to_embed": ["meta_field_1", "meta_field_2"],
                 "meta_data_separator": ",",
                 "max_tokens_per_doc": 100,
             },
         }
         component = CohereRanker.from_dict(data)
-        assert component.model_name == "rerank-multilingual-v2.0"
+        assert component.model_name == "rerank-multilingual-v3.0"
         assert component.top_k == 2
         assert component.api_key == Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"])
         assert component.api_base_url == "test-base-url"
-        assert component.max_chunks_per_doc == 50
         assert component.meta_fields_to_embed == ["meta_field_1", "meta_field_2"]
         assert component.meta_data_separator == ","
         assert component.max_tokens_per_doc == 100
@@ -153,10 +145,9 @@ class TestCohereRanker:
         data = {
             "type": "haystack_integrations.components.rankers.cohere.ranker.CohereRanker",
             "init_parameters": {
-                "model": "rerank-multilingual-v2.0",
+                "model": "rerank-multilingual-v3.0",
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "top_k": 2,
-                "max_chunks_per_doc": 50,
                 "max_tokens_per_doc": 100,
             },
         }


### PR DESCRIPTION
### Related Issues
- [Nightly tests are failing](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/14786049398/job/41514528760) because the default model has been shutdown: https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v20

### Proposed Changes:
- replace the default model with the suggested one
- remove unused `max_chunks_per_doc parameter`: we were already ignoring this parameter and warning the user. Since I will release a new major version, this seems like a good time to remove this parameter.

### How did you test it?
CI

### Notes for the reviewer
It can be considered a breaking change, so I will release a new major version.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
