### PR TITLE
chore: skip checking `adbc-driver-snowflake` license

### DIFF
--- a/.github/workflows/CI_license_compliance.yml
+++ b/.github/workflows/CI_license_compliance.yml
@@ -13,7 +13,7 @@ on:
 env:
   CORE_DATADOG_API_KEY: ${{ secrets.CORE_DATADOG_API_KEY }}
   PYTHON_VERSION: "3.10"
-  EXCLUDE_PACKAGES: "(?i)^(deepeval|fastembed|ollama|ragas|tqdm|psycopg|typing_extensions|adbc-driver-snowflake).*"
+  EXCLUDE_PACKAGES: "(?i)^(deepeval|fastembed|ollama|ragas|tqdm|psycopg|typing_extensions|adbc_driver_snowflake).*"
 
   # Exclusions must be explicitly motivated
   #
@@ -23,7 +23,7 @@ env:
   # - ragas is Apache 2.0 but the license is not available on PyPI
   # - typing_extensions>=4.13.0 has a Python Software Foundation License 2.0 but pip-license-checker does not recognize it
   #   (https://github.com/pilosus/pip-license-checker/issues/143)
-  # - adbc-driver-snowflake is Apache 2.0 but the license is not correctly specified on PyPI
+  # - adbc_driver_snowflake is Apache 2.0 but the license is not correctly specified on PyPI
 
   # - tqdm is MLP but there are no better alternatives
   # - psycopg is LGPL-3.0 but FOSSA is fine with it


### PR DESCRIPTION
### Related Issues

- nightly license check failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/16130642079/job/45517245497
- [a new version of `adbc-driver-snowflake` was released yesterday](https://pypi.org/project/adbc-driver-snowflake/1.7.0/), but the license information (which is Apache 2.0) is not correctly recognized

### Proposed Changes:
- skip checking `adbc-driver-snowflake` license

### How did you test it?
CI; tried locally

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
