### PR TITLE
test: pinecone - generate UUID for namespace names in tests

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/filters.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/filters.py
@@ -161,10 +161,7 @@ def _in(field: str, value: Any) -> Dict[str, Any]:
     supported_types = (int, float, str)
     for v in value:
         if not isinstance(v, supported_types):
-            msg = (
-                f"Unsupported type for 'in' comparison: {type(v)}. "
-                f"Types supported by Pinecone are: {supported_types}"
-            )
+            msg = f"Unsupported type for 'in' comparison: {type(v)}. Types supported by Pinecone are: {supported_types}"
             raise FilterError(msg)
 
     return {field: {"$in": value}}

--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -1,16 +1,11 @@
 import asyncio
 import time
+import uuid
 
 import pytest
 import pytest_asyncio
 from haystack.document_stores.types import DuplicatePolicy
-
-try:
-    # pinecone-client < 5.0.0
-    from pinecone.core.client.exceptions import NotFoundException
-except ModuleNotFoundError:
-    # pinecone-client >= 5.0.0
-    from pinecone.exceptions import NotFoundException
+from pinecone.exceptions import NotFoundException
 
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
@@ -31,7 +26,7 @@ def document_store(request):
     """
     index = "default"
     # Use a different namespace for each test so we can run them in parallel
-    namespace = f"{request.node.name}-{int(time.time())}"
+    namespace = f"{request.node.name}-{uuid.uuid4()}"
     dimension = 768
 
     store = PineconeDocumentStore(
@@ -72,7 +67,7 @@ async def document_store_async(request):
     """
     index = "default"
     # Use a different namespace for each test so we can run them in parallel
-    namespace = f"{request.node.name}-{int(time.time())}"
+    namespace = f"{request.node.name}-{uuid.uuid4()}"
     dimension = 768
 
     store = PineconeDocumentStore(


### PR DESCRIPTION
### Related Issues

- nightly test failures: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/15801017498
- Reading the logs, I get the impression that integration tests on different python version may interfere with the same Pinecone namespace

### Proposed Changes:
- adopt `uuid.uuid4()` instead of `int(time.time())` to generate unique namespace names

### How did you test it?
CI

### Notes for the reviewer
I am not sure that this will fix the failures in nightly tests but, in any case, it is an improvement

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
