### PR TITLE
feat: Adding watsonx support in Haystack

### DIFF
--- a/integrations/watsonx/LICENSE.txt
+++ b/integrations/watsonx/LICENSE.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/integrations/watsonx/README.md
+++ b/integrations/watsonx/README.md
@@ -1,0 +1,23 @@
+# watsonx-haystack
+
+[![PyPI - Version](https://img.shields.io/pypi/v/watsonx.svg)](https://pypi.org/project/watsonx)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/watsonx.svg)](https://pypi.org/project/watsonx)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+Install the package using pip:
+
+```bash
+pip install watsonx-haystack
+```
+
+## License
+
+`watsonx` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/integrations/watsonx/examples/chat_generator_example.py
+++ b/integrations/watsonx/examples/chat_generator_example.py
@@ -1,0 +1,219 @@
+# In order to run this example, you will need watsonx credentials.
+import asyncio
+import os
+
+from haystack.dataclasses import ChatMessage
+from haystack.utils.auth import Secret
+
+from haystack_integrations.components.generators.watsonx.chat.chat_generator import WatsonxChatGenerator
+
+# Initialize the generator
+generator = WatsonxChatGenerator(
+    api_key=Secret.from_env_var('WATSONX_API_KEY'),  # Or use from_token("<apikey>")
+    model='meta-llama/llama-3-2-1b-instruct',
+    project_id=os.getenv('WATSONX_PROJECT_ID'),
+    generation_kwargs={
+        'max_tokens': 500,
+        'temperature': 0.7,
+        'top_p': 0.9,
+    },
+    tools=[
+        {
+            'name': 'get_weather',
+            'description': 'Get the current weather in a given location',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'location': {'type': 'string', 'description': 'The city and state, e.g. San Francisco, CA'},
+                    'unit': {'type': 'string', 'enum': ['celsius', 'fahrenheit'], 'default': 'celsius'},
+                },
+                'required': ['location'],
+            },
+        }
+    ],
+    max_retries=3,
+    timeout=30.0,
+)
+
+
+# Example 1: Basic synchronous chat
+def basic_chat():
+    messages = [
+        ChatMessage.from_system('You are a helpful assistant.'),
+        ChatMessage.from_user('Explain quantum computing in simple terms'),
+    ]
+    generator.run(messages)
+
+
+# Example 2: Tool calling
+def tool_calling_chat():
+    messages = [ChatMessage.from_user("What's the weather in Berlin today?")]
+    response = generator.run(messages)
+    reply = response['replies'][0]
+    if reply.tool_calls:
+        for _tool_call in reply.tool_calls:
+            pass
+    else:
+        pass
+
+
+# Example 3: Streaming chat (sync)
+def streaming_chat():
+    messages = [ChatMessage.from_user('Write a short poem about artificial intelligence')]
+    generator.run(messages, stream=True)
+
+
+# Example 4: Asynchronous chat
+def run_async_chat():
+    async def _async_chat():
+        messages = [ChatMessage.from_user('Tell me about the history of the internet')]
+        await generator.run_async(messages)
+
+    _run_async(_async_chat)
+
+
+# Example 5: Asynchronous streaming chat
+def run_async_streaming_chat():
+    async def _async_streaming_chat():
+        messages = [ChatMessage.from_user('Explain blockchain technology')]
+        await generator.run_async(messages, stream=True)
+
+    _run_async(_async_streaming_chat)
+
+
+# Handle both notebook and script environments
+def _run_async(coro_func):
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            return loop.create_task(coro_func())
+        else:
+            return loop.run_until_complete(coro_func())
+    except RuntimeError:
+        import nest_asyncio
+
+        nest_asyncio.apply()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(coro_func())
+
+
+# Main
+if __name__ == '__main__':
+    basic_chat()
+    tool_calling_chat()
+    streaming_chat()
+    run_async_chat()
+    run_async_streaming_chat()
+
+
+## Result
+# === Watsonx Chat Generator Demo ===
+
+# --- Basic Chat ---
+# Quantum computing is a fascinating technology that uses the principles of quantum mechanics to perform calculations and operations on data. Here's a simple explanation:
+
+# **Classical computers vs. Quantum Computers**
+
+# A classical computer uses "bits" to store and process information. A bit is either 0 or 1, and it's like a light switch - it's either on or off. A quantum computer uses "qubits" (quantum bits), which can exist in multiple states at the same time. This means a quantum computer can process a vast number of possibilities simultaneously.
+
+# **How Quantum Computers Work**
+
+# Imagine you have a deck of cards with 52 cards in it. A classical computer would look at each card one by one, and if it finds a match, it would move on to the next card. A quantum computer, on the other hand, can look at all the cards simultaneously and find matches instantly.
+
+# This is because qubits can exist in multiple states (0, 1, and both at the same time) and can be connected in a way that allows them to communicate with each other instantly, no matter how far apart they are.
+
+# **Quantum Computing Steps**
+
+# Here's a simplified step-by-step explanation of how a quantum computer works:
+
+# 1. **Qubit Preparation**: The qubits are created and prepared in a special way to represent the problem we want to solve.
+# 2. **Quantum Gates**: The qubits are then passed through a series of quantum gates, which are like the "switches" that control the qubits' behavior.
+# 3. **Quantum Measurement**: The qubits are measured, and the outcome is determined.
+# 4. **Data Processing**: The data is processed using the qubits' quantum gates, which allows for fast and efficient calculations.
+
+# **What Quantum Computers Can Do**
+
+# Quantum computers have the potential to solve certain problems much faster than classical computers. They can:
+
+# * Break complex encryption codes
+# * Simulate the behavior of molecules and materials
+# * Optimize complex systems and processes
+# * Discover new materials and compounds
+
+# **Challenges and Limitations**
+
+# While quantum computers have tremendous potential, they face several challenges and limitations, including:
+
+# * **Error Correction**: Quantum computers are prone to errors due to the fragile nature of qubits.
+# * **Scalability**: Currently, quantum computers are not scalable enough to solve complex problems.
+# * **Quantum Noise**: Random fluctuations in qubits can affect the accuracy of quantum computations.
+
+# Metadata: {'model': 'meta-llama/llama-3-2-1b-instruct', 'index': 0, 'finish_reason': 'length', 'usage': {'completion_tokens': 500, 'prompt_tokens': 48, 'total_tokens': 548}}
+
+# --- Tool Calling Chat ---
+# I'm not aware of any real-time weather information. However, I can suggest some ways for you to find out the current weather in Berlin. You can:
+
+# * Check online weather websites such as AccuWeather, Weather.com, or the German national weather service, Deutscher Wetterdienst (DWD).
+# * Use a mobile app such as Dark Sky or Weather Underground.
+# * Tune into local news or radio stations for weather updates.
+
+# If you'd like, I can help you find the most up-to-date weather information for Berlin.
+
+# --- Streaming Chat ---
+
+# Full message: I don't have the capability to write poems. However, I can assist you with generating a poem about artificial intelligence if you'd like.
+
+# --- Async Chat ---
+# Here's an overview of the history of the internet:
+
+# *   **Early beginnings:** The internet has its roots in the 1960s, when the United States Department of Defense's Advanced Research Projects Agency (ARPA) funded a project to create a network of computers that could communicate with each other. This project, called ARPANET, was the first operational packet switching network.
+# *   **Network expansion:** In the 1970s and 1980s, other networks, such as the National Science Foundation Network (NSFNET), were established, connecting universities and research institutions across the United States.
+# *   **The World Wide Web (WWW):** In 1989, Tim Berners-Lee invented the World Wide Web, which revolutionized the way people access and share information online. The web made it easy for users to navigate and access information using web browsers and hyperlinks.
+# *   **Internet growth:** The 1990s saw the rise of commercial internet services, such as America Online (AOL) and CompuServe. This led to the growth of the internet as a mainstream technology.
+# *   **Globalization:** The internet became increasingly global, with the establishment of international networks and the development of new technologies, such as broadband and mobile internet.
+# *   **Social media and online communities:** The 2000s saw the rise of social media platforms, such as Facebook and Twitter, which enabled people to connect with each other and share information online.
+# *   **The internet today:** The internet is now a global network of billions of interconnected devices, with applications ranging from online shopping and education to social media and entertainment.
+
+# Here's a summary of the key events and milestones in the history of the internet:
+
+# *   1969: ARPANET is launched
+# *   1989: The World Wide Web is invented
+# *   1991: The internet is opened to commercial use
+# *   1993: The World Wide Web is made available to the general public
+# *   1995: Broadband internet becomes available
+# *   2000: Social media platforms begin to emerge
+# *   2007: Facebook becomes one of the most popular social media platforms
+# *   2010s: The internet continues to evolve with the development of new technologies, such as mobile internet and artificial intelligence.
+
+# --- Async Streaming Chat ---
+
+# Full message: **Tool Call: Blockchain Technology**
+
+# The tool call "Blockchain Technology" is a fundamental concept in the field of cryptography and distributed ledger technology. Here's a brief explanation:
+
+# Blockchain technology is a decentralized, digital ledger that records transactions across a network of computers in a secure and transparent manner. It allows for the creation of a permanent, immutable record of all transactions, making it ideal for applications such as cryptocurrency, supply chain management, and voting systems.
+
+# Here's a high-level overview of how blockchain technology works:
+
+# 1.  **Distributed Ledger**: A blockchain is a distributed ledger that is maintained by a network of computers (nodes) that are connected to each other through a peer-to-peer network.
+# 2.  **Transactions**: When a user wants to make a transaction, they create a new entry in the blockchain by broadcasting the transaction to the network of nodes.
+# 3.  **Verification**: Each node verifies the transaction by checking its validity and ensuring that it is not tampered with.
+# 4.  **Block Creation**: Once a node verifies the transaction, it creates a new block and adds it to the blockchain.
+# 5.  **Blockchain Update**: Each node updates its copy of the blockchain with the new block, ensuring that all nodes have the same version of the blockchain.
+
+# **Benefits of Blockchain Technology**
+
+# 1.  **Security**: Blockchain technology is secure due to the use of cryptography and the decentralized nature of the network.
+# 2.  **Transparency**: All transactions are recorded in a public ledger, making it transparent and tamper-proof.
+# 3.  **Immutable**: The blockchain is an immutable record, meaning that once a transaction is recorded, it cannot be altered or deleted.
+# 4.  **Decentralization**: Blockchain technology is decentralized, meaning that there is no single point of control or authority.
+
+# **Real-World Applications of Blockchain Technology**
+
+# 1.  **Cryptocurrencies**: Blockchain technology is the foundation for cryptocurrencies such as Bitcoin and Ethereum.
+# 2.  **Supply Chain Management**: Blockchain technology is being used to track the movement of goods and materials throughout the supply chain.
+# 3.  **Voting Systems**: Blockchain technology is being used to create secure and transparent voting systems.
+# 4.  **Identity Verification**: Blockchain technology is being used to create secure and decentralized identity verification systems.
+
+# In summary, blockchain technology is a decentralized, digital ledger that records transactions in a secure and transparent manner. Its benefits include security, transparency, immutability, and decentralization.

--- a/integrations/watsonx/examples/embedders_example.py
+++ b/integrations/watsonx/examples/embedders_example.py
@@ -1,0 +1,56 @@
+# In order to run this example, you will need watsonx credentials.
+from haystack import Document, Pipeline
+from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.utils.auth import Secret
+
+from haystack_integrations.components.embedders.watsonx.document_embedder import WatsonXDocumentEmbedder
+from haystack_integrations.components.embedders.watsonx.text_embedder import WatsonXTextEmbedder
+
+# Step 1: Set your credentials
+api_key = '<api-key>'
+project_id = '<project-id>'
+
+# Step 2: Create document store
+document_store = InMemoryDocumentStore(embedding_similarity_function='cosine')
+
+# Step 3: Prepare documents
+documents = [
+    Document(content='I saw a black horse running'),
+    Document(content='Germany has many big cities'),
+    Document(content='My name is Wolfgang and I live in Berlin'),
+]
+
+# Step 4: Embed documents
+document_embedder = WatsonXDocumentEmbedder(
+    model='ibm/slate-125m-english-rtrvr',
+    api_key=Secret.from_token(api_key),
+    project_id=project_id,
+    url='https://us-south.ml.cloud.ibm.com',
+)
+documents_with_embeddings = document_embedder.run(documents)['documents']
+
+document_store.write_documents(documents_with_embeddings)
+
+# Step 5: Build pipeline
+query_pipeline = Pipeline()
+query_pipeline.add_component(
+    'text_embedder',
+    WatsonXTextEmbedder(
+        model='ibm/slate-125m-english-rtrvr',
+        api_key=Secret.from_token(api_key),
+        project_id=project_id,
+        url='https://us-south.ml.cloud.ibm.com',
+    ),
+)
+query_pipeline.add_component('retriever', InMemoryEmbeddingRetriever(document_store=document_store))
+query_pipeline.connect('text_embedder.embedding', 'retriever.query_embedding')
+
+# Step 6: Run query
+query = 'Who lives in Berlin?'
+result = query_pipeline.run({'text_embedder': {'text': query}})
+
+# Step 7: Print result
+
+### Result
+# Document(id=62fad790ad2af927af9432c87330ed2ea5e31332cdec8e9d6235a5105ab0aaf5, content: 'My name is Wolfgang and I live in Berlin', score: 0.7287276769333577)

--- a/integrations/watsonx/examples/generator_example.py
+++ b/integrations/watsonx/examples/generator_example.py
@@ -1,0 +1,54 @@
+# In order to run this example, you will need watsonx credentials.
+import os
+
+from haystack import Pipeline
+from haystack.utils import Secret
+
+from haystack_integrations.components.generators.watsonx.generator import WatsonxGenerator
+
+# Basic Usage of WatsonxGenerator
+generator = WatsonxGenerator(
+    model='ibm/granite-13b-instruct-v2',
+    api_key=Secret.from_env_var('WATSONX_API_KEY'),
+    project_id=os.getenv('WATSONX_PROJECT_ID'),
+    generation_kwargs={
+        'max_new_tokens': 100,
+        'temperature': 0.7,
+        'top_p': 0.9,
+        'decoding_method': 'sample',
+        'concurrency_limit': 5,
+    },
+)
+prompts = ['Who is the president of the USA?', 'What is the tallest mountain?']
+
+for prompt in prompts:
+    result = generator.run(prompt)
+
+
+## Result
+## Output will vary based on model behavior
+## Who is the president of the USA? → trump
+## What is the tallest mountain? → The tallest mountain is Mount Everest, which is 8,848 meters (29,029 feet) tall.
+
+# Initialize with streaming enabled
+streaming_generator = WatsonxGenerator(
+    api_key=Secret.from_token(os.environ['WATSONX_API_KEY']),
+    model='ibm/granite-13b-instruct-v2',
+    project_id=os.environ['WATSONX_PROJECT_ID'],
+    generation_kwargs={'max_new_tokens': 450, 'temperature': 0.9, 'top_p': 0.9, 'repetition_penalty': 1.2},
+)
+
+# Create pipeline
+streaming_pipeline = Pipeline()
+streaming_pipeline.add_component('generator', streaming_generator)
+
+# Run with streaming
+prompt = 'Write a short story about an AI assistant.'
+result = streaming_pipeline.run({'generator': {'prompt': prompt, 'stream': True}})
+
+# Process streaming results
+
+
+##Result for steaming generator
+##Full response: The AI assistant is a friendly and helpful robot that can help you with many tasks, such as setting reminders,
+## managing your calendar, and creating to-do lists. You can also use the AI assistant to search for information online, or just have fun conversations with it.

--- a/integrations/watsonx/pydoc/config.yml
+++ b/integrations/watsonx/pydoc/config.yml
@@ -1,0 +1,32 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../src]
+    modules: [
+      "haystack_integrations.components.generators.watsonx.generator",
+      "haystack_integrations.components.generators.watsonx.chat.chat_generator",
+      "haystack_integrations.components.embedders.watsonx.document_embedder",
+      "haystack_integrations.components.embedders.watsonx.text_embedder",
+    ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.ReadmeIntegrationRenderer
+  excerpt: IBM watsonx.ai integration for Haystack
+  category_slug: integrations-api
+  title: IBM watsonx.ai
+  slug: integrations-watsonx
+  order: 240  
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: _readme_watsonx.md

--- a/integrations/watsonx/pyproject.toml
+++ b/integrations/watsonx/pyproject.toml
@@ -1,0 +1,121 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "watsonx-haystack"
+version = "0.1.0"
+description = "Watsonx integration for Haystack"
+authors = [{ name = "Divya", email = "divyaruhil999@gmail.com" }]
+dependencies = [
+    "haystack-ai",
+    "ibm-watsonx-ai"
+]
+
+[project.urls]
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/watsonx#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/watsonx"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.envs.default]
+installer = "uv"
+dependencies = [
+    "pytest",
+    "pytest-asyncio",
+    "haystack-ai",
+    "ibm-watsonx-ai",
+    "ruff",
+    "haystack-pydoc-tools"
+]
+
+[tool.hatch.envs.default.scripts]
+docs = ["pydoc-markdown pydoc/config.yml"]
+fmt = "ruff check --fix {args} && ruff format {args}"
+fmt-check = "ruff check {args} && ruff format --check {args}"
+test = "pytest"
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest",
+    "pytest-asyncio",
+    "anyio",
+    "haystack-ai",
+    "ibm-watsonx-ai",
+    "pytest-mock"
+]
+
+[tool.hatch.envs.docs]
+dependencies = ["haystack-pydoc-tools"]
+
+[tool.hatch.envs.docs.scripts]
+docs = "haystack-pydoc build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/haystack_integrations"]
+
+[tool.hatch.build.targets.editable]
+packages = ["src/haystack_integrations"]
+
+[tool.pytest.ini_options]
+markers = [
+    "asyncio: mark tests as using asyncio",
+    "integration: mark tests as integration tests"
+]
+asyncio_mode = "auto"
+addopts = "--tb=short -v"
+
+[tool.black]
+target-version = ["py38"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py38"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "A", "ARG", "B", "C", "DTZ", "E", "F", "FA", "I", "TID", "UP", "RUF"
+]
+ignore = [
+    "A003",    # Class attribute shadows builtin
+    "ARG001",  # Unused function argument
+    "ARG002",  # Unused method argument
+    "B027",    # Allow empty abstract methods
+    "C901",    # Complex function
+    "DTZ005",  # Missing timezone info
+    "E501",    # Line too long (handled by formatter)
+    "EM101",   # Exception message in string literal
+    "FBT001",  # Boolean positional argument in function definition
+    "FBT002",  # Boolean default positional argument in function definition
+    "G004",    # Logging statement uses f-string
+    "PLR0911", # Too many return statements
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments
+    "PLR2004", # Magic value used in comparison
+    "RET505",  # Unnecessary else after return
+    "S101",    # Use of assert
+    "S105",    # Possible hardcoded password
+    "S106",    # Possible hardcoded password
+    "S107",    # Possible hardcoded password
+    "SLF001",  # Private member accessed
+    "T201",    # Print statement
+    "TRY003",  # Avoid long messages outside exception class
+    "TRY401",  # Redundant exception object in logging.exception call
+    "UP007",   # Use X | Y for type union
+]
+
+[tool.ruff.lint.per-file-ignores]
+"examples/**" = ["T201", "RET505", "INP001"]
+"watsonx/tests/**" = ["ALL"]
+"tests/**" = ["ALL"]
+"**/test_*.py" = ["ALL"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "parents"
+
+[tool.ruff.format]
+quote-style = "single"

--- a/integrations/watsonx/src/haystack_integrations/components/__init__.py
+++ b/integrations/watsonx/src/haystack_integrations/components/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/__init__.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/__init__.py
@@ -1,0 +1,4 @@
+from haystack_integrations.components.embedders.watsonx.document_embedder import WatsonXDocumentEmbedder
+from haystack_integrations.components.embedders.watsonx.text_embedder import WatsonXTextEmbedder
+
+__all__ = ['WatsonXDocumentEmbedder', 'WatsonXTextEmbedder']

--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from haystack import Document, component, default_from_dict, default_to_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
+from ibm_watsonx_ai import Credentials
+from ibm_watsonx_ai.foundation_models import Embeddings
+
+
+@component
+class WatsonXDocumentEmbedder:
+    """
+    Computes document embeddings using IBM watsonx.ai models.
+
+    ### Usage example
+
+    ```python
+    from haystack import Document
+    from haystack.components.embedders import WatsonXDocumentEmbedder
+
+    documents = [
+        Document(content='I love pizza!'),
+        Document(content='Pasta is great too'),
+    ]
+
+    document_embedder = WatsonXDocumentEmbedder(
+        model='ibm/slate-30m-english-rtrvr',
+        api_key=Secret.from_env_var('WATSONX_API_KEY'),
+        url='https://us-south.ml.cloud.ibm.com',
+        project_id='your-project-id',
+    )
+
+    result = document_embedder.run(documents=documents)
+    print(result['documents'][0].embedding)
+
+    # [0.017020374536514282, -0.023255806416273117, ...]
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str = 'ibm/slate-30m-english-rtrvr',
+        api_key: Secret | None = None,
+        url: str = 'https://us-south.ml.cloud.ibm.com',
+        project_id: str | None = None,
+        space_id: str | None = None,
+        truncate_input_tokens: int | None = None,
+        prefix: str = '',
+        suffix: str = '',
+        batch_size: int = 1000,
+        concurrency_limit: int = 5,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+    ):
+        """
+        Creates a WatsonXDocumentEmbedder component.
+
+        :param model:
+            The name of the model to use for calculating embeddings.
+            Default is "ibm/slate-30m-english-rtrvr".
+        :param api_key:
+            The WATSONX API key. Can be set via environment variable WATSONX_API_KEY.
+        :param url:
+            The WATSONX URL for the watsonx.ai service.
+            Default is "https://us-south.ml.cloud.ibm.com".
+        :param project_id:
+            The ID of the Watson Studio project. Either project_id or space_id must be provided.
+        :param space_id:
+            The ID of the Watson Studio space. Either project_id or space_id must be provided.
+        :param truncate_input_tokens:
+            Maximum number of tokens to use from the input text.
+        :param prefix:
+            A string to add at the beginning of each text.
+        :param suffix:
+            A string to add at the end of each text.
+        :param batch_size:
+            Number of documents to embed in one API call. Default is 1000.
+        :param concurrency_limit:
+            Number of parallel requests to make. Default is 5.
+        :param timeout:
+            Timeout for API requests in seconds.
+        :param max_retries:
+            Maximum number of retries for API requests.
+        """
+        if api_key is None:
+            api_key = Secret.from_env_var('WATSONX_API_KEY')
+
+        if not project_id and not space_id:
+            msg = 'Either project_id or space_id must be provided'
+            raise ValueError(msg)
+
+        self.model = model
+        self.api_key = api_key
+        self.url = url
+        self.project_id = project_id
+        self.space_id = space_id
+        self.truncate_input_tokens = truncate_input_tokens
+        self.prefix = prefix
+        self.suffix = suffix
+        self.batch_size = batch_size
+        self.concurrency_limit = concurrency_limit
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+        # Initialize the embeddings client
+        credentials = Credentials(api_key=api_key.resolve_value(), url=url)
+
+        params = {}
+        if truncate_input_tokens is not None:
+            params['truncate_input_tokens'] = truncate_input_tokens
+
+        self.embedder = Embeddings(
+            model_id=model,
+            credentials=credentials,
+            project_id=project_id,
+            space_id=space_id,
+            params=params if params else None,
+            batch_size=batch_size,
+            concurrency_limit=concurrency_limit,
+            max_retries=max_retries or 10,
+        )
+
+    def _get_telemetry_data(self) -> dict[str, Any]:
+        """
+        Data that is sent to Posthog for usage analytics.
+        """
+        return {'model': self.model}
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+        """
+        return default_to_dict(
+            self,
+            model=self.model,
+            api_key=self.api_key.to_dict(),
+            url=self.url,
+            project_id=self.project_id,
+            space_id=self.space_id,
+            truncate_input_tokens=self.truncate_input_tokens,
+            prefix=self.prefix,
+            suffix=self.suffix,
+            batch_size=self.batch_size,
+            concurrency_limit=self.concurrency_limit,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WatsonXDocumentEmbedder:
+        """
+        Deserializes the component from a dictionary.
+        """
+        deserialize_secrets_inplace(data['init_parameters'], keys=['api_key'])
+        return default_from_dict(cls, data)
+
+    def _prepare_text(self, text: str) -> str:
+        """
+        Prepares text for embedding by adding prefix and suffix.
+        """
+        return self.prefix + text + self.suffix
+
+    @component.output_types(documents=List[Document], meta=Dict[str, Any])
+    def run(self, documents: list[Document]):
+        """
+        Embeds a list of documents.
+
+        :param documents:
+            A list of documents to embed.
+        :returns:
+            A dictionary with:
+            - 'documents': List of Documents with embeddings added
+            - 'meta': Information about the model usage
+        """
+        if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
+            msg = (
+                'WatsonXDocumentEmbedder expects a list of Documents as input.'
+                'In case you want to embed a string, please use the WatsonXTextEmbedder.'
+            )
+            raise TypeError(msg)
+
+        texts_to_embed = [self._prepare_text(doc.content or '') for doc in documents]
+        embeddings = self.embedder.embed_documents(texts_to_embed)
+
+        for doc, emb in zip(documents, embeddings):
+            doc.embedding = emb
+
+        return {
+            'documents': documents,
+            'meta': {
+                'model': self.model,
+                'truncate_input_tokens': self.truncate_input_tokens,
+                'batch_size': self.batch_size,
+            },
+        }

--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/text_embedder.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/text_embedder.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
+from ibm_watsonx_ai import Credentials
+from ibm_watsonx_ai.foundation_models import Embeddings
+
+
+@component
+class WatsonXTextEmbedder:
+    """
+    Embeds strings using IBM watsonx.ai foundation models.
+
+    You can use it to embed user query and send it to an embedding Retriever.
+
+    ### Usage example
+
+    ```python
+    from haystack.components.embedders import WatsonXTextEmbedder
+
+    text_to_embed = 'I love pizza!'
+
+    text_embedder = WatsonXTextEmbedder(
+        model='ibm/slate-30m-english-rtrvr',
+        api_key=Secret.from_env_var('WATSONX_API_KEY'),
+        url='https://us-south.ml.cloud.ibm.com',
+        project_id='your-project-id',
+    )
+
+    print(text_embedder.run(text_to_embed))
+
+    # {'embedding': [0.017020374536514282, -0.023255806416273117, ...],
+    #  'meta': {'model': 'ibm/slate-30m-english-rtrvr',
+    #           'truncated_input_tokens': 3}}
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str = 'ibm/slate-30m-english-rtrvr',
+        api_key: Secret | None = None,
+        url: str = 'https://us-south.ml.cloud.ibm.com',
+        project_id: str | None = None,
+        space_id: str | None = None,
+        truncate_input_tokens: int | None = None,
+        prefix: str = '',
+        suffix: str = '',
+        timeout: float | None = None,
+        max_retries: int | None = None,
+    ):
+        """
+        Creates an WatsonXTextEmbedder component.
+
+        :param model:
+            The name of the IBM watsonx model to use for calculating embeddings.
+            Default is "ibm/slate-30m-english-rtrvr".
+        :param api_key:
+            The WATSONX API key. Can be set via environment variable WATSONX_API_KEY.
+        :param url:
+            The WATSONX URL for the watsonx.ai service.
+            Default is "https://us-south.ml.cloud.ibm.com".
+        :param project_id:
+            The ID of the Watson Studio project. Either project_id or space_id must be provided.
+        :param space_id:
+            The ID of the Watson Studio space. Either project_id or space_id must be provided.
+        :param truncate_input_tokens:
+            Maximum number of tokens to use from the input text.
+        :param prefix:
+            A string to add at the beginning of each text to embed.
+        :param suffix:
+            A string to add at the end of each text to embed.
+        :param timeout:
+            Timeout for API requests in seconds.
+        :param max_retries:
+            Maximum number of retries for API requests.
+        """
+        if api_key is None:
+            api_key = Secret.from_env_var('WATSONX_API_KEY')
+
+        if not project_id and not space_id:
+            msg = 'Either project_id or space_id must be provided'
+            raise ValueError(msg)
+
+        self.model = model
+        self.api_key = api_key
+        self.url = url
+        self.project_id = project_id
+        self.space_id = space_id
+        self.truncate_input_tokens = truncate_input_tokens
+        self.prefix = prefix
+        self.suffix = suffix
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+        # Initialize the embeddings client
+        credentials = Credentials(api_key=api_key.resolve_value(), url=url)
+
+        params = {}
+        if truncate_input_tokens is not None:
+            params['truncate_input_tokens'] = truncate_input_tokens
+
+        self.embedder = Embeddings(
+            model_id=model,
+            credentials=credentials,
+            project_id=project_id,
+            space_id=space_id,
+            params=params if params else None,
+        )
+
+    def _get_telemetry_data(self) -> dict[str, Any]:
+        """
+        Data that is sent to Posthog for usage analytics.
+        """
+        return {'model': self.model}
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+        """
+        return default_to_dict(
+            self,
+            model=self.model,
+            api_key=self.api_key.to_dict(),
+            url=self.url,
+            project_id=self.project_id,
+            space_id=self.space_id,
+            truncate_input_tokens=self.truncate_input_tokens,
+            prefix=self.prefix,
+            suffix=self.suffix,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WatsonXTextEmbedder:
+        """
+        Deserializes the component from a dictionary.
+        """
+        deserialize_secrets_inplace(data['init_parameters'], keys=['api_key'])
+        return default_from_dict(cls, data)
+
+    def _prepare_input(self, text: str) -> str:
+        if not isinstance(text, str):
+            msg = (
+                'WatsonXTextEmbedder expects a string as an input. '
+                'In case you want to embed a list of Documents, please use the WatsonXDocumentEmbedder.'
+            )
+            raise TypeError(msg)
+        return self.prefix + text + self.suffix
+
+    def _prepare_output(self, embedding: list[float]) -> dict[str, Any]:
+        return {
+            'embedding': embedding,
+            'meta': {'model': self.model, 'truncated_input_tokens': self.truncate_input_tokens},
+        }
+
+    @component.output_types(embedding=List[float], meta=Dict[str, Any])
+    def run(self, text: str):
+        """
+        Embeds a single string.
+
+        :param text: Text to embed.
+        :returns: A dictionary with:
+            - 'embedding': The embedding of the input text
+            - 'meta': Information about the model usage
+        """
+        text_to_embed = self._prepare_input(text=text)
+        embedding = self.embedder.embed_query(text_to_embed)
+        return self._prepare_output(embedding)

--- a/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/__init__.py
+++ b/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/__init__.py
@@ -1,0 +1,3 @@
+from haystack_integrations.components.generators.watsonx.generator import WatsonxGenerator
+
+__all__ = ['WatsonxGenerator']

--- a/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/__init__.py
+++ b/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/__init__.py
@@ -1,0 +1,3 @@
+from haystack_integrations.components.generators.watsonx.chat.chat_generator import WatsonxChatGenerator
+
+__all__ = ['WatsonxChatGenerator']

--- a/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
+++ b/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, List
+
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall
+from haystack.utils import Secret, deserialize_secrets_inplace
+from ibm_watsonx_ai import Credentials
+from ibm_watsonx_ai.foundation_models import ModelInference
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class WatsonxChatGenerator:
+    """
+    Enables chat completions using IBM's watsonx.ai foundation models.
+
+    This component interacts with IBM's watsonx.ai platform to generate chat responses
+    using various foundation models. It supports the [ChatMessage](https://docs.haystack.deepset.ai/docs/chatmessage)
+    format for both input and output.
+
+    The generator works with IBM's foundation models including:
+    - granite-13b-chat-v2
+    - llama-2-70b-chat
+    - llama-3-70b-instruct
+    - Other watsonx.ai chat models
+
+    You can customize the generation behavior by passing parameters to the
+    watsonx.ai API through the `generation_kwargs` argument. These parameters
+    are passed directly to the watsonx.ai inference endpoint.
+
+    For details on watsonx.ai API parameters, see
+    [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-parameters.html).
+
+    ### Usage example
+
+    ```python
+    from haystack.components.generators.chat import WatsonxChatGenerator
+    from haystack.dataclasses import ChatMessage
+
+    messages = [ChatMessage.from_user('Explain quantum computing in simple terms')]
+
+    client = WatsonxChatGenerator(
+        model='ibm/granite-13b-chat-v2', project_id='your-project-id'
+    )
+    response = client.run(messages)
+    print(response)
+    ```
+    Output:
+    ```
+    {'replies':
+        [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=
+        [TextContent(text="Quantum computing uses quantum-mechanical phenomena like ....")],
+         _name=None,
+         _meta={'model': 'ibm/granite-13b-chat-v2', 'project_id': 'your-project-id',
+         'usage': {'prompt_tokens': 12, 'completion_tokens': 45, 'total_tokens': 57}})
+        ]
+    }
+    ```
+
+    The component also supports streaming responses and function calling through
+    watsonx.ai's tools parameter.
+    """
+
+    def __init__(
+        self,
+        api_key: Secret | None = None,
+        model: str = 'ibm/granite-13b-chat-v2',
+        project_id: str | None = None,
+        space_id: str | None = None,
+        api_base_url: str | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        verify: bool | str | None = None,
+    ):
+        """
+        Initializes the WatsonxChatGenerator with connection and generation parameters.
+
+        Before initializing the component, you can set environment variables:
+        - `WATSONX_TIMEOUT` to override the default timeout
+        - `WATSONX_MAX_RETRIES` to override the default retry count
+
+        :param api_key: IBM Cloud API key for watsonx.ai access.
+            Can be set via `WATSONX_API_KEY` environment variable or passed directly.
+        :param model: The model ID to use for completions. Defaults to "ibm/granite-13b-chat-v2".
+            Available models can be found in your IBM Cloud account.
+        :param project_id: IBM Cloud project ID (required if space_id is not provided).
+        :param space_id: watsonx.ai deployment space ID (required if project_id is not provided).
+        :param api_base_url: Custom base URL for the API endpoint.
+            Defaults to "https://us-south.ml.cloud.ibm.com".
+        :param generation_kwargs: Additional parameters to control text generation.
+            These parameters are passed directly to the watsonx.ai inference endpoint.
+            Supported parameters include:
+            - `temperature`: Controls randomness (lower = more deterministic)
+            - `max_new_tokens`: Maximum number of tokens to generate
+            - `min_new_tokens`: Minimum number of tokens to generate
+            - `top_p`: Nucleus sampling probability threshold
+            - `top_k`: Number of highest probability tokens to consider
+            - `repetition_penalty`: Penalty for repeated tokens
+            - `length_penalty`: Penalty based on output length
+            - `stop_sequences`: List of sequences where generation should stop
+            - `random_seed`: Seed for reproducible results
+        :param timeout: Timeout in seconds for API requests.
+            Defaults to environment variable `WATSONX_TIMEOUT` or 30 seconds.
+        :param max_retries: Maximum number of retry attempts for failed requests.
+            Defaults to environment variable `WATSONX_MAX_RETRIES` or 5.
+        :param tools: List of tools in Watsonx format for function calling.
+            Each tool should be a dictionary with:
+            - `name`: Tool name
+            - `description`: Tool description
+            - `parameters`: JSON schema for parameters
+        :param verify: SSL verification setting. Can be:
+            - True: Verify SSL certificates (default)
+            - False: Skip verification (insecure)
+            - Path to CA bundle for custom certificates
+        """
+        self.api_key = api_key or Secret.from_env_var('WATSONX_API_KEY')
+        self.model = model
+        self.project_id = project_id
+        self.space_id = space_id
+        self.api_base_url = api_base_url or 'https://us-south.ml.cloud.ibm.com'
+        self.generation_kwargs = generation_kwargs or {}
+        self.timeout = timeout or float(os.environ.get('WATSONX_TIMEOUT', '30.0'))
+        self.max_retries = max_retries or int(os.environ.get('WATSONX_MAX_RETRIES', '5'))
+        self.tools = tools
+        self.verify = verify
+
+        if not project_id and not space_id:
+            msg = 'Either project_id or space_id must be provided'
+            raise ValueError(msg)
+
+        self._initialize_client()
+
+    def _initialize_client(self):
+        """Initialize the Watsonx client with configured credentials."""
+        credentials = Credentials(api_key=self.api_key.resolve_value(), url=self.api_base_url)
+
+        self.client = ModelInference(
+            model_id=self.model,
+            credentials=credentials,
+            project_id=self.project_id,
+            space_id=self.space_id,
+            verify=self.verify,
+            max_retries=self.max_retries,
+            delay_time=0.5,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the component to a dictionary."""
+        return default_to_dict(
+            self,
+            model=self.model,
+            project_id=self.project_id,
+            space_id=self.space_id,
+            api_base_url=self.api_base_url,
+            generation_kwargs=self.generation_kwargs,
+            api_key=self.api_key.to_dict(),
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+            tools=self.tools,
+            verify=self.verify,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WatsonxChatGenerator:
+        """Deserialize the component from a dictionary."""
+        deserialize_secrets_inplace(data['init_parameters'], keys=['api_key'])
+        return default_from_dict(cls, data)
+
+    @component.output_types(replies=List[ChatMessage])
+    def run(self, messages: list[ChatMessage], generation_kwargs: dict[str, Any] | None = None, stream: bool = False):
+        """
+        Generate chat completions synchronously.
+
+        :param messages: List of ChatMessage objects
+        :param generation_kwargs: Additional generation parameters
+        :param stream: Enable streaming response
+        :return: Dictionary with generated replies
+        """
+        if not messages:
+            return {'replies': []}
+
+        api_args = self._prepare_api_call(messages=messages, generation_kwargs=generation_kwargs)
+
+        if stream:
+            return self._handle_streaming(api_args)
+        return self._handle_standard(api_args)
+
+    @component.output_types(replies=List[ChatMessage])
+    async def run_async(
+        self, messages: list[ChatMessage], generation_kwargs: dict[str, Any] | None = None, stream: bool = False
+    ):
+        """
+        Generate chat completions asynchronously.
+
+        :param messages: List of ChatMessage objects
+        :param generation_kwargs: Additional generation parameters
+        :param stream: Enable streaming response
+        :return: Dictionary with generated replies
+        """
+        if not messages:
+            return {'replies': []}
+
+        api_args = self._prepare_api_call(messages=messages, generation_kwargs=generation_kwargs)
+
+        if stream:
+            return await self._handle_async_streaming(api_args)
+        return await self._handle_async_standard(api_args)
+
+    def _prepare_api_call(
+        self, *, messages: list[ChatMessage], generation_kwargs: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        merged_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+
+        watsonx_messages = []
+        for msg in messages:
+            if msg.is_from('user'):
+                content = msg.text
+            elif msg.is_from('assistant'):
+                content = msg.text
+                if msg.tool_calls:
+                    merged_kwargs['tools'] = [
+                        {'name': tc.tool_name, 'description': '', 'parameters': tc.arguments} for tc in msg.tool_calls
+                    ]
+            elif msg.is_from('tool'):
+                content = {
+                    'tool_call_id': msg.tool_call_results[0].origin.id,
+                    'content': msg.tool_call_results[0].result,
+                }
+            else:
+                content = msg.text
+
+            watsonx_msg = {'role': msg.role.value, 'content': content}
+            if msg.name:
+                watsonx_msg['name'] = msg.name
+            watsonx_messages.append(watsonx_msg)
+
+        merged_kwargs.pop('stream', None)
+
+        return {'messages': watsonx_messages, 'params': merged_kwargs}
+
+    def _handle_streaming(self, api_args: dict[str, Any]) -> dict[str, Any]:
+        """Handle synchronous streaming response."""
+        chunks: list[StreamingChunk] = []
+        full_text = ''
+
+        stream = self.client.chat_stream(messages=api_args['messages'], params=api_args['params'])
+
+        for chunk in stream:
+            if not isinstance(chunk, dict) or not chunk.get('choices'):
+                continue
+
+            content = chunk['choices'][0].get('delta', {}).get('content', '')
+            if content:
+                full_text += content
+                chunk_meta = {
+                    'model': self.model,
+                    'index': chunk['choices'][0].get('index', 0),
+                    'finish_reason': chunk['choices'][0].get('finish_reason'),
+                    'received_at': datetime.now(timezone.utc).isoformat(),
+                }
+                chunks.append(StreamingChunk(content=content, meta=chunk_meta))
+
+        return {
+            'replies': [
+                ChatMessage.from_assistant(
+                    text=full_text,
+                    meta={
+                        'model': self.model,
+                        'finish_reason': chunks[-1].meta['finish_reason'] if chunks else 'completed',
+                    },
+                )
+            ],
+            'chunks': chunks,
+        }
+
+    def _handle_standard(self, api_args: dict[str, Any]) -> dict[str, Any]:
+        """Handle synchronous standard response."""
+        response = self.client.chat(messages=api_args['messages'], params=api_args['params'])
+        return self._process_response(response)
+
+    async def _handle_async_streaming(self, api_args: dict[str, Any]) -> dict[str, Any]:
+        """Handle asynchronous streaming response."""
+        chunks: list[StreamingChunk] = []
+        full_text = ''
+
+        stream = await self.client.achat_stream(messages=api_args['messages'], params=api_args['params'])
+
+        async for chunk in stream:
+            if not isinstance(chunk, dict) or not chunk.get('choices'):
+                continue
+
+            content = chunk['choices'][0].get('delta', {}).get('content', '')
+            if content:
+                full_text += content
+                chunk_meta = {
+                    'model': self.model,
+                    'index': chunk['choices'][0].get('index', 0),
+                    'finish_reason': chunk['choices'][0].get('finish_reason'),
+                    'received_at': datetime.now(timezone.utc).isoformat(),
+                }
+                chunks.append(StreamingChunk(content=content, meta=chunk_meta))
+
+        return {
+            'replies': [
+                ChatMessage.from_assistant(
+                    text=full_text,
+                    meta={
+                        'model': self.model,
+                        'finish_reason': chunks[-1].meta['finish_reason'] if chunks else 'completed',
+                    },
+                )
+            ],
+            'chunks': chunks,
+        }
+
+    async def _handle_async_standard(self, api_args: dict[str, Any]) -> dict[str, Any]:
+        """Handle asynchronous standard response."""
+        response = await self.client.achat(**api_args)
+        return self._process_response(response)
+
+    def _process_response(self, response: dict[str, Any]) -> dict[str, Any]:
+        """Process standard response into Haystack format."""
+        if not response.get('choices'):
+            return {'replies': []}
+
+        choice = response['choices'][0]
+        message = choice.get('message', {})
+        content = message.get('content', '')
+        tool_calls = []
+
+        if 'tool_calls' in message:
+            for tc in message['tool_calls']:
+                if tc['type'] == 'function':
+                    try:
+                        arguments = json.loads(tc['function']['arguments'])
+                        tool_calls.append(
+                            ToolCall(id=tc.get('id'), tool_name=tc['function']['name'], arguments=arguments)
+                        )
+                    except json.JSONDecodeError:
+                        logger.warning('Failed to parse tool call arguments: %s', tc['function']['arguments'])
+
+        return {
+            'replies': [
+                ChatMessage.from_assistant(
+                    text=content,
+                    tool_calls=tool_calls,
+                    meta={
+                        'model': self.model,
+                        'index': choice.get('index', 0),
+                        'finish_reason': choice.get('finish_reason'),
+                        'usage': response.get('usage', {}),
+                    },
+                )
+            ]
+        }

--- a/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/generator.py
+++ b/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/generator.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.dataclasses import StreamingChunk
+from haystack.utils import Secret, deserialize_secrets_inplace
+from ibm_watsonx_ai import Credentials
+from ibm_watsonx_ai.foundation_models import ModelInference
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class WatsonxGenerator:
+    """
+    Generates text using IBM's watsonx.ai foundational models.
+
+    This component supports IBM's Granite and other watsonx.ai models with features like:
+    - Single prompt text generation
+    - Streaming responses
+    - Content moderation (guardrails)
+    - Custom generation parameters
+
+    You can customize the text generation by passing parameters to the watsonx API through
+    the `generation_kwargs` argument during initialization or at runtime. Any parameter that
+    works with `ibm_watsonx_ai.foundation_models.ModelInference.generate_text()` will work here.
+
+    For details on watsonx API parameters, see:
+    [IBM watsonx.ai documentation](https://ibm.github.io/watsonx-ai-python-sdk/fm_model.html)
+
+    ### Supported Models
+    Works with IBM's foundation models including:
+    - granite-13b-instruct-v2 (default)
+    - granite-20b-instruct-v1
+    - llama-2-70b-chat
+    - Other watsonx.ai models
+
+    ### Usage example
+
+    ```python
+    from haystack.components.generators import WatsonxGenerator
+    from haystack.utils import Secret
+
+    # Initialize with default model
+    generator = WatsonxGenerator(
+        api_key=Secret.from_token('your-api-key'),
+        project_id='your-project-id',
+        generation_kwargs={'max_new_tokens': 100},
+    )
+
+    # Generate text
+    response = generator.run('Explain quantum computing in simple terms')
+    print(response)
+
+    # Example output:
+    # {'replies': ['Quantum computing uses quantum bits that can exist in multiple states...'],
+    #  'meta': [{'model': 'ibm/granite-13b-instruct-v2', 'finish_reason': 'completed'}],
+    #  'chunks': []}
+    ```
+
+    ### Streaming Support
+    The component supports streaming responses through watsonx's `generate_text_stream` API.
+
+    ### Streaming example
+    ```python
+    # Initialize with streaming
+    streaming_generator = WatsonxGenerator(
+        api_key=Secret.from_env_var('WATSONX_API_KEY'), project_id='your-project-id'
+    )
+
+    # Generate with streaming
+    response = streaming_generator.run('Write a poem about AI', stream=True)
+    for chunk in response['chunks']:
+        print(chunk.content, end='', flush=True)
+    ```
+    """
+
+    def __init__(
+        self,
+        api_key: Secret | None = None,
+        model: str = 'ibm/granite-13b-instruct-v2',
+        project_id: str | None = None,
+        space_id: str | None = None,
+        api_base_url: str | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        verify: bool | str | None = None,
+    ):
+        """
+        Creates an instance of WatsonxGenerator. Uses IBM's granite-13b-instruct-v2 model by default.
+
+        Authentication requires either:
+        - A project_id (for IBM Cloud projects)
+        - A space_id (for watsonx.ai deployments)
+
+        :param api_key: The IBM Cloud API key for watsonx.ai access.
+            Can be provided directly or via environment variable WATSONX_API_KEY.
+        :param model: The model ID to use for generation. Defaults to "ibm/granite-13b-instruct-v2".
+            Other options include:
+            - "ibm/granite-20b-instruct-v1"
+            - "ibm/llama-2-70b-chat"
+            - Other watsonx.ai foundation models
+        :param project_id: The IBM Cloud project ID. Required if space_id is not provided.
+        :param space_id: The watsonx.ai deployment space ID. Required if project_id is not provided.
+        :param api_base_url: Custom base URL for the API endpoint.
+            Defaults to "https://us-south.ml.cloud.ibm.com".
+        :param generation_kwargs: Additional parameters for text generation. These parameters are
+            sent directly to the watsonx.ai API. Common parameters include:
+            - `max_new_tokens`: Maximum number of tokens to generate (default: 20)
+            - `temperature`: Value between 0-2 controlling randomness (1.0 is neutral)
+            - `top_p`: Nucleus sampling parameter (0.0-1.0)
+            - `decoding_method`: "greedy" or "sample"
+            - `repetition_penalty`: Penalty for repeated tokens (1.0 is neutral)
+            See IBM documentation for full parameter list.
+        :param verify: SSL verification setting. Can be:
+            - True: Verify SSL certificates (default)
+            - False: Skip verification
+            - Path to CA bundle for custom certificates
+
+        ### Environment Variables
+        The component respects these environment variables:
+        - WATSONX_API_KEY: API key if not provided directly
+        - WATSONX_PROJECT_ID: Project ID if not provided directly
+        - WATSONX_SPACE_ID: Space ID if not provided directly
+
+        """
+        self.api_key = api_key or Secret.from_env_var('WATSONX_API_KEY')
+        self.model = model
+        self.project_id = project_id
+        self.space_id = space_id
+        self.api_base_url = api_base_url
+        self.verify = verify
+        self.generation_kwargs = generation_kwargs or {}
+
+        if not project_id and not space_id:
+            msg = 'Either project_id or space_id must be provided'
+            raise ValueError(msg)
+
+        self._initialize_client()
+
+    def _initialize_client(self):
+        """Initialize the Watsonx client with the configured credentials."""
+        credentials = Credentials(
+            api_key=self.api_key.resolve_value(), url=self.api_base_url or 'https://us-south.ml.cloud.ibm.com'
+        )
+        self.client = ModelInference(
+            model_id=self.model,
+            credentials=credentials,
+            project_id=self.project_id,
+            space_id=self.space_id,
+            params=self.generation_kwargs,
+            verify=self.verify,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the component to a dictionary."""
+        return default_to_dict(
+            self,
+            model=self.model,
+            api_base_url=self.api_base_url,
+            generation_kwargs=self.generation_kwargs,
+            api_key=self.api_key.to_dict(),
+            project_id=self.project_id,
+            space_id=self.space_id,
+            verify=self.verify,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WatsonxGenerator:
+        """Deserialize the component from a dictionary."""
+        deserialize_secrets_inplace(data['init_parameters'], keys=['api_key'])
+        return default_from_dict(cls, data)
+
+    @component.output_types(replies=List[str], meta=List[Dict[str, Any]], chunks=List[StreamingChunk])
+    def run(
+        self,
+        prompt: str,
+        generation_kwargs: dict[str, Any] | None = None,
+        guardrails: bool = False,
+        stream: bool = False,
+    ):
+        """
+        Generate text using the watsonx.ai model.
+
+        Args:
+            prompt: The input prompt string
+            generation_kwargs: Additional generation parameters
+            guardrails: Enable HAP content filtering
+            stream: Enable streaming response
+
+        Returns:
+            Dictionary containing:
+            - replies: List of generated texts
+            - meta: List of metadata dictionaries
+            - chunks: List of streaming chunks (if streaming)
+        """
+        if not prompt.strip():
+            return self._create_empty_response()
+
+        merged_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+
+        try:
+            if stream:
+                return self._handle_streaming(prompt, merged_kwargs, guardrails)
+            return self._handle_standard(prompt, merged_kwargs, guardrails)
+        except Exception as e:
+            logger.exception(f'Generation failed: {e!s}')
+            return self._create_error_response(str(e))
+
+    def _handle_streaming(self, prompt: str, generation_kwargs: dict[str, Any], guardrails: bool) -> dict[str, Any]:
+        """Handle streaming generation."""
+        try:
+            stream = self.client.generate_text_stream(
+                prompt=prompt, params=generation_kwargs, guardrails=guardrails, raw_response=True
+            )
+
+            chunks = []
+            full_text = ''
+
+            for chunk in stream:
+                if not isinstance(chunk, dict):
+                    continue
+
+                chunk_text = chunk.get('results', [{}])[0].get('generated_text', '')
+                if chunk_text:
+                    full_text += chunk_text
+                    chunks.append(
+                        StreamingChunk(
+                            content=chunk_text,
+                            meta={'model': self.model, 'finish_reason': chunk.get('stop_reason', 'streaming')},
+                        )
+                    )
+
+            return {
+                'replies': [full_text] if full_text else ['[No content]'],
+                'meta': [{'model': self.model, 'finish_reason': 'completed', 'chunk_count': len(chunks)}],
+                'chunks': chunks,
+            }
+        except Exception as e:
+            logger.exception(f'Streaming generation failed: {e!s}')
+            return self._create_error_response(str(e))
+
+    def _handle_standard(self, prompt: str, generation_kwargs: dict[str, Any], guardrails: bool) -> dict[str, Any]:
+        """Handle standard (non-streaming) generation."""
+        try:
+            response = self.client.generate_text(
+                prompt=prompt, params=generation_kwargs, guardrails=guardrails, raw_response=True
+            )
+
+            reply = response.get('results', [{}])[0].get('generated_text', '')
+            return {
+                'replies': [reply] if reply.strip() else ['[Empty response]'],
+                'meta': [{'model': self.model, 'finish_reason': response.get('stop_reason', 'completed')}],
+                'chunks': [],
+            }
+        except Exception as e:
+            logger.exception(f'Generation failed: {e!s}')
+            return self._create_error_response(str(e))
+
+    def _create_empty_response(self) -> dict[str, Any]:
+        """Create response for empty input."""
+        return {'replies': [''], 'meta': [{'model': self.model, 'finish_reason': 'empty_input'}], 'chunks': []}
+
+    def _create_error_response(self, error_msg: str) -> dict[str, Any]:
+        """Create response for error cases."""
+        return {
+            'replies': [f'[Error: {error_msg}]'],
+            'meta': [{'model': self.model, 'finish_reason': 'error', 'error': error_msg}],
+            'chunks': [],
+        }

--- a/integrations/watsonx/tests/__init__.py
+++ b/integrations/watsonx/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/watsonx/tests/test_chat_generator.py
+++ b/integrations/watsonx/tests/test_chat_generator.py
@@ -1,0 +1,305 @@
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from haystack.dataclasses import ChatMessage, StreamingChunk
+from haystack.utils import Secret
+from haystack_integrations.components.generators.watsonx.chat.chat_generator import WatsonxChatGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class TestWatsonxChatGenerator:
+    @pytest.fixture
+    def mock_watsonx(self, monkeypatch):
+        """Fixture for setting up common mocks"""
+        monkeypatch.setenv('WATSONX_API_KEY', 'fake-api-key')
+
+        with patch(
+            'haystack_integrations.components.generators.watsonx.chat.chat_generator.ModelInference'
+        ) as mock_model:
+            mock_model_instance = MagicMock()
+            mock_model_instance.chat = MagicMock(
+                return_value={
+                    'choices': [
+                        {
+                            'message': {'content': 'This is a generated response', 'role': 'assistant'},
+                            'finish_reason': 'completed',
+                        }
+                    ]
+                }
+            )
+            mock_model_instance.achat = AsyncMock(
+                return_value={
+                    'choices': [
+                        {
+                            'message': {'content': 'Async generated response', 'role': 'assistant'},
+                            'finish_reason': 'completed',
+                        }
+                    ]
+                }
+            )
+            mock_model_instance.chat_stream = MagicMock(
+                return_value=[
+                    {'choices': [{'delta': {'content': 'Streaming'}, 'finish_reason': None}]},
+                    {'choices': [{'delta': {'content': ' response'}, 'finish_reason': 'completed'}]},
+                ]
+            )
+
+            async def mock_achat_stream_generator():
+                yield {'choices': [{'delta': {'content': 'Async streaming'}, 'finish_reason': None}]}
+                yield {'choices': [{'delta': {'content': ' response'}, 'finish_reason': 'completed'}]}
+
+            async def mock_achat_stream(messages=None, params=None):
+                return mock_achat_stream_generator()
+
+            mock_model_instance.achat_stream = mock_achat_stream
+            mock_model.return_value = mock_model_instance
+
+            yield {'model': mock_model, 'model_instance': mock_model_instance}
+
+    def test_init_default(self, mock_watsonx):
+        generator = WatsonxChatGenerator(model='ibm/granite-3-2b-instruct', project_id='fake-project-id')
+
+        args, kwargs = mock_watsonx['model'].call_args
+        assert kwargs['model_id'] == 'ibm/granite-3-2b-instruct'
+        assert kwargs['project_id'] == 'fake-project-id'
+        assert kwargs['space_id'] is None
+        assert kwargs['verify'] is None
+
+        assert generator.model == 'ibm/granite-3-2b-instruct'
+        assert generator.project_id == 'fake-project-id'
+        assert generator.space_id is None
+        assert generator.api_base_url == 'https://us-south.ml.cloud.ibm.com'
+
+    def test_init_with_all_params(self, mock_watsonx):
+        WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'),
+            model='ibm/granite-3-2b-instruct',
+            project_id='test-project',
+            space_id='test-space',
+            api_base_url='https://custom-url.com',
+            generation_kwargs={'max_tokens': 100, 'temperature': 0.7, 'top_p': 0.9},
+            verify=False,
+        )
+
+        args, kwargs = mock_watsonx['model'].call_args
+        assert kwargs['model_id'] == 'ibm/granite-3-2b-instruct'
+        assert kwargs['project_id'] == 'test-project'
+        assert kwargs['space_id'] == 'test-space'
+        assert kwargs['verify'] is False
+
+    def test_init_fails_without_project_or_space(self, mock_watsonx):
+        with pytest.raises(ValueError, match='Either project_id or space_id must be provided'):
+            WatsonxChatGenerator(api_key=Secret.from_token('test-api-key'), model='ibm/granite-3-2b-instruct')
+
+    def test_to_dict(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            model='ibm/granite-3-2b-instruct', project_id='test-project', generation_kwargs={'max_tokens': 100}
+        )
+
+        data = generator.to_dict()
+
+        expected = {
+            'type': 'haystack_integrations.components.generators.watsonx.chat.chat_generator.WatsonxChatGenerator',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/granite-3-2b-instruct',
+                'project_id': 'test-project',
+                'space_id': None,
+                'api_base_url': 'https://us-south.ml.cloud.ibm.com',
+                'generation_kwargs': {'max_tokens': 100},
+                'verify': None,
+                'timeout': 30.0,
+                'max_retries': 5,
+                'tools': None,
+            },
+        }
+        assert data == expected
+
+    def test_from_dict(self, mock_watsonx):
+        data = {
+            'type': 'haystack_integrations.components.generators.watsonx.chat.chat_generator.WatsonxChatGenerator',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/granite-3-2b-instruct',
+                'project_id': 'test-project',
+                'generation_kwargs': {'max_tokens': 100},
+            },
+        }
+
+        generator = WatsonxChatGenerator.from_dict(data)
+        assert generator.model == 'ibm/granite-3-2b-instruct'
+        assert generator.project_id == 'test-project'
+        assert generator.generation_kwargs == {'max_tokens': 100}
+
+    def test_run_single_message(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-3-2b-instruct', project_id='test-project'
+        )
+
+        messages = [ChatMessage.from_user('Test prompt')]
+        result = generator.run(messages)
+
+        assert len(result['replies']) == 1
+        assert result['replies'][0].text == 'This is a generated response'
+        assert result['replies'][0].meta['finish_reason'] == 'completed'
+
+        mock_watsonx['model_instance'].chat.assert_called_once_with(
+            messages=[{'role': 'user', 'content': 'Test prompt'}], params={}
+        )
+
+    def test_run_with_generation_params(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'),
+            model='ibm/granite-3-2b-instruct',
+            project_id='test-project',
+            generation_kwargs={'max_tokens': 100, 'temperature': 0.7, 'top_p': 0.9},
+        )
+
+        messages = [ChatMessage.from_user('Test prompt')]
+        result = generator.run(messages)
+
+        assert len(result['replies']) == 1
+        mock_watsonx['model_instance'].chat.assert_called_once_with(
+            messages=[{'role': 'user', 'content': 'Test prompt'}],
+            params={'max_tokens': 100, 'temperature': 0.7, 'top_p': 0.9},
+        )
+
+    def test_run_with_streaming(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-3-2b-instruct', project_id='test-project'
+        )
+
+        messages = [ChatMessage.from_user('Test prompt')]
+        result = generator.run(messages, stream=True)
+
+        assert len(result['replies']) == 1
+        assert result['replies'][0].text == 'Streaming response'
+        assert len(result['chunks']) == 2
+        assert isinstance(result['chunks'][0], StreamingChunk)
+        assert result['chunks'][0].content == 'Streaming'
+
+    def test_run_with_empty_messages(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-3-2b-instruct', project_id='test-project'
+        )
+
+        result = generator.run([])
+        assert result['replies'] == []
+
+    def test_run_with_tool_calls(self, mock_watsonx):
+        mock_watsonx['model_instance'].chat.return_value = {
+            'choices': [
+                {
+                    'message': {
+                        'content': '',
+                        'tool_calls': [
+                            {
+                                'type': 'function',
+                                'function': {'name': 'get_weather', 'arguments': '{"location": "Berlin"}'},
+                            }
+                        ],
+                    },
+                    'finish_reason': 'tool_calls',
+                }
+            ]
+        }
+
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-3-2b-instruct', project_id='test-project'
+        )
+
+        messages = [ChatMessage.from_user("What's the weather in Berlin?")]
+        result = generator.run(messages)
+
+        assert len(result['replies']) == 1
+        assert len(result['replies'][0].tool_calls) == 1
+        assert result['replies'][0].tool_calls[0].tool_name == 'get_weather'
+        assert result['replies'][0].tool_calls[0].arguments == {'location': 'Berlin'}
+
+    @pytest.mark.asyncio
+    async def test_run_async_single_message(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-3-2b-instruct', project_id='test-project'
+        )
+
+        messages = [ChatMessage.from_user('Test prompt')]
+        result = await generator.run_async(messages)
+
+        assert len(result['replies']) == 1
+        assert result['replies'][0].text == 'Async generated response'
+        assert result['replies'][0].meta['finish_reason'] == 'completed'
+
+    @pytest.mark.asyncio
+    async def test_run_async_streaming(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-3-2b-instruct', project_id='test-project'
+        )
+
+        messages = [ChatMessage.from_user('Test prompt')]
+        result = await generator.run_async(messages, stream=True)
+
+        assert len(result['replies']) == 1
+        assert result['replies'][0].text == 'Async streaming response'
+        assert len(result['chunks']) == 2
+        assert isinstance(result['chunks'][0], StreamingChunk)
+        assert result['chunks'][0].content == 'Async streaming'
+
+
+@pytest.mark.integration
+class TestWatsonxChatGeneratorIntegration:
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_live_run(self):
+        generator = WatsonxChatGenerator(
+            model='ibm/granite-3-2b-instruct',
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            generation_kwargs={'max_tokens': 50, 'temperature': 0.7, 'top_p': 0.9},
+        )
+        messages = [ChatMessage.from_user("What's the capital of France?")]
+        results = generator.run(messages)
+
+        assert isinstance(results, dict)
+        assert 'replies' in results
+        assert isinstance(results['replies'], list)
+        assert len(results['replies']) == 1
+        assert isinstance(results['replies'][0], ChatMessage)
+        assert len(results['replies'][0].text) > 0
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_live_streaming(self):
+        generator = WatsonxChatGenerator(model='ibm/granite-3-2b-instruct', project_id=os.environ['WATSONX_PROJECT_ID'])
+
+        messages = [ChatMessage.from_user('Explain quantum computing')]
+        results = generator.run(messages, stream=True)
+
+        assert isinstance(results, dict)
+        assert 'replies' in results
+        assert 'chunks' in results
+        assert len(results['replies']) == 1
+        assert isinstance(results['replies'][0], ChatMessage)
+        assert all(isinstance(chunk, StreamingChunk) for chunk in results['chunks'])
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    async def test_live_async(self):
+        generator = WatsonxChatGenerator(model='ibm/granite-3-2b-instruct', project_id=os.environ['WATSONX_PROJECT_ID'])
+        messages = [ChatMessage.from_user("What's the capital of Germany?")]
+        results = await generator.run_async(messages)
+
+        assert isinstance(results, dict)
+        assert 'replies' in results
+        assert isinstance(results['replies'], list)
+        assert len(results['replies']) == 1
+        assert isinstance(results['replies'][0], ChatMessage)
+        assert len(results['replies'][0].text) > 0

--- a/integrations/watsonx/tests/test_document_embedder.py
+++ b/integrations/watsonx/tests/test_document_embedder.py
@@ -1,0 +1,273 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from haystack import Document
+from haystack.utils.auth import Secret
+from haystack_integrations.components.embedders.watsonx.document_embedder import WatsonXDocumentEmbedder
+
+
+class TestWatsonXDocumentEmbedder:
+    @pytest.fixture
+    def mock_watsonx(self, monkeypatch):
+        """Fixture for setting up common mocks"""
+        monkeypatch.setenv('WATSONX_API_KEY', 'fake-api-key')
+
+        with (
+            patch('haystack_integrations.components.embedders.watsonx.document_embedder.Embeddings') as mock_embeddings,
+            patch(
+                'haystack_integrations.components.embedders.watsonx.document_embedder.Credentials'
+            ) as mock_credentials,
+        ):
+            mock_creds_instance = MagicMock()
+            mock_credentials.return_value = mock_creds_instance
+
+            mock_embeddings_instance = MagicMock()
+            mock_embeddings.return_value = mock_embeddings_instance
+
+            yield {
+                'credentials': mock_credentials,
+                'embeddings': mock_embeddings,
+                'creds_instance': mock_creds_instance,
+                'embeddings_instance': mock_embeddings_instance,
+            }
+
+    def test_init_default(self, mock_watsonx):
+        embedder = WatsonXDocumentEmbedder(project_id='fake-project-id')
+
+        mock_watsonx['credentials'].assert_called_once_with(
+            api_key='fake-api-key', url='https://us-south.ml.cloud.ibm.com'
+        )
+        mock_watsonx['embeddings'].assert_called_once_with(
+            model_id='ibm/slate-30m-english-rtrvr',
+            credentials=mock_watsonx['creds_instance'],
+            project_id='fake-project-id',
+            space_id=None,
+            params=None,
+            batch_size=1000,
+            concurrency_limit=5,
+            max_retries=10,
+        )
+
+        assert embedder.model == 'ibm/slate-30m-english-rtrvr'
+        assert embedder.prefix == ''
+        assert embedder.suffix == ''
+        assert embedder.batch_size == 1000
+        assert embedder.concurrency_limit == 5
+
+    def test_init_with_parameters(self, mock_watsonx):
+        WatsonXDocumentEmbedder(
+            api_key=Secret.from_token('fake-api-key'),
+            model='ibm/slate-125m-english-rtrvr',
+            url='https://custom-url.ibm.com',
+            project_id='custom-project-id',
+            space_id='custom-space-id',
+            truncate_input_tokens=128,
+            prefix='prefix ',
+            suffix=' suffix',
+            batch_size=500,
+            concurrency_limit=3,
+            timeout=30.0,
+            max_retries=5,
+        )
+
+        mock_watsonx['credentials'].assert_called_once_with(api_key='fake-api-key', url='https://custom-url.ibm.com')
+        mock_watsonx['embeddings'].assert_called_once_with(
+            model_id='ibm/slate-125m-english-rtrvr',
+            credentials=mock_watsonx['creds_instance'],
+            project_id='custom-project-id',
+            space_id='custom-space-id',
+            params={'truncate_input_tokens': 128},
+            batch_size=500,
+            concurrency_limit=3,
+            max_retries=5,
+        )
+
+    def test_init_fail_wo_api_key(self, monkeypatch):
+        monkeypatch.delenv('WATSONX_API_KEY', raising=False)
+        with pytest.raises(ValueError, match='None of the .* environment variables are set'):
+            WatsonXDocumentEmbedder(project_id='fake-project-id')
+
+    def test_init_fail_wo_project_or_space_id(self, monkeypatch):
+        monkeypatch.setenv('WATSONX_API_KEY', 'fake-api-key')
+        with pytest.raises(ValueError, match='Either project_id or space_id must be provided'):
+            WatsonXDocumentEmbedder()
+
+    def test_to_dict(self, mock_watsonx):
+        component = WatsonXDocumentEmbedder(project_id='fake-project-id')
+        data = component.to_dict()
+
+        assert data == {
+            'type': 'haystack_integrations.components.embedders.watsonx.document_embedder.WatsonXDocumentEmbedder',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/slate-30m-english-rtrvr',
+                'url': 'https://us-south.ml.cloud.ibm.com',
+                'project_id': 'fake-project-id',
+                'space_id': None,
+                'truncate_input_tokens': None,
+                'prefix': '',
+                'suffix': '',
+                'batch_size': 1000,
+                'concurrency_limit': 5,
+                'timeout': None,
+                'max_retries': None,
+            },
+        }
+
+    def test_from_dict(self, mock_watsonx):
+        data = {
+            'type': 'haystack_integrations.components.embedders.watsonx.document_embedder.WatsonXDocumentEmbedder',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/slate-125m-english-rtrvr',
+                'url': 'https://custom-url.ibm.com',
+                'project_id': 'custom-project-id',
+                'prefix': 'prefix ',
+                'suffix': ' suffix',
+                'batch_size': 500,
+                'concurrency_limit': 3,
+            },
+        }
+
+        component = WatsonXDocumentEmbedder.from_dict(data)
+
+        assert component.model == 'ibm/slate-125m-english-rtrvr'
+        assert component.url == 'https://custom-url.ibm.com'
+        assert component.project_id == 'custom-project-id'
+        assert component.prefix == 'prefix '
+        assert component.suffix == ' suffix'
+        assert component.batch_size == 500
+        assert component.concurrency_limit == 3
+
+    def test_prepare_text(self, mock_watsonx):
+        embedder = WatsonXDocumentEmbedder(project_id='fake-project-id', prefix='prefix ', suffix=' suffix')
+        prepared_text = embedder._prepare_text('The food was delicious')
+        assert prepared_text == 'prefix The food was delicious suffix'
+
+    def test_run_wrong_input_format(self, mock_watsonx):
+        embedder = WatsonXDocumentEmbedder(project_id='fake-project-id')
+        with pytest.raises(TypeError, match='WatsonXDocumentEmbedder expects a list of Documents as input.'):
+            embedder.run(documents='not a list')  # type: ignore
+
+    def test_run_empty_documents(self, mock_watsonx):
+        embedder = WatsonXDocumentEmbedder(project_id='fake-project-id')
+        result = embedder.run(documents=[])
+        assert result == {
+            'documents': [],
+            'meta': {'model': 'ibm/slate-30m-english-rtrvr', 'truncate_input_tokens': None, 'batch_size': 1000},
+        }
+
+
+@pytest.mark.integration
+class TestWatsonXDocumentEmbedderIntegration:
+    """Integration tests for WatsonXDocumentEmbedder (requires real credentials)"""
+
+    @pytest.fixture
+    def test_documents(self):
+        return [
+            Document(content='The quick brown fox jumps over the lazy dog'),
+            Document(content='Artificial intelligence is transforming industries'),
+            Document(content='Haystack is an open-source framework for building search systems'),
+        ]
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_run(self, test_documents):
+        """Test real API call with documents"""
+        embedder = WatsonXDocumentEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            truncate_input_tokens=128,
+        )
+        result = embedder.run(test_documents)
+
+        assert len(result['documents']) == 3
+        for doc in result['documents']:
+            assert isinstance(doc.embedding, list)
+            assert len(doc.embedding) > 0
+            assert all(isinstance(x, float) for x in doc.embedding)
+
+        assert result['meta']['model'] == 'ibm/slate-30m-english-rtrvr'
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_batch_processing(self, test_documents):
+        """Test that batch processing works"""
+        # Create enough documents to require multiple batches
+        many_documents = test_documents * 50
+
+        embedder = WatsonXDocumentEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            batch_size=50,
+            truncate_input_tokens=128,
+        )
+
+        result = embedder.run(many_documents)
+        assert len(result['documents']) == 150
+        assert all(doc.embedding is not None for doc in result['documents'])
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_text_truncation(self, test_documents):
+        """Test that truncation works with long documents"""
+        # Create a document with very long content
+        long_content = 'This is a very long document. ' * 1000
+        long_document = Document(content=long_content)
+
+        embedder = WatsonXDocumentEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            truncate_input_tokens=128,
+        )
+
+        result = embedder.run([long_document])
+        assert len(result['documents'][0].embedding) > 0
+        assert result['meta']['truncate_input_tokens'] == 128
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_prefix_suffix(self, test_documents):
+        """Test that prefix and suffix are correctly applied"""
+        embedder = WatsonXDocumentEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            prefix='PREFIX: ',
+            suffix=' :SUFFIX',
+            truncate_input_tokens=128,
+        )
+
+        result = embedder.run([test_documents[0]])
+        assert result['documents'][0].embedding is not None
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_concurrency_handling(self, test_documents):
+        """Test that concurrency limits are respected"""
+        embedder = WatsonXDocumentEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            concurrency_limit=2,
+            batch_size=1,  # Force multiple batches to test concurrency
+        )
+
+        # 3 documents with batch_size=1 and concurrency_limit=2
+        # should complete without errors
+        result = embedder.run(test_documents)
+        assert len(result['documents']) == 3

--- a/integrations/watsonx/tests/test_generator.py
+++ b/integrations/watsonx/tests/test_generator.py
@@ -1,0 +1,265 @@
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from haystack.dataclasses import StreamingChunk
+from haystack.utils import Secret
+from haystack_integrations.components.generators.watsonx.generator import WatsonxGenerator
+from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
+
+logger = logging.getLogger(__name__)
+
+
+class TestWatsonxGenerator:
+    @pytest.fixture
+    def mock_watsonx(self, monkeypatch):
+        """Fixture for setting up common mocks"""
+        monkeypatch.setenv('WATSONX_API_KEY', 'fake-api-key')
+
+        with patch('haystack_integrations.components.generators.watsonx.generator.ModelInference') as mock_model:
+            mock_model_instance = MagicMock()
+            mock_model.return_value = mock_model_instance
+
+            # Configure mock responses
+            mock_model_instance.generate_text.return_value = {
+                'results': [{'generated_text': 'This is a generated response'}],
+                'model_id': 'ibm/granite-13b-instruct-v2',
+                'stop_reason': 'completed',
+            }
+
+            mock_model_instance.generate_text_stream.return_value = [
+                {'results': [{'generated_text': 'Streaming'}], 'stop_reason': None},
+                {'results': [{'generated_text': ' response'}], 'stop_reason': 'completed'},
+            ]
+
+            yield {'model': mock_model, 'model_instance': mock_model_instance}
+
+    def test_init_default(self, mock_watsonx):
+        generator = WatsonxGenerator(model='ibm/granite-13b-instruct-v2', project_id='fake-project-id')
+
+        args, kwargs = mock_watsonx['model'].call_args
+        assert kwargs['model_id'] == 'ibm/granite-13b-instruct-v2'
+        assert kwargs['project_id'] == 'fake-project-id'
+        assert kwargs['space_id'] is None
+        assert kwargs['params'] == {}
+        assert kwargs['verify'] is None
+
+        assert generator.model == 'ibm/granite-13b-instruct-v2'
+        assert generator.project_id == 'fake-project-id'
+        assert generator.space_id is None
+        assert generator.api_base_url is None
+        assert generator.generation_kwargs == {}
+
+    def test_init_with_all_params(self, mock_watsonx):
+        WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'),
+            model='ibm/granite-13b-instruct-v2',
+            project_id='test-project',
+            space_id='test-space',
+            api_base_url='https://custom-url.com',
+            generation_kwargs={
+                GenParams.MAX_NEW_TOKENS: 100,
+                GenParams.TEMPERATURE: 0.7,
+                GenParams.DECODING_METHOD: 'sample',
+                GenParams.TOP_P: 0.9,
+            },
+            verify=False,
+        )
+
+        args, kwargs = mock_watsonx['model'].call_args
+        assert kwargs['model_id'] == 'ibm/granite-13b-instruct-v2'
+        assert kwargs['project_id'] == 'test-project'
+        assert kwargs['space_id'] == 'test-space'
+        assert kwargs['params'] == {
+            'max_new_tokens': 100,
+            'temperature': 0.7,
+            'decoding_method': 'sample',
+            'top_p': 0.9,
+        }
+        assert kwargs['verify'] is False
+
+    def test_init_fails_without_project_or_space(self, mock_watsonx):
+        with pytest.raises(ValueError, match='Either project_id or space_id must be provided'):
+            WatsonxGenerator(api_key=Secret.from_token('test-api-key'), model='ibm/granite-13b-instruct-v2')
+
+    def test_to_dict(self, mock_watsonx):
+        generator = WatsonxGenerator(
+            model='ibm/granite-13b-instruct-v2', project_id='test-project', generation_kwargs={'max_new_tokens': 100}
+        )
+
+        data = generator.to_dict()
+
+        assert data == {
+            'type': 'haystack_integrations.components.generators.watsonx.generator.WatsonxGenerator',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/granite-13b-instruct-v2',
+                'project_id': 'test-project',
+                'space_id': None,
+                'api_base_url': None,
+                'generation_kwargs': {'max_new_tokens': 100},
+                'verify': None,
+            },
+        }
+
+    def test_from_dict(self, mock_watsonx):
+        data = {
+            'type': 'haystack_integrations.components.generators.watsonx.generator.WatsonxGenerator',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/granite-13b-instruct-v2',
+                'project_id': 'test-project',
+                'generation_kwargs': {'max_new_tokens': 100},
+            },
+        }
+
+        generator = WatsonxGenerator.from_dict(data)
+
+        assert generator.model == 'ibm/granite-13b-instruct-v2'
+        assert generator.project_id == 'test-project'
+        assert generator.generation_kwargs == {'max_new_tokens': 100}
+
+    def test_run_single_prompt(self, mock_watsonx):
+        generator = WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-13b-instruct-v2', project_id='test-project'
+        )
+
+        result = generator.run('Test prompt')
+
+        assert result['replies'] == ['This is a generated response']
+        assert len(result['meta']) == 1
+        assert result['meta'][0]['model'] == 'ibm/granite-13b-instruct-v2'
+        assert result['meta'][0]['finish_reason'] == 'completed'
+
+        mock_watsonx['model_instance'].generate_text.assert_called_once_with(
+            prompt='Test prompt', params={}, guardrails=False, raw_response=True
+        )
+
+    def test_run_with_watsonx_params(self, mock_watsonx):
+        generator = WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'),
+            model='ibm/granite-13b-instruct-v2',
+            project_id='test-project',
+            generation_kwargs={
+                GenParams.MAX_NEW_TOKENS: 100,
+                GenParams.TEMPERATURE: 0.7,
+                GenParams.DECODING_METHOD: 'sample',
+                GenParams.TOP_P: 0.9,
+            },
+        )
+
+        result = generator.run('Test prompt')
+
+        assert result['replies'] == ['This is a generated response']
+        mock_watsonx['model_instance'].generate_text.assert_called_once_with(
+            prompt='Test prompt',
+            params={'max_new_tokens': 100, 'temperature': 0.7, 'decoding_method': 'sample', 'top_p': 0.9},
+            guardrails=False,
+            raw_response=True,
+        )
+
+    def test_run_with_guardrails(self, mock_watsonx):
+        generator = WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-13b-instruct-v2', project_id='test-project'
+        )
+
+        result = generator.run('Test prompt', guardrails=True)
+
+        assert result['replies'] == ['This is a generated response']
+        mock_watsonx['model_instance'].generate_text.assert_called_once_with(
+            prompt='Test prompt', params={}, guardrails=True, raw_response=True
+        )
+
+    def test_run_with_streaming(self, mock_watsonx):
+        generator = WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-13b-instruct-v2', project_id='test-project'
+        )
+
+        result = generator.run('Test prompt', stream=True)
+
+        assert result['replies'] == ['Streaming response']
+        assert len(result['chunks']) == 2
+        assert isinstance(result['chunks'][0], StreamingChunk)
+        assert result['chunks'][0].content == 'Streaming'
+        assert result['meta'][0]['chunk_count'] == 2
+
+        mock_watsonx['model_instance'].generate_text_stream.assert_called_once_with(
+            prompt='Test prompt', params={}, guardrails=False, raw_response=True
+        )
+
+    def test_run_with_empty_prompt(self, mock_watsonx):
+        generator = WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-13b-instruct-v2', project_id='test-project'
+        )
+
+        result = generator.run('')
+        assert result['replies'] == ['']
+        assert result['meta'][0]['finish_reason'] == 'empty_input'
+
+    def test_run_with_empty_response(self, mock_watsonx):
+        mock_watsonx['model_instance'].generate_text.return_value = {'results': [{}]}
+
+        generator = WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-13b-instruct-v2', project_id='test-project'
+        )
+
+        result = generator.run('Test prompt')
+        assert result['replies'] == ['[Empty response]']
+        assert result['meta'][0]['finish_reason'] == 'completed'
+
+    def test_run_with_api_error(self, mock_watsonx):
+        mock_watsonx['model_instance'].generate_text.side_effect = Exception('API error')
+
+        generator = WatsonxGenerator(
+            api_key=Secret.from_token('test-api-key'), model='ibm/granite-13b-instruct-v2', project_id='test-project'
+        )
+
+        result = generator.run('Test prompt')
+        assert result['replies'] == ['[Error: API error]']
+        assert result['meta'][0]['finish_reason'] == 'error'
+        assert 'error' in result['meta'][0]
+
+
+@pytest.mark.integration
+class TestWatsonxGeneratorIntegration:
+    """Integration tests for WatsonxGenerator (requires real credentials)"""
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_live_run(self):
+        generator = WatsonxGenerator(
+            model='ibm/granite-13b-instruct-v2',
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            generation_kwargs={'max_new_tokens': 50, 'temperature': 0.7, 'top_p': 0.9},
+        )
+        results = generator.run("What's the capital of France?")
+
+        assert isinstance(results, dict)
+        assert 'replies' in results
+        assert isinstance(results['replies'], list)
+        assert len(results['replies']) == 1
+        assert isinstance(results['replies'][0], str)
+
+        if 'meta' in results:
+            assert isinstance(results['meta'], list)
+            assert len(results['meta']) == 1
+            assert results['meta'][0]['model'] == 'ibm/granite-13b-instruct-v2'
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_live_streaming(self):
+        generator = WatsonxGenerator(model='ibm/granite-13b-instruct-v2', project_id=os.environ['WATSONX_PROJECT_ID'])
+
+        results = generator.run('Explain quantum computing', stream=True)
+
+        assert isinstance(results, dict)
+        assert 'replies' in results
+        assert 'chunks' in results
+        assert len(results['replies']) == 1
+        assert isinstance(results['replies'][0], str)
+        assert all(isinstance(chunk, StreamingChunk) for chunk in results['chunks'])

--- a/integrations/watsonx/tests/test_text_embedder.py
+++ b/integrations/watsonx/tests/test_text_embedder.py
@@ -1,0 +1,250 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from haystack.utils.auth import Secret
+from haystack_integrations.components.embedders.watsonx.text_embedder import WatsonXTextEmbedder
+from ibm_watsonx_ai.wml_client_error import ApiRequestFailure
+
+
+class TestWatsonXTextEmbedder:
+    @pytest.fixture
+    def mock_watsonx(self, monkeypatch):
+        """Fixture for setting up common mocks"""
+        monkeypatch.setenv('WATSONX_API_KEY', 'fake-api-key')
+
+        with (
+            patch('haystack_integrations.components.embedders.watsonx.text_embedder.Embeddings') as mock_embeddings,
+            patch('haystack_integrations.components.embedders.watsonx.text_embedder.Credentials') as mock_credentials,
+        ):
+            mock_creds_instance = MagicMock()
+            mock_credentials.return_value = mock_creds_instance
+
+            mock_embeddings_instance = MagicMock()
+            mock_embeddings.return_value = mock_embeddings_instance
+
+            yield {
+                'credentials': mock_credentials,
+                'embeddings': mock_embeddings,
+                'creds_instance': mock_creds_instance,
+                'embeddings_instance': mock_embeddings_instance,
+            }
+
+    def test_init_default(self, mock_watsonx):
+        embedder = WatsonXTextEmbedder(project_id='fake-project-id')
+
+        mock_watsonx['credentials'].assert_called_once_with(
+            api_key='fake-api-key', url='https://us-south.ml.cloud.ibm.com'
+        )
+        mock_watsonx['embeddings'].assert_called_once_with(
+            model_id='ibm/slate-30m-english-rtrvr',
+            credentials=mock_watsonx['creds_instance'],
+            project_id='fake-project-id',
+            space_id=None,
+            params=None,
+        )
+
+        assert embedder.model == 'ibm/slate-30m-english-rtrvr'
+        assert embedder.prefix == ''
+        assert embedder.suffix == ''
+
+    def test_init_with_parameters(self, mock_watsonx):
+        WatsonXTextEmbedder(
+            api_key=Secret.from_token('fake-api-key'),
+            model='ibm/slate-125m-english-rtrvr',
+            url='https://custom-url.ibm.com',
+            project_id='custom-project-id',
+            space_id='custom-space-id',
+            truncate_input_tokens=128,
+            prefix='prefix ',
+            suffix=' suffix',
+            timeout=30.0,
+            max_retries=5,
+        )
+
+        mock_watsonx['credentials'].assert_called_once_with(api_key='fake-api-key', url='https://custom-url.ibm.com')
+        mock_watsonx['embeddings'].assert_called_once_with(
+            model_id='ibm/slate-125m-english-rtrvr',
+            credentials=mock_watsonx['creds_instance'],
+            project_id='custom-project-id',
+            space_id='custom-space-id',
+            params={'truncate_input_tokens': 128},
+        )
+
+    def test_init_fail_wo_api_key(self, monkeypatch):
+        monkeypatch.delenv('WATSONX_API_KEY', raising=False)
+        with pytest.raises(ValueError, match='None of the .* environment variables are set'):
+            WatsonXTextEmbedder(project_id='fake-project-id')
+
+    def test_init_fail_wo_project_or_space_id(self, monkeypatch):
+        monkeypatch.setenv('WATSONX_API_KEY', 'fake-api-key')
+        with pytest.raises(ValueError, match='Either project_id or space_id must be provided'):
+            WatsonXTextEmbedder()
+
+    def test_to_dict(self, mock_watsonx):
+        component = WatsonXTextEmbedder(project_id='fake-project-id')
+        data = component.to_dict()
+
+        assert data == {
+            'type': 'haystack_integrations.components.embedders.watsonx.text_embedder.WatsonXTextEmbedder',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/slate-30m-english-rtrvr',
+                'url': 'https://us-south.ml.cloud.ibm.com',
+                'project_id': 'fake-project-id',
+                'space_id': None,
+                'truncate_input_tokens': None,
+                'prefix': '',
+                'suffix': '',
+                'timeout': None,
+                'max_retries': None,
+            },
+        }
+
+    def test_from_dict(self, mock_watsonx):
+        data = {
+            'type': 'haystack_integrations.components.embedders.watsonx.text_embedder.WatsonXTextEmbedder',
+            'init_parameters': {
+                'api_key': {'env_vars': ['WATSONX_API_KEY'], 'strict': True, 'type': 'env_var'},
+                'model': 'ibm/slate-125m-english-rtrvr',
+                'url': 'https://custom-url.ibm.com',
+                'project_id': 'custom-project-id',
+                'prefix': 'prefix ',
+                'suffix': ' suffix',
+            },
+        }
+
+        component = WatsonXTextEmbedder.from_dict(data)
+
+        assert component.model == 'ibm/slate-125m-english-rtrvr'
+        assert component.url == 'https://custom-url.ibm.com'
+        assert component.project_id == 'custom-project-id'
+        assert component.prefix == 'prefix '
+        assert component.suffix == ' suffix'
+
+    def test_prepare_input(self, mock_watsonx):
+        embedder = WatsonXTextEmbedder(project_id='fake-project-id', prefix='prefix ', suffix=' suffix')
+        input_text = 'The food was delicious'
+        prepared_input = embedder._prepare_input(input_text)
+        assert prepared_input == 'prefix The food was delicious suffix'
+
+    def test_prepare_output(self, mock_watsonx):
+        embedder = WatsonXTextEmbedder(
+            project_id='fake-project-id', model='ibm/slate-125m-english-rtrvr', truncate_input_tokens=128
+        )
+        embedding = [0.1, 0.2, 0.3]
+        result = embedder._prepare_output(embedding)
+        assert result == {
+            'embedding': [0.1, 0.2, 0.3],
+            'meta': {'model': 'ibm/slate-125m-english-rtrvr', 'truncated_input_tokens': 128},
+        }
+
+    def test_run_wrong_input_format(self, mock_watsonx):
+        embedder = WatsonXTextEmbedder(project_id='fake-project-id')
+        with pytest.raises(
+            TypeError,
+            match='WatsonXTextEmbedder expects a string as an input. In case you want to embed a list of Documents, please use the WatsonXDocumentEmbedder.',
+        ):
+            embedder.run(text=[1, 2, 3])
+
+
+@pytest.mark.integration
+class TestWatsonXTextEmbedderIntegration:
+    """Integration tests for WatsonXTextEmbedder (requires real credentials)"""
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_run(self):
+        """Test real API call with simple text"""
+        embedder = WatsonXTextEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            prefix='prefix ',
+            suffix=' suffix',
+            truncate_input_tokens=128,
+        )
+        result = embedder.run('The food was delicious')
+
+        assert isinstance(result['embedding'], list)
+        assert len(result['embedding']) > 0
+        assert all(isinstance(x, float) for x in result['embedding'])
+        assert 'slate' in result['meta']['model'].lower()
+        assert '30m' in result['meta']['model'].lower()
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_long_text(self):
+        """Test with longer text input"""
+        embedder = WatsonXTextEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            truncate_input_tokens=128,
+        )
+        long_text = 'This is a test text that should work fine. ' * 10
+        result = embedder.run(long_text)
+
+        assert len(result['embedding']) > 0
+        assert 'model' in result['meta']
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_different_model(self):
+        """Test with a different model if available"""
+        embedder = WatsonXTextEmbedder(
+            model='ibm/slate-125m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            truncate_input_tokens=128,
+        )
+        result = embedder.run('Test different model')
+
+        assert len(result['embedding']) > 0
+        assert '125m' in result['meta']['model']
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_text_too_long(self):
+        """Test handling of text that exceeds token limit when truncation is disabled"""
+        embedder = WatsonXTextEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            truncate_input_tokens=None,
+        )
+
+        very_long_text = 'word ' * 1024
+
+        with pytest.raises(ApiRequestFailure) as exc_info:
+            embedder.run(very_long_text)
+
+        assert 'exceeds the maximum sequence length' in str(exc_info.value)
+        assert '512' in str(exc_info.value)
+
+    @pytest.mark.skipif(
+        not os.environ.get('WATSONX_API_KEY') or not os.environ.get('WATSONX_PROJECT_ID'),
+        reason='WATSONX_API_KEY or WATSONX_PROJECT_ID not set',
+    )
+    def test_text_truncation(self):
+        """Test that truncation works with long text"""
+        embedder = WatsonXTextEmbedder(
+            model='ibm/slate-30m-english-rtrvr',
+            api_key=Secret.from_env_var('WATSONX_API_KEY'),
+            project_id=os.environ['WATSONX_PROJECT_ID'],
+            truncate_input_tokens=128,
+        )
+
+        long_text = 'This is a test sentence. ' * 1000
+        result = embedder.run(long_text)
+
+        assert len(result['embedding']) > 0
+        assert result['meta']['truncated_input_tokens'] == 128


### PR DESCRIPTION
### Related Issues

- fixes: Add watsonx support to Haystack #1891


### Proposed Changes:
Add WatsonxGenerator and WatsonxChatGenerator components to wrap IBM watsonx.ai’s text- and chat-generation APIs (supporting streaming, custom models, and generation parameters).

Add WatsonxTextEmbedder and WatsonxDocumentEmbedder components that support embedding use cases for both  text and documents.

Ensure all components follow the existing Haystack interfaces and patterns for Generator and Embedder.

Include tests files accordingly.


### How did you test it?

- Created unit and integration test files for the new WatsonxGenerator, WatsonxTextEmbedder, and WatsonxDocumentEmbedder components.
- Verified functionality by running the test suite to ensure all components behave as expected.
- Manually tested by importing the components into a Jupyter Notebook and running example queries to confirm that:
--Text generation works with WatsonxGenerator
--Chat generation works with WatsonxChatGenerator
-- Embeddings are correctly generated for both text and documents using the respective embedder components


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
