### PR TITLE
feat: Add `timeout`, `max_retries` to `AnthropicChatGenerator` and async support to `AnthropicVertexChatGenerator`

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
@@ -126,7 +126,7 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
 
         # mypy is not happy that we override the type of the clients
         self.client = AnthropicVertex(**client_kwargs)  # type: ignore[assignment]
-        self.async_client = AsyncAnthropicVertex(**client_kwargs) # type: ignore[assignment]
+        self.async_client = AsyncAnthropicVertex(**client_kwargs)  # type: ignore[assignment]
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
@@ -6,7 +6,7 @@ from haystack.dataclasses import StreamingChunk
 from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_or_toolset_inplace
 from haystack.utils import deserialize_callable, serialize_callable
 
-from anthropic import AnthropicVertex
+from anthropic import AnthropicVertex, AsyncAnthropicVertex
 
 from .chat_generator import AnthropicChatGenerator
 
@@ -68,6 +68,9 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
         generation_kwargs: Optional[Dict[str, Any]] = None,
         ignore_tools_thinking_messages: bool = True,
         tools: Optional[List[Tool]] = None,
+        *,
+        timeout: Optional[float] = None,
+        max_retries: Optional[int] = None,
     ):
         """
         Creates an instance of AnthropicVertexChatGenerator.
@@ -96,6 +99,11 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
             use is detected. See the Anthropic [tools](https://docs.anthropic.com/en/docs/tool-use#chain-of-thought-tool-use)
             for more details.
         :param tools: A list of Tool objects that the model can use. Each tool should have a unique name.
+        :param timeout:
+            Timeout for Anthropic client calls. If not set, it defaults to the default set by the Anthropic client.
+        :param max_retries:
+            Maximum number of retries to attempt for failed requests. If not set, it defaults to the default set by
+            the Anthropic client.
         """
         _check_duplicate_tool_names(tools)
         self.region = region or os.environ.get("REGION")
@@ -105,9 +113,20 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
         self.streaming_callback = streaming_callback
         self.ignore_tools_thinking_messages = ignore_tools_thinking_messages
         self.tools = tools
+        self.timeout = timeout
+        self.max_retries = max_retries
 
-        # mypy is not happy that we override the type of the client
-        self.client = AnthropicVertex(region=self.region, project_id=self.project_id)  # type: ignore
+        client_kwargs: Dict[str, Any] = {"region": self.region, "project_id": self.project_id}
+        # We do this since timeout=None is not the same as not setting it in Anthropic
+        if timeout is not None:
+            client_kwargs["timeout"] = timeout
+        # We do this since max_retries must be an int when passing to Anthropic
+        if max_retries is not None:
+            client_kwargs["max_retries"] = max_retries
+
+        # mypy is not happy that we override the type of the clients
+        self.client = AnthropicVertex(**client_kwargs)  # type: ignore[assignment]
+        self.async_client = AsyncAnthropicVertex(**client_kwargs) # type: ignore[assignment]
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -128,6 +147,8 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
             generation_kwargs=self.generation_kwargs,
             ignore_tools_thinking_messages=self.ignore_tools_thinking_messages,
             tools=serialized_tools,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
         )
 
     @classmethod

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -165,6 +165,8 @@ class TestAnthropicChatGenerator:
                 "ignore_tools_thinking_messages": True,
                 "generation_kwargs": {},
                 "tools": None,
+                "timeout": None,
+                "max_retries": None,
             },
         }
 
@@ -181,6 +183,8 @@ class TestAnthropicChatGenerator:
             streaming_callback=print_streaming_chunk,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
             tools=[tool],
+            timeout=10.0,
+            max_retries=1,
         )
         data = component.to_dict()
 
@@ -207,6 +211,8 @@ class TestAnthropicChatGenerator:
                         "type": "haystack.tools.tool.Tool",
                     }
                 ],
+                "timeout": 10.0,
+                "max_retries": 1,
             },
         }
 
@@ -697,6 +703,8 @@ class TestAnthropicChatGenerator:
                                 },
                             }
                         ],
+                        "timeout": None,
+                        "max_retries": None,
                     },
                 }
             },

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -186,3 +186,30 @@ class TestAnthropicVertexChatGenerator:
 
     # Anthropic messages API is similar for AnthropicVertex and Anthropic endpoint,
     # remaining tests are skipped for AnthropicVertexChatGenerator as they are already tested in AnthropicChatGenerator.
+
+
+class TestAnthropicVertexChatGeneratorAsync:
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not (os.environ.get("REGION", None) or os.environ.get("PROJECT_ID", None)),
+        reason="Authenticate with GCP and set env variables REGION and PROJECT_ID to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_live_run_async(self):
+        """
+        Integration test that the async run method of AnthropicVertexChatGenerator works correctly
+        """
+        component = AnthropicVertexChatGenerator(
+            region=os.environ.get("REGION"),
+            project_id=os.environ.get("PROJECT_ID"),
+            model="claude-3-5-sonnet@20240620",
+        )
+        results = await component.run_async(messages=[ChatMessage.from_user("What's the capital of France?")])
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "claude-3-5-sonnet-20240620" in message.meta["model"]
+        assert message.meta["finish_reason"] == "end_turn"
+
+    # Anthropic messages API is similar for AnthropicVertex and Anthropic endpoint,
+    # remaining tests are skipped for AnthropicVertexChatGenerator as they are already tested in AnthropicChatGenerator.

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -58,6 +58,8 @@ class TestAnthropicVertexChatGenerator:
                 "generation_kwargs": {},
                 "ignore_tools_thinking_messages": True,
                 "tools": None,
+                "timeout": None,
+                "max_retries": None,
             },
         }
 
@@ -67,6 +69,9 @@ class TestAnthropicVertexChatGenerator:
             project_id="test-project-id",
             streaming_callback=print_streaming_chunk,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+            ignore_tools_thinking_messages=False,
+            timeout=10.0,
+            max_retries=1,
         )
         data = component.to_dict()
         assert data == {
@@ -80,8 +85,10 @@ class TestAnthropicVertexChatGenerator:
                 "model": "claude-3-5-sonnet@20240620",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "ignore_tools_thinking_messages": True,
+                "ignore_tools_thinking_messages": False,
                 "tools": None,
+                "timeout": 10.0,
+                "max_retries": 1,
             },
         }
 
@@ -98,6 +105,9 @@ class TestAnthropicVertexChatGenerator:
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "ignore_tools_thinking_messages": True,
+                "tools": None,
+                "timeout": None,
+                "max_retries": None,
             },
         }
         component = AnthropicVertexChatGenerator.from_dict(data)
@@ -106,6 +116,9 @@ class TestAnthropicVertexChatGenerator:
         assert component.project_id == "test-project-id"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.ignore_tools_thinking_messages is True
+        assert component.timeout is None
+        assert component.max_retries is None
 
     def test_run(self, chat_messages, mock_chat_completion):
         component = AnthropicVertexChatGenerator(region="us-central1", project_id="test-project-id")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Expose `timeout` and `max_retries` from the Anthropic clients.
- Added the async version of the Anthropic Vertex client so async would work with `AnthropicVertexChatGenerator`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated unit tests and added integration test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
