### PR TITLE
fix: ollama streaming metadata 1686

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -272,7 +272,8 @@ class OllamaChatGenerator:
                 streaming_callback(chunk_delta)
 
         replies = [ChatMessage.from_assistant("".join([c.content for c in chunks]))]
-        meta = {key: value for key, value in chunks[0].meta.items() if key != "message"}
+        # Convert the last chunk's metadata to OpenAI format
+        meta = _convert_ollama_meta_to_openai_format(chunks[-1].meta) if chunks else {}
 
         return {"replies": replies, "meta": [meta]}
 

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -271,11 +271,16 @@ class OllamaChatGenerator:
             if streaming_callback is not None:
                 streaming_callback(chunk_delta)
 
-        replies = [ChatMessage.from_assistant("".join([c.content for c in chunks]))]
-        # Convert the last chunk's metadata to OpenAI format
-        meta = _convert_ollama_meta_to_openai_format(chunks[-1].meta) if chunks else {}
+        # Create the ChatMessage with the combined content
+        combined_text = "".join([c.content for c in chunks])
+        reply = ChatMessage.from_assistant(combined_text)
 
-        return {"replies": replies, "meta": [meta]}
+        # Convert the last chunk's metadata to OpenAI format and attach it to the ChatMessage
+        if chunks:
+            meta = _convert_ollama_meta_to_openai_format(chunks[-1].meta)
+            reply._meta = meta
+
+        return {"replies": [reply]}
 
     @component.output_types(replies=List[ChatMessage])
     def run(

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -419,12 +419,12 @@ class TestOllamaChatGenerator:
         assert result["replies"][0].role == "assistant"
 
         # Verify metadata is properly processed and includes usage information
-        assert "meta" in result
-        assert result["meta"][0]["done"] is True
-        assert "usage" in result["meta"][0]
-        assert result["meta"][0]["usage"]["prompt_tokens"] == 26
-        assert result["meta"][0]["usage"]["completion_tokens"] == 282
-        assert result["meta"][0]["usage"]["total_tokens"] == 308
+        assert hasattr(result["replies"][0], "_meta")
+        assert result["replies"][0]._meta["done"] is True
+        assert "usage" in result["replies"][0]._meta
+        assert result["replies"][0]._meta["usage"]["prompt_tokens"] == 26
+        assert result["replies"][0]._meta["usage"]["completion_tokens"] == 282
+        assert result["replies"][0]._meta["usage"]["total_tokens"] == 308
 
     @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
     def test_run_streaming_at_runtime(self, mock_client):
@@ -472,12 +472,12 @@ class TestOllamaChatGenerator:
         assert result["replies"][0].role == "assistant"
 
         # Verify metadata is properly processed and includes usage information
-        assert "meta" in result
-        assert result["meta"][0]["done"] is True
-        assert "usage" in result["meta"][0]
-        assert result["meta"][0]["usage"]["prompt_tokens"] == 26
-        assert result["meta"][0]["usage"]["completion_tokens"] == 282
-        assert result["meta"][0]["usage"]["total_tokens"] == 308
+        assert hasattr(result["replies"][0], "_meta")
+        assert result["replies"][0]._meta["done"] is True
+        assert "usage" in result["replies"][0]._meta
+        assert result["replies"][0]._meta["usage"]["prompt_tokens"] == 26
+        assert result["replies"][0]._meta["usage"]["completion_tokens"] == 282
+        assert result["replies"][0]._meta["usage"]["total_tokens"] == 308
 
     def test_run_fail_with_tools_and_streaming(self, tools):
         component = OllamaChatGenerator(tools=tools, streaming_callback=print_streaming_chunk)

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -418,6 +418,14 @@ class TestOllamaChatGenerator:
         assert result["replies"][0].text == "first chunk second chunk"
         assert result["replies"][0].role == "assistant"
 
+        # Verify metadata is properly processed and includes usage information
+        assert "meta" in result
+        assert result["meta"][0]["done"] is True
+        assert "usage" in result["meta"][0]
+        assert result["meta"][0]["usage"]["prompt_tokens"] == 26
+        assert result["meta"][0]["usage"]["completion_tokens"] == 282
+        assert result["meta"][0]["usage"]["total_tokens"] == 308
+
     @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
     def test_run_streaming_at_runtime(self, mock_client):
         streaming_callback_called = False
@@ -462,6 +470,14 @@ class TestOllamaChatGenerator:
         assert len(result["replies"]) == 1
         assert result["replies"][0].text == "first chunk second chunk"
         assert result["replies"][0].role == "assistant"
+
+        # Verify metadata is properly processed and includes usage information
+        assert "meta" in result
+        assert result["meta"][0]["done"] is True
+        assert "usage" in result["meta"][0]
+        assert result["meta"][0]["usage"]["prompt_tokens"] == 26
+        assert result["meta"][0]["usage"]["completion_tokens"] == 282
+        assert result["meta"][0]["usage"]["total_tokens"] == 308
 
     def test_run_fail_with_tools_and_streaming(self, tools):
         component = OllamaChatGenerator(tools=tools, streaming_callback=print_streaming_chunk)


### PR DESCRIPTION
### Related Issues

- fixes #1686

### Proposed Changes:

 Update _handle_streaming_response() to return data in the same format as a non-streaming-response. Specifically:
- use the metadata from the last streaming chunk which has the completion information
- convert the metadata to OpenAI format and insert it into the ChatMesssage (instead of an object outside the replies)

### How did you test it?

Updated streaming tests to add assertions for metadata `done` and `usage` fields to validata metadata exists and returns usage in OpenAI format.

### Notes for the reviewer

Here is a comparison of the ollama chat generator with and without streaming callbacks to show the the return values are the same. The linked bug shows the previous value for streaming callbacks.

OllamaChatGenerator without streaming_callback
```
{'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text=' To get started with Natural Language Processing, you can start by learning a programming language such as Python or Java, and then incorporating NLP libraries to analyze and process natural language data.')], _name=None, _meta={'model': 'orca-mini', 'done': True, 'total_duration': 11742676791, 'load_duration': 10859628000, 'prompt_eval_duration': 471739167, 'eval_duration': 410146708, 'finish_reason': 'stop', 'completion_start_time': '2025-05-04T12:00:09.535316Z', 'usage': {'completion_tokens': 37, 'prompt_tokens': 97, 'total_tokens': 134}})]}
```

OllamaChatGenerator with streaming_callback
```
{'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text=' To get started with Natural Language Processing, you can start by learning programming languages such as Python or Java, and then explore libraries and tools for NLP tasks.')], _name=None, _meta={'model': 'orca-mini', 'done': True, 'total_duration': 384262625, 'load_duration': 3048250, 'prompt_eval_duration': 12056041, 'eval_duration': 366724459, 'role': 'assistant', 'finish_reason': 'stop', 'completion_start_time': '2025-05-04T12:00:09.941023Z', 'usage': {'completion_tokens': 33, 'prompt_tokens': 97, 'total_tokens': 130}})]}
```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
