### PR TITLE
fix: rermove None key

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/converters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/converters.py
@@ -57,7 +57,10 @@ def _from_pg_to_haystack_documents(documents: List[Dict[str, Any]]) -> List[Docu
                 haystack_dict["embedding"] = document["embedding"].tolist()
             else:  # halfvec
                 haystack_dict["embedding"] = document["embedding"].to_list()
-
+        # Document.from_dict expects the meta field to be a a dict or not be present (not None)
+        if "meta" in haystack_dict and haystack_dict["meta"] is None:
+            haystack_dict.pop("meta")
+            
         haystack_document = Document.from_dict(haystack_dict)
 
         if blob_data:


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

Access in "Document.to_dict" expects "meta" to not be present or a dict (not None).

### How did you test it?

Manual test.