### PR TITLE
feat: pass `component_info`to `StreamingChunk` in `AnthropicChatGenerator`

### DIFF
--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.13.1", "anthropic>=0.47.0"]
+dependencies = ["haystack-ai>=2.15.1", "anthropic>=0.47.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/anthropic#readme"

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -536,13 +536,15 @@ class AnthropicChatGenerator:
             model: Optional[str] = None
             component_info = ComponentInfo.from_component(self)
             for chunk in response:
-                if chunk.type == "message_start":
-                    model = chunk.message.model
+                if chunk.type in ["message_start", "content_block_start", "content_block_delta", "message_delta"]:
+                    # Extract model from message_start chunks
+                    if chunk.type == "message_start":
+                        model = chunk.message.model
 
-                streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk, component_info)
-                chunks.append(streaming_chunk)
-                if streaming_callback:
-                    streaming_callback(streaming_chunk)
+                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk, component_info)
+                    chunks.append(streaming_chunk)
+                    if streaming_callback:
+                        streaming_callback(streaming_chunk)
 
             completion = self._convert_streaming_chunks_to_chat_message(chunks, model)
             return {"replies": [completion]}

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -531,10 +531,10 @@ class AnthropicChatGenerator:
         if not isinstance(response, Message):
             chunks: List[StreamingChunk] = []
             model: Optional[str] = None
+            component_info = ComponentInfo.from_component(self)
             for chunk in response:
                 if chunk.type == "message_start":
                     model = chunk.message.model
-                    component_info = ComponentInfo.from_component(self)
                 elif chunk.type in [
                     "content_block_start",
                     "content_block_delta",
@@ -573,6 +573,7 @@ class AnthropicChatGenerator:
         if stream:
             chunks: List[StreamingChunk] = []
             model: Optional[str] = None
+            component_info = ComponentInfo.from_component(self)
             async for chunk in response:
                 if chunk.type == "message_start":
                     model = chunk.message.model
@@ -581,7 +582,7 @@ class AnthropicChatGenerator:
                     "content_block_delta",
                     "message_delta",
                 ]:
-                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk)
+                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk, component_info)
                     chunks.append(streaming_chunk)
                     if streaming_callback:
                         await streaming_callback(streaming_chunk)

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -5,6 +5,7 @@ from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole, ToolCall, ToolCallResult
 from haystack.dataclasses.streaming_chunk import (
     AsyncStreamingCallbackT,
+    ComponentInfo,
     StreamingCallbackT,
     StreamingChunk,
     SyncStreamingCallbackT,
@@ -344,8 +345,7 @@ class AnthropicChatGenerator:
         )
         return message
 
-    @staticmethod
-    def _convert_anthropic_chunk_to_streaming_chunk(chunk: Any) -> StreamingChunk:
+    def _convert_anthropic_chunk_to_streaming_chunk(self, chunk: Any) -> StreamingChunk:
         """
         Converts an Anthropic StreamEvent to a StreamingChunk.
         """
@@ -353,7 +353,9 @@ class AnthropicChatGenerator:
         if chunk.type == "content_block_delta" and chunk.delta.type == "text_delta":
             content = chunk.delta.text
 
-        return StreamingChunk(content=content, meta=chunk.model_dump())
+        component_info = ComponentInfo.from_component(self)
+
+        return StreamingChunk(content=content, meta=chunk.model_dump(), component_info=component_info)
 
     def _convert_streaming_chunks_to_chat_message(
         self, chunks: List[StreamingChunk], model: Optional[str] = None

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -345,15 +345,13 @@ class AnthropicChatGenerator:
         )
         return message
 
-    def _convert_anthropic_chunk_to_streaming_chunk(self, chunk: Any) -> StreamingChunk:
+    def _convert_anthropic_chunk_to_streaming_chunk(self, chunk: Any, component_info: ComponentInfo) -> StreamingChunk:
         """
         Converts an Anthropic StreamEvent to a StreamingChunk.
         """
         content = ""
         if chunk.type == "content_block_delta" and chunk.delta.type == "text_delta":
             content = chunk.delta.text
-
-        component_info = ComponentInfo.from_component(self)
 
         return StreamingChunk(content=content, meta=chunk.model_dump(), component_info=component_info)
 
@@ -536,12 +534,13 @@ class AnthropicChatGenerator:
             for chunk in response:
                 if chunk.type == "message_start":
                     model = chunk.message.model
+                    component_info = ComponentInfo.from_component(self)
                 elif chunk.type in [
                     "content_block_start",
                     "content_block_delta",
                     "message_delta",
                 ]:
-                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk)
+                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk, component_info)
                     chunks.append(streaming_chunk)
                     if streaming_callback:
                         streaming_callback(streaming_chunk)

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -345,7 +345,10 @@ class AnthropicChatGenerator:
         )
         return message
 
-    def _convert_anthropic_chunk_to_streaming_chunk(self, chunk: Any, component_info: ComponentInfo) -> StreamingChunk:
+    @staticmethod
+    def _convert_anthropic_chunk_to_streaming_chunk(
+        chunk: RawMessageStreamEvent, component_info: ComponentInfo
+    ) -> StreamingChunk:
         """
         Converts an Anthropic StreamEvent to a StreamingChunk.
         """
@@ -535,15 +538,11 @@ class AnthropicChatGenerator:
             for chunk in response:
                 if chunk.type == "message_start":
                     model = chunk.message.model
-                elif chunk.type in [
-                    "content_block_start",
-                    "content_block_delta",
-                    "message_delta",
-                ]:
-                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk, component_info)
-                    chunks.append(streaming_chunk)
-                    if streaming_callback:
-                        streaming_callback(streaming_chunk)
+
+                streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk, component_info)
+                chunks.append(streaming_chunk)
+                if streaming_callback:
+                    streaming_callback(streaming_chunk)
 
             completion = self._convert_streaming_chunks_to_chat_message(chunks, model)
             return {"replies": [completion]}

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -820,11 +820,13 @@ class TestAnthropicChatGenerator:
             def __call__(self, chunk: StreamingChunk) -> None:
                 self.counter += 1
                 self.responses += chunk.content if chunk.content else ""
+                assert chunk.component_info is not None
+                assert chunk.component_info.type.endswith("chat_generator.AnthropicChatGenerator")
 
         callback = Callback()
+
         component = AnthropicChatGenerator(streaming_callback=callback, timeout=30.0, max_retries=1)
         results = component.run([ChatMessage.from_user("What's the capital of France?")])
-
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
@@ -1479,6 +1481,8 @@ class TestAnthropicChatGeneratorAsync:
             nonlocal responses
             counter += 1
             responses += chunk.content if chunk.content else ""
+            assert chunk.component_info is not None
+            assert chunk.component_info.type.endswith("chat_generator.AnthropicChatGenerator")
 
         # Run the async streaming test
         results = await component.run_async(messages=initial_messages, streaming_callback=callback)

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -329,12 +329,13 @@ class TestAnthropicChatGenerator:
         Test converting Anthropic stream events to Haystack StreamingChunks
         """
         component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component_info = ComponentInfo.from_component(component)
 
         # Test text delta chunk
         text_delta_chunk = ContentBlockDeltaEvent(
             type="content_block_delta", index=0, delta=TextDelta(type="text_delta", text="Hello, world!")
         )
-        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(text_delta_chunk)
+        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(text_delta_chunk, component_info)
         assert streaming_chunk.content == "Hello, world!"
         assert streaming_chunk.meta == {
             "type": "content_block_delta",
@@ -356,7 +357,7 @@ class TestAnthropicChatGenerator:
                 "usage": {"input_tokens": 25, "output_tokens": 1},
             },
         )
-        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(message_start_chunk)
+        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(message_start_chunk, component_info)
         assert streaming_chunk.content == ""
 
         # remove fields not present in the pinned version of the Anthropic SDK.
@@ -389,7 +390,7 @@ class TestAnthropicChatGenerator:
             index=1,
             content_block={"type": "tool_use", "id": "toolu_123", "name": "weather", "input": {"city": "Paris"}},
         )
-        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(tool_use_chunk)
+        streaming_chunk = component._convert_anthropic_chunk_to_streaming_chunk(tool_use_chunk, component_info)
         assert streaming_chunk.content == ""
         assert streaming_chunk.meta == {
             "type": "content_block_start",

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -20,7 +20,7 @@ from anthropic.types import (
 )
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
+from haystack.dataclasses import ChatMessage, ChatRole, ComponentInfo, StreamingChunk, ToolCall
 from haystack.tools import Tool, Toolset
 from haystack.utils.auth import Secret
 
@@ -396,6 +396,7 @@ class TestAnthropicChatGenerator:
             "index": 1,
             "content_block": {"type": "tool_use", "id": "toolu_123", "name": "weather", "input": {"city": "Paris"}},
         }
+        assert streaming_chunk.component_info.type.endswith("chat_generator.AnthropicChatGenerator")
 
     def test_convert_streaming_chunks_to_chat_message(self):
         """
@@ -419,11 +420,13 @@ class TestAnthropicChatGenerator:
                         "usage": {"input_tokens": 25, "output_tokens": 0},
                     },
                 },
+                component_info=ComponentInfo.from_component(self),
             ),
             # Initial text content
             StreamingChunk(
                 content="",
                 meta={"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+                component_info=ComponentInfo.from_component(self),
             ),
             StreamingChunk(
                 content="Let me check",
@@ -432,6 +435,7 @@ class TestAnthropicChatGenerator:
                     "index": 0,
                     "delta": {"type": "text_delta", "text": "Let me check"},
                 },
+                component_info=ComponentInfo.from_component(self),
             ),
             StreamingChunk(
                 content=" the weather",


### PR DESCRIPTION
### Related Issues

- fixes #1820 

### Proposed Changes:

pass `component_info` to `StreamingChunk` in `AnthropicChatGenerator`

### How did you test it?

Updated the test
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
