### PR TITLE
test: Remove failing test. No need to have it here since it's already teste…

### DIFF
--- a/integrations/meta_llama/tests/test_llama_chat_generator.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator.py
@@ -239,36 +239,6 @@ class TestLlamaChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    def test_check_abnormal_completions(self, caplog):
-        component = MetaLlamaChatGenerator(api_key=Secret.from_token("test-api-key"))
-        messages = [
-            ChatMessage.from_assistant(
-                "",
-                meta={
-                    "finish_reason": "content_filter" if i % 2 == 0 else "length",
-                    "index": i,
-                },
-            )
-            for i, _ in enumerate(range(4))
-        ]
-
-        for m in messages:
-            component._check_finish_reason(m.meta)
-
-        # check truncation warning
-        message_template = (
-            "The completion for index {index} has been truncated before reaching a natural stopping point. "
-            "Increase the max_tokens parameter to allow for longer completions."
-        )
-
-        for index in [1, 3]:
-            assert caplog.records[index].message == message_template.format(index=index)
-
-        # check content filter warning
-        message_template = "The completion for index {index} has been truncated due to the content filter."
-        for index in [0, 2]:
-            assert caplog.records[index].message == message_template.format(index=index)
-
     @pytest.mark.skipif(
         not os.environ.get("LLAMA_API_KEY", None),
         reason="Export an env var called LLAMA_API_KEY containing the OpenAI API key to run this test.",

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -208,32 +208,6 @@ class TestMistralChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    def test_check_abnormal_completions(self, caplog):
-        component = MistralChatGenerator(api_key=Secret.from_token("test-api-key"))
-        messages = [
-            ChatMessage.from_assistant(
-                "", meta={"finish_reason": "content_filter" if i % 2 == 0 else "length", "index": i}
-            )
-            for i, _ in enumerate(range(4))
-        ]
-
-        for m in messages:
-            component._check_finish_reason(m.meta)
-
-        # check truncation warning
-        message_template = (
-            "The completion for index {index} has been truncated before reaching a natural stopping point. "
-            "Increase the max_tokens parameter to allow for longer completions."
-        )
-
-        for index in [1, 3]:
-            assert caplog.records[index].message == message_template.format(index=index)
-
-        # check content filter warning
-        message_template = "The completion for index {index} has been truncated due to the content filter."
-        for index in [0, 2]:
-            assert caplog.records[index].message == message_template.format(index=index)
-
     @pytest.mark.skipif(
         not os.environ.get("MISTRAL_API_KEY", None),
         reason="Export an env var called MISTRAL_API_KEY containing the OpenAI API key to run this test.",

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -240,32 +240,6 @@ class TestOpenRouterChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    def test_check_abnormal_completions(self, caplog):
-        component = OpenRouterChatGenerator(api_key=Secret.from_token("test-api-key"))
-        messages = [
-            ChatMessage.from_assistant(
-                "", meta={"finish_reason": "content_filter" if i % 2 == 0 else "length", "index": i}
-            )
-            for i, _ in enumerate(range(4))
-        ]
-
-        for m in messages:
-            component._check_finish_reason(m.meta)
-
-        # check truncation warning
-        message_template = (
-            "The completion for index {index} has been truncated before reaching a natural stopping point. "
-            "Increase the max_tokens parameter to allow for longer completions."
-        )
-
-        for index in [1, 3]:
-            assert caplog.records[index].message == message_template.format(index=index)
-
-        # check content filter warning
-        message_template = "The completion for index {index} has been truncated due to the content filter."
-        for index in [0, 2]:
-            assert caplog.records[index].message == message_template.format(index=index)
-
     @pytest.mark.skipif(
         not os.environ.get("OPENROUTER_API_KEY", None),
         reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",


### PR DESCRIPTION
### Related Issues

- fixes failing CI for Mistral, Meta LLama, OpenRouter, and Stackit

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Remove failing test. No need to have it here since it's already tested in Haystack main and none of the integrations modified the underlying private function being tested. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
