### PR TITLE
test: add `service_tier` to `test_convert_anthropic_chunk_to_streaming_chunk`

### DIFF
--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -355,6 +355,7 @@ class TestAnthropicChatGenerator:
                     "cache_creation_input_tokens": None,
                     "cache_read_input_tokens": None,
                     "server_tool_use": None,
+                    "service_tier": None,
                 },
             },
         }


### PR DESCRIPTION
### Related Issues

- failing nightly test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/15199181100/job/42749953346

### Proposed Changes:
- add the `service_tier` missing key to `test_convert_anthropic_chunk_to_streaming_chunk`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
