### PR TITLE
chore: stop testing instructor-embedders on windows + python 3.13

### DIFF
--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -23,6 +23,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.13"]
         
+        # sentence-piece cannot be installed on Windows
+        # https://github.com/google/sentencepiece/issues/1111
+        exclude:
+          - os: windows-latest
+            python-version: "3.13"
+
+        
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.13"]
         
-        # sentence-piece cannot be installed on Windows
+        # sentence-piece cannot be installed on Windows with Python 3.13
         # https://github.com/google/sentencepiece/issues/1111
         exclude:
           - os: windows-latest

--- a/.github/workflows/instructor_embedders.yml
+++ b/.github/workflows/instructor_embedders.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.13"]
         
-        # sentence-piece cannot be installed on Windows with Python 3.13
+        # sentencepiece cannot be installed on Windows with Python 3.13
         # https://github.com/google/sentencepiece/issues/1111
         exclude:
           - os: windows-latest


### PR DESCRIPTION
### Related Issues

- nightly tests failure: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/15623348070/job/44027576451
- in short, sentencepiece (a dependency of sentence-transformers) cannot be installed on Windows with Python 3.13: see https://github.com/google/sentencepiece/issues/1111 and other similar issues
- (Instructor embedder should be moved to staging in a near future: #1883)

### Proposed Changes:
- do not test this integration with Windows + Python 3.13

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
