### PR TITLE
test: Update how test skipping works in Langfuse

### DIFF
--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -57,6 +57,10 @@ def basic_pipeline(llm_class, expected_trace):
     return pipe
 
 
+@pytest.mark.skipif(
+    not all([os.environ.get("LANGFUSE_SECRET_KEY"), os.environ.get("LANGFUSE_PUBLIC_KEY")]),
+    reason="Missing required environment variables: LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY",
+)
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "llm_class, env_var, expected_trace",
@@ -68,7 +72,7 @@ def basic_pipeline(llm_class, expected_trace):
 )
 def test_tracing_integration(llm_class, env_var, expected_trace, basic_pipeline):
     if not all([os.environ.get("LANGFUSE_SECRET_KEY"), os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get(env_var)]):
-        pytest.skip(f"Missing required environment variables: LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, or {env_var}")
+        pytest.skip(f"Missing required environment variable: {env_var}")
 
     messages = [
         ChatMessage.from_system("Always respond in German even if some input data is in other languages."),
@@ -102,14 +106,18 @@ def test_tracing_integration(llm_class, env_var, expected_trace, basic_pipeline)
     assert res_json["observations"][0]["type"] == "GENERATION"
 
 
+@pytest.mark.skipif(
+    not all(
+        [
+            os.environ.get("LANGFUSE_SECRET_KEY"),
+            os.environ.get("LANGFUSE_PUBLIC_KEY"),
+            os.environ.get("OPENAI_API_KEY"),
+        ]
+    ),
+    reason="Missing required environment variables: LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY",
+)
 @pytest.mark.integration
 def test_tracing_with_sub_pipelines():
-    if not all(
-        [os.environ.get("LANGFUSE_SECRET_KEY"), os.environ.get("LANGFUSE_PUBLIC_KEY"), os.environ.get("OPENAI_API_KEY")]
-    ):
-        pytest.skip(
-            f"Missing required environment variables: LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, or OPENAI_API_KEY"
-        )
 
     @component
     class SubGenerator:


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Integration test skipping wasn't working as intended meaning when community members opened PRs that updated Langfuse the tests failed instead of skipped.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Ran tests locally with unset env variables to check they were skipped

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
