### PR TITLE
chore: Upgrade default model to command-r-plus

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -236,7 +236,7 @@ class CohereChatGenerator:
     from haystack.utils import Secret
     from haystack_integrations.components.generators.cohere import CohereChatGenerator
 
-    client = CohereChatGenerator(model="command-r", api_key=Secret.from_env_var("COHERE_API_KEY"))
+    client = CohereChatGenerator(model="command-r-plus", api_key=Secret.from_env_var("COHERE_API_KEY"))
     messages = [ChatMessage.from_user("What's Natural Language Processing?")]
     client.run(messages)
 
@@ -296,7 +296,7 @@ class CohereChatGenerator:
     def __init__(
         self,
         api_key: Secret = Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
-        model: str = "command-r",
+        model: str = "command-r-plus",
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
         api_base_url: Optional[str] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,

--- a/integrations/cohere/tests/test_cohere_chat_generator.py
+++ b/integrations/cohere/tests/test_cohere_chat_generator.py
@@ -46,7 +46,7 @@ class TestCohereChatGenerator:
 
         component = CohereChatGenerator()
         assert component.api_key == Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"])
-        assert component.model == "command-r"
+        assert component.model == "command-r-plus"
         assert component.streaming_callback is None
         assert component.api_base_url == "https://api.cohere.com"
         assert not component.generation_kwargs
@@ -78,7 +78,7 @@ class TestCohereChatGenerator:
         assert data == {
             "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model": "command-r",
+                "model": "command-r-plus",
                 "streaming_callback": None,
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "api_base_url": "https://api.cohere.com",
@@ -116,7 +116,7 @@ class TestCohereChatGenerator:
         data = {
             "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model": "command-r",
+                "model": "command-r-plus",
                 "api_base_url": "test-base-url",
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
@@ -124,7 +124,7 @@ class TestCohereChatGenerator:
             },
         }
         component = CohereChatGenerator.from_dict(data)
-        assert component.model == "command-r"
+        assert component.model == "command-r-plus"
         assert component.streaming_callback is print_streaming_chunk
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -135,7 +135,7 @@ class TestCohereChatGenerator:
         data = {
             "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model": "command-r",
+                "model": "command-r-plus",
                 "api_base_url": "test-base-url",
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
@@ -226,7 +226,7 @@ class TestCohereChatGenerator:
                 },
             }
         ]
-        client = CohereChatGenerator(model="command-r")
+        client = CohereChatGenerator(model="command-r-plus")
         response = client.run(
             messages=[ChatMessage.from_user("What is the current price of AAPL?")],
             generation_kwargs={"tools": tools_schema},
@@ -267,7 +267,7 @@ class TestCohereChatGenerator:
             function=stock_price,
         )
         initial_messages = [ChatMessage.from_user("What is the current price of AAPL?")]
-        client = CohereChatGenerator(model="command-r")
+        client = CohereChatGenerator(model="command-r-plus")
         response = client.run(
             messages=initial_messages,
             tools=[stock_price_tool],
@@ -327,7 +327,7 @@ class TestCohereChatGenerator:
 
         initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         component = CohereChatGenerator(
-            model="command-r",  # Cohere's model that supports tools
+            model="command-r-plus",  # Cohere's model that supports tools
             tools=[weather_tool],
             streaming_callback=print_streaming_chunk,
         )
@@ -384,7 +384,7 @@ class TestCohereChatGenerator:
         )
 
         pipeline = Pipeline()
-        pipeline.add_component("generator", CohereChatGenerator(model="command-r", tools=[weather_tool]))
+        pipeline.add_component("generator", CohereChatGenerator(model="command-r-plus", tools=[weather_tool]))
         pipeline.add_component("tool_invoker", ToolInvoker(tools=[weather_tool]))
 
         pipeline.connect("generator", "tool_invoker")
@@ -416,7 +416,7 @@ class TestCohereChatGenerator:
 
         # Create generator with specific configuration
         generator = CohereChatGenerator(
-            model="command-r",
+            model="command-r-plus",
             generation_kwargs={"temperature": 0.7},
             streaming_callback=print_streaming_chunk,
             tools=[tool],
@@ -437,7 +437,7 @@ class TestCohereChatGenerator:
                 "generator": {
                     "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",  # noqa: E501
                     "init_parameters": {
-                        "model": "command-r",
+                        "model": "command-r-plus",
                         "api_key": {"type": "env_var", "env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True},
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.cohere.com",


### PR DESCRIPTION
### Why:

This PR upgrades the Cohere integration to use the `command-r-plus` chat model, Cohere’s most advanced LLM as of August 2024. Compared to `command-r`, the `command-r-plus` model delivers significantly better performance for complex tasks such as multi-step agent workflows and RAG-heavy pipelines. It is optimized for long-context conversational use cases and is intended for production-grade applications, making it a better fit for most Haystack usage scenarios. 

The previous `command-r` model remains suitable for lightweight tasks and latency-sensitive applications, but `command-r-plus` is now the recommended default for more capable, reliable outputs in realistic production settings.

Cohere has even newer model [Command A](https://docs.cohere.com/docs/command-a) the performant model to date, excelling at real world enterprise tasks including tool use, retrieval augmented generation (RAG), agents, and multilingual use cases. At 111B parameters, Command A has a context length of 256K. But we can update to this one once it stabilizes as the current version seems more beta - i.e. it doesn't have full name as command-r-plus but rather command-a-03-2025

### What:

* Updated the Cohere integration to reference `command-r-plus` instead of `command-r`.
* Adjusted associated test cases to validate against the updated model.

### How can it be used:

No changes needed from the user—new pipelines using Cohere will default to the upgraded model automatically.

### How did you test it:

* Ran unit tests to validate output structure and model invocation.
* Confirmed compatibility with existing tool use cases and RAG patterns.

### Notes for the reviewer:

* Focus on verifying model name substitution and test coverage.
