### PR TITLE
fix: fix openrouter types + add py.typed

### DIFF
--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -49,12 +49,9 @@ jobs:
 
       - name: Install Hatch
         run: pip install --upgrade hatch
-
-    # TODO: Once this integration is properly typed, use hatch run test:types
-    # https://github.com/deepset-ai/haystack-core-integrations/issues/1771
       - name: Lint
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run fmt-check && hatch run lint:typing
+        run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'

--- a/integrations/openrouter/pyproject.toml
+++ b/integrations/openrouter/pyproject.toml
@@ -65,17 +65,14 @@ unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 cov-retry = 'all --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x'
-types = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
 
-# TODO: remove lint environment once this integration is properly typed
-# test environment should be used instead
-# https://github.com/deepset-ai/haystack-core-integrations/issues/1771
-[tool.hatch.envs.lint]
-installer = "uv"
-detached = true
-dependencies = ["pip", "mypy>=1.0.0", "ruff>=0.0.243"]
-[tool.hatch.envs.lint.scripts]
-typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+types = "mypy -p haystack_integrations.components.generators.openrouter {args}"
+
+[tool.mypy]
+install_types = true
+non_interactive = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
 
 
 [tool.ruff]
@@ -152,22 +149,9 @@ omit = ["*/tests/*", "*/__init__.py"]
 show_missing = true
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
-
-[[tool.mypy.overrides]]
-module = [
-  "haystack.*",
-  "haystack_integrations.*",
-  "openai.*",
-  "pytest.*",
-  "numpy.*",
-]
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
 markers = [
   "integration: integration tests",
-  "unit: unit tests",
-  "chat_generators: chat_generators tests",
 ]
 log_cli = true

--- a/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
+++ b/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
@@ -173,7 +173,7 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
 
         tools = tools or self.tools
         tools_strict = tools_strict if tools_strict is not None else self.tools_strict
-        _check_duplicate_tool_names(tools)
+        _check_duplicate_tool_names(list(tools or []))
 
         openai_tools = {}
         if tools:


### PR DESCRIPTION
### Related Issues

- part of #1771

### Proposed Changes:
- run `hatch run test:types`
  (this means testing with all dependencies installed, differently from `hatch run lint:typing` that did not install dependencies) and fix type errors
- use `hatch run test:types` in the test workflow
- remove `hatch run lint:typing`
- introduce stricter configuration in pyproject.toml (and fix errors)
- add py.typed to allows usage of types in downstream projects

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
