### PR TITLE
feat: `LlamaCppChatGenerator` streaming support

### DIFF
--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -335,7 +335,7 @@ class LlamaCppChatGenerator:
             # They are often spread across multiple chunks.
             new_tool_call_ids = set()
 
-            if chunk.get("choices"):
+            if chunk.get("choices") and len(chunk["choices"]) > 0:
                 choice = chunk["choices"][0]
                 delta = choice.get("delta", {})
 
@@ -388,7 +388,11 @@ class LlamaCppChatGenerator:
             streaming_chunks.append(streaming_chunk)
 
             # Stream the chunk
-            streaming_callback(streaming_chunk)
+            try:
+                streaming_callback(streaming_chunk)
+            except Exception as e:
+                logger.error(f"Error in streaming callback invocation: {e}")
+                continue
 
         message = _convert_streaming_chunks_to_chat_message(streaming_chunks)
         return {"replies": [message]}

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -290,7 +290,6 @@ class LlamaCppChatGenerator:
                 response_stream=response_stream,  # type: ignore[arg-type]
                 streaming_callback=streaming_callback,
                 component_info=ComponentInfo.from_component(self),
-                model_path=self.model_path,
             )  # we know that response_stream is Iterator[CreateChatCompletionStreamResponse]
             # because create_chat_completion was called with stream=True, but mypy doesn't know that
 

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -313,9 +313,10 @@ class LlamaCppChatGenerator:
         component_info: ComponentInfo,
     ) -> Dict[str, List[ChatMessage]]:
         """
-        Handle streaming response from llama.cpp create_chat_completion.
+        Take streaming responses from llama.cpp, convert to Haystack StreamingChunk objects, stream them,
+        and finally convert them to a ChatMessage.
 
-        :param response_stream: The streaming response from create_chat_completion.
+        :param response_stream: The streaming responses from llama.cpp.
         :param streaming_callback: The callback function for streaming chunks.
         :param component_info: The component info.
         :returns: A dictionary with the replies.

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -340,7 +340,7 @@ class LlamaCppChatGenerator:
                 delta = choice.get("delta", {})
 
                 finish_reason = choice.get("finish_reason")
-                mapped_finish_reason = FINISH_REASON_MAPPING.get(finish_reason or "") if finish_reason else None
+                mapped_finish_reason = FINISH_REASON_MAPPING.get(finish_reason or "")
 
                 if content_raw := delta.get("content"):
                     content = str(content_raw)
@@ -422,12 +422,14 @@ class LlamaCppChatGenerator:
                         tc_args=arguments_str,
                     )
 
+        finish_reason = choice.get("finish_reason")
+
         meta = {
             "response_id": response["id"],
             "model": response["model"],
             "created": response["created"],
             "index": choice["index"],
-            "finish_reason": choice["finish_reason"],
+            "finish_reason": FINISH_REASON_MAPPING.get(finish_reason or ""),
             "usage": response["usage"],
         }
 

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -111,7 +111,7 @@ class LlamaCppChatGenerator:
     """
     Provides an interface to generate text using LLM via llama.cpp.
 
-    [llama.cpp](https://github.com/ggerganov/llama.cpp) is a project written in C/C++ for efficient inference of LLMs.
+    [llama.cpp](https://github.com/ggml-org/llama.cpp) is a project written in C/C++ for efficient inference of LLMs.
     It employs the quantized GGUF format, suitable for running these models on standard machines (even without GPUs).
 
     Usage example:

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/generator.py
@@ -12,7 +12,7 @@ class LlamaCppGenerator:
     """
     Provides an interface to generate text using LLM via llama.cpp.
 
-    [llama.cpp](https://github.com/ggerganov/llama.cpp) is a project written in C/C++ for efficient inference of LLMs.
+    [llama.cpp](https://github.com/ggml-org/llama.cpp) is a project written in C/C++ for efficient inference of LLMs.
     It employs the quantized GGUF format, suitable for running these models on standard machines (even without GPUs).
 
     Usage example:

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -829,6 +829,7 @@ class TestLlamaCppChatGenerator:
     @pytest.mark.integration
     def test_run_streaming(self, generator):
         component_info = ComponentInfo.from_component(generator)
+
         class Callback:
             def __init__(self):
                 self.responses = ""

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -648,6 +648,7 @@ class TestLlamaCppChatGenerator:
             model="test_model.gguf",
             n_ctx=8192,
             n_batch=512,
+            streaming_callback=print_streaming_chunk,
         )
 
         assert generator.model_path == "test_model.gguf"
@@ -655,6 +656,7 @@ class TestLlamaCppChatGenerator:
         assert generator.n_batch == 512
         assert generator.model_kwargs == {"model_path": "test_model.gguf", "n_ctx": 8192, "n_batch": 512}
         assert generator.generation_kwargs == {}
+        assert generator.streaming_callback == print_streaming_chunk
 
     def test_init_with_toolset(self, temperature_tool):
         toolset = Toolset([temperature_tool])
@@ -672,6 +674,7 @@ class TestLlamaCppChatGenerator:
                 "model_kwargs": {"model_path": "test_model.gguf", "n_ctx": 8192, "n_batch": 512},
                 "generation_kwargs": {},
                 "tools": None,
+                "streaming_callback": None,
             },
         }
 
@@ -704,6 +707,7 @@ class TestLlamaCppChatGenerator:
                 "model_kwargs": {"model_path": "test_model.gguf", "n_ctx": 8192, "n_batch": 512},
                 "generation_kwargs": {},
                 "tools": None,
+                "streaming_callback": None,
             },
         }
         deserialized = LlamaCppChatGenerator.from_dict(serialized)


### PR DESCRIPTION
### Related Issues

- fixes  #730: streaming support only added for ChatGenerator. I don't think we should add new features to Generator.
- fixes #1825
- fixes #2075

### Proposed Changes:
- introduce streaming support for `LlamaCppChatGenerator`, using the new `StreamingChunk` and passing `ComponentInfo`

### How did you test it?
- CI, several new tests
- locally tested with `print_streaming_chunk`: both standard completions and tool calls are correctly printed

### Notes for the reviewer
Don't get scared by the size of this PR. Most of the code consist of llama.cpp chunk objects for tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
