### PR TITLE
feat: support custom content field

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -712,7 +712,10 @@ class MongoDBAtlasDocumentStore:
 
     def _mongo_doc_to_haystack_doc(self, mongo_doc: Dict[str, Any]) -> Document:
         """
-        Parses a MongoDB document to a Haystack Document.
+        Converts the dictionary coming out of MongoDB into a Haystack document
+
+        :param mongo_doc: A dictionary representing a document as stored in MongoDB
+        :returns: A Haystack Document object
         """
         mongo_doc.pop("_id", None)  # MongoDB's internal id doesn't belong into a Haystack document, so we remove it.
         if self.content_field != "content":

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -89,8 +89,8 @@ class MongoDBAtlasDocumentStore:
         :param embedding_field: The name of the field containing document embeddings. Default is "embedding".
         :param content_field: The name of the field containing the document content. Default is "content".
             This field is allows defining which field to load into the Haystack Document object as content.
-            It can be particularly when integrating with an existing database for retrieval. We discourage
-            using this parameter when working with indexes created by Haystack.
+            It can be particularly useful when integrating with an existing collection for retrieval. We discourage
+            using this parameter when working with collections created by Haystack.
         :raises ValueError: If the collection name contains invalid characters.
         """
         if collection_name and not bool(re.match(r"^[a-zA-Z0-9\-_]+$", collection_name)):

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -724,6 +724,9 @@ class MongoDBAtlasDocumentStore:
     def _haystack_doc_to_mongo_doc(self, haystack_doc: Document) -> Dict[str, Any]:
         """
         Parses a Haystack Document to a MongoDB document.
+        
+        :param haystack_doc: the Haystack Document to convert
+        :returns: the MongoDB document in a dictionary representation
         """
         mongo_doc = haystack_doc.to_dict(flatten=False)
         if self.content_field != "content":

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -459,6 +459,7 @@ class MongoDBAtlasDocumentStore:
                 }
             },
             {"$addFields": {"score": {"$meta": "vectorSearchScore"}}},
+            {"$project": {"_id": 0}},
         ]
         try:
             documents = list(self._collection.aggregate(pipeline))  # type: ignore[union-attr]
@@ -507,6 +508,7 @@ class MongoDBAtlasDocumentStore:
                 }
             },
             {"$addFields": {"score": {"$meta": "vectorSearchScore"}}},
+            {"$project": {"_id": 0}},
         ]
         try:
             documents = await self._collection_async.aggregate(pipeline).to_list()  # type: ignore[union-attr]
@@ -600,6 +602,7 @@ class MongoDBAtlasDocumentStore:
             {"$match": filters},
             {"$limit": top_k},
             {"$addFields": {"score": {"$meta": "searchScore"}}},
+            {"$project": {"_id": 0}},
         ]
 
         self._ensure_connection_setup()
@@ -691,6 +694,7 @@ class MongoDBAtlasDocumentStore:
             {"$match": filters},
             {"$limit": top_k},
             {"$addFields": {"score": {"$meta": "searchScore"}}},
+            {"$project": {"_id": 0}},
         ]
 
         await self._ensure_connection_setup_async()

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -739,14 +739,5 @@ class MongoDBAtlasDocumentStore:
                     "The `sparse_embedding` field will be ignored.",
                     id=haystack_doc.id,
                 )
-        if "dataframe" in mongo_doc:
-            dataframe = mongo_doc.pop("dataframe", None)
-            if dataframe:
-                logger.warning(
-                    "Document {id} has the `dataframe` field set,"
-                    "MongoDBAtlasDocumentStore no longer supports dataframes and this field will be ignored. "
-                    "The `dataframe` field will soon be removed from Haystack Document.",
-                    id=haystack_doc.id,
-                )
         mongo_doc.pop("_id", None)
         return mongo_doc

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -748,5 +748,5 @@ class MongoDBAtlasDocumentStore:
                     "The `dataframe` field will soon be removed from Haystack Document.",
                     id=haystack_doc.id,
                 )
-        mongo_doc.pop("_id")
+        mongo_doc.pop("_id", None)
         return mongo_doc

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -66,6 +66,7 @@ class MongoDBAtlasDocumentStore:
         vector_search_index: str,
         full_text_search_index: str,
         embedding_field: str = "embedding",
+        content_field: str = "content",
     ):
         """
         Creates a new MongoDBAtlasDocumentStore instance.
@@ -86,6 +87,10 @@ class MongoDBAtlasDocumentStore:
             MongoDBAtlasDocumentStore. For more details refer to MongoDB Atlas
             [documentation](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
         :param embedding_field: The name of the field containing document embeddings. Default is "embedding".
+        :param content_field: The name of the field containing the document content. Default is "content".
+            This field is allows defining which field to load into the Haystack Document object as content. 
+            It can be particularly when integrating with an existing database for retrieval. We discourage
+            using this parameter when working with indexes created by Haystack.
         :raises ValueError: If the collection name contains invalid characters.
         """
         if collection_name and not bool(re.match(r"^[a-zA-Z0-9\-_]+$", collection_name)):
@@ -99,6 +104,7 @@ class MongoDBAtlasDocumentStore:
         self.vector_search_index = vector_search_index
         self.full_text_search_index = full_text_search_index
         self.embedding_field = embedding_field
+        self.content_field = content_field
         self._connection: Optional[MongoClient] = None
         self._connection_async: Optional[AsyncMongoClient] = None
         self._collection: Optional[Collection] = None
@@ -292,8 +298,6 @@ class MongoDBAtlasDocumentStore:
         self._ensure_connection_setup()
         filters = _normalize_filters(filters) if filters else None
         documents = list(self._collection.find(filters))  # type: ignore[union-attr]
-        for doc in documents:
-            doc.pop("_id", None)  # MongoDB's internal id doesn't belong into a Haystack document, so we remove it.
         return [Document.from_dict(doc) for doc in documents]
 
     async def filter_documents_async(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
@@ -309,9 +313,7 @@ class MongoDBAtlasDocumentStore:
         await self._ensure_connection_setup_async()
         filters = _normalize_filters(filters) if filters else None
         documents = await self._collection_async.find(filters).to_list()  # type: ignore[union-attr]
-        for doc in documents:
-            doc.pop("_id", None)
-        return [Document.from_dict(doc) for doc in documents]
+        return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
     def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE) -> int:
         """
@@ -334,19 +336,7 @@ class MongoDBAtlasDocumentStore:
         if policy == DuplicatePolicy.NONE:
             policy = DuplicatePolicy.FAIL
 
-        mongo_documents = []
-        for doc in documents:
-            doc_dict = doc.to_dict(flatten=False)
-            if "sparse_embedding" in doc_dict:
-                sparse_embedding = doc_dict.pop("sparse_embedding", None)
-                if sparse_embedding:
-                    logger.warning(
-                        "Document {id} has the `sparse_embedding` field set,"
-                        "but storing sparse embeddings in MongoDB Atlas is not currently supported."
-                        "The `sparse_embedding` field will be ignored.",
-                        id=doc.id,
-                    )
-            mongo_documents.append(doc_dict)
+        mongo_documents = [self._haystack_doc_to_mongo_doc(doc) for doc in documents]
         operations: List[Union[UpdateOne, InsertOne, ReplaceOne]]
         written_docs = len(documents)
 
@@ -390,28 +380,8 @@ class MongoDBAtlasDocumentStore:
         if policy == DuplicatePolicy.NONE:
             policy = DuplicatePolicy.FAIL
 
-        mongo_documents = []
-        for doc in documents:
-            doc_dict = doc.to_dict(flatten=False)
-            if "sparse_embedding" in doc_dict:
-                sparse_embedding = doc_dict.pop("sparse_embedding", None)
-                if sparse_embedding:
-                    logger.warning(
-                        "Document {id} has the `sparse_embedding` field set,"
-                        "but storing sparse embeddings in MongoDB Atlas is not currently supported."
-                        "The `sparse_embedding` field will be ignored.",
-                        id=doc.id,
-                    )
-            if "dataframe" in doc_dict:
-                dataframe = doc_dict.pop("dataframe", None)
-                if dataframe:
-                    logger.warning(
-                        "Document {id} has the `dataframe` field set,"
-                        "MongoDBAtlasDocumentStore no longer supports dataframes and this field will be ignored. "
-                        "The `dataframe` field will soon be removed from Haystack Document.",
-                        id=doc.id,
-                    )
-            mongo_documents.append(doc_dict)
+        mongo_documents = [self._haystack_doc_to_mongo_doc(doc) for doc in documents]
+
         operations: List[Union[UpdateOne, InsertOne, ReplaceOne]]
         written_docs = len(documents)
 
@@ -772,13 +742,43 @@ class MongoDBAtlasDocumentStore:
 
         return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
-    @staticmethod
-    def _mongo_doc_to_haystack_doc(mongo_doc: Dict[str, Any]) -> Document:
+    def _mongo_doc_to_haystack_doc(self, mongo_doc: Dict[str, Any]) -> Document:
         """
-        Converts the dictionary coming out of MongoDB into a Haystack document
-
-        :param mongo_doc: A dictionary representing a document as stored in MongoDB
-        :returns: A Haystack Document object
+        Parses a MongoDB document to a Haystack Document.
         """
-        mongo_doc.pop("_id", None)
+        mongo_doc.pop("_id", None)  # MongoDB's internal id doesn't belong into a Haystack document, so we remove it.
+        if self.content_field != "content":
+            mongo_doc["content"] = mongo_doc.pop(self.content_field, None)
+        if self.embedding_field != "embedding":
+            mongo_doc["embedding"] = mongo_doc.pop(self.embedding_field, None)
         return Document.from_dict(mongo_doc)
+
+    def _haystack_doc_to_mongo_doc(self, haystack_doc: Document) -> Dict[str, Any]:
+        """
+        Parses a Haystack Document to a MongoDB document.
+        """
+        mongo_doc = haystack_doc.to_dict(flatten=False)
+        mongo_doc["_id"] = mongo_doc.pop("_id", None)
+        if self.content_field != "content":
+            mongo_doc[self.content_field] = mongo_doc.pop("content", None)
+        if self.embedding_field != "embedding":
+            mongo_doc[self.embedding_field] = mongo_doc.pop("embedding", None)
+        if "sparse_embedding" in mongo_doc:
+            sparse_embedding = mongo_doc.pop("sparse_embedding", None)
+            if sparse_embedding:
+                logger.warning(
+                    "Document {id} has the `sparse_embedding` field set,"
+                    "but storing sparse embeddings in MongoDB Atlas is not currently supported."
+                    "The `sparse_embedding` field will be ignored.",
+                    id=haystack_doc.id,
+                )
+        if "dataframe" in mongo_doc:
+            dataframe = mongo_doc.pop("dataframe", None)
+            if dataframe:
+                logger.warning(
+                    "Document {id} has the `dataframe` field set,"
+                    "MongoDBAtlasDocumentStore no longer supports dataframes and this field will be ignored. "
+                    "The `dataframe` field will soon be removed from Haystack Document.",
+                    id=haystack_doc.id,
+                )
+        return mongo_doc

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -726,7 +726,6 @@ class MongoDBAtlasDocumentStore:
         Parses a Haystack Document to a MongoDB document.
         """
         mongo_doc = haystack_doc.to_dict(flatten=False)
-        mongo_doc["_id"] = mongo_doc.pop("_id", None)
         if self.content_field != "content":
             mongo_doc[self.content_field] = mongo_doc.pop("content", None)
         if self.embedding_field != "embedding":
@@ -749,4 +748,5 @@ class MongoDBAtlasDocumentStore:
                     "The `dataframe` field will soon be removed from Haystack Document.",
                     id=haystack_doc.id,
                 )
+        mongo_doc.pop("_id")
         return mongo_doc

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -464,6 +464,7 @@ class MongoDBAtlasDocumentStore:
                     "content": 1,
                     "blob": 1,
                     "meta": 1,
+                    self.content_field: 1,
                     self.embedding_field: 1,
                     "score": {"$meta": "vectorSearchScore"},
                 }
@@ -521,6 +522,7 @@ class MongoDBAtlasDocumentStore:
                     "content": 1,
                     "blob": 1,
                     "meta": 1,
+                    self.content_field: 1,
                     self.embedding_field: 1,
                     "score": {"$meta": "vectorSearchScore"},
                 }

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -447,7 +447,7 @@ class MongoDBAtlasDocumentStore:
 
         filters = _normalize_filters(filters) if filters else {}
 
-        pipeline = [
+        pipeline: List[Dict[str, Any]] = [
             {
                 "$vectorSearch": {
                     "index": self.vector_search_index,
@@ -458,17 +458,7 @@ class MongoDBAtlasDocumentStore:
                     "filter": filters,
                 }
             },
-            {
-                "$project": {
-                    "_id": 0,
-                    "content": 1,
-                    "blob": 1,
-                    "meta": 1,
-                    self.content_field: 1,
-                    self.embedding_field: 1,
-                    "score": {"$meta": "vectorSearchScore"},
-                }
-            },
+            {"$addFields": {"score": {"$meta": "vectorSearchScore"}}},
         ]
         try:
             documents = list(self._collection.aggregate(pipeline))  # type: ignore[union-attr]
@@ -505,7 +495,7 @@ class MongoDBAtlasDocumentStore:
 
         filters = _normalize_filters(filters) if filters else {}
 
-        pipeline = [
+        pipeline: List[Dict[str, Any]] = [
             {
                 "$vectorSearch": {
                     "index": self.vector_search_index,
@@ -516,17 +506,7 @@ class MongoDBAtlasDocumentStore:
                     "filter": filters,
                 }
             },
-            {
-                "$project": {
-                    "_id": 0,
-                    "content": 1,
-                    "blob": 1,
-                    "meta": 1,
-                    self.content_field: 1,
-                    self.embedding_field: 1,
-                    "score": {"$meta": "vectorSearchScore"},
-                }
-            },
+            {"$addFields": {"score": {"$meta": "vectorSearchScore"}}},
         ]
         try:
             documents = await self._collection_async.aggregate(pipeline).to_list()  # type: ignore[union-attr]
@@ -609,7 +589,7 @@ class MongoDBAtlasDocumentStore:
             text_search["score"] = score
 
         # Define the pipeline for MongoDB aggregation
-        pipeline = [
+        pipeline: List[Dict[str, Any]] = [
             {
                 "$search": {
                     "index": self.full_text_search_index,
@@ -619,16 +599,7 @@ class MongoDBAtlasDocumentStore:
             # TODO: Use compound filter. See: (https://www.mongodb.com/docs/atlas/atlas-search/performance/query-performance/#avoid--match-after--search)
             {"$match": filters},
             {"$limit": top_k},
-            {
-                "$project": {
-                    "_id": 0,
-                    "content": 1,
-                    "blob": 1,
-                    "meta": 1,
-                    self.embedding_field: 1,
-                    "score": {"$meta": "searchScore"},
-                }
-            },
+            {"$addFields": {"score": {"$meta": "searchScore"}}},
         ]
 
         self._ensure_connection_setup()
@@ -709,7 +680,7 @@ class MongoDBAtlasDocumentStore:
             text_search["score"] = score
 
         # Define the pipeline for MongoDB aggregation
-        pipeline = [
+        pipeline: List[Dict[str, Any]] = [
             {
                 "$search": {
                     "index": self.full_text_search_index,
@@ -719,16 +690,7 @@ class MongoDBAtlasDocumentStore:
             # TODO: Use compound filter. See: (https://www.mongodb.com/docs/atlas/atlas-search/performance/query-performance/#avoid--match-after--search)
             {"$match": filters},
             {"$limit": top_k},
-            {
-                "$project": {
-                    "_id": 0,
-                    "content": 1,
-                    "blob": 1,
-                    "meta": 1,
-                    self.embedding_field: 1,
-                    "score": {"$meta": "searchScore"},
-                }
-            },
+            {"$addFields": {"score": {"$meta": "searchScore"}}},
         ]
 
         await self._ensure_connection_setup_async()

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -88,7 +88,7 @@ class MongoDBAtlasDocumentStore:
             [documentation](https://www.mongodb.com/docs/atlas/atlas-search/create-index/).
         :param embedding_field: The name of the field containing document embeddings. Default is "embedding".
         :param content_field: The name of the field containing the document content. Default is "content".
-            This field is allows defining which field to load into the Haystack Document object as content. 
+            This field is allows defining which field to load into the Haystack Document object as content.
             It can be particularly when integrating with an existing database for retrieval. We discourage
             using this parameter when working with indexes created by Haystack.
         :raises ValueError: If the collection name contains invalid characters.

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -727,7 +727,7 @@ class MongoDBAtlasDocumentStore:
     def _haystack_doc_to_mongo_doc(self, haystack_doc: Document) -> Dict[str, Any]:
         """
         Parses a Haystack Document to a MongoDB document.
-        
+
         :param haystack_doc: the Haystack Document to convert
         :returns: the MongoDB document in a dictionary representation
         """

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -298,7 +298,7 @@ class MongoDBAtlasDocumentStore:
         self._ensure_connection_setup()
         filters = _normalize_filters(filters) if filters else None
         documents = list(self._collection.find(filters))  # type: ignore[union-attr]
-        return [Document.from_dict(doc) for doc in documents]
+        return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
     async def filter_documents_async(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         """

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -255,73 +255,8 @@ class TestDocumentStore(DocumentStoreBaseTests):
         finally:
             database[collection_name].drop()
 
-    @pytest.mark.integration
-    def test_document_conversion_methods(self):
-        """Test the document conversion helper methods with custom field mappings."""
-        database_name = "haystack_integration_test"
-        collection_name = "test_document_conversion_" + str(uuid4())
 
-        connection: MongoClient = MongoClient(
-            os.environ["MONGO_CONNECTION_STRING"], driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
-        )
-        database = connection[database_name]
-        if collection_name in database.list_collection_names():
-            database[collection_name].drop()
-        database.create_collection(collection_name)
-        database[collection_name].create_index("id", unique=True)
-
-        try:
-            # Create a document store with custom field names
-            custom_store = MongoDBAtlasDocumentStore(
-                database_name=database_name,
-                collection_name=collection_name,
-                vector_search_index="cosine_index",
-                full_text_search_index="full_text_index",
-                embedding_field="custom_vector",
-                content_field="custom_text",
-            )
-
-            # Test haystack_doc_to_mongo_doc
-            haystack_doc = Document(content="test content", embedding=[0.1, 0.2, 0.3], meta={"test_meta": "test_value"})
-
-            mongo_doc = custom_store._haystack_doc_to_mongo_doc(haystack_doc)
-
-            # Check field mapping
-            assert "custom_text" in mongo_doc
-            assert mongo_doc["custom_text"] == "test content"
-            assert "content" not in mongo_doc
-
-            assert "custom_vector" in mongo_doc
-            assert mongo_doc["custom_vector"] == [0.1, 0.2, 0.3]
-            assert "embedding" not in mongo_doc
-
-            assert "meta" in mongo_doc
-            assert mongo_doc["meta"] == {"test_meta": "test_value"}
-
-            # Test mongo_doc_to_haystack_doc
-            converted_doc = {
-                "id": "test_id",
-                "custom_text": "test content from mongo",
-                "custom_vector": [0.4, 0.5, 0.6],
-                "meta": {"mongo_meta": "mongo_value"},
-                "_id": "mongodb_internal_id",  # This should be removed
-            }
-
-            haystack_doc = custom_store._mongo_doc_to_haystack_doc(converted_doc)
-
-            # Check field mapping back to haystack format
-            assert haystack_doc.content == "test content from mongo"
-            assert haystack_doc.embedding == [0.4, 0.5, 0.6]
-            assert haystack_doc.meta == {"mongo_meta": "mongo_value"}
-            assert haystack_doc.id == "test_id"
-
-            # Make sure MongoDB's internal _id is removed
-            assert not hasattr(haystack_doc, "_id")
-
-        finally:
-            database[collection_name].drop()
-
-    @pytest.mark.integration
+class TestMongoDBDocumentStoreConversion:
     def test_document_conversion_with_unsupported_fields(self):
         """Test the document conversion with unsupported fields like sparse_embedding and dataframe."""
         docstore = MongoDBAtlasDocumentStore(
@@ -357,3 +292,52 @@ class TestDocumentStore(DocumentStoreBaseTests):
         mongo_doc = docstore._haystack_doc_to_mongo_doc(doc)
         # Verify dataframe was removed and warning was logged
         assert "dataframe" not in mongo_doc
+
+    def test_document_conversion_methods(self):
+        """Test the document conversion helper methods with custom field mappings."""
+        # Create a document store with custom field names - no need for real DB connection in unit test
+        custom_store = MongoDBAtlasDocumentStore(
+            database_name="test_db",
+            collection_name="test_collection",
+            vector_search_index="test_index",
+            full_text_search_index="test_index",
+            embedding_field="custom_vector",
+            content_field="custom_text",
+        )
+
+        # Test haystack_doc_to_mongo_doc
+        haystack_doc = Document(content="test content", embedding=[0.1, 0.2, 0.3], meta={"test_meta": "test_value"})
+
+        mongo_doc = custom_store._haystack_doc_to_mongo_doc(haystack_doc)
+
+        # Check field mapping
+        assert "custom_text" in mongo_doc
+        assert mongo_doc["custom_text"] == "test content"
+        assert "content" not in mongo_doc
+
+        assert "custom_vector" in mongo_doc
+        assert mongo_doc["custom_vector"] == [0.1, 0.2, 0.3]
+        assert "embedding" not in mongo_doc
+
+        assert "meta" in mongo_doc
+        assert mongo_doc["meta"] == {"test_meta": "test_value"}
+
+        # Test mongo_doc_to_haystack_doc
+        converted_doc = {
+            "id": "test_id",
+            "custom_text": "test content from mongo",
+            "custom_vector": [0.4, 0.5, 0.6],
+            "meta": {"mongo_meta": "mongo_value"},
+            "_id": "mongodb_internal_id",  # This should be removed
+        }
+
+        haystack_doc = custom_store._mongo_doc_to_haystack_doc(converted_doc)
+
+        # Check field mapping back to haystack format
+        assert haystack_doc.content == "test content from mongo"
+        assert haystack_doc.embedding == [0.4, 0.5, 0.6]
+        assert haystack_doc.meta == {"mongo_meta": "mongo_value"}
+        assert haystack_doc.id == "test_id"
+
+        # Make sure MongoDB's internal _id is removed
+        assert not hasattr(haystack_doc, "_id")

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -322,7 +322,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
             database[collection_name].drop()
 
     @pytest.mark.integration
-    def test_document_conversion_with_unsupported_fields(self, caplog):
+    def test_document_conversion_with_unsupported_fields(self):
         """Test the document conversion with unsupported fields like sparse_embedding and dataframe."""
         docstore = MongoDBAtlasDocumentStore(
             database_name="haystack_integration_test",
@@ -340,16 +340,10 @@ class TestDocumentStore(DocumentStoreBaseTests):
         }
         doc = Document.from_dict(doc_dict)
 
-        # Convert to mongo doc and check for warning about sparse_embedding
-        with caplog.at_level("WARNING"):
-            mongo_doc = docstore._haystack_doc_to_mongo_doc(doc)
+        mongo_doc = docstore._haystack_doc_to_mongo_doc(doc)
 
         # Verify sparse_embedding was removed and warning was logged
         assert "sparse_embedding" not in mongo_doc
-        assert "sparse_embedding" in caplog.text
-        assert "not currently supported" in caplog.text
-
-        caplog.clear()
 
         # Test with dataframe
         doc_dict = {
@@ -360,11 +354,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
         }
         doc = Document.from_dict(doc_dict)
 
-        # Convert to mongo doc and check for warning about dataframe
-        with caplog.at_level("WARNING"):
-            mongo_doc = docstore._haystack_doc_to_mongo_doc(doc)
-
+        mongo_doc = docstore._haystack_doc_to_mongo_doc(doc)
         # Verify dataframe was removed and warning was logged
         assert "dataframe" not in mongo_doc
-        assert "dataframe" in caplog.text
-        assert "no longer supports dataframes" in caplog.text

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -192,7 +192,6 @@ class TestDocumentStore(DocumentStoreBaseTests):
                 # Verify that the correct embedding field was used in the pipeline
                 args = mock_collection.aggregate.call_args[0][0]
                 assert args[0]["$vectorSearch"]["path"] == "custom_vector"
-                assert args[1]["$project"]["custom_vector"] == 1
 
         finally:
             database[collection_name].drop()

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -195,3 +195,176 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
         finally:
             database[collection_name].drop()
+
+    @pytest.mark.integration
+    def test_custom_content_field(self):
+        """Test that the custom content field is correctly used in the document store."""
+        # Create a document store with a custom content field
+        database_name = "haystack_integration_test"
+        collection_name = "test_custom_content_" + str(uuid4())
+
+        connection: MongoClient = MongoClient(
+            os.environ["MONGO_CONNECTION_STRING"], driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
+        )
+        database = connection[database_name]
+        if collection_name in database.list_collection_names():
+            database[collection_name].drop()
+        database.create_collection(collection_name)
+        database[collection_name].create_index("id", unique=True)
+
+        try:
+            custom_field_store = MongoDBAtlasDocumentStore(
+                database_name=database_name,
+                collection_name=collection_name,
+                vector_search_index="cosine_index",
+                full_text_search_index="full_text_index",
+                content_field="custom_text",
+            )
+
+            # Check that the content field is correctly set
+            assert custom_field_store.content_field == "custom_text"
+
+            # Write a document with standard content field
+            doc = Document(content="test content")
+            custom_field_store.write_documents([doc])
+
+            # Verify it's stored with the custom field name in MongoDB
+            database_doc = database[collection_name].find_one({"id": doc.id})
+            assert "custom_text" in database_doc
+            assert database_doc["custom_text"] == "test content"
+            assert "content" not in database_doc
+
+            # Retrieve the document and verify it has the standard content field
+            retrieved_docs = custom_field_store.filter_documents()
+            assert len(retrieved_docs) == 1
+            assert retrieved_docs[0].content == "test content"
+
+            # This is a mock test for text search
+            with patch.object(custom_field_store, "_collection") as mock_collection:
+                # Setup the mock
+                mock_collection.aggregate.return_value = []
+
+                # Execute the method
+                custom_field_store._fulltext_retrieval(query="test query")
+
+                # Verify that the text search is using the standard content path
+                # Note: The content path in _fulltext_retrieval is hardcoded to "content"
+                args = mock_collection.aggregate.call_args[0][0]
+                assert args[0]["$search"]["compound"]["must"][0]["text"]["path"] == "content"
+
+        finally:
+            database[collection_name].drop()
+
+    @pytest.mark.integration
+    def test_document_conversion_methods(self):
+        """Test the document conversion helper methods with custom field mappings."""
+        database_name = "haystack_integration_test"
+        collection_name = "test_document_conversion_" + str(uuid4())
+
+        connection: MongoClient = MongoClient(
+            os.environ["MONGO_CONNECTION_STRING"], driver=DriverInfo(name="MongoDBAtlasHaystackIntegration")
+        )
+        database = connection[database_name]
+        if collection_name in database.list_collection_names():
+            database[collection_name].drop()
+        database.create_collection(collection_name)
+        database[collection_name].create_index("id", unique=True)
+
+        try:
+            # Create a document store with custom field names
+            custom_store = MongoDBAtlasDocumentStore(
+                database_name=database_name,
+                collection_name=collection_name,
+                vector_search_index="cosine_index",
+                full_text_search_index="full_text_index",
+                embedding_field="custom_vector",
+                content_field="custom_text",
+            )
+
+            # Test haystack_doc_to_mongo_doc
+            haystack_doc = Document(content="test content", embedding=[0.1, 0.2, 0.3], meta={"test_meta": "test_value"})
+
+            mongo_doc = custom_store._haystack_doc_to_mongo_doc(haystack_doc)
+
+            # Check field mapping
+            assert "custom_text" in mongo_doc
+            assert mongo_doc["custom_text"] == "test content"
+            assert "content" not in mongo_doc
+
+            assert "custom_vector" in mongo_doc
+            assert mongo_doc["custom_vector"] == [0.1, 0.2, 0.3]
+            assert "embedding" not in mongo_doc
+
+            assert "meta" in mongo_doc
+            assert mongo_doc["meta"] == {"test_meta": "test_value"}
+
+            # Test mongo_doc_to_haystack_doc
+            converted_doc = {
+                "id": "test_id",
+                "custom_text": "test content from mongo",
+                "custom_vector": [0.4, 0.5, 0.6],
+                "meta": {"mongo_meta": "mongo_value"},
+                "_id": "mongodb_internal_id",  # This should be removed
+            }
+
+            haystack_doc = custom_store._mongo_doc_to_haystack_doc(converted_doc)
+
+            # Check field mapping back to haystack format
+            assert haystack_doc.content == "test content from mongo"
+            assert haystack_doc.embedding == [0.4, 0.5, 0.6]
+            assert haystack_doc.meta == {"mongo_meta": "mongo_value"}
+            assert haystack_doc.id == "test_id"
+
+            # Make sure MongoDB's internal _id is removed
+            assert not hasattr(haystack_doc, "_id")
+
+        finally:
+            database[collection_name].drop()
+
+    @pytest.mark.integration
+    def test_document_conversion_with_unsupported_fields(self, caplog):
+        """Test the document conversion with unsupported fields like sparse_embedding and dataframe."""
+        docstore = MongoDBAtlasDocumentStore(
+            database_name="haystack_integration_test",
+            collection_name="test_collection",
+            vector_search_index="cosine_index",
+            full_text_search_index="full_text_index",
+        )
+
+        # Create a document with sparse_embedding
+        doc_dict = {
+            "id": "test_id",
+            "content": "test content",
+            "embedding": [0.1, 0.2, 0.3],
+            "sparse_embedding": {"indices": [1, 2, 3], "values": [0.1, 0.2, 0.3]},
+        }
+        doc = Document.from_dict(doc_dict)
+
+        # Convert to mongo doc and check for warning about sparse_embedding
+        with caplog.at_level("WARNING"):
+            mongo_doc = docstore._haystack_doc_to_mongo_doc(doc)
+
+        # Verify sparse_embedding was removed and warning was logged
+        assert "sparse_embedding" not in mongo_doc
+        assert "sparse_embedding" in caplog.text
+        assert "not currently supported" in caplog.text
+
+        caplog.clear()
+
+        # Test with dataframe
+        doc_dict = {
+            "id": "test_id2",
+            "content": "test content",
+            "embedding": [0.1, 0.2, 0.3],
+            "dataframe": {"some": "dataframe"},
+        }
+        doc = Document.from_dict(doc_dict)
+
+        # Convert to mongo doc and check for warning about dataframe
+        with caplog.at_level("WARNING"):
+            mongo_doc = docstore._haystack_doc_to_mongo_doc(doc)
+
+        # Verify dataframe was removed and warning was logged
+        assert "dataframe" not in mongo_doc
+        assert "dataframe" in caplog.text
+        assert "no longer supports dataframes" in caplog.text

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -122,8 +122,8 @@ class TestFullTextRetrieval:
         # Verify the pipeline structure
         assert len(actual_pipeline) == 5
         assert "$limit" in actual_pipeline[2]
-        assert "$project" in actual_pipeline[3]
-        assert "$addFields" in actual_pipeline[4]
+        assert "$addFields" in actual_pipeline[3]
+        assert "$project" in actual_pipeline[4]
 
     def test_query_retrieval(self, document_store: MongoDBAtlasDocumentStore):
         results = document_store._fulltext_retrieval(query="fox", top_k=2)

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -25,10 +25,10 @@ def get_document_store(**kwargs):
     )
 
 
-@pytest.mark.skipif(
-    not os.environ.get("MONGO_CONNECTION_STRING_2"),
-    reason="No MongoDB Atlas connection string provided",
-)
+# @pytest.mark.skipif(
+#     not os.environ.get("MONGO_CONNECTION_STRING_2"),
+#     reason="No MongoDB Atlas connection string provided",
+# )
 @pytest.mark.integration
 class TestFullTextRetrieval:
     @pytest.fixture(scope="class")
@@ -119,7 +119,7 @@ class TestFullTextRetrieval:
         # in the text search, regardless of the content_field parameter
         assert actual_pipeline[0]["$search"]["compound"]["must"][0]["text"]["path"] == "content"
 
-        # Verify the pipeline structurefasdf
+        # Verify the pipeline structure
         assert len(actual_pipeline) == 5
         assert "$limit" in actual_pipeline[2]
         assert "$project" in actual_pipeline[3]

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -14,13 +14,14 @@ from haystack.utils import Secret
 from haystack_integrations.document_stores.mongodb_atlas import MongoDBAtlasDocumentStore
 
 
-def get_document_store():
+def get_document_store(**kwargs):
     return MongoDBAtlasDocumentStore(
         mongo_connection_string=Secret.from_env_var("MONGO_CONNECTION_STRING_2"),
         database_name="haystack_test",
         collection_name="test_collection",
         vector_search_index="cosine_index",
         full_text_search_index="full_text_index",
+        **kwargs,
     )
 
 
@@ -90,19 +91,38 @@ class TestFullTextRetrieval:
             },
             {"$match": {"meta.meta_field": {"$eq": "right_value"}}},
             {"$limit": 5},
-            {
-                "$project": {
-                    "_id": 0,
-                    "blob": 1,
-                    "content": 1,
-                    "embedding": 1,
-                    "meta": 1,
-                    "score": {"$meta": "searchScore"},
-                }
-            },
+            {"$addFields": {"score": {"$meta": "searchScore"}}},
+            {"$project": {"_id": 0}},
         ]
 
         assert actual_pipeline == expected_pipeline
+
+    def test_pipeline_with_custom_content_field(self, document_store):
+        # Create a document store with a custom content field
+        document_store = get_document_store(content_field="custom_text")
+        mock_collection = MagicMock()
+        document_store._collection = mock_collection
+        mock_collection.aggregate.return_value = []
+
+        # Execute the fulltext retrieval with the custom content field
+        document_store._fulltext_retrieval(
+            query="test query",
+            top_k=3,
+        )
+
+        # Assert aggregate was called with the correct pipeline
+        assert mock_collection.aggregate.called
+        actual_pipeline = mock_collection.aggregate.call_args[0][0]
+
+        # Verify the text search path is still "content" in the search pipeline
+        # This is important because the current implementation hardcodes "content" as the path
+        # in the text search, regardless of the content_field parameter
+        assert actual_pipeline[0]["$search"]["compound"]["must"][0]["text"]["path"] == "content"
+
+        # Verify the pipeline structure
+        assert len(actual_pipeline) == 4
+        assert "$addFields" in actual_pipeline[2]
+        assert "$project" in actual_pipeline[3]
 
     def test_query_retrieval(self, document_store: MongoDBAtlasDocumentStore):
         results = document_store._fulltext_retrieval(query="fox", top_k=2)

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -25,10 +25,10 @@ def get_document_store(**kwargs):
     )
 
 
-# @pytest.mark.skipif(
-#     not os.environ.get("MONGO_CONNECTION_STRING_2"),
-#     reason="No MongoDB Atlas connection string provided",
-# )
+@pytest.mark.skipif(
+    not os.environ.get("MONGO_CONNECTION_STRING_2"),
+    reason="No MongoDB Atlas connection string provided",
+)
 @pytest.mark.integration
 class TestFullTextRetrieval:
     @pytest.fixture(scope="class")

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -120,7 +120,7 @@ class TestFullTextRetrieval:
         assert actual_pipeline[0]["$search"]["compound"]["must"][0]["text"]["path"] == "content"
 
         # Verify the pipeline structure
-        assert len(actual_pipeline) == 4
+        assert len(actual_pipeline) == 5
         assert "$addFields" in actual_pipeline[2]
         assert "$project" in actual_pipeline[3]
 

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -119,10 +119,11 @@ class TestFullTextRetrieval:
         # in the text search, regardless of the content_field parameter
         assert actual_pipeline[0]["$search"]["compound"]["must"][0]["text"]["path"] == "content"
 
-        # Verify the pipeline structure
+        # Verify the pipeline structurefasdf
         assert len(actual_pipeline) == 5
-        assert "$addFields" in actual_pipeline[2]
+        assert "$limit" in actual_pipeline[2]
         assert "$project" in actual_pipeline[3]
+        assert "$addFields" in actual_pipeline[4]
 
     def test_query_retrieval(self, document_store: MongoDBAtlasDocumentStore):
         results = document_store._fulltext_retrieval(query="fox", top_k=2)


### PR DESCRIPTION
### Related Issues
- Allows defining an embedding field & content field that is used to load the documents content and embedding. This is particularly helpful for existing indexes that contain some sort of textfield and an embedding

### Changes 
- add a key `content_field` thats used to identify the `content` field of haystack docs while loading 
- apply the loading logic to the embedding vector key mapping `embedding_field`
- remove the unnessary projections. The whole docstore shoud anyways mainly works with haystack (with an exception of the two cases above). Therefore we don't need to remove some keys when we load the same ones. Benefit here is just that for existing datasets, the rest will just end up in the metadata key. 
       ⚠️ just keep in mind that either you can load the flattened or the `meta` nesting


GH summary:
This pull request introduces enhancements to the `MongoDBAtlasDocumentStore` class, focusing on improving flexibility, modularity, and code maintainability. The key changes include the addition of a `content_field` parameter for better control over document content mapping, the refactoring of document conversion methods, and updates to MongoDB aggregation pipelines.

### New Features:
* Added a `content_field` parameter to the `__init__` method, allowing users to specify which field in the database should be treated as the document content when integrating with existing databases. This is discouraged for indexes created by Haystack. (`document_store.py`, [[1]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fR69) [[2]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fR90-R93) [[3]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fR107)

### Refactoring:
* Replaced inline document conversion logic in `filter_documents`, `filter_documents_async`, `write_documents`, and `write_documents_async` methods with reusable `_mongo_doc_to_haystack_doc` and `_haystack_doc_to_mongo_doc` helper methods. These methods handle field mappings and warnings for unsupported fields like `sparse_embedding` and `dataframe`. (`document_store.py`, [[1]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL295-R301) [[2]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL312-R316) [[3]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL337-R339) [[4]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL393-R384) [[5]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL775-R752)

### MongoDB Pipeline Updates:
* Refactored aggregation pipelines in `_embedding_retrieval`, `_embedding_retrieval_async`, `_fulltext_retrieval`, and `_fulltext_retrieval_async` methods to use `"$addFields"` for adding metadata scores and `"$project"` for excluding `_id` fields. This simplifies the pipeline structure and improves maintainability. (`document_store.py`, [[1]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL480-R450) [[2]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL491-R462) [[3]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL537-R499) [[4]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL548-R511) [[5]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL640-R594) [[6]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL650-R605) [[7]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL740-R686) [[8]](diffhunk://#diff-59f69a09d98f9712f13798f7c0efa00058f3528d4898cc00343887f093272a5fL750-R697)

These changes enhance the usability of the `MongoDBAtlasDocumentStore` and make the codebase more modular and easier to maintain.



### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
