### PR TITLE
test: Ollama - make `test_run_with_response_format` more robust

### DIFF
--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -574,10 +574,11 @@ class TestOllamaChatGenerator:
         response_format = {
             "type": "object",
             "properties": {"capital": {"type": "string"}, "population": {"type": "number"}},
+            "required": ["capital", "population"],
         }
         chat_generator = OllamaChatGenerator(model="llama3.2:3b", response_format=response_format)
 
-        message = ChatMessage.from_user("What's the capital of France and its population?")
+        message = ChatMessage.from_user("What's the capital of France and its population? Respond in JSON format.")
         response = chat_generator.run([message])
 
         assert isinstance(response, dict)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
