### PR TITLE
ci: Reduce impact of integration tests for Watsonx integration

### DIFF
--- a/integrations/watsonx/tests/test_chat_generator.py
+++ b/integrations/watsonx/tests/test_chat_generator.py
@@ -393,7 +393,7 @@ class TestWatsonxChatGeneratorIntegration:
             project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
             generation_kwargs={"max_tokens": 50, "temperature": 0.7, "top_p": 0.9},
         )
-        messages = [ChatMessage.from_user("What's the capital of France?")]
+        messages = [ChatMessage.from_user("What's the capital of France? Answer concisely.")]
         results = generator.run(messages=messages)
 
         assert isinstance(results, dict)
@@ -417,7 +417,7 @@ class TestWatsonxChatGeneratorIntegration:
         def callback(chunk: StreamingChunk):
             collected_chunks.append(chunk)
 
-        messages = [ChatMessage.from_user("Explain quantum computing")]
+        messages = [ChatMessage.from_user("What's the capital of France? Answer concisely.")]
         results = generator.run(messages=messages, streaming_callback=callback)
 
         assert isinstance(results, dict)
@@ -437,7 +437,7 @@ class TestWatsonxChatGeneratorIntegration:
         generator = WatsonxChatGenerator(
             model="ibm/granite-3-2b-instruct", project_id=Secret.from_env_var("WATSONX_PROJECT_ID")
         )
-        messages = [ChatMessage.from_user("What's the capital of Germany?")]
+        messages = [ChatMessage.from_user("What's the capital of Germany? Answer concisely.")]
         results = await generator.run_async(messages=messages)
 
         assert isinstance(results, dict)

--- a/integrations/watsonx/tests/test_document_embedder.py
+++ b/integrations/watsonx/tests/test_document_embedder.py
@@ -235,16 +235,16 @@ class TestWatsonxDocumentEmbedderIntegration:
     )
     def test_text_truncation(self):
         """Test that truncation works with long documents"""
-        long_content = "This is a very long document. " * 1000
+        long_content = "This is a very long document. " * 10
         long_document = Document(content=long_content)
 
         embedder = WatsonxDocumentEmbedder(
             model="ibm/slate-30m-english-rtrvr",
             api_key=Secret.from_env_var("WATSONX_API_KEY"),
             project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
-            truncate_input_tokens=128,
+            truncate_input_tokens=4,
         )
 
         result = embedder.run([long_document])
         assert len(result["documents"][0].embedding) > 0
-        assert result["meta"]["truncate_input_tokens"] == 128
+        assert result["meta"]["truncate_input_tokens"] == 4

--- a/integrations/watsonx/tests/test_generator.py
+++ b/integrations/watsonx/tests/test_generator.py
@@ -370,7 +370,10 @@ class TestWatsonxGeneratorIntegration:
             generation_kwargs={"max_tokens": 50, "temperature": 0.7, "top_p": 0.9},
         )
 
-        result = generator.run(prompt="What's the capital of France?")
+        result = generator.run(
+            prompt="What's the capital of France? Answer concisely.",
+            system_prompt="You are a geography expert. Answer concisely."
+        )
 
         assert isinstance(result, dict)
         assert "replies" in result
@@ -387,27 +390,6 @@ class TestWatsonxGeneratorIntegration:
         not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
         reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
     )
-    def test_live_run_with_system_prompt(self):
-        generator = WatsonxGenerator(
-            model="ibm/granite-3-2b-instruct",
-            project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
-        )
-
-        result = generator.run(
-            prompt="What's the capital of France?", system_prompt="You are a geography expert. Answer concisely."
-        )
-
-        assert isinstance(result, dict)
-        assert "replies" in result
-        assert "meta" in result
-        assert len(result["replies"]) == 1
-        assert isinstance(result["replies"][0], str)
-        assert len(result["replies"][0]) > 0
-
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_live_run_streaming(self):
         generator = WatsonxGenerator(
             model="ibm/granite-3-2b-instruct", project_id=Secret.from_env_var("WATSONX_PROJECT_ID")
@@ -418,7 +400,7 @@ class TestWatsonxGeneratorIntegration:
         def callback(chunk: StreamingChunk):
             collected_chunks.append(chunk)
 
-        result = generator.run(prompt="Explain quantum computing", streaming_callback=callback)
+        result = generator.run(prompt="What is the capital of France? Answer concisely.", streaming_callback=callback)
 
         assert isinstance(result, dict)
         assert "replies" in result
@@ -441,7 +423,7 @@ class TestWatsonxGeneratorIntegration:
             model="ibm/granite-3-2b-instruct", project_id=Secret.from_env_var("WATSONX_PROJECT_ID")
         )
 
-        result = await generator.run_async(prompt="What's the capital of Germany?")
+        result = await generator.run_async(prompt="What's the capital of Germany? Answer concisely.")
 
         assert isinstance(result, dict)
         assert "replies" in result

--- a/integrations/watsonx/tests/test_generator.py
+++ b/integrations/watsonx/tests/test_generator.py
@@ -372,7 +372,7 @@ class TestWatsonxGeneratorIntegration:
 
         result = generator.run(
             prompt="What's the capital of France? Answer concisely.",
-            system_prompt="You are a geography expert. Answer concisely."
+            system_prompt="You are a geography expert. Answer concisely.",
         )
 
         assert isinstance(result, dict)

--- a/integrations/watsonx/tests/test_text_embedder.py
+++ b/integrations/watsonx/tests/test_text_embedder.py
@@ -207,11 +207,11 @@ class TestWatsonxTextEmbedderIntegration:
             model="ibm/slate-30m-english-rtrvr",
             api_key=Secret.from_env_var("WATSONX_API_KEY"),
             project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
-            truncate_input_tokens=128,
+            truncate_input_tokens=4,
         )
 
-        long_text = "This is a test sentence. " * 1000
+        long_text = "This is a test sentence. " * 10
         result = embedder.run(long_text)
 
         assert len(result["embedding"]) > 0
-        assert result["meta"]["truncated_input_tokens"] == 128
+        assert result["meta"]["truncated_input_tokens"] == 4

--- a/integrations/watsonx/tests/test_text_embedder.py
+++ b/integrations/watsonx/tests/test_text_embedder.py
@@ -179,43 +179,6 @@ class TestWatsonxTextEmbedderIntegration:
         not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
         reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
     )
-    def test_long_text(self):
-        """Test with longer text input"""
-        embedder = WatsonxTextEmbedder(
-            model="ibm/slate-30m-english-rtrvr",
-            api_key=Secret.from_env_var("WATSONX_API_KEY"),
-            project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
-            truncate_input_tokens=128,
-        )
-        long_text = "This is a test text that should work fine. " * 10
-        result = embedder.run(long_text)
-
-        assert len(result["embedding"]) > 0
-        assert "model" in result["meta"]
-
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
-    def test_different_model(self):
-        """Test with a different model if available"""
-        embedder = WatsonxTextEmbedder(
-            model="ibm/slate-125m-english-rtrvr",
-            api_key=Secret.from_env_var("WATSONX_API_KEY"),
-            project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
-            truncate_input_tokens=128,
-        )
-        result = embedder.run("Test different model")
-
-        assert len(result["embedding"]) > 0
-        assert "125m" in result["meta"]["model"]
-
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_text_too_long(self):
         """Test handling of text that exceeds token limit when truncation is disabled"""
         embedder = WatsonxTextEmbedder(


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Removed some integration tests and modified others to use less tokens. This is in response to us passing our quota for watsonx usage.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
