### PR TITLE
test: Pinecone - reenable tests for `comparison_not_equal` and `or_operator`

### DIFF
--- a/integrations/pinecone/tests/test_filters.py
+++ b/integrations/pinecone/tests/test_filters.py
@@ -63,13 +63,3 @@ class TestFilters(FilterDocumentsTest):
 
     @pytest.mark.skip(reason="Pinecone does not support the 'not' operator")
     def test_not_operator(self, document_store, filterable_docs): ...
-
-    # the following skipped tests should be reworked when Pinecone introduces a better handling of null values
-    # see https://github.com/deepset-ai/haystack-core-integrations/issues/590
-    @pytest.mark.skip(reason="Pinecone does not include null values in the result of the $ne operator")
-    def test_comparison_not_equal(self, document_store, filterable_docs): ...
-
-    @pytest.mark.skip(
-        reason="Pinecone has inconsistent behavior with respect to other Document Stores with the $or operator"
-    )
-    def test_or_operator(self, document_store, filterable_docs): ...


### PR DESCRIPTION
### Related Issues

- fixes #590

### Proposed Changes:
- re-enable the tests that were skipped due to Pinecone handling of null values. They made progress on this aspect and the tests run successfully.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
