### PR TITLE
chore: review license compliance workflow

### DIFF
--- a/.github/workflows/CI_license_compliance.yml
+++ b/.github/workflows/CI_license_compliance.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - "integrations/**/pyproject.toml"
+    - ".github/workflows/CI_license_compliance.yml"
   # Since we test PRs, there is no need to run the workflow at each
   # merge on `main`. Let's use a cron job instead.
   schedule:
@@ -12,13 +13,12 @@ on:
 env:
   CORE_DATADOG_API_KEY: ${{ secrets.CORE_DATADOG_API_KEY }}
   PYTHON_VERSION: "3.10"
-  EXCLUDE_PACKAGES: "(?i)^(deepeval|cohere|fastembed|ragas|tqdm|psycopg|typing_extensions).*"
+  EXCLUDE_PACKAGES: "(?i)^(fastembed|ollama|ragas|tqdm|psycopg|typing_extensions).*"
 
   # Exclusions must be explicitly motivated
   #
-  # - deepeval is Apache 2.0 but the license is not available on PyPI
-  # - cohere is MIT but the license is not available on PyPI
   # - fastembed is Apache 2.0 but the license on PyPI is unclear ("Other/Proprietary License (Apache License)")
+  # - ollama is MIT but the license is not available on PyPI
   # - ragas is Apache 2.0 but the license is not available on PyPI
   # - typing_extensions>=4.13.0 has a Python Software Foundation License 2.0 but pip-license-checker does not recognize it
   #   (https://github.com/pilosus/pip-license-checker/issues/143)

--- a/.github/workflows/CI_license_compliance.yml
+++ b/.github/workflows/CI_license_compliance.yml
@@ -41,25 +41,28 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Get changed pyproject files (for pull requests only)
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Get changed files (for pull requests only)
+        if: ${{ github.event_name == 'pull_request'}}
         id: changed-files
         uses: tj-actions/changed-files@v46
         with:
-          files: |
-            integrations/**/pyproject.toml       
+          files_yaml: |
+            pyproject:
+              - integrations/**/pyproject.toml
+            workflow:
+              - .github/workflows/CI_license_compliance.yml
 
       - name: Get direct dependencies from pyproject.toml files
         run: |
           pip install toml
 
           # Determine the list of pyproject.toml files to process
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "Scheduled run: processing all pyproject.toml files..."
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ steps.changed-files.outputs.workflow_any_changed }}" = "true" ]; then
+            echo "Scheduled run or workflow changed: processing all pyproject.toml files..."
             FILES=$(find integrations -type f -name 'pyproject.toml')
           else
-            echo "Pull request: processing changed pyproject.toml files..."
-            FILES="${{ steps.changed-files.outputs.all_changed_files }}"
+            echo "Pull request with pyproject changes: processing changed pyproject.toml files..."
+            FILES="${{ steps.changed-files.outputs.pyproject_all_changed_files }}"
           fi
 
           for file in $FILES; do

--- a/.github/workflows/CI_license_compliance.yml
+++ b/.github/workflows/CI_license_compliance.yml
@@ -13,10 +13,11 @@ on:
 env:
   CORE_DATADOG_API_KEY: ${{ secrets.CORE_DATADOG_API_KEY }}
   PYTHON_VERSION: "3.10"
-  EXCLUDE_PACKAGES: "(?i)^(fastembed|ollama|ragas|tqdm|psycopg|typing_extensions).*"
+  EXCLUDE_PACKAGES: "(?i)^(deepeval|fastembed|ollama|ragas|tqdm|psycopg|typing_extensions).*"
 
   # Exclusions must be explicitly motivated
   #
+  # - deepeval is Apache 2.0 but the license is not available on PyPI
   # - fastembed is Apache 2.0 but the license on PyPI is unclear ("Other/Proprietary License (Apache License)")
   # - ollama is MIT but the license is not available on PyPI
   # - ragas is Apache 2.0 but the license is not available on PyPI


### PR DESCRIPTION
### Related Issues

- failing license compliance: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/15288339909/job/43003064649 - this happens because a new version of ollama-python was released but they wrongly removed the MIT specification from pyproject.toml (I opened an issue for this: https://github.com/ollama/ollama-python/issues/522)

### Proposed Changes:
- put Ollama in the list of exclusions (and remove Cohere, that now comes with the correct license specification)
- refactor the workflow to also run when it is modified

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
