### PR TITLE
feat: pass `component_info` to `StreamingChunk` in `OllamaChatGenerator`

### DIFF
--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.15.0", "ollama>=0.4.0", "pydantic"]
+dependencies = ["haystack-ai>=2.15.1", "ollama>=0.4.0", "pydantic"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ollama#readme"
@@ -158,9 +158,7 @@ show_missing = true
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.pytest.ini_options]
-markers = [
-    "integration: marks tests as slow (deselect with '-m \"not integration\"')",
-]
+markers = ["integration: integration tests"]
 log_cli = true
 addopts = ["--import-mode=importlib"]
 asyncio_mode = "auto"

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.13.1", "ollama>=0.4.0", "pydantic"]
+dependencies = ["haystack-ai>=2.15.0", "ollama>=0.4.0", "pydantic"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ollama#readme"

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -288,6 +288,9 @@ class TestOllamaChatGenerator:
                                     "type": "string",
                                 },
                             },
+                            "outputs_to_string": None,
+                            "inputs_from_state": None,
+                            "outputs_to_state": None,
                         },
                     },
                 ],
@@ -297,15 +300,6 @@ class TestOllamaChatGenerator:
                 },
             },
         }
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = tool.outputs_to_string
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = tool.inputs_from_state
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = tool.outputs_to_state
 
         assert data == expected_dict
 
@@ -366,7 +360,6 @@ class TestOllamaChatGenerator:
             "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
         }
 
-    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
     def test_build_chunk(self):
         generator = OllamaChatGenerator()
 


### PR DESCRIPTION
### Related Issues

- fixes #1823

### Proposed Changes:
- pass `component_info` to `StreamingChunk` in `OllamaChatGenerator`
- other small improvements to tests and types

### How did you test it?
CI; new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
