### PR TITLE
ci: Bedrock - improve worfklow; skip tests from CI

### DIFF
--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -27,7 +27,6 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   AWS_REGION: us-east-1
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
 jobs:
   run:
@@ -68,15 +67,15 @@ jobs:
 
       # Do not authenticate on pull requests from forks
       - name: AWS authentication
+        id: aws-auth
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
 
-      # Do not run integration tests on pull requests from forks
       - name: Run integration tests
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: success() && steps.aws-auth.outcome == 'success'
         run: hatch run cov-retry -m "integration"
 
       - name: Nightly - run unit tests with Haystack main branch

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, Dict, Optional
 
 import pytest
@@ -265,14 +264,8 @@ class TestAmazonBedrockChatGenerator:
         assert request_params["toolConfig"] == top_song_tool_config
 
 
+# In the CI, those tests are skipped if AWS Authentication fails
 @pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("AWS_CI_ROLE_ARN", None) and not os.environ.get("AWS_REGION", None),
-    reason=(
-        "Skipping test because AWS_CI_ROLE_ARN and AWS_REGION environment variables are not set. "
-        "This test requires AWS credentials to run."
-    ),
-)
 class TestAmazonBedrockChatGeneratorInference:
     @pytest.mark.parametrize("model_name", MODELS_TO_TEST)
     def test_default_inference_params(self, model_name, chat_messages):
@@ -437,14 +430,8 @@ class TestAmazonBedrockChatGeneratorInference:
         )
 
 
+# In the CI, those tests are skipped if AWS Authentication fails
 @pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("AWS_CI_ROLE_ARN", None) and not os.environ.get("AWS_REGION", None),
-    reason=(
-        "Skipping test because AWS_CI_ROLE_ARN and AWS_REGION environment variables are not set. "
-        "This test requires AWS credentials to run."
-    ),
-)
 class TestAmazonBedrockChatGeneratorAsyncInference:
     """
     Test class for async inference functionality of AmazonBedrockChatGenerator

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -52,14 +51,8 @@ def test_bedrock_ranker_run(mock_aws_session):
     assert result["documents"][1].score == 0.7
 
 
+# In the CI, those tests are skipped if AWS Authentication fails
 @pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("AWS_CI_ROLE_ARN", None) and not os.environ.get("AWS_REGION", None),
-    reason=(
-        "Skipping test because AWS_CI_ROLE_ARN and AWS_REGION environment variables are not set. "
-        "This test requires AWS credentials to run."
-    ),
-)
 def test_amazon_bedrock_ranker_live_run():
     ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",


### PR DESCRIPTION
### Related Issues

When working locally with Bedrock, I cannot run integration tests because they are skipped if `AWS_CI_ROLE_ARN` and `AWS_REGION` env vars are not set. `AWS_CI_ROLE_ARN` in particular is specific to Haystack CI. If the AWS account is properly configured and these skip conditions are removed, I can successfully run the integration tests.

### Proposed Changes:
- remove skipif condition from integration tests
- cosmetic refinements to GitHub workflow

### How did you test it?
- local tests
- CI: I have created this PR from a fork and integration tests are correctly skipped (from CI, not from tests code)

### Notes for the reviewer
In general, I found it hard to skip tests from code programmatically because I think that there are several different legitimate ways to authenticate to AWS. So I'm just relying on the CI for this aspect.

What will happen after this PR?

In the CI:
- PRs from our official branches will run authentication and integration tests will be executed
- PRs from forks will not run authentication and integration tests will be skipped

Local execution:
- With `hatch run test`, integration tests will run and fail if AWS account is not properly configured

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
