### PR TITLE
chore: meta llama - improve type checking + add py.typed

### DIFF
--- a/.github/workflows/meta_llama.yml
+++ b/.github/workflows/meta_llama.yml
@@ -49,12 +49,9 @@ jobs:
 
       - name: Install Hatch
         run: pip install --upgrade hatch
-
-    # TODO: Once this integration is properly typed, use hatch run test:types
-    # https://github.com/deepset-ai/haystack-core-integrations/issues/1771
       - name: Lint
         if: matrix.python-version == '3.9' && runner.os == 'Linux'
-        run: hatch run fmt-check && hatch run lint:typing
+        run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
         if: matrix.python-version == '3.9' && runner.os == 'Linux'

--- a/integrations/meta_llama/pyproject.toml
+++ b/integrations/meta_llama/pyproject.toml
@@ -65,18 +65,14 @@ unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 cov-retry = 'all --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x'
-types = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
 
-# TODO: remove lint environment once this integration is properly typed
-# test environment should be used instead
-# https://github.com/deepset-ai/haystack-core-integrations/issues/1771
-[tool.hatch.envs.lint]
-installer = "uv"
-detached = true
-dependencies = ["pip", "mypy>=1.0.0", "ruff>=0.0.243"]
-[tool.hatch.envs.lint.scripts]
-typing = "mypy --install-types --non-interactive --explicit-package-bases {args:src/ tests}"
+types = "mypy -p haystack_integrations.components.generators.meta_llama {args}"
 
+[tool.mypy]
+install_types = true
+non_interactive = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
 
 [tool.ruff]
 target-version = "py38"
@@ -152,22 +148,9 @@ omit = ["*/tests/*", "*/__init__.py"]
 show_missing = true
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
-
-[[tool.mypy.overrides]]
-module = [
-  "llama.*",
-  "haystack.*",
-  "haystack_integrations.*",
-  "openai.*",
-  "pytest.*",
-  "numpy.*",
-]
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
 markers = [
   "integration: integration tests",
-  "unit: unit tests",
 ]
 log_cli = true


### PR DESCRIPTION
### Related Issues

- part of #1771

### Proposed Changes:
- run `hatch run test:types`
  (this means testing with all dependencies installed, differently from `hatch run lint:typing` that did not install dependencies) -> no type errors in this integration, already OK
- use `hatch run test:types` in the test workflow
- remove `hatch run lint:typing`
- introduce stricter configuration in pyproject.toml -> no type errors in this integration, already OK
- add py.typed to allows usage of types in downstream projects

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
