### PR TITLE
feat: pass `component_info` to `StreamingChunk` in `AmazonBedrockChatGenerator`

### DIFF
--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.13.1", "boto3>=1.28.57", "aioboto3>=14.0.0"]
+dependencies = ["haystack-ai>=2.15.1", "boto3>=1.28.57", "aioboto3>=14.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_bedrock#readme"
@@ -163,9 +163,6 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
 markers = [
-  "unit: unit tests",
   "integration: integration tests",
-  "embedders: embedders tests",
-  "generators: generators tests",
 ]
 log_cli = true

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -298,6 +298,7 @@ class TestAmazonBedrockChatGeneratorInference:
             streaming_callback_called = True
             assert isinstance(chunk, StreamingChunk)
             assert chunk.content is not None
+            assert chunk.component_info is not None
             if not paris_found_in_response:
                 paris_found_in_response = "paris" in chunk.content.lower()
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
+from haystack.dataclasses import ChatMessage, ChatRole, ComponentInfo, StreamingChunk, ToolCall
 from haystack.tools import Tool
 
 from haystack_integrations.components.generators.amazon_bedrock.chat.utils import (
@@ -339,6 +339,9 @@ class TestAmazonBedrockChatGeneratorUtils:
         Test that process_streaming_response correctly handles streaming events and accumulates responses
         """
         model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        type_ = (
+            "haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator.AmazonBedrockChatGenerator"
+        )
         streaming_chunks = []
 
         def test_callback(chunk: StreamingChunk):
@@ -379,7 +382,11 @@ class TestAmazonBedrockChatGeneratorUtils:
             },
         ]
 
-        replies = _parse_streaming_response(events, test_callback, model)
+        component_info = ComponentInfo(
+            type=type_,
+        )
+
+        replies = _parse_streaming_response(events, test_callback, model, component_info)
         # Pop completion_start_time since it will always change
         replies[0].meta.pop("completion_start_time")
         expected_messages = [
@@ -413,6 +420,9 @@ class TestAmazonBedrockChatGeneratorUtils:
                 "type": "function",
             }
         ]
+        for chunk in streaming_chunks:
+            assert chunk.component_info.type == type_
+            assert chunk.component_info.name is None  # not in a pipeline
 
         # Verify final replies
         assert len(replies) == 1
@@ -420,6 +430,9 @@ class TestAmazonBedrockChatGeneratorUtils:
 
     def test_parse_streaming_response_with_two_tool_calls(self, mock_boto3_session):
         model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        type_ = (
+            "haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator.AmazonBedrockChatGenerator"
+        )
         streaming_chunks = []
 
         def test_callback(chunk: StreamingChunk):
@@ -468,7 +481,11 @@ class TestAmazonBedrockChatGeneratorUtils:
             },
         ]
 
-        replies = _parse_streaming_response(events, test_callback, model)
+        component_info = ComponentInfo(
+            type=type_,
+        )
+
+        replies = _parse_streaming_response(events, test_callback, model, component_info)
         # Pop completion_start_time since it will always change
         replies[0].meta.pop("completion_start_time")
         expected_messages = [


### PR DESCRIPTION
### Related Issues

- fixes #1819

### Proposed Changes:
- pass `component_info` to `StreamingChunk` in `AmazonBedrockChatGenerator`

### How did you test it?
CI, extended existing tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
