### PR TITLE
chore: Use GEMINI_API_KEY as default env var for the api key (in addition to GOOGLE_API_KEY)

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
@@ -39,7 +39,7 @@ class GoogleGenAIDocumentEmbedder:
     def __init__(
         self,
         *,
-        api_key: Secret = Secret.from_env_var("GOOGLE_API_KEY"),
+        api_key: Secret = Secret.from_env_var(["GOOGLE_API_KEY", "GEMINI_API_KEY"]),
         model: str = "text-embedding-004",
         prefix: str = "",
         suffix: str = "",
@@ -54,8 +54,8 @@ class GoogleGenAIDocumentEmbedder:
 
         :param api_key:
             The Google API key.
-            You can set it with the environment variable `GOOGLE_API_KEY`, or pass it via this parameter
-            during initialization.
+            You can set it with the environment variable `GOOGLE_API_KEY` or `GEMINI_API_KEY`, or pass it via
+            this parameter during initialization.
         :param model:
             The name of the model to use for calculating embeddings.
             The default model is `text-embedding-ada-002`.

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
@@ -39,7 +39,7 @@ class GoogleGenAITextEmbedder:
     def __init__(
         self,
         *,
-        api_key: Secret = Secret.from_env_var("GOOGLE_API_KEY"),
+        api_key: Secret = Secret.from_env_var(["GOOGLE_API_KEY", "GEMINI_API_KEY"]),
         model: str = "text-embedding-004",
         prefix: str = "",
         suffix: str = "",
@@ -50,8 +50,8 @@ class GoogleGenAITextEmbedder:
 
         :param api_key:
             The Google API key.
-            You can set it with the environment variable `GOOGLE_API_KEY`, or pass it via this parameter
-            during initialization.
+            You can set it with the environment variable `GOOGLE_API_KEY` or `GEMINI_API_KEY`, or pass it via
+            this parameter during initialization.
         :param model:
             The name of the model to use for calculating embeddings.
             The default model is `text-embedding-004`.

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -230,7 +230,7 @@ class GoogleGenAIChatGenerator:
     def __init__(
         self,
         *,
-        api_key: Secret = Secret.from_env_var("GOOGLE_API_KEY"),
+        api_key: Secret = Secret.from_env_var(["GOOGLE_API_KEY", "GEMINI_API_KEY"]),
         model: str = "gemini-2.0-flash",
         generation_kwargs: Optional[Dict[str, Any]] = None,
         safety_settings: Optional[List[Dict[str, Any]]] = None,
@@ -240,7 +240,7 @@ class GoogleGenAIChatGenerator:
         """
         Initialize a GoogleGenAIChatGenerator instance.
 
-        :param api_key: Google API key, defaults to the `GOOGLE_API_KEY` environment variable,
+        :param api_key: Google API key, defaults to the `GOOGLE_API_KEY` and `GEMINI_API_KEY` environment variables,
         see https://ai.google.dev/gemini-api/docs/api-key for more information.
         :param model: Name of the model to use (e.g., "gemini-2.0-flash")
         :param generation_kwargs: Configuration for generation (temperature, max_tokens, etc.)

--- a/integrations/google_genai/tests/test_document_embedder.py
+++ b/integrations/google_genai/tests/test_document_embedder.py
@@ -102,7 +102,7 @@ class TestGoogleGenAIDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
-                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY"], "strict": True},
+                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"], "strict": True},
                 "config": {"task_type": "SEMANTIC_SIMILARITY"},
             },
         }

--- a/integrations/google_genai/tests/test_text_embedder.py
+++ b/integrations/google_genai/tests/test_text_embedder.py
@@ -57,7 +57,7 @@ class TestGoogleGenAITextEmbedder:
         assert data == {
             "type": "haystack_integrations.components.embedders.google_genai.text_embedder.GoogleGenAITextEmbedder",
             "init_parameters": {
-                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY"], "strict": True},
+                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"], "strict": True},
                 "model": "text-embedding-004",
                 "prefix": "",
                 "suffix": "",
@@ -91,7 +91,7 @@ class TestGoogleGenAITextEmbedder:
         data = {
             "type": "haystack_integrations.components.embedders.google_genai.text_embedder.GoogleGenAITextEmbedder",
             "init_parameters": {
-                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY"], "strict": True},
+                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"], "strict": True},
                 "model": "text-embedding-004",
                 "prefix": "",
                 "suffix": "",


### PR DESCRIPTION
- GEMINI_API_KEY is used in all the docs