### PR TITLE
fix: fix deepeval types + add py.typed

### DIFF
--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -49,12 +49,9 @@ jobs:
 
       - name: Install Hatch
         run: pip install --upgrade hatch
-
-    # TODO: Once this integration is properly typed, use hatch run test:types
-    # https://github.com/deepset-ai/haystack-core-integrations/issues/1771
       - name: Lint
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run fmt-check && hatch run lint:typing
+        run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -64,17 +64,17 @@ unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 cov-retry = 'all --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x'
-types = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+types = "mypy -p haystack_integrations.components.evaluators.deepeval {args}"
 
-# TODO: remove lint environment once this integration is properly typed
-# test environment should be used instead
-# https://github.com/deepset-ai/haystack-core-integrations/issues/1771
-[tool.hatch.envs.lint]
-installer = "uv"
-detached = true
-dependencies = ["pip", "mypy>=1.0.0", "ruff>=0.0.243"]
-[tool.hatch.envs.lint.scripts]
-typing = "mypy --install-types --non-interactive {args:src/}"
+[tool.mypy]
+install_types = true
+non_interactive = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = ["deepeval.*"]
+ignore_missing_imports = true
 
 [tool.ruff]
 target-version = "py38"
@@ -153,15 +153,3 @@ parallel = false
 omit = ["*/tests/*", "*/__init__.py"]
 show_missing = true
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
-
-
-[[tool.mypy.overrides]]
-module = [
-  "haystack.*",
-  "pytest.*",
-  "deepeval.*",
-  "numpy",
-  "grpc",
-  "haystack_integrations.*",
-]
-ignore_missing_imports = true

--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
@@ -72,7 +72,7 @@ class DeepEvalEvaluator:
         component.set_input_types(self, **expected_inputs)
 
     @component.output_types(results=List[List[Dict[str, Any]]])
-    def run(self, **inputs) -> Dict[str, Any]:
+    def run(self, **inputs: Any) -> Dict[str, Any]:
         """
         Run the DeepEval evaluator on the provided inputs.
 
@@ -107,7 +107,7 @@ class DeepEvalEvaluator:
             If the component cannot be serialized.
         """
 
-        def check_serializable(obj: Any):
+        def check_serializable(obj: Any) -> bool:
             try:
                 json.dumps(obj)
                 return True

--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
@@ -175,7 +175,7 @@ class InputConverters:
             raise ValueError(msg)
 
     @staticmethod
-    def validate_input_parameters(metric: DeepEvalMetric, expected: Dict[str, Any], received: Dict[str, Any]):
+    def validate_input_parameters(metric: DeepEvalMetric, expected: Dict[str, Any], received: Dict[str, Any]) -> None:
         for param, _ in expected.items():
             if param not in received:
                 msg = f"DeepEval evaluator expected input parameter '{param}' for metric '{metric}'"


### PR DESCRIPTION
### Related Issues

- part of #1771

### Proposed Changes:
- run `hatch run test:types`
  (this means testing with all dependencies installed, differently from `hatch run lint:typing` that did not install dependencies) and fix type errors
- use `hatch run test:types` in the test workflow
- remove `hatch run lint:typing`
- introduce stricter configuration in pyproject.toml (and fix errors)
- add py.typed to allows usage of types in downstream projects

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
