### PR TITLE
fix: hard coded embedding field for mongodb

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -65,6 +65,7 @@ class MongoDBAtlasDocumentStore:
         collection_name: str,
         vector_search_index: str,
         full_text_search_index: str,
+        embedding_field: str = "embedding",
     ):
         """
         Creates a new MongoDBAtlasDocumentStore instance.
@@ -84,7 +85,7 @@ class MongoDBAtlasDocumentStore:
             Create a full_text_search_index in the Atlas web UI and specify the init params of
             MongoDBAtlasDocumentStore. For more details refer to MongoDB Atlas
             [documentation](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
-
+        :param embedding_field: The name of the field containing document embeddings. Default is "embedding".
         :raises ValueError: If the collection name contains invalid characters.
         """
         if collection_name and not bool(re.match(r"^[a-zA-Z0-9\-_]+$", collection_name)):
@@ -97,6 +98,7 @@ class MongoDBAtlasDocumentStore:
         self.collection_name = collection_name
         self.vector_search_index = vector_search_index
         self.full_text_search_index = full_text_search_index
+        self.embedding_field = embedding_field
         self._connection: Optional[MongoClient] = None
         self._connection_async: Optional[AsyncMongoClient] = None
         self._collection: Optional[Collection] = None
@@ -479,7 +481,7 @@ class MongoDBAtlasDocumentStore:
             {
                 "$vectorSearch": {
                     "index": self.vector_search_index,
-                    "path": "embedding",
+                    "path": self.embedding_field,
                     "queryVector": query_embedding,
                     "numCandidates": 100,
                     "limit": top_k,
@@ -492,7 +494,7 @@ class MongoDBAtlasDocumentStore:
                     "content": 1,
                     "blob": 1,
                     "meta": 1,
-                    "embedding": 1,
+                    self.embedding_field: 1,
                     "score": {"$meta": "vectorSearchScore"},
                 }
             },
@@ -536,7 +538,7 @@ class MongoDBAtlasDocumentStore:
             {
                 "$vectorSearch": {
                     "index": self.vector_search_index,
-                    "path": "embedding",
+                    "path": self.embedding_field,
                     "queryVector": query_embedding,
                     "numCandidates": 100,
                     "limit": top_k,
@@ -549,7 +551,7 @@ class MongoDBAtlasDocumentStore:
                     "content": 1,
                     "blob": 1,
                     "meta": 1,
-                    "embedding": 1,
+                    self.embedding_field: 1,
                     "score": {"$meta": "vectorSearchScore"},
                 }
             },
@@ -651,7 +653,7 @@ class MongoDBAtlasDocumentStore:
                     "content": 1,
                     "blob": 1,
                     "meta": 1,
-                    "embedding": 1,
+                    self.embedding_field: 1,
                     "score": {"$meta": "searchScore"},
                 }
             },
@@ -751,7 +753,7 @@ class MongoDBAtlasDocumentStore:
                     "content": 1,
                     "blob": 1,
                     "meta": 1,
-                    "embedding": 1,
+                    self.embedding_field: 1,
                     "score": {"$meta": "searchScore"},
                 }
             },

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -89,7 +89,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
                 "database_name": "haystack_integration_test",
                 "vector_search_index": "cosine_index",
                 "full_text_search_index": "full_text_index",
-                "embedding_field": "embedding",
             },
         }
 


### PR DESCRIPTION
### Related Issues

- make embedding filed configurable 

We should make this field configurable since we can't assume a data format of our customers. 

Even the sample dataset from mongodb you can use in atlas uses a different key to store embeddings: https://huggingface.co/datasets/MongoDB/embedded_movies

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
