### PR TITLE
fix: `AnthropicChatGenerator` now properly can call tools that have no arguments when streaming is enabled

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -367,12 +367,18 @@ class AnthropicChatGenerator:
             elif chunk_type == "message_delta":
                 if chunk.meta.get("delta", {}).get("stop_reason") == "tool_use" and current_tool_call:
                     try:
-                        # arguments is a string, convert to json
+                        # When calling a tool with no arguments, the `arguments` field is an empty string.
+                        # We handle this by checking if `arguments` is empty and setting it to an empty dict.
+                        arguments = (
+                            json.loads(current_tool_call.get("arguments", "{}"))
+                            if current_tool_call.get("arguments")
+                            else {}
+                        )
                         tool_calls.append(
                             ToolCall(
                                 id=current_tool_call.get("id"),
                                 tool_name=str(current_tool_call.get("name")),
-                                arguments=json.loads(current_tool_call.get("arguments", {})),
+                                arguments=arguments,
                             )
                         )
                     except json.JSONDecodeError:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1947

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updates `_convert_streaming_chunks_to_chat_message` to properly handle when a Tool Call is made with no arguments. Previoulsy we were getting a JSON decode error when `arguments=""`. Now we properly check for this case and set the arguments to `{}`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a unit test and an integration test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
