### PR TITLE
fix: Fix exposing Qdrant api-key in `metadata` field when running `to_dict`

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -46,7 +46,7 @@ class QdrantEmbeddingRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> None:
         """
         Create a QdrantEmbeddingRetriever component.
 
@@ -136,7 +136,7 @@ class QdrantEmbeddingRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Run the Embedding Retriever on the given input data.
 
@@ -180,7 +180,7 @@ class QdrantEmbeddingRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Asynchronously run the Embedding Retriever on the given input data.
 
@@ -252,7 +252,7 @@ class QdrantSparseEmbeddingRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> None:
         """
         Create a QdrantSparseEmbeddingRetriever component.
 
@@ -342,7 +342,7 @@ class QdrantSparseEmbeddingRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Run the Sparse Embedding Retriever on the given input data.
 
@@ -391,7 +391,7 @@ class QdrantSparseEmbeddingRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Asynchronously run the Sparse Embedding Retriever on the given input data.
 
@@ -473,7 +473,7 @@ class QdrantHybridRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> None:
         """
         Create a QdrantHybridRetriever component.
 
@@ -557,7 +557,7 @@ class QdrantHybridRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Run the Sparse Embedding Retriever on the given input data.
 
@@ -606,7 +606,7 @@ class QdrantHybridRetriever:
         score_threshold: Optional[float] = None,
         group_by: Optional[str] = None,
         group_size: Optional[int] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Asynchronously run the Sparse Embedding Retriever on the given input data.
 

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -1,6 +1,6 @@
 import inspect
 from itertools import islice
-from typing import Any, AsyncGenerator, ClassVar, Dict, Generator, List, Optional, Set, Union
+from typing import Any, AsyncGenerator, ClassVar, Dict, Generator, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import qdrant_client
@@ -21,6 +21,7 @@ from .converters import (
     convert_haystack_documents_to_qdrant_points,
     convert_id,
     convert_qdrant_point_to_haystack_document,
+    QdrantPoint
 )
 from .filters import convert_filters_to_qdrant
 
@@ -34,7 +35,7 @@ class QdrantStoreError(DocumentStoreError):
 FilterType = Dict[str, Union[Dict[str, Any], List[Any], str, int, float, bool]]
 
 
-def get_batches_from_generator(iterable, n):
+def get_batches_from_generator(iterable: List, n: int) -> Generator:
     """
     Batch elements of an iterable into fixed-length chunks or blocks.
     """
@@ -127,7 +128,7 @@ class QdrantDocumentStore:
         write_batch_size: int = 100,
         scroll_size: int = 10_000,
         payload_fields_to_index: Optional[List[dict]] = None,
-    ):
+    ) -> None:
         """
         :param location:
             If `memory` - use in-memory Qdrant instance.
@@ -164,7 +165,7 @@ class QdrantDocumentStore:
             Dimension of the embeddings.
         :param on_disk:
             Whether to store the collection on disk.
-        :param use_sparse_embedding:
+        :param use_sparse_embeddings:
             If set to `True`, enables support for sparse embeddings.
         :param sparse_idf:
             If set to `True`, computes the Inverse Document Frequency (IDF) when using sparse embeddings.
@@ -257,7 +258,7 @@ class QdrantDocumentStore:
         self.write_batch_size = write_batch_size
         self.scroll_size = scroll_size
 
-    def _initialize_client(self):
+    def _initialize_client(self) -> None:
         if self._client is None:
             client_params = self._prepare_client_params()
             self._client = qdrant_client.QdrantClient(**client_params)
@@ -273,7 +274,7 @@ class QdrantDocumentStore:
                 self.payload_fields_to_index,
             )
 
-    async def _initialize_async_client(self):
+    async def _initialize_async_client(self) -> None:
         """
         Returns the asynchronous Qdrant client, initializing it if necessary.
         """
@@ -627,8 +628,6 @@ class QdrantDocumentStore:
 
         :param ids:
             A list of document IDs to retrieve.
-        :param index:
-            The name of the index to retrieve documents from.
         :returns:
             A list of documents.
         """
@@ -660,8 +659,6 @@ class QdrantDocumentStore:
 
         :param ids:
             A list of document IDs to retrieve.
-        :param index:
-            The name of the index to retrieve documents from.
         :returns:
             A list of documents.
         """
@@ -1209,7 +1206,7 @@ class QdrantDocumentStore:
             )
             raise QdrantStoreError(msg) from ke
 
-    def _create_payload_index(self, collection_name: str, payload_fields_to_index: Optional[List[dict]] = None):
+    def _create_payload_index(self, collection_name: str, payload_fields_to_index: Optional[List[dict]] = None) -> None:
         """
         Create payload index for the collection if payload_fields_to_index is provided
         See: https://qdrant.tech/documentation/concepts/indexing/#payload-index
@@ -1228,7 +1225,7 @@ class QdrantDocumentStore:
 
     async def _create_payload_index_async(
         self, collection_name: str, payload_fields_to_index: Optional[List[dict]] = None
-    ):
+    ) -> None:
         """
         Asynchronously create payload index for the collection if payload_fields_to_index is provided
         See: https://qdrant.tech/documentation/concepts/indexing/#payload-index
@@ -1256,7 +1253,7 @@ class QdrantDocumentStore:
         sparse_idf: bool,
         on_disk: bool = False,
         payload_fields_to_index: Optional[List[dict]] = None,
-    ):
+    ) -> None:
         """
         Sets up the Qdrant collection with the specified parameters.
         :param collection_name:
@@ -1312,7 +1309,7 @@ class QdrantDocumentStore:
         sparse_idf: bool,
         on_disk: bool = False,
         payload_fields_to_index: Optional[List[dict]] = None,
-    ):
+    ) -> None:
         """
         Asynchronously sets up the Qdrant collection with the specified parameters.
         :param collection_name:
@@ -1366,7 +1363,7 @@ class QdrantDocumentStore:
         on_disk: Optional[bool] = None,
         use_sparse_embeddings: Optional[bool] = None,
         sparse_idf: bool = False,
-    ):
+    ) -> None:
         """
         Recreates the Qdrant collection with the specified parameters.
 
@@ -1409,7 +1406,7 @@ class QdrantDocumentStore:
         on_disk: Optional[bool] = None,
         use_sparse_embeddings: Optional[bool] = None,
         sparse_idf: bool = False,
-    ):
+    ) -> None:
         """
         Asynchronously recreates the Qdrant collection with the specified parameters.
 
@@ -1448,7 +1445,7 @@ class QdrantDocumentStore:
         self,
         documents: List[Document],
         policy: DuplicatePolicy = None,
-    ):
+    ) -> List[Document]:
         """
         Checks whether any of the passed documents is already existing in the chosen index and returns a list of
         documents that are not in the index yet.
@@ -1475,7 +1472,7 @@ class QdrantDocumentStore:
         self,
         documents: List[Document],
         policy: DuplicatePolicy = None,
-    ):
+    ) -> List[Document]:
         """
         Asynchronously checks whether any of the passed documents is already existing
         in the chosen index and returns a list of
@@ -1520,7 +1517,7 @@ class QdrantDocumentStore:
 
         return _documents
 
-    def _prepare_collection_params(self):
+    def _prepare_collection_params(self) -> Dict[str, Any]:
         """
         Prepares the common parameters for collection creation.
         """
@@ -1536,7 +1533,7 @@ class QdrantDocumentStore:
             "init_from": self.init_from,
         }
 
-    def _prepare_client_params(self):
+    def _prepare_client_params(self) -> Dict[str, Any]:
         """
         Prepares the common parameters for client initialization.
 
@@ -1564,7 +1561,7 @@ class QdrantDocumentStore:
         on_disk: Optional[bool] = None,
         use_sparse_embeddings: Optional[bool] = None,
         sparse_idf: bool = False,
-    ):
+    ) -> Tuple[Dict[str, rest.VectorParams], Optional[Dict[str, rest.SparseVectorParams]]]:
         """
         Prepares the configuration for creating or recreating a Qdrant collection.
 
@@ -1594,9 +1591,12 @@ class QdrantDocumentStore:
 
         return vectors_config, sparse_vectors_config
 
-    def _validate_filters(self, filters: Optional[Union[Dict[str, Any], rest.Filter]] = None):
+    def _validate_filters(self, filters: Optional[Union[Dict[str, Any], rest.Filter]] = None) -> None:
         """
         Validates the filters provided for querying.
+
+        :param filters: Filters to validate. Can be a dictionary or an instance of `qdrant_client.http.models.Filter`.
+        :raises ValueError: If the filters are not in the correct format or syntax.
         """
         if filters and not isinstance(filters, dict) and not isinstance(filters, rest.Filter):
             msg = "Filter must be a dictionary or an instance of `qdrant_client.http.models.Filter`"
@@ -1606,7 +1606,7 @@ class QdrantDocumentStore:
             msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
             raise ValueError(msg)
 
-    def _process_query_point_results(self, results, scale_score: bool = False):
+    def _process_query_point_results(self, results: List[QdrantPoint], scale_score: bool = False) -> List[Document]:
         """
         Processes query results from Qdrant.
         """
@@ -1626,7 +1626,7 @@ class QdrantDocumentStore:
 
         return documents
 
-    def _process_group_results(self, groups):
+    def _process_group_results(self, groups: List[rest.PointGroup]) -> List[Document]:
         """
         Processes grouped query results from Qdrant.
 
@@ -1646,7 +1646,7 @@ class QdrantDocumentStore:
         collection_info,
         distance,
         embedding_dim: int,
-    ):
+    ) -> None:
         """
         Validates that an existing collection is compatible with the current configuration.
         """

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -1,5 +1,4 @@
 import inspect
-from copy import deepcopy
 from itertools import islice
 from typing import Any, AsyncGenerator, ClassVar, Dict, Generator, List, Optional, Set, Tuple, Union
 
@@ -1540,26 +1539,24 @@ class QdrantDocumentStore:
         Prepares the common parameters for client initialization.
 
         """
-        # NOTE: We need to use deepcopy here to avoid modifying the original class attributes.
-        # For example, the resolved api key is added to metadata by the QdrantClient class when using a hosted
-        # Qdrant service, which means running to_dict() exposes the api key.
-        return deepcopy(
-            {
-                "location": self.location,
-                "url": self.url,
-                "port": self.port,
-                "grpc_port": self.grpc_port,
-                "prefer_grpc": self.prefer_grpc,
-                "https": self.https,
-                "api_key": self.api_key.resolve_value() if self.api_key else None,
-                "prefix": self.prefix,
-                "timeout": self.timeout,
-                "host": self.host,
-                "path": self.path,
-                "metadata": self.metadata,
-                "force_disable_check_same_thread": self.force_disable_check_same_thread,
-            }
-        )
+        return {
+            "location": self.location,
+            "url": self.url,
+            "port": self.port,
+            "grpc_port": self.grpc_port,
+            "prefer_grpc": self.prefer_grpc,
+            "https": self.https,
+            "api_key": self.api_key.resolve_value() if self.api_key else None,
+            "prefix": self.prefix,
+            "timeout": self.timeout,
+            "host": self.host,
+            "path": self.path,
+            # NOTE: We purposefully expand the fields of self.metadata to avoid modifying the original self.metadata
+            # class attribute. For example, the resolved api key is added to metadata by the QdrantClient class
+            # when using a hosted Qdrant service, which means running to_dict() exposes the api key.
+            "metadata": {**self.metadata},
+            "force_disable_check_same_thread": self.force_disable_check_same_thread,
+        }
 
     def _prepare_collection_config(
         self,

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -232,7 +232,6 @@ class QdrantDocumentStore:
         self.path = path
         self.force_disable_check_same_thread = force_disable_check_same_thread
         self.metadata = metadata or {}
-        self.api_key = api_key
 
         # Store the Qdrant collection specific attributes
         self.shard_number = shard_number

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/filters.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/filters.py
@@ -138,10 +138,10 @@ def convert_filters_to_qdrant(
 
 
 def build_filters_for_repeated_operators(
-    must_clauses,
-    should_clauses,
-    must_not_clauses,
-    qdrant_filter,
+    must_clauses: List,
+    should_clauses: List,
+    must_not_clauses: List,
+    qdrant_filter: List[models.Filter],
 ) -> List[models.Filter]:
     """
     Flattens the nested lists of clauses by creating separate Filters for each clause of a logical operator.

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/migrate_to_sparse.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/migrate_to_sparse.py
@@ -11,7 +11,7 @@ logger.addHandler(python_logging.StreamHandler())
 logger.setLevel(python_logging.INFO)
 
 
-def migrate_to_sparse_embeddings_support(old_document_store: QdrantDocumentStore, new_index: str):
+def migrate_to_sparse_embeddings_support(old_document_store: QdrantDocumentStore, new_index: str) -> None:
     """
     Utility function to migrate an existing `QdrantDocumentStore` to a new one with support for sparse embeddings.
 

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -6,6 +6,7 @@ from haystack import Document
 from haystack.dataclasses import SparseEmbedding
 from haystack.document_stores.errors import DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
+from haystack.utils import Secret
 from haystack.testing.document_store import (
     CountDocumentsTest,
     DeleteDocumentsTest,
@@ -37,6 +38,62 @@ class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocu
         with patch("haystack_integrations.document_stores.qdrant.document_store.qdrant_client") as mocked_qdrant:
             QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True)
             mocked_qdrant.assert_not_called()
+
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("QDRANT_API_KEY", "test_api_key")
+        doc_store = QdrantDocumentStore(
+            ":memory:",
+            recreate_index=True,
+            return_embedding=True,
+            wait_result_from_api=True,
+            use_sparse_embeddings=False,
+            api_key=Secret.from_env_var("QDRANT_API_KEY"),
+        )
+        expected_dict = {
+            "type": "haystack_integrations.document_stores.qdrant.document_store.QdrantDocumentStore",
+            "init_parameters": {
+                "location": ":memory:",
+                "url": None,
+                "port": 6333,
+                "grpc_port": 6334,
+                "prefer_grpc": False,
+                "https": None,
+                "api_key": {
+                    "env_vars": ["QDRANT_API_KEY"],
+                    "strict": True,
+                    "type": "env_var",
+                },
+                "prefix": None,
+                "timeout": None,
+                "host": None,
+                "path": None,
+                "force_disable_check_same_thread": False,
+                "index": "Document",
+                "embedding_dim": 768,
+                "on_disk": False,
+                "use_sparse_embeddings": False,
+                "sparse_idf": False,
+                "similarity": "cosine",
+                "return_embedding": True,
+                "progress_bar": True,
+                "recreate_index": True,
+                "shard_number": None,
+                "replication_factor": None,
+                "write_consistency_factor": None,
+                "on_disk_payload": None,
+                "hnsw_config": None,
+                "optimizers_config": None,
+                "wal_config": None,
+                "quantization_config": None,
+                "init_from": None,
+                "wait_result_from_api": True,
+                "metadata": {},
+                "write_batch_size": 100,
+                "scroll_size": 10000,
+                "payload_fields_to_index": None,
+            },
+        }
+        assert doc_store.to_dict() == expected_dict
 
     def assert_documents_are_equal(self, received: List[Document], expected: List[Document]):
         """

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -6,13 +6,13 @@ from haystack import Document
 from haystack.dataclasses import SparseEmbedding
 from haystack.document_stores.errors import DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
-from haystack.utils import Secret
 from haystack.testing.document_store import (
     CountDocumentsTest,
     DeleteDocumentsTest,
     WriteDocumentsTest,
     _random_embeddings,
 )
+from haystack.utils import Secret
 from qdrant_client.http import models as rest
 
 from haystack_integrations.document_stores.qdrant.document_store import (

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -39,6 +39,23 @@ class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocu
             QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True)
             mocked_qdrant.assert_not_called()
 
+    def test_prepare_client_params_no_mutability(self):
+        metadata = {"key": "value"}
+        doc_store = QdrantDocumentStore(
+            ":memory:",
+            recreate_index=True,
+            return_embedding=True,
+            wait_result_from_api=True,
+            use_sparse_embeddings=False,
+            metadata=metadata,
+        )
+        client_params = doc_store._prepare_client_params()
+        # Mutate value of metadata in client_params
+        client_params["metadata"] = client_params["metadata"].update({"new_key": "new_value"})
+
+        # Assert that the original metadata in the document store is unchanged
+        assert metadata == {"key": "value"}
+
     def test_to_dict(self, monkeypatch):
         monkeypatch.setenv("QDRANT_API_KEY", "test_api_key")
         doc_store = QdrantDocumentStore(


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1786#issuecomment-2909698240

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Deepcopy the returned client params in `_prepare_client_params` to prevent changing the original class attributes.

This specifically only occurs when you run a hosted version of QDrant (but not when running the in memory version), initialize the client and then run `to_dict`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
