### PR TITLE
build: add pins for Optimum

### DIFF
--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -60,9 +60,16 @@ jobs:
       - name: Run tests
         run: hatch run cov-retry
 
+      - name: Run unit tests with lowest direct dependencies
+        run: |
+          hatch run uv pip compile pyproject.toml --resolution lowest-direct --output-file requirements_lowest_direct.txt
+          hatch run uv pip install -r requirements_lowest_direct.txt
+          hatch run test -m "not integration"
+
       - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
+          hatch env prune
           hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run cov-retry -m "not integration"
 

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.12"] # onnx does not support 3.13 yet
-
+        python-version: ["3.9", "3.13"]
+        
     steps:
       - name: Support longpaths
         if: matrix.os == 'windows-latest'

--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   # Ref: https://github.com/huggingface/optimum/blob/8651c0ca1cccf095458bc80329dec9df4601edb4/optimum/exporters/onnx/__main__.py#L164
   # "sentence-transformers" has been added, since most embedding models use it
   "sentence-transformers>=2.3",
-  "optimum[onnxruntime]",
+  "optimum[onnxruntime]>=1.17.0",
 ]
 
 [project.urls]

--- a/integrations/optimum/tests/test_optimum_document_embedder.py
+++ b/integrations/optimum/tests/test_optimum_document_embedder.py
@@ -311,7 +311,7 @@ class TestOptimumDocumentEmbedder:
 
     def test_run_wrong_input_format(self, mock_check_valid_model):  # noqa: ARG002
         embedder = OptimumDocumentEmbedder(model="sentence-transformers/all-mpnet-base-v2", pooling_mode="mean")
-        embedder.warm_up()
+        embedder._initialized = True
         # wrong formats
         string_input = "text"
         list_integers_input = [1, 2, 3]
@@ -326,7 +326,7 @@ class TestOptimumDocumentEmbedder:
         embedder = OptimumDocumentEmbedder(
             model="sentence-transformers/paraphrase-albert-small-v2",
         )
-        embedder.warm_up()
+        embedder._initialized = True
         empty_list_input = []
         result = embedder.run(documents=empty_list_input)
 

--- a/integrations/optimum/tests/test_optimum_document_embedder.py
+++ b/integrations/optimum/tests/test_optimum_document_embedder.py
@@ -235,7 +235,7 @@ class TestOptimumDocumentEmbedder:
                 model="sentence-transformers/all-mpnet-base-v2", pooling_mode="Invalid_pooling_mode"
             )
 
-    def test_infer_pooling_mode_from_str(self):
+    def test_infer_pooling_mode_from_str(self, mock_check_valid_model):  # noqa: ARG002
         """
         Test that the pooling mode is correctly inferred from a string.
         The pooling mode is "mean" as per the model config.

--- a/integrations/optimum/tests/test_optimum_text_embedder.py
+++ b/integrations/optimum/tests/test_optimum_text_embedder.py
@@ -198,7 +198,7 @@ class TestOptimumTextEmbedder:
         with pytest.raises(ValueError):
             OptimumTextEmbedder(model="sentence-transformers/all-mpnet-base-v2", pooling_mode="Invalid_pooling_mode")
 
-    def test_infer_pooling_mode_from_str(self):
+    def test_infer_pooling_mode_from_str(self, mock_check_valid_model):  # noqa: ARG002
         """
         Test that the pooling mode is correctly inferred from a string.
         The pooling mode is "mean" as per the model config.


### PR DESCRIPTION
### Related Issues

- fixes #1803

### Proposed Changes:
- pin optimum
- add CI job
- modify some tests to make them faster and proper unit tests
- test with python 3.13 (now onnx supports it) 

### How did you test it?
CI

### Notes for the reviewer
Not breaking -> bugfix release

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
