### PR TITLE
fix: Prevent MCPToolset GC during toolset add

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -13,6 +14,7 @@ from haystack.tools import Tool, Toolset
 
 from .mcp_tool import (
     AsyncExecutor,
+    MCPClient,
     MCPConnectionError,
     MCPServerInfo,
     MCPToolNotFoundError,
@@ -145,7 +147,12 @@ class MCPToolset(Toolset):
                     )
 
             # This is a factory that creates the invocation function for the Tool
-            def create_invoke_tool(owner_toolset, mcp_client, tool_name, tool_timeout):
+            def create_invoke_tool(
+                owner_toolset: "MCPToolset",
+                mcp_client: MCPClient,
+                tool_name: str,
+                tool_timeout: float,
+            ) -> Callable[..., Any]:
                 """Return a closure that keeps a strong reference to *owner_toolset* alive."""
 
                 def invoke_tool(**kwargs) -> Any:


### PR DESCRIPTION
### Why:
Fixes a garbage collection issue that prevented users from properly combining multiple MCPToolset instances using the inline syntax `tools.add(MCPToolset(...))`. When MCPToolset objects were created inline and added to another toolset, Python's garbage collector would prematurely destroy the temporary toolset objects, closing their MCP connections and leaving orphaned tools that failed with "Not connected to an MCP server" errors.

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1986


### What:
- Use`owner_toolset` parameter to maintain strong references to prevent garbage collection  

### How can it be used:
```python
# Previously broken - temporary MCPToolset would be garbage collected
server_info = SSEServerInfo(url="https://mcp.amap.com/sse?key=xxx")
htw_server_info = SSEServerInfo(url="http://127.0.0.1:8333/sse")
tools = MCPToolset(server_info=htw_server_info)
tools.add(MCPToolset(server_info=server_info))  # Now works correctly!

# Alternative approach that always worked
tools_a = MCPToolset(server_info=htw_server_info)
tools_b = MCPToolset(server_info=server_info)
all_tools = tools_a + tools_b  # Still works

```

### How did you test it:
- Manual confirmation of the original issue example
- Using itinerary agent with the previously "broken" setup of MCPToolset usage
- Ran full MCP integration test suite to ensure no regressions in existing functionality

### Notes for the reviewer:
N/A