### PR TITLE
docs: update ChatMessage examples

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
@@ -51,11 +51,12 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
     response = client.run(messages)
     print(response)
 
-    >> {'replies': [ChatMessage(content='Natural Language Processing (NLP) is a field of artificial intelligence that
+    >> {'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text=
+    >> "Natural Language Processing (NLP) is a field of artificial intelligence that
     >> focuses on enabling computers to understand, interpret, and generate human language. It involves developing
     >> techniques and algorithms to analyze and process text or speech data, allowing machines to comprehend and
-    >> communicate in natural languages like English, Spanish, or Chinese.', role=<ChatRole.ASSISTANT: 'assistant'>,
-    >> name=None, meta={'model': 'claude-3-sonnet@20240229', 'index': 0, 'finish_reason': 'end_turn',
+    >> communicate in natural languages like English, Spanish, or Chinese.")],
+    >> _name=None, _meta={'model': 'claude-3-sonnet@20240229', 'index': 0, 'finish_reason': 'end_turn',
     >> 'usage': {'input_tokens': 15, 'output_tokens': 64}})]}
     ```
 

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -48,11 +48,12 @@ class MistralChatGenerator(OpenAIChatGenerator):
     response = client.run(messages)
     print(response)
 
-    >>{'replies': [ChatMessage(content='Natural Language Processing (NLP) is a branch of artificial intelligence
-    >>that focuses on enabling computers to understand, interpret, and generate human language in a way that is
-    >>meaningful and useful.', role=<ChatRole.ASSISTANT: 'assistant'>, name=None,
-    >>meta={'model': 'mistral-small-latest', 'index': 0, 'finish_reason': 'stop',
-    >>'usage': {'prompt_tokens': 15, 'completion_tokens': 36, 'total_tokens': 51}})]}
+    >>{'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text=
+    >> "Natural Language Processing (NLP) is a branch of artificial intelligence
+    >> that focuses on enabling computers to understand, interpret, and generate human language in a way that is
+    >> meaningful and useful.")], _name=None,
+    >> _meta={'model': 'mistral-small-latest', 'index': 0, 'finish_reason': 'stop',
+    >> 'usage': {'prompt_tokens': 15, 'completion_tokens': 36, 'total_tokens': 51}})]}
     ```
     """
 


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/9366

### Proposed Changes:

- Fixing example ChatMessage responses to include TextContent, fix `_name` and `_meta` format.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
