### PR TITLE
build: pinning `unstructured` to lowest working versions

### DIFF
--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -72,9 +72,16 @@ jobs:
       - name: Run tests
         run: hatch run cov-retry
 
+      - name: Run unit tests with lowest direct dependencies
+        run: |
+          hatch run uv pip compile pyproject.toml --resolution lowest-direct --output-file requirements_lowest_direct.txt
+          hatch run uv pip install -r requirements_lowest_direct.txt
+          hatch run test -m "not integration"
+
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
+          hatch env prune
           hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,9 +24,11 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai",
+  "haystack-ai>=2.0.0",
   "unstructured",
-  "unstructured-client<0.30.0"]
+  "unstructured-client"
+]
+
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/unstructured#readme"

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.9.0",
+  "haystack-ai>=2.4.0",
   "unstructured>=0.17.0",
   "unstructured-client<0.30.0"]
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.4.0",
+  "haystack-ai>=2.8.0",
   "unstructured>=0.17.2",
   "unstructured-client<0.30.0"]
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
   "haystack-ai>=2.0.0",
   "unstructured>=0.15.0",
-  "unstructured-client>=0.21.0"
+  "unstructured-client>=0.21.0,<0.30.0",
 ]
 
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.10.0",
+  "haystack-ai==2.13.0",
   "unstructured",
   "unstructured-client<0.30.0"]
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
   "haystack-ai>=2.0.0",
   "unstructured>=0.15.0",
-  "unstructured-client>=0.21.0,<0.30.0",
+  "unstructured-client>=0.21.0",
 ]
 
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.0.0",
-  "unstructured",
-  "unstructured-client"
+  "unstructured>=0.15.0",
+  "unstructured-client>=0.21.0"
 ]
 
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai",
+  "haystack-ai>=2.10.0",
   "unstructured",
   "unstructured-client<0.30.0"]
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.8.0",
+  "haystack-ai",
   "unstructured",
   "unstructured-client<0.30.0"]
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.4.0",
-  "unstructured>=0.17.0",
+  "unstructured>=0.17.2",
   "unstructured-client<0.30.0"]
 
 [project.urls]

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.9.0",
-  "unstructured>=0.17.2",
+  "unstructured>=0.17.0",
   "unstructured-client<0.30.0"]
 
 [project.urls]

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai==2.13.0",
+  "haystack-ai",
   "unstructured",
   "unstructured-client<0.30.0"]
 

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -23,7 +23,10 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "unstructured", "unstructured-client<0.30.0"]
+dependencies = [
+  "haystack-ai>=2.9.0",
+  "unstructured>=0.17.2",
+  "unstructured-client<0.30.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/unstructured#readme"

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.8.0",
-  "unstructured>=0.17.2",
+  "unstructured",
   "unstructured-client<0.30.0"]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- fixes #1809 

### Proposed Changes:

- "haystack-ai>=2.0.0",
- "unstructured>=0.15.0",
- "unstructured-client>=0.21.0"

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
