### PR TITLE
feat: Add detailed tracing for GoogleGenAIChatGenerator

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -45,6 +45,7 @@ _SUPPORTED_CHAT_GENERATORS = [
     "HuggingFaceLocalChatGenerator",
     "CohereChatGenerator",
     "OllamaChatGenerator",
+    "GoogleGenAIChatGenerator",
 ]
 _ALL_SUPPORTED_GENERATORS = _SUPPORTED_GENERATORS + _SUPPORTED_CHAT_GENERATORS
 


### PR DESCRIPTION
## Why:
The newly released Google GenAI Haystack integration includes a `GoogleGenAIChatGenerator` component that wasn't included in Langfuse's list of supported chat generators. This meant that Google GenAI chat interactions weren't receiving proper generation-level tracing and metadata extraction in Langfuse, limiting observability for users of this integration.

## What:
- **Core component**: Added `GoogleGenAIChatGenerator` to `_SUPPORTED_CHAT_GENERATORS` list
- **Key features**: 
  - Enables generation-level spans for `GoogleGenAIChatGenerator`
  - Provides proper token usage and model metadata extraction
  - Ensures consistent tracing behavior across all supported chat generators
- **Integration**: Google GenAI chat components now receive the same detailed tracing treatment as other supported generators

## How can it be used:
- No changes for existing clients

## How did you test it:
- **Integration tests**: Verified Google GenAI chat generator creates generation spans instead of generic spans. Here is the [trace](https://us.cloud.langfuse.com/project/cm9inpne801ruad07ci8vevid/traces/5bd896ff-4062-494c-add9-196f736de00f?timestamp=2025-06-02T12%3A33%3A12.750Z&display=timeline&observation=bec3eee7-fca7-42bd-af17-eb50aa4bdc5a)
- **Metadata extraction**: Confirmed token usage and model information are properly captured

## Notes for the reviewer:
- **Dependencies**: No new dependencies - leverages existing Google GenAI integration
       - We need to integrate this [PR](https://github.com/deepset-ai/haystack-core-integrations/pull/1885) first 
- **Consistency**: Aligns Google GenAI tracing behavior with other supported chat generators
- **Timing**: Supports the recently released google-genai-haystack package