### PR TITLE
feat: GoogleAIGeminiChatGenerator - add `Toolset` support

### DIFF
--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -18,15 +18,14 @@ from haystack.core.component import component
 from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import AsyncStreamingCallbackT, StreamingCallbackT, StreamingChunk, select_streaming_callback
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole, ToolCall
-from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
+from haystack.tools import (
+    Tool,
+    _check_duplicate_tool_names,
+    deserialize_tools_or_toolset_inplace,
+    serialize_tools_or_toolset,
+)
 from haystack.tools.toolset import Toolset
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
-
-# Compatibility with Haystack 2.12.0 and 2.13.0 - remove after 2.13.0 is released
-try:
-    from haystack.tools import deserialize_tools_or_toolset_inplace
-except ImportError:
-    from haystack.tools import deserialize_tools_inplace as deserialize_tools_or_toolset_inplace
 
 logger = logging.getLogger(__name__)
 
@@ -268,8 +267,9 @@ class GoogleAIGeminiChatGenerator:
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param tools:
-            A list of tools or a Toolset for which the model can prepare calls. If set, it will override the `tools` parameter set
-            during component initialization. This parameter can accept either a list of `Tool` objects or a `Toolset` instance.
+            A list of tools or a Toolset for which the model can prepare calls. If set, it will
+            override the `tools` parameter set during component initialization. This parameter
+            can accept either a list of `Tool` objects or a `Toolset` instance.
         :returns:
             A dictionary containing the following key:
             - `replies`:  A list containing the generated responses as `ChatMessage` instances.
@@ -322,8 +322,9 @@ class GoogleAIGeminiChatGenerator:
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param tools:
-            A list of tools or a Toolset for which the model can prepare calls. If set, it will override the `tools` parameter set
-            during component initialization. This parameter can accept either a list of `Tool` objects or a `Toolset` instance.
+            A list of tools or a Toolset for which the model can prepare calls. If set, it will
+            override the `tools` parameter set during component initialization. This parameter can
+            accept either a list of `Tool` objects or a `Toolset` instance.
         :returns:
             A dictionary containing the following key:
             - `replies`:  A list containing the generated responses as `ChatMessage` instances.

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -700,28 +700,28 @@ class TestGoogleAIGeminiChatGenerator:
     def test_init_with_toolset(self, tools, monkeypatch):
         """Test that the GoogleAIGeminiChatGenerator can be initialized with a Toolset."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test")
-        
+
         toolset = Toolset(tools)
-        
+
         with patch(
             "haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"
         ) as mock_genai_configure:
             gemini = GoogleAIGeminiChatGenerator(tools=toolset)
-            
+
         mock_genai_configure.assert_called_once_with(api_key="test")
         assert gemini._tools == toolset
 
     def test_to_dict_with_toolset(self, tools, monkeypatch):
         """Test that the GoogleAIGeminiChatGenerator can be serialized to a dictionary with a Toolset."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test")
-        
+
         toolset = Toolset(tools)
-        
+
         with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
             gemini = GoogleAIGeminiChatGenerator(tools=toolset)
-            
+
         data = gemini.to_dict()
-        
+
         expected_tools_data = {
             "type": "haystack.tools.toolset.Toolset",
             "data": {
@@ -745,13 +745,13 @@ class TestGoogleAIGeminiChatGenerator:
                                     }
                                 }
                             },
-                            "function": "haystack_integrations.components.generators.google_ai.chat.test_chat_gemini.get_current_weather",
+                            "function": "test_chat_gemini.get_current_weather",
                         }
                     }
                 ]
             }
         }
-        
+
         # Add compatibility fields for haystack 2.12.0+
         tool = tools[0]
         if hasattr(tool, "outputs_to_string"):
@@ -760,21 +760,20 @@ class TestGoogleAIGeminiChatGenerator:
             expected_tools_data["data"]["tools"][0]["data"]["inputs_from_state"] = tool.inputs_from_state
         if hasattr(tool, "outputs_to_state"):
             expected_tools_data["data"]["tools"][0]["data"]["outputs_to_state"] = tool.outputs_to_state
-            
         assert data["init_parameters"]["tools"] == expected_tools_data
 
     def test_from_dict_with_toolset(self, tools, monkeypatch):
         """Test that the GoogleAIGeminiChatGenerator can be deserialized from a dictionary with a Toolset."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test")
-        
+
         toolset = Toolset(tools)
-        
+
         with patch("haystack_integrations.components.generators.google_ai.chat.gemini.genai.configure"):
             gemini = GoogleAIGeminiChatGenerator(tools=toolset)
             data = gemini.to_dict()
-            
+
             deserialized_component = GoogleAIGeminiChatGenerator.from_dict(data)
-            
+
         assert isinstance(deserialized_component._tools, Toolset)
         assert len(deserialized_component._tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in deserialized_component._tools)

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -737,21 +737,21 @@ class TestGoogleAIGeminiChatGenerator:
                                     "city": {
                                         "default": "Munich",
                                         "type": "string",
-                                        "description": "the city for which to get the weather, e.g. 'San Francisco'"
+                                        "description": "the city for which to get the weather, e.g. 'San Francisco'",
                                     },
                                     "unit": {
                                         "default": "Celsius",
                                         "type": "string",
                                         "enum": ["Celsius", "Fahrenheit"],
-                                        "description": "the unit for the temperature"
-                                    }
-                                }
+                                        "description": "the unit for the temperature",
+                                    },
+                                },
                             },
                             "function": "test_chat_gemini.get_current_weather",
-                        }
+                        },
                     }
                 ]
-            }
+            },
         }
 
         # Add compatibility fields for haystack 2.12.0+

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -735,10 +735,12 @@ class TestGoogleAIGeminiChatGenerator:
                                 "type": "object",
                                 "properties": {
                                     "city": {
+                                        "default": "Munich",
                                         "type": "string",
                                         "description": "the city for which to get the weather, e.g. 'San Francisco'"
                                     },
                                     "unit": {
+                                        "default": "Celsius",
                                         "type": "string",
                                         "enum": ["Celsius", "Fahrenheit"],
                                         "description": "the unit for the temperature"


### PR DESCRIPTION
## Why:
Update GoogleAIGeminiChatGenerator to support initialization and run with a Toolset, aligning with other ChatGenerator implementations across the Haystack ecosystem.

## What:
- Modified the `tools` parameter in GoogleAIGeminiChatGenerator to accept either a list of `Tool` objects or a `Toolset` instance
- Simplified code by leveraging `serialize_tools_or_toolset` utility function
- Updated docstrings to clearly explain the support for both List[Tool] and Toolset formats
- Added unit tests to validate Toolset functionality

## How can it be used:
The GoogleAIGeminiChatGenerator can now be instantiated with a `Toolset`, enabling more flexible tool management:
```python
from haystack.tools import Tool, Toolset
from haystack_integrations.components.generators.google_ai import GoogleAIGeminiChatGenerator

# Create a toolset from your tools
toolset = Toolset(....

# Initialize with a toolset
generator = GoogleAIGeminiChatGenerator(
    api_key=Secret.from_token("your-api-key"), 
    tools=toolset
)

# Or provide a toolset at runtime
results = generator.run(messages=chat_messages, tools=toolset)
```

## How did you test it:
Added three dedicated test cases:
- `test_init_with_toolset`: Verifies initialization with a Toolset
- `test_to_dict_with_toolset`: Tests serialization with a Toolset
- `test_from_dict_with_toolset`: Validates deserialization with a Toolset

## Notes for the reviewer:
This implementation follows the same pattern used across other ChatGenerator components, ensuring a consistent interface throughout the Haystack ecosystem. Special care was taken to maintain backward compatibility with existing code that uses List[Tool].
