### PR TITLE
fix!: Use model_dump_json for tool results instead of returning mcp-sdk types.CallToolResult

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import concurrent.futures
+import json
 import threading
 import warnings
 from abc import ABC, abstractmethod
@@ -233,16 +234,16 @@ class MCPClient(ABC):
         """
         pass
 
-    async def call_tool(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+    async def call_tool(self, tool_name: str, tool_args: dict[str, Any]) -> str:
         """
         Call a tool on the connected MCP server.
 
         :param tool_name: Name of the tool to call
         :param tool_args: Arguments to pass to the tool
-        :returns: Result of the tool invocation
+        :returns: JSON string representation of the tool invocation result
         :raises MCPConnectionError: If not connected to an MCP server
         :raises MCPInvocationError: If the tool invocation fails
-        :raises MCPResponseTypeError: If response type is not TextContent
+        :raises MCPResponseTypeError: If response type is not TextContent or ImageContent
         """
         if not self.session:
             message = "Not connected to an MCP server"
@@ -250,8 +251,10 @@ class MCPClient(ABC):
 
         try:
             result = await self.session.call_tool(tool_name, tool_args)
-            validated_result = self._validate_response(tool_name, result)
-            return validated_result
+            if result.isError:
+                message = f"Tool '{tool_name}' returned an error: {result.content!s}"
+                raise MCPInvocationError(message=message, tool_name=tool_name)
+            return result.model_dump_json()
         except MCPError:
             # Re-raise specific MCP errors directly
             raise
@@ -259,44 +262,6 @@ class MCPClient(ABC):
             # Wrap other exceptions with context about which tool failed
             message = f"Failed to invoke tool '{tool_name}' with args: {tool_args} , got error: {e!s}"
             raise MCPInvocationError(message, tool_name, tool_args) from e
-
-    def _validate_response(self, tool_name: str, result: types.CallToolResult) -> types.CallToolResult:
-        """
-        Validate response from an MCP tool call, accepting only TextContent.
-
-        :param tool_name: Name of the called tool (for error messages)
-        :param result: CallToolResult from MCP tool call
-        :returns: The original CallToolResult object
-        :raises MCPResponseTypeError: If content type is not TextContent
-        :raises MCPInvocationError: If the tool call resulted in an error
-        """
-
-        # Check for error response
-        if result.isError:
-            if len(result.content) > 0 and isinstance(result.content[0], types.TextContent):
-                # Get the error message from the first item
-                first_item = result.content[0]
-                message = f"Tool '{tool_name}' returned an error: {first_item.text}"
-            else:
-                message = f"Tool '{tool_name}' returned an error: {result.content!s}"
-            raise MCPInvocationError(
-                message=message,
-                tool_name=tool_name,
-            )
-
-        # Validate content types - only allow TextContent for now
-        if result.content:
-            for item in result.content:
-                if not isinstance(item, types.TextContent):
-                    # Reject any non-TextContent
-                    message = (
-                        f"Unsupported content type in response from tool '{tool_name}'. "
-                        f"Only TextContent is currently supported."
-                    )
-                    raise MCPResponseTypeError(message, result, tool_name)
-
-        # Return the original result object
-        return result
 
     async def aclose(self) -> None:
         """
@@ -608,11 +573,14 @@ class MCPTool(Tool):
     compatibility with the Haystack tool ecosystem.
 
     Response handling:
-    - Text content is supported and returned as strings
-    - Unsupported content types (like binary/images) will raise MCPResponseTypeError
+    - Text and image content are supported and returned as JSON strings
+    - The JSON contains the structured response from the MCP server
+    - Use json.loads() to parse the response into a dictionary
+    - Unsupported content types will raise MCPResponseTypeError
 
     Example using HTTP:
     ```python
+    import json
     from haystack.tools import MCPTool, SSEServerInfo
 
     # Create tool instance
@@ -621,12 +589,14 @@ class MCPTool(Tool):
         server_info=SSEServerInfo(url="http://localhost:8000/sse")
     )
 
-    # Use the tool
-    result = tool.invoke(a=5, b=3)
+    # Use the tool and parse result
+    result_json = tool.invoke(a=5, b=3)
+    result = json.loads(result_json)
     ```
 
     Example using stdio:
     ```python
+    import json
     from haystack.tools import MCPTool, StdioServerInfo
 
     # Create tool instance
@@ -635,8 +605,9 @@ class MCPTool(Tool):
         server_info=StdioServerInfo(command="python", args=["path/to/server.py"])
     )
 
-    # Use the tool
-    result = tool.invoke(timezone="America/New_York")
+    # Use the tool and parse result
+    result_json = tool.invoke(timezone="America/New_York")
+    result = json.loads(result_json)
     ```
     """
 
@@ -732,12 +703,12 @@ class MCPTool(Tool):
             message = f"Failed to initialize MCPTool '{name}': {error_message}"
             raise MCPConnectionError(message=message, server_info=server_info, operation="initialize") from e
 
-    def _invoke_tool(self, **kwargs: Any) -> Any:
+    def _invoke_tool(self, **kwargs: Any) -> str:
         """
         Synchronous tool invocation.
 
         :param kwargs: Arguments to pass to the tool
-        :returns: Result of the tool invocation
+        :returns: JSON string representation of the tool invocation result
         """
         logger.debug(f"TOOL: Invoking tool '{self.name}' with args: {kwargs}")
         try:
@@ -764,12 +735,12 @@ class MCPTool(Tool):
             message = f"Failed to invoke tool '{self.name}' with args: {kwargs} , got error: {e!s}"
             raise MCPInvocationError(message, self.name, kwargs) from e
 
-    async def ainvoke(self, **kwargs: Any) -> Any:
+    async def ainvoke(self, **kwargs: Any) -> str:
         """
         Asynchronous tool invocation.
 
         :param kwargs: Arguments to pass to the tool
-        :returns: Result of the tool invocation, processed based on content type
+        :returns: JSON string representation of the tool invocation result
         :raises MCPInvocationError: If the tool invocation fails
         :raises MCPResponseTypeError: If response type is not supported
         :raises TimeoutError: If the operation times out

--- a/integrations/mcp/tests/test_mcp_integration.py
+++ b/integrations/mcp/tests/test_mcp_integration.py
@@ -86,21 +86,29 @@ if __name__ == "__main__":
             tool = MCPTool(name="add", server_info=server_info)
 
             # Invoke the tool
-            result = tool.invoke(a=5, b=3)
+            result_json = tool.invoke(a=5, b=3)
+
+            # Parse the JSON result
+            import json
+
+            result = json.loads(result_json)
 
             # Verify the result
-            assert not result.isError
-            assert len(result.content) == 1
-            assert result.content[0].text == "8"
+            assert not result["isError"]
+            assert len(result["content"]) == 1
+            assert result["content"][0]["text"] == "8"
 
             # Try another tool from the same server
             subtract_tool = MCPTool(name="subtract", server_info=server_info)
-            result = subtract_tool.invoke(a=10, b=4)
+            result_json = subtract_tool.invoke(a=10, b=4)
+
+            # Parse the JSON result
+            result = json.loads(result_json)
 
             # Verify the result
-            assert not result.isError
-            assert len(result.content) == 1
-            assert result.content[0].text == "6"
+            assert not result["isError"]
+            assert len(result["content"]) == 1
+            assert result["content"][0]["text"] == "6"
 
         except Exception:
             # Check server output for clues
@@ -234,6 +242,6 @@ if __name__ == "__main__":
         # Check for platform-agnostic error message patterns
         error_message = str(exc_info.value)
         assert error_message, "Error message should not be empty"
-        assert any(text in error_message.lower() for text in ["failed", "connection", "initialize"]), (
-            f"Error message '{error_message}' should contain connection failure information"
-        )
+        assert any(
+            text in error_message.lower() for text in ["failed", "connection", "initialize"]
+        ), f"Error message '{error_message}' should contain connection failure information"

--- a/integrations/mcp/tests/test_mcp_toolset.py
+++ b/integrations/mcp/tests/test_mcp_toolset.py
@@ -213,6 +213,7 @@ class TestMCPToolsetIntegration:
         import socket
         import subprocess
         import tempfile
+        import json
 
         # Find an available port
         def find_free_port():
@@ -270,13 +271,19 @@ if __name__ == "__main__":
 
             # Test the add tool
             add_tool = next(tool for tool in toolset.tools if tool.name == "add")
-            result = add_tool.invoke(a=5, b=3)
-            assert result.content[0].text == "8"
+            result_json = add_tool.invoke(a=5, b=3)
+
+            # Parse the JSON result
+            result = json.loads(result_json)
+            assert result["content"][0]["text"] == "8"
 
             # Test the subtract tool
             subtract_tool = next(tool for tool in toolset.tools if tool.name == "subtract")
-            result = subtract_tool.invoke(a=10, b=4)
-            assert result.content[0].text == "6"
+            result_json = subtract_tool.invoke(a=10, b=4)
+
+            # Parse the JSON result
+            result = json.loads(result_json)
+            assert result["content"][0]["text"] == "6"
 
         except Exception:
             # Check server output for clues
@@ -311,6 +318,7 @@ if __name__ == "__main__":
         import socket
         import subprocess
         import tempfile
+        import json
 
         # Find an available port
         def find_free_port():
@@ -369,13 +377,19 @@ if __name__ == "__main__":
 
             # Test the add tool
             add_tool = next(tool for tool in toolset.tools if tool.name == "add")
-            result = add_tool.invoke(a=5, b=3)
-            assert result.content[0].text == "8"
+            result_json = add_tool.invoke(a=5, b=3)
+
+            # Parse the JSON result
+            result = json.loads(result_json)
+            assert result["content"][0]["text"] == "8"
 
             # Test the subtract tool
             subtract_tool = next(tool for tool in toolset.tools if tool.name == "subtract")
-            result = subtract_tool.invoke(a=10, b=4)
-            assert result.content[0].text == "6"
+            result_json = subtract_tool.invoke(a=10, b=4)
+
+            # Parse the JSON result
+            result = json.loads(result_json)
+            assert result["content"][0]["text"] == "6"
 
         except Exception:
             # Check server output for clues


### PR DESCRIPTION
### Why:
Fixed incorrect serialization of `MCPTool` responses. Previously, when tools returned TextContent or ImageContent objects, they were being converted to strings using `str()` which produced raw Python object representations instead of proper JSON. This made the responses difficult to parse and use, especially for LLMs and users expecting structured JSON data.

*Note*: this is a breaking change as we are switching from raw mcp-sdk CallToolResult types being returned from tool calls to JSON strings

### What:
- Proper JSON serialization of TextContent and ImageContent using `model_dump_json()`
- Consistent JSON string responses for all tool calls
- Fixed string representation of error messages


### How can it be used:

No changes in usage patterns:

```python
from haystack.tools import MCPTool, SSEServerInfo
import json

tool = MCPTool(
    name="image_tool",
    server_info=SSEServerInfo(url="http://localhost:8000/sse")
)

# Now returns proper JSON string instead of raw string representation
result_json = tool.invoke(param="value")
result = json.loads(result_json)
```

### How did you test it:
- **Unit tests**: Verified proper JSON serialization in tool response tests
- **Integration tests**: Confirmed correct handling of TextContent serialization
- **Feature tests**: Tested error cases ensure proper JSON formatting

### Notes for the reviewer:
- **Compatibility**: breaking change as now we return json object string representation instead of mcp-sdk objects 