### PR TITLE
fix: Fix passing filters and topks to OpenSearchHybridRetriever at runtime

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
@@ -4,7 +4,7 @@
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from haystack import Pipeline, default_from_dict, default_to_dict, logging, super_component
+from haystack import Document, Pipeline, default_from_dict, default_to_dict, logging, super_component
 from haystack.components.embedders.types import TextEmbedder
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.joiners.document_joiner import JoinMode
@@ -244,7 +244,9 @@ class OpenSearchHybridRetriever:
             query: str,
             filters_bm25: Optional[Dict[str, Any]] = None,
             filters_embedding: Optional[Dict[str, Any]] = None,
-        ) -> Dict[str, Any]: ...
+            top_k_bm25: Optional[int] = None,
+            top_k_embedding: Optional[int] = None,
+        ) -> Dict[str, List[Document]]: ...
 
     def _create_pipeline(self, data: dict[str, Any]) -> Pipeline:
         """
@@ -268,6 +270,10 @@ class OpenSearchHybridRetriever:
         self.input_mapping = {
             # The pipeline input "query" feeds into each of the retrievers
             "query": ["text_embedder.text", "bm25_retriever.query"],
+            "filters_bm25": ["bm25_retriever.filters"],
+            "filters_embedding": ["embedding_retriever.filters"],
+            "top_k_bm25": ["bm25_retriever.top_k"],
+            "top_k_embedding": ["embedding_retriever.top_k"],
         }
         self.output_mapping = {"document_joiner.documents": "documents"}
 

--- a/integrations/opensearch/tests/test_open_search_hybrid_retriever.py
+++ b/integrations/opensearch/tests/test_open_search_hybrid_retriever.py
@@ -177,3 +177,36 @@ class TestOpenSearchHybridRetriever:
                 invalid_a={"raise_on_failure": True},
                 invalid_b={"raise_on_failure": False},
             )
+
+    def test_run_with_extra_runtime_params(self, mock_embedder):
+        # mocked document store
+        mock_store = Mock(spec=OpenSearchDocumentStore)
+        mock_store._bm25_retrieval.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval.return_value = [Document(content="Test doc Embedding")]
+
+        # use the mocked embedder
+        retriever = OpenSearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
+        _ = retriever.run(
+            query="test query",
+            filters_bm25={"key": "value"},
+            filters_embedding={"key": "value"},
+            top_k_bm25=1,
+            top_k_embedding=1,
+        )
+
+        mock_store._bm25_retrieval.assert_called_once_with(
+            query="test query",
+            filters={"key": "value"},
+            top_k=1,
+            all_terms_must_match=False,
+            fuzziness="AUTO",
+            scale_score=False,
+            custom_query=None,
+        )
+        mock_store._embedding_retrieval.assert_called_once_with(
+            query_embedding=[0.1, 0.2, 0.3],
+            filters={"key": "value"},
+            top_k=1,
+            custom_query=None,
+            efficient_filtering=False,
+        )

--- a/integrations/opensearch/tests/test_open_search_hybrid_retriever.py
+++ b/integrations/opensearch/tests/test_open_search_hybrid_retriever.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from unittest.mock import Mock
 
 import pytest
-from haystack import Document
+from haystack import Document, Pipeline
 from haystack.components.embedders import SentenceTransformersTextEmbedder
 from haystack.core.component import component
 
@@ -207,6 +207,38 @@ class TestOpenSearchHybridRetriever:
             query_embedding=[0.1, 0.2, 0.3],
             filters={"key": "value"},
             top_k=1,
+            custom_query=None,
+            efficient_filtering=False,
+        )
+
+    def test_run_in_pipeline(self, mock_embedder):
+        # mocked document store
+        pipeline = Pipeline()
+        mock_store = Mock(spec=OpenSearchDocumentStore)
+        mock_store._bm25_retrieval.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval.return_value = [Document(content="Test doc Embedding")]
+
+        # use the mocked embedder
+        retriever = OpenSearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
+        # result = retriever.run(query="test query")
+        pipeline.add_component("retriever", retriever)
+
+        # Should not fail
+        _ = pipeline.run(data={"retriever": {"query": "test query", "filters_bm25": {"param_a": "default"}}})
+
+        mock_store._bm25_retrieval.assert_called_once_with(
+            query="test query",
+            filters={"param_a": "default"},
+            top_k=10,
+            all_terms_must_match=False,
+            fuzziness="AUTO",
+            scale_score=False,
+            custom_query=None,
+        )
+        mock_store._embedding_retrieval.assert_called_once_with(
+            query_embedding=[0.1, 0.2, 0.3],
+            filters={},
+            top_k=10,
             custom_query=None,
             efficient_filtering=False,
         )


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Updates the `input_mapping` to 
```python
        self.input_mapping = {
            # The pipeline input "query" feeds into each of the retrievers
            "query": ["text_embedder.text", "bm25_retriever.query"],
            "filters_bm25": ["bm25_retriever.filters"],
            "filters_embedding": ["embedding_retriever.filters"],
            "top_k_bm25": ["bm25_retriever.top_k"],
            "top_k_embedding": ["embedding_retriever.top_k"],
        }
```
to include more parameters `top_k_bm25` and `top_k_embedding` which users may want to change at runtime. 

It also includes `filters_bm25` and `filters_embedding` which were in the type stubs for `def run` but missing from the input mapping.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

- Added tests with mock assert called once with

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
