### PR TITLE
chore: pgvector - update docker image in examples

### DIFF
--- a/integrations/pgvector/examples/embedding_retrieval.py
+++ b/integrations/pgvector/examples/embedding_retrieval.py
@@ -1,7 +1,7 @@
 # Before running this example, ensure you have PostgreSQL installed with the pgvector extension.
 # For a quick setup using Docker:
 # docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres
-# -e POSTGRES_DB=postgres ankane/pgvector
+# -e POSTGRES_DB=postgres pgvector/pgvector:pg17
 
 # Install required packages for this example, including pgvector-haystack and other libraries needed
 # for Markdown conversion and embeddings generation. Use the following command:

--- a/integrations/pgvector/examples/hybrid_retrieval.py
+++ b/integrations/pgvector/examples/hybrid_retrieval.py
@@ -1,7 +1,7 @@
 # Before running this example, ensure you have PostgreSQL installed with the pgvector extension.
 # For a quick setup using Docker:
 # docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres
-# -e POSTGRES_DB=postgres ankane/pgvector
+# -e POSTGRES_DB=postgres pgvector/pgvector:pg17
 
 # Install required packages for this example, including pgvector-haystack and other libraries needed
 # for Markdown conversion and embeddings generation. Use the following command:


### PR DESCRIPTION
### Related Issues
In the past, pgvector used the `ankane/pgvector`docker image.
Now it needs `pgvector/pgvector` (with a mandatory tag; latest does not exist).

I've already updated docs and the integration page.

### Proposed Changes:
- change the docker image in examples

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
