### PR TITLE
test: Anthropic - add `server_tool_use` to `usage`

### DIFF
--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -354,6 +354,7 @@ class TestAnthropicChatGenerator:
                     "output_tokens": 1,
                     "cache_creation_input_tokens": None,
                     "cache_read_input_tokens": None,
+                    "server_tool_use_tokens": None,
                 },
             },
         }

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -354,7 +354,7 @@ class TestAnthropicChatGenerator:
                     "output_tokens": 1,
                     "cache_creation_input_tokens": None,
                     "cache_read_input_tokens": None,
-                    "server_tool_use_tokens": None,
+                    "server_tool_use": None,
                 },
             },
         }


### PR DESCRIPTION
### Related Issues

- nightly tests failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/14895585564/job/41837347229
- this is probably related to the recent introduction of [Web search tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool)

### Proposed Changes:
- fix `test_convert_anthropic_chunk_to_streaming_chunk` to include `server_tool_use` in `mata['usage']`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
