### PR TITLE
fix: fix Unstructured types + add py.typed

### DIFF
--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -61,11 +61,9 @@ jobs:
       - name: Install Hatch
         run: pip install --upgrade hatch
 
-    # TODO: Once this integration is properly typed, use hatch run test:types
-    # https://github.com/deepset-ai/haystack-core-integrations/issues/1771
       - name: Lint
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run fmt-check && hatch run lint:typing
+        run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -71,18 +71,13 @@ integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 cov-retry = 'all --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x'
 
-types = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+types = "mypy -p haystack_integrations.components.converters.unstructured {args}"
 
-# TODO: remove lint environment once this integration is properly typed
-# test environment should be used instead
-# https://github.com/deepset-ai/haystack-core-integrations/issues/1771
-[tool.hatch.envs.lint]
-installer = "uv"
-detached = true
-dependencies = ["pip", "black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
-
-[tool.hatch.envs.lint.scripts]
-typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+[tool.mypy]
+install_types = true
+non_interactive = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
 
 [tool.hatch.metadata]
 allow-direct-references = true
@@ -167,8 +162,4 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-markers = ["unit: unit tests", "integration: integration tests"]
-
-[[tool.mypy.overrides]]
-module = ["haystack.*", "haystack_integrations.*", "pytest.*", "unstructured.*"]
-ignore_missing_imports = true
+markers = ["integration: integration tests"]

--- a/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
+++ b/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
@@ -126,7 +126,7 @@ class UnstructuredFileConverter:
         self,
         paths: Union[List[str], List[os.PathLike]],
         meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-    ):
+    ) -> Dict[str, List[Document]]:
         """
         Convert files to Haystack Documents using the Unstructured API.
 
@@ -227,11 +227,16 @@ class UnstructuredFileConverter:
         Partition a file into elements using the Unstructured API.
         """
         elements = []
+
+        resolved_api_key = ""
+        if self.api_key:
+            resolved_api_key = self.api_key.resolve_value() or ""
+
         try:
             elements = partition_via_api(
                 filename=str(filepath),
                 api_url=self.api_url,
-                api_key=self.api_key.resolve_value() if self.api_key else "",
+                api_key=resolved_api_key,
                 **self.unstructured_kwargs,
             )
         except Exception as e:

--- a/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
+++ b/integrations/unstructured/src/haystack_integrations/components/converters/unstructured/converter.py
@@ -231,7 +231,7 @@ class UnstructuredFileConverter:
             elements = partition_via_api(
                 filename=str(filepath),
                 api_url=self.api_url,
-                api_key=self.api_key.resolve_value() if self.api_key else None,
+                api_key=self.api_key.resolve_value() if self.api_key else "",
                 **self.unstructured_kwargs,
             )
         except Exception as e:


### PR DESCRIPTION
### Related Issues

- part of #1771

### Proposed Changes:
  - run `hatch run test:types ` and fix type errors
  - use `hatch run test:types` in the test workflow
  - remove `hatch run lint:typing`
  - introduce stricter configuration in pyproject.toml (and fix small errors)
  - add py.typed to allows usage of types in downstream projects

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
