### PR TITLE
fix: Fix BedrockChatGenerator to be able to handle multiple tool calls from one response

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -422,7 +422,7 @@ def _parse_streaming_response(
 
     final_usage = None
     final_finish_reason = None
-    content_blocks = {}
+    content_blocks: Dict[str, Any] = {}
     for event in response_stream:
         content_blocks, finish_reason, usage = _convert_event_to_content_blocks(
             event=event, current_content_blocks=content_blocks
@@ -462,7 +462,7 @@ async def _parse_streaming_response_async(
 
     final_usage = None
     final_finish_reason = None
-    content_blocks = {}
+    content_blocks: Dict[str, Any] = {}
     async for event in response_stream:
         content_blocks, finish_reason, usage = _convert_event_to_content_blocks(
             event=event, current_content_blocks=content_blocks

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -376,9 +376,7 @@ def _convert_streaming_chunks_to_chat_message(chunks: List[StreamingChunk]) -> C
     finish_reason = finish_reasons[-1] if finish_reasons else None
 
     # usage is usually last but we look for it as well
-    usages = [
-        chunk.meta.get("usage") for chunk in chunks if chunk.meta.get("usage") is not None
-    ]
+    usages = [chunk.meta.get("usage") for chunk in chunks if chunk.meta.get("usage") is not None]
     usage = usages[-1] if usages else None
 
     meta = {

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -253,6 +253,7 @@ def _convert_event_to_streaming_chunk(event: Dict[str, Any], model: str) -> Stre
     )
 
     if "contentBlockStart" in event:
+        # contentBlockStart always has the key "contentBlockIndex"
         block_start = event["contentBlockStart"]
         block_idx = block_start["contentBlockIndex"]
         if "start" in block_start and "toolUse" in block_start["start"]:
@@ -282,6 +283,7 @@ def _convert_event_to_streaming_chunk(event: Dict[str, Any], model: str) -> Stre
             )
 
     elif "contentBlockDelta" in event:
+        # contentBlockDelta always has the key "contentBlockIndex" and "delta"
         block_idx = event["contentBlockDelta"]["contentBlockIndex"]
         delta = event["contentBlockDelta"]["delta"]
         # This is for accumulating text deltas

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -247,9 +247,8 @@ def _convert_event_to_streaming_chunk(event: Dict[str, Any], model: str) -> Stre
 
     Following same format as used in Haystack's OpenAIChatGenerator.
     """
-    # We ignore messageStart and contentBlockStop events for now
-
     # Initialize an empty StreamingChunk to return if no relevant event is found
+    # (e.g. for messageStart and contentBlockStop)
     streaming_chunk = StreamingChunk(
         content="", meta={"model": model, "received_at": datetime.now(timezone.utc).isoformat()}
     )

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -23,7 +23,8 @@ MODELS_TO_TEST_WITH_TOOLS = [
 ]
 
 # so far we've discovered these models support streaming and tool use
-STREAMING_TOOL_MODELS = ["anthropic.claude-3-5-sonnet-20240620-v1:0", "cohere.command-r-plus-v1:0"]
+# STREAMING_TOOL_MODELS = ["anthropic.claude-3-5-sonnet-20240620-v1:0", "cohere.command-r-plus-v1:0"]
+STREAMING_TOOL_MODELS = ["cohere.command-r-plus-v1:0"]
 
 
 def weather(city: str):

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -23,8 +23,7 @@ MODELS_TO_TEST_WITH_TOOLS = [
 ]
 
 # so far we've discovered these models support streaming and tool use
-# STREAMING_TOOL_MODELS = ["anthropic.claude-3-5-sonnet-20240620-v1:0", "cohere.command-r-plus-v1:0"]
-STREAMING_TOOL_MODELS = ["cohere.command-r-plus-v1:0"]
+STREAMING_TOOL_MODELS = ["anthropic.claude-3-5-sonnet-20240620-v1:0", "cohere.command-r-plus-v1:0"]
 
 
 def weather(city: str):

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -359,7 +359,7 @@ class TestAmazonBedrockChatGeneratorInference:
             ChatMessage.from_tool(tool_result="22° C", origin=tool_call) for tool_call in tool_calls
         ]
 
-        new_messages = initial_messages + [tool_call_message] + tool_result_messages
+        new_messages = [*initial_messages, tool_call_message, *tool_result_messages]
         results = component.run(new_messages)
 
         assert len(results["replies"]) == 1

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -348,6 +348,7 @@ class TestAmazonBedrockChatGeneratorInference:
         assert ChatMessage.is_from(tool_call_message, ChatRole.ASSISTANT), "Tool message is not from the assistant"
 
         tool_calls = tool_call_message.tool_calls
+        assert len(tool_calls) == 2
         for tool_call in tool_calls:
             assert tool_call.id, "Tool call does not contain value for 'id' key"
             assert tool_call.tool_name == "weather"

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -177,18 +177,13 @@ class TestAmazonBedrockChatGeneratorUtils:
                             "toolUseId": "tooluse_evFtOFYeSiG_TQ0cAAgy4Q",
                             "content": [{"text": "Mostly sunny"}],
                         }
-                    }
-                ],
-            },
-            {
-                "role": "user",
-                "content": [
+                    },
                     {
                         "toolResult": {
                             "toolUseId": "tooluse_Oc0n2we2RvquHwuPEflaQA",
                             "content": [{"text": "Mostly cloudy"}],
                         }
-                    }
+                    },
                 ],
             },
         ]

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -399,11 +399,18 @@ class TestAmazonBedrockChatGeneratorUtils:
             )
         ]
 
-        # TODO Reactivate
-        # Verify streaming chunks were received for text content
-        # assert len(streaming_chunks) == 2
-        # assert streaming_chunks[0].content == "Let me "
-        # assert streaming_chunks[1].content == "help you."
+        # Verify streaming chunks were received for all content
+        assert len(streaming_chunks) == 21
+        assert streaming_chunks[1].content == "Certainly! I can"
+        assert streaming_chunks[2].content == " help you find out"
+        assert streaming_chunks[12].meta["tool_calls"] == [
+            {
+                "index": 1,
+                "id": "tooluse_pLGRAmK7TNKoZQ_rntVN_Q",
+                "function": {"arguments": "", "name": "weather_tool"},
+                "type": "function",
+            }
+        ]
 
         # Verify final replies
         assert len(replies) == 1

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -380,6 +380,8 @@ class TestAmazonBedrockChatGeneratorUtils:
         ]
 
         replies = _parse_streaming_response(events, test_callback, model)
+        # Pop completion_start_time since it will always change
+        replies[0].meta.pop("completion_start_time")
         expected_messages = [
             ChatMessage.from_assistant(
                 text="Certainly! I can help you find out the weather in Berlin. To get this information, I'll use the "
@@ -467,6 +469,8 @@ class TestAmazonBedrockChatGeneratorUtils:
         ]
 
         replies = _parse_streaming_response(events, test_callback, model)
+        # Pop completion_start_time since it will always change
+        replies[0].meta.pop("completion_start_time")
         expected_messages = [
             ChatMessage.from_assistant(
                 text="To answer your question about the weather in Berlin and Paris, I'll need to use the "

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -334,7 +334,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         )
         assert replies[0] == expected_message
 
-    def test_process_streaming_response(self, mock_boto3_session):
+    def test_process_streaming_response_one_tool_call(self, mock_boto3_session):
         """
         Test that process_streaming_response correctly handles streaming events and accumulates responses
         """
@@ -346,35 +346,139 @@ class TestAmazonBedrockChatGeneratorUtils:
 
         # Simulate a stream of events for both text and tool use
         events = [
-            {"contentBlockStart": {"start": {"text": ""}}},
-            {"contentBlockDelta": {"delta": {"text": "Let me "}}},
-            {"contentBlockDelta": {"delta": {"text": "help you."}}},
-            {"contentBlockStop": {}},
-            {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "123", "name": "search_tool"}}}},
-            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"query":'}}}},
-            {"contentBlockDelta": {"delta": {"toolUse": {"input": '"test"}'}}}},
-            {"contentBlockStop": {}},
-            {"messageStop": {"stopReason": "complete"}},
-            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30}}},
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"delta": {"text": "Certainly! I can"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " help you find out"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " the weather"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " in Berlin. To"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " get this information, I'll"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " use the weather tool available"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " to me."}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " Let me fetch"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " that data for"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " you."}, "contentBlockIndex": 0}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": "tooluse_pLGRAmK7TNKoZQ_rntVN_Q", "name": "weather_tool"}},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ""}}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"'}}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": 'location": '}}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '"B'}}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": 'erlin"}'}}, "contentBlockIndex": 1}},
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {
+                "metadata": {
+                    "usage": {"inputTokens": 364, "outputTokens": 71, "totalTokens": 435},
+                    "metrics": {"latencyMs": 2449},
+                }
+            },
         ]
 
         replies = _parse_streaming_response(events, test_callback, model)
+        expected_messages = [
+            ChatMessage.from_assistant(
+                text="Certainly! I can help you find out the weather in Berlin. To get this information, I'll use the "
+                "weather tool available to me. Let me fetch that data for you.",
+                name=None,
+                tool_calls=[
+                    ToolCall(
+                        tool_name="weather_tool", arguments={"location": "Berlin"}, id="tooluse_pLGRAmK7TNKoZQ_rntVN_Q"
+                    )
+                ],
+                meta={
+                    "model": model,
+                    "index": 0,
+                    "finish_reason": "tool_use",
+                    "usage": {"prompt_tokens": 364, "completion_tokens": 71, "total_tokens": 435},
+                },
+            )
+        ]
 
+        # TODO Reactivate
         # Verify streaming chunks were received for text content
-        assert len(streaming_chunks) == 2
-        assert streaming_chunks[0].content == "Let me "
-        assert streaming_chunks[1].content == "help you."
+        # assert len(streaming_chunks) == 2
+        # assert streaming_chunks[0].content == "Let me "
+        # assert streaming_chunks[1].content == "help you."
 
         # Verify final replies
-        assert len(replies) == 2
-        # Check text reply
-        assert replies[0].text == "Let me help you."
-        assert replies[0].meta["model"] == model
-        assert replies[0].meta["finish_reason"] == "complete"
-        assert replies[0].meta["usage"] == {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+        assert len(replies) == 1
+        assert replies == expected_messages
 
-        # Check tool use reply
-        tool_content = replies[1].tool_call
-        assert tool_content.id == "123"
-        assert tool_content.tool_name == "search_tool"
-        assert tool_content.arguments == {"query": "test"}
+    def test_parse_streaming_response_with_two_tool_calls(self, mock_boto3_session):
+        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        streaming_chunks = []
+
+        def test_callback(chunk: StreamingChunk):
+            streaming_chunks.append(chunk)
+
+        events = [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"delta": {"text": "To"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " answer your question about the"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " weather in Berlin and Paris, I'll"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " need to use the weather_tool"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " for each city. Let"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " me fetch that information for"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " you."}, "contentBlockIndex": 0}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": "tooluse_A0jTtaiQTFmqD_cIq8I1BA", "name": "weather_tool"}},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ""}}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"location":'}}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ' "Be'}}, "contentBlockIndex": 1}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": 'rlin"}'}}, "contentBlockIndex": 1}},
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": "tooluse_LTc2TUMgTRiobK5Z5CCNSw", "name": "weather_tool"}},
+                    "contentBlockIndex": 2,
+                }
+            },
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": ""}}, "contentBlockIndex": 2}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"l'}}, "contentBlockIndex": 2}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": "ocati"}}, "contentBlockIndex": 2}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": 'on": "P'}}, "contentBlockIndex": 2}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": "ari"}}, "contentBlockIndex": 2}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": 's"}'}}, "contentBlockIndex": 2}},
+            {"contentBlockStop": {"contentBlockIndex": 2}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {
+                "metadata": {
+                    "usage": {"inputTokens": 366, "outputTokens": 83, "totalTokens": 449},
+                    "metrics": {"latencyMs": 3194},
+                }
+            },
+        ]
+
+        replies = _parse_streaming_response(events, test_callback, model)
+        expected_messages = [
+            ChatMessage.from_assistant(
+                text="To answer your question about the weather in Berlin and Paris, I'll need to use the "
+                "weather_tool for each city. Let me fetch that information for you.",
+                name=None,
+                tool_calls=[
+                    ToolCall(
+                        tool_name="weather_tool", arguments={"location": "Berlin"}, id="tooluse_A0jTtaiQTFmqD_cIq8I1BA"
+                    ),
+                    ToolCall(
+                        tool_name="weather_tool", arguments={"location": "Paris"}, id="tooluse_LTc2TUMgTRiobK5Z5CCNSw"
+                    ),
+                ],
+                meta={
+                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "index": 0,
+                    "finish_reason": "tool_use",
+                    "usage": {"prompt_tokens": 366, "completion_tokens": 83, "total_tokens": 449},
+                },
+            ),
+        ]
+        assert replies == expected_messages


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1677
- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1680
- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1681

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

**Fixing Multi Tool Calling**
Repairs the expected formatting of the bedrock messages.

Basically if a ChatMessage has multiple Tool Calls in it then the corresponding Tool Result ChatMessage must also contain both tool results. This is currently not possible because the ToolInvoker in Haystack returns a separate ChatMessage per Tool Call no matter if the original Tool Calls came one from one or multiple ChatMessages.

As a workaround, we retroactively repair the bedrock formatted messages to regroup the Tool Results based on how the Tool Calls are grouped. 

This could also be "fixed" in the ToolInvoker, but I'm not sure if that would have adverse effects on our other integrations. **Update:** Nothing to fix in the ToolInvoker, most providers expect separate messages per tool result. So it's better to modify the behavior only in this integration.

**Fixing Tool Call Streaming**
Changed the internal logic of the integration to take Events from Bedrock, convert them into Haystack `StreamingChunk`s that follow the same format as `OpenAIChatGenerator` and then pass the streaming chunk to the streaming callback. Now we will be able to reuse the `print_streaming_chunk` in Haystack main after a slight change is made. Here is an example of the output with the updated  `print_streaming_chunk` coming in a separate PR.
<img width="1108" alt="Screenshot 2025-05-09 at 09 54 38" src="https://github.com/user-attachments/assets/fbbbd14f-3cf0-4f59-b83d-e55833f549ec" />

**Fixing Consistency Between Streaming and Non-Streaming**
I updated the streaming processing to produce one ChatMessage like the non-streaming processing. This makes the most sense since this singular ChatMessage is converted into a single Bedrock formatted message. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added unit tests
- Updated integration tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
