### PR TITLE
fix: Anthropic reports input tokens in first message delta

### DIFF
--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -403,6 +403,23 @@ class TestAnthropicChatGenerator:
         """
         # Create a sequence of streaming chunks that simulate Anthropic's response
         chunks = [
+            # Message start with input tokens
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_123",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": "claude-3-sonnet",
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 25, "output_tokens": 0},
+                    },
+                },
+            ),
             # Initial text content
             StreamingChunk(
                 content="",
@@ -479,7 +496,7 @@ class TestAnthropicChatGenerator:
         assert message._meta["model"] == "claude-3-sonnet"
         assert message._meta["index"] == 0
         assert message._meta["finish_reason"] == "tool_use"
-        assert message._meta["usage"] == {"completion_tokens": 40}
+        assert message._meta["usage"] == {"prompt_tokens": 25, "completion_tokens": 40}
 
     def test_convert_streaming_chunks_to_chat_message_malformed_json(self, caplog):
         """
@@ -558,6 +575,23 @@ class TestAnthropicChatGenerator:
         Test converting streaming chunks with an empty tool call arguments
         """
         chunks = [
+            # Message start with input tokens
+            StreamingChunk(
+                content="",
+                meta={
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_456",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": "claude-3-sonnet",
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 50, "output_tokens": 0},
+                    },
+                },
+            ),
             StreamingChunk(
                 content="",
                 meta={
@@ -659,7 +693,7 @@ class TestAnthropicChatGenerator:
             "cache_creation_input_tokens": None,
             "cache_read_input_tokens": None,
             "completion_tokens": 69,
-            "prompt_tokens": None,
+            "prompt_tokens": 50,
             "server_tool_use": None,
         }
 


### PR DESCRIPTION
### Related Issues

- fixes [#issue-number
](https://github.com/deepset-ai/haystack-core-integrations/issues/1992)
### Proposed Changes:

 Get the input tokens from the first message delta.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
