### PR TITLE
chore: Remove example as a requirement from new integration proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-integration-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-integration-proposal.md
@@ -28,7 +28,6 @@ If the request is accepted, ensure the following checklist is complete before cl
 - [ ] A new label named like `integration:<your integration name>` has been added to the list of labels for this [repository](https://github.com/deepset-ai/haystack-core-integrations/labels)
 - [ ] The [labeler.yml](https://github.com/deepset-ai/haystack-core-integrations/blob/main/.github/labeler.yml) file has been updated
 - [ ] The package has been released on PyPI
-- [ ] An integration tile has been added to https://github.com/deepset-ai/haystack-integrations
+- [ ] An integration tile with a usage example has been added to https://github.com/deepset-ai/haystack-integrations
 - [ ] The integration has been listed in the [Inventory section](https://github.com/deepset-ai/haystack-core-integrations#inventory) of this repo README
-- [ ] There is an example available to demonstrate the feature
 - [ ] The feature was announced through social media


### PR DESCRIPTION
### Related Issues

- no issue

### Proposed Changes:

Remove example as a requirement from new integration proposal after talking to Bilge

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
