### PR TITLE
fix: fix Snowflake types + add py.typed

### DIFF
--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -49,11 +49,9 @@ jobs:
       - name: Install Hatch
         run: pip install --upgrade hatch
 
-    # TODO: Once this integration is properly typed, use hatch run test:types
-    # https://github.com/deepset-ai/haystack-core-integrations/issues/1771
       - name: Lint
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run fmt-check && hatch run lint:typing
+        run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'

--- a/integrations/snowflake/pyproject.toml
+++ b/integrations/snowflake/pyproject.toml
@@ -68,19 +68,13 @@ integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 cov-retry = 'all --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x'
 
-types = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+types = "mypy -p haystack_integrations.components.retrievers.snowflake {args}"
 
-# TODO: remove lint environment once this integration is properly typed
-# test environment should be used instead
-# https://github.com/deepset-ai/haystack-core-integrations/issues/1771
-[tool.hatch.envs.lint]
-installer = "uv"
-detached = true
-dependencies = ["pip", "mypy>=1.0.0", "ruff>=0.0.243"]
-
-[tool.hatch.envs.lint.scripts]
-typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
-
+[tool.mypy]
+install_types = true
+non_interactive = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
 
 [tool.ruff]
 target-version = "py38"
@@ -156,7 +150,3 @@ parallel = false
 omit = ["*/tests/*", "*/__init__.py"]
 show_missing = true
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
-
-[[tool.mypy.overrides]]
-module = ["haystack.*", "haystack_integrations.*", "pytest.*", "openai.*", "polars.*"]
-ignore_missing_imports = true

--- a/integrations/snowflake/src/haystack_integrations/components/retrievers/snowflake/snowflake_table_retriever.py
+++ b/integrations/snowflake/src/haystack_integrations/components/retrievers/snowflake/snowflake_table_retriever.py
@@ -143,7 +143,9 @@ class SnowflakeTableRetriever:
         uri = uri.rstrip("&?")
 
         # Logging placeholder for the actual password
-        masked_uri = uri.replace(self.api_key.resolve_value(), "***REDACTED***")
+        masked_uri = uri
+        if resolved_api_key := self.api_key.resolve_value():
+            masked_uri = uri.replace(resolved_api_key, "***REDACTED***")
         logger.info("Constructed Snowflake URI: {masked_uri}", masked_uri=masked_uri)
         return uri
 


### PR DESCRIPTION
### Related Issues

- part of #1771

### Proposed Changes:
- run `hatch run test:types`
  (this means testing with all dependencies installed, differently from `hatch run lint:typing` that did not install dependencies) and fix type errors
- use `hatch run test:types` in the test workflow
- remove `hatch run lint:typing`
- introduce stricter configuration in pyproject.toml (and fix errors)
- add py.typed to allows usage of types in downstream projects

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
