### PR TITLE
feat: Add Toolset support to AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "boto3>=1.28.57", "aioboto3>=14.0.0"]
+dependencies = ["haystack-ai>=2.13.1", "boto3>=1.28.57", "aioboto3>=14.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_bedrock#readme"

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -1,19 +1,13 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from botocore.config import Config
 from botocore.eventstream import EventStream
 from botocore.exceptions import ClientError
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ChatMessage, StreamingCallbackT, select_streaming_callback
-from haystack.tools import Tool, _check_duplicate_tool_names
+from haystack.tools import Tool, Toolset, _check_duplicate_tool_names, deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
 from haystack.utils.auth import Secret, deserialize_secrets_inplace
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
-
-# Compatibility with Haystack 2.12.0 and 2.13.0 - remove after 2.13.0 is released
-try:
-    from haystack.tools import deserialize_tools_or_toolset_inplace
-except ImportError:
-    from haystack.tools import deserialize_tools_inplace as deserialize_tools_or_toolset_inplace
 
 from haystack_integrations.common.amazon_bedrock.errors import (
     AmazonBedrockConfigurationError,
@@ -140,7 +134,7 @@ class AmazonBedrockChatGenerator:
         stop_words: Optional[List[str]] = None,
         streaming_callback: Optional[StreamingCallbackT] = None,
         boto3_config: Optional[Dict[str, Any]] = None,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
     ):
         """
         Initializes the `AmazonBedrockChatGenerator` with the provided parameters. The parameters are passed to the
@@ -172,7 +166,7 @@ class AmazonBedrockChatGenerator:
             [StreamingChunk](https://docs.haystack.deepset.ai/docs/data-classes#streamingchunk) object and switches
             the streaming mode on.
         :param boto3_config: The configuration for the boto3 client.
-        :param tools: A list of Tool objects that the model can use. Each tool should have a unique name.
+        :param tools: A list of Tool objects or a Toolset that the model can use. Each tool should have a unique name.
 
         :raises ValueError: If the model name is empty or None.
         :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly or the model is
@@ -190,7 +184,7 @@ class AmazonBedrockChatGenerator:
         self.stop_words = stop_words or []
         self.streaming_callback = streaming_callback
         self.boto3_config = boto3_config
-        _check_duplicate_tool_names(tools)
+        _check_duplicate_tool_names(list(tools or [])) # handles Toolset as well
         self.tools = tools
 
         def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
@@ -260,7 +254,6 @@ class AmazonBedrockChatGenerator:
             Dictionary with serialized data.
         """
         callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
-        serialized_tools = [tool.to_dict() for tool in self.tools] if self.tools else None
         return default_to_dict(
             self,
             aws_access_key_id=self.aws_access_key_id.to_dict() if self.aws_access_key_id else None,
@@ -273,7 +266,7 @@ class AmazonBedrockChatGenerator:
             generation_kwargs=self.generation_kwargs,
             streaming_callback=callback_name,
             boto3_config=self.boto3_config,
-            tools=serialized_tools,
+            tools=serialize_tools_or_toolset(self.tools),
         )
 
     @classmethod
@@ -301,7 +294,7 @@ class AmazonBedrockChatGenerator:
         messages: List[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
         requires_async: bool = False,
     ) -> Tuple[Dict[str, Any], Optional[StreamingCallbackT]]:
         """
@@ -310,7 +303,7 @@ class AmazonBedrockChatGenerator:
         :param messages: List of ChatMessage objects representing the conversation history.
         :param streaming_callback: Optional callback function for handling streaming responses.
         :param generation_kwargs: Optional dictionary of generation parameters.
-        :param tools: Optional list of Tool objects that the model can use.
+        :param tools: Optional list of Tool objects or a Toolset that the model can use.
         :param requires_async: Boolean indicating whether the request is for async execution.
             This affects how the streaming callback is selected.
         :return: Tuple of (request parameters dict, callback function)
@@ -331,9 +324,12 @@ class AmazonBedrockChatGenerator:
 
         # Handle tools - either toolConfig or Haystack Tool objects but not both
         tools = tools or self.tools
-        _check_duplicate_tool_names(tools)
+        _check_duplicate_tool_names(list(tools or []))
         tool_config = merged_kwargs.pop("toolConfig", None)
         if tools:
+            # Convert Toolset to list if needed
+            if isinstance(tools, Toolset):
+                tools = list(tools)
             # Format Haystack tools to Bedrock format
             tool_config = _format_tools(tools)
 
@@ -369,7 +365,7 @@ class AmazonBedrockChatGenerator:
         messages: List[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
     ):
         params, callback = self._prepare_request_params(
             messages=messages,
@@ -402,7 +398,7 @@ class AmazonBedrockChatGenerator:
         messages: List[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
     ):
         """
         Async version of the run method. Completes chats using LLMs hosted on Amazon Bedrock.
@@ -410,7 +406,7 @@ class AmazonBedrockChatGenerator:
         :param messages: List of ChatMessage objects representing the conversation history.
         :param streaming_callback: Optional callback function for handling streaming responses.
         :param generation_kwargs: Optional dictionary of generation parameters.
-        :param tools: Optional list of Tool objects that the model can use.
+        :param tools: Optional list of Tool objects or a Toolset that the model can use.
         :return: Dictionary containing the model's replies as a list of ChatMessage objects.
         """
         params, callback = self._prepare_request_params(


### PR DESCRIPTION
### Why:

Update AmazonBedrockChatGenerator` to support initialization and run method with a `Toolset`.

### What:

* Modified the `tools` parameter of `AmazonBedrockChatGenerator` to accept either a list of `Tool` objects or a `Toolset` instance.
* Added serialization logic to handle `Toolset` in the `to_dict()` method of `AmazonBedrockChatGenerator`.
* Updated relevant tests to validate initialization and behavior when using a `Toolset`.

### How can it be used:

`AmazonBedrockChatGenerator` can now be initialized with a `Toolset`, streamlining tool configuration:

```python
toolset = Toolset(tools)  # where tools is a list of Tool objects
generator = AmazonBedrockChatGenerator(api_key="your-key", tools=toolset)
```

Users can now pass a `Toolset` directly, enabling more structured tool management.

### How did you test it:

Manual tests, Toolset is extensively tested already elsewhere

### Notes for the reviewer:

Please ensure changes to `AmazonBedrockChatGenerator` maintain compatibility with the previous list-based `tools` setup. Focus on validating both `Tool` list and `Toolset` integration. Confirm that serialization and test coverage are thorough.
