### PR TITLE
docs: add missing STACKIT Embedders to API Reference

### DIFF
--- a/integrations/stackit/pydoc/config.yml
+++ b/integrations/stackit/pydoc/config.yml
@@ -3,6 +3,8 @@ loaders:
     search_path: [../src]
     modules: [
       "haystack_integrations.components.generators.stackit.chat.chat_generator",
+      "haystack_integrations.components.embedders.stackit.document_embedder",
+      "haystack_integrations.components.embedders.stackit.text_embedder",
     ]
     ignore_when_discovered: ["__init__"]
 processors:


### PR DESCRIPTION
### Proposed Changes:

Add currently missing STACKIT Embedders to API Reference.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
