### PR TITLE
fix: files should not be passed as a single string

### DIFF
--- a/.github/workflows/sync_code_to_deepset.yml
+++ b/.github/workflows/sync_code_to_deepset.yml
@@ -51,5 +51,5 @@ jobs:
         
         # Run the script with changed and deleted files
         uv run --no-project --no-config --no-cache .github/utils/deepset_sync.py \
-          --changed "$CHANGED_FILES" \
-          --deleted "${{ steps.changed-files.outputs.deleted_files }}"
+          --changed $CHANGED_FILES \
+          --deleted ${{ steps.changed-files.outputs.deleted_files }}


### PR DESCRIPTION
### Related Issues


### Proposed Changes:

 Quoting changed files means that the script interprets multiple paths as a single string. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
