### PR TITLE
refactor: add AmazonBedrockRanker and keep BedrockRanker as alias

### DIFF
--- a/integrations/amazon_bedrock/pydoc/config.yml
+++ b/integrations/amazon_bedrock/pydoc/config.yml
@@ -18,6 +18,8 @@ processors:
     documented_only: true
     do_not_filter_modules: false
     skip_empty_modules: true
+  - type: filter
+    expression: "name not in ['BedrockRanker']"
   - type: smart
   - type: crossref
 renderer:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/__init__.py
@@ -1,3 +1,3 @@
-from .ranker import BedrockRanker
+from .ranker import AmazonBedrockRanker, BedrockRanker
 
-__all__ = ["BedrockRanker"]
+__all__ = ["AmazonBedrockRanker", "BedrockRanker"]

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, List, Optional
 import warnings
+from typing import Any, Dict, List, Optional
 
 from botocore.exceptions import ClientError
 from haystack import Document, component, default_from_dict, default_to_dict, logging
@@ -33,7 +33,11 @@ class AmazonBedrockRanker:
     from haystack.utils import Secret
     from haystack_integrations.components.rankers.amazon_bedrock import AmazonBedrockRanker
 
-    ranker = AmazonBedrockRanker(model="cohere.rerank-v3-5:0", top_k=2, aws_region_name=Secret.from_token("eu-central-1"))
+    ranker = AmazonBedrockRanker(
+        model="cohere.rerank-v3-5:0",
+        top_k=2,
+        aws_region_name=Secret.from_token("eu-central-1")
+    )
 
     docs = [Document(content="Paris"), Document(content="Berlin")]
     query = "What is the capital of germany?"

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+import warnings
 
 from botocore.exceptions import ClientError
 from haystack import Document, component, default_from_dict, default_to_dict, logging
@@ -16,7 +17,7 @@ MAX_NUM_DOCS_FOR_BEDROCK_RANKER = 1000
 
 
 @component
-class BedrockRanker:
+class AmazonBedrockRanker:
     """
     Ranks Documents based on their similarity to the query using Amazon Bedrock's Cohere Rerank model.
 
@@ -30,9 +31,9 @@ class BedrockRanker:
     ```python
     from haystack import Document
     from haystack.utils import Secret
-    from haystack_integrations.components.rankers.amazon_bedrock import BedrockRanker
+    from haystack_integrations.components.rankers.amazon_bedrock import AmazonBedrockRanker
 
-    ranker = BedrockRanker(model="cohere.rerank-v3-5:0", top_k=2, aws_region_name=Secret.from_token("eu-central-1"))
+    ranker = AmazonBedrockRanker(model="cohere.rerank-v3-5:0", top_k=2, aws_region_name=Secret.from_token("eu-central-1"))
 
     docs = [Document(content="Paris"), Document(content="Berlin")]
     query = "What is the capital of germany?"
@@ -40,7 +41,7 @@ class BedrockRanker:
     docs = output["documents"]
     ```
 
-    BedrockRanker uses AWS for authentication. You can use the AWS CLI to authenticate through your IAM.
+    AmazonBedrockRanker uses AWS for authentication. You can use the AWS CLI to authenticate through your IAM.
     For more information on setting up an IAM identity-based policy, see [Amazon Bedrock documentation]
     (https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html).
 
@@ -71,7 +72,7 @@ class BedrockRanker:
             msg = "'model' cannot be None or empty string"
             raise ValueError(msg)
         """
-        Creates an instance of the 'BedrockRanker'.
+        Creates an instance of the 'AmazonBedrockRanker'.
 
         :param model: Amazon Bedrock model name for Cohere Rerank. Default is "cohere.rerank-v3-5:0".
         :param top_k: The maximum number of documents to return.
@@ -140,7 +141,7 @@ class BedrockRanker:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "BedrockRanker":
+    def from_dict(cls, data: Dict[str, Any]) -> "AmazonBedrockRanker":
         """
         Deserializes the component from a dictionary.
 
@@ -260,3 +261,20 @@ class BedrockRanker:
         except Exception as e:
             msg = f"Error during Amazon Bedrock API call: {e!s}"
             raise AmazonBedrockInferenceError(msg) from e
+
+
+class BedrockRanker(AmazonBedrockRanker):
+    """
+    Deprecated alias for AmazonBedrockRanker.
+    This class will be removed in a future version.
+    Please use AmazonBedrockRanker instead.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "BedrockRanker is deprecated and will be removed in a future version. "
+            "Please use AmazonBedrockRanker instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,7 +9,7 @@ from haystack.utils import Secret
 from haystack_integrations.common.amazon_bedrock.errors import (
     AmazonBedrockInferenceError,
 )
-from haystack_integrations.components.rankers.amazon_bedrock import BedrockRanker
+from haystack_integrations.components.rankers.amazon_bedrock import AmazonBedrockRanker, BedrockRanker
 
 
 @pytest.fixture
@@ -19,8 +20,8 @@ def mock_aws_session():
         yield mock_client
 
 
-def test_bedrock_ranker_initialization(mock_aws_session):
-    ranker = BedrockRanker(
+def test_amazon_bedrock_ranker_initialization(mock_aws_session):
+    ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",
         top_k=2,
         aws_access_key_id=Secret.from_token("test_access_key"),
@@ -60,8 +61,8 @@ def test_bedrock_ranker_run(mock_aws_session):
         "This test requires AWS credentials to run."
     ),
 )
-def test_bedrock_ranker_live_run():
-    ranker = BedrockRanker(
+def test_amazon_bedrock_ranker_live_run():
+    ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",
         top_k=2,
         aws_region_name=Secret.from_token("eu-central-1"),
@@ -73,8 +74,8 @@ def test_bedrock_ranker_live_run():
     assert isinstance(result["documents"][0].score, float)
 
 
-def test_bedrock_ranker_run_inference_error(mock_aws_session):
-    ranker = BedrockRanker(
+def test_amazon_bedrock_ranker_run_inference_error(mock_aws_session):
+    ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",
         top_k=2,
         aws_access_key_id=Secret.from_token("test_access_key"),
@@ -89,21 +90,21 @@ def test_bedrock_ranker_run_inference_error(mock_aws_session):
         ranker.run(query="test query", documents=docs)
 
 
-def test_bedrock_ranker_serialization(mock_aws_session):
-    ranker = BedrockRanker(model="cohere.rerank-v3-5:0", top_k=2)
+def test_amazon_bedrock_ranker_serialization(mock_aws_session):
+    ranker = AmazonBedrockRanker(model="cohere.rerank-v3-5:0", top_k=2)
 
     serialized = ranker.to_dict()
     assert serialized["init_parameters"]["model"] == "cohere.rerank-v3-5:0"
     assert serialized["init_parameters"]["top_k"] == 2
 
-    deserialized = BedrockRanker.from_dict(serialized)
-    assert isinstance(deserialized, BedrockRanker)
+    deserialized = AmazonBedrockRanker.from_dict(serialized)
+    assert isinstance(deserialized, AmazonBedrockRanker)
     assert deserialized.model_name == "cohere.rerank-v3-5:0"
     assert deserialized.top_k == 2
 
 
-def test_bedrock_ranker_empty_documents(mock_aws_session):
-    ranker = BedrockRanker(
+def test_amazon_bedrock_ranker_empty_documents(mock_aws_session):
+    ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",
         top_k=2,
         aws_access_key_id=Secret.from_token("test_access_key"),

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/haystack-core-integrations/issues/1544

### Proposed Changes:

- Rename BedrockRanker to AmazonBedrockRanker but keep BedrockRanker as an alias inheriting from AmazonBedrockRanker
- Exclude BedrockRanker from pydocs config
- Expose both AmazonBedrockRanker and BedrockRanker in module init file
- Add deprecation warning to BedrockRanker init

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
