### PR TITLE
chore: extend error message for unknown model family in AmazonBedrockGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -271,8 +271,8 @@ class AmazonBedrockGenerator:
             f"Could not auto-detect model family of {model}. "
             f"`model_family` parameter must be one of {get_args(cls.MODEL_FAMILIES)}. "
             "We highly recommend using the `AmazonBedrockChatGenerator` instead. "
-            "It has support additional support for Amazon's Nova Canvas, Nova Lite, "
-            "Nova Pro models, DeepSeek's DeepSeek-R1, and more. "
+            "It has additional support for Amazon's Nova Canvas, Nova Lite, "
+            "Nova Pro, DeepSeek's DeepSeek-R1, and more models. "
             "See https://haystack.deepset.ai/integrations/amazon-bedrock"
         )
         raise AmazonBedrockConfigurationError(msg)

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -269,7 +269,11 @@ class AmazonBedrockGenerator:
 
         msg = (
             f"Could not auto-detect model family of {model}. "
-            f"`model_family` parameter must be one of {get_args(cls.MODEL_FAMILIES)}."
+            f"`model_family` parameter must be one of {get_args(cls.MODEL_FAMILIES)}. "
+            "We highly recommend using the `AmazonBedrockChatGenerator` instead. "
+            "It has support additional support for Amazon's Nova Canvas, Nova Lite, "
+            "Nova Pro models, DeepSeek's DeepSeek-R1, and more. "
+            "See https://haystack.deepset.ai/integrations/amazon-bedrock"
         )
         raise AmazonBedrockConfigurationError(msg)
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -270,10 +270,10 @@ class AmazonBedrockGenerator:
         msg = (
             f"Could not auto-detect model family of {model}. "
             f"`model_family` parameter must be one of {get_args(cls.MODEL_FAMILIES)}. "
-            "We highly recommend using the `AmazonBedrockChatGenerator` instead. "
-            "It has additional support for Amazon's Nova Canvas, Nova Lite, "
-            "Nova Pro, DeepSeek's DeepSeek-R1, and more models. "
-            "See https://haystack.deepset.ai/integrations/amazon-bedrock"
+            f"We highly recommend using the `AmazonBedrockChatGenerator` instead. "
+            f"It has additional support for Amazon's Nova Canvas, Nova Lite, "
+            f"Nova Pro, DeepSeek's DeepSeek-R1, and more models. "
+            f"See https://haystack.deepset.ai/integrations/amazon-bedrock"
         )
         raise AmazonBedrockConfigurationError(msg)
 


### PR DESCRIPTION
### Related Issues

- fixes #1673

### Proposed Changes:

- Extend error message shown when the model family could not be detected, which means it is unsupported

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
