### PR TITLE
build: remove pin for Deepeval

### DIFF
--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -61,9 +61,16 @@ jobs:
       - name: Run tests
         run: hatch run cov-retry
 
+      - name: Run unit tests with lowest direct dependencies
+        run: |
+          hatch run uv pip compile pyproject.toml --resolution lowest-direct --output-file requirements_lowest_direct.txt
+          hatch run uv pip install -r requirements_lowest_direct.txt
+          hatch run test -m "not integration"
+
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
+          hatch env prune
           hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval==0.20.57", "langchain<0.3; python_version < '3.10'"]
+dependencies = ["haystack-ai", "deepeval==0.20.57"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"


### PR DESCRIPTION
### Related Issues

- fixes #1792

### Proposed Changes:
- remove a langchain pin that caused failures (see https://github.com/deepset-ai/haystack-core-integrations/actions/runs/15256494841/job/42905281051) - reverts #1187
- (no need to pin Haystack; the lowest version works)
- add job to check direct dependencies

### How did you test it?
CI

### Notes for the reviewer
Not a breaking change -> bugfix release

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
