### PR TITLE
fix: ClientSession expires after idle periods causing ClosedResourceError with empty error message

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, fields
 from datetime import timedelta
 from typing import Any, cast
 
-import anyio  # Added for ClosedResourceError detection
+import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from exceptiongroup import ExceptionGroup
 from haystack import logging
@@ -264,7 +264,7 @@ class MCPClient(ABC):
 
                 # Only attempt reconnection for SSE/HTTP transports
                 if isinstance(self, SSEClient| StreamableHttpClient):
-                    logger.warning(f"Connection lost during tool call '{tool_name}' (attempt {attempt + 1}/{max_retries + 1}): {error_type}: {error_msg}")
+                    logger.warning(f"Connection lost during tool call '{tool_name}': {error_type}: {error_msg}")
 
                     try:
                         # Exponential backoff before reconnection attempt

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -263,7 +263,7 @@ class MCPClient(ABC):
                     raise MCPInvocationError(message, tool_name, tool_args) from e
 
                 # Only attempt reconnection for SSE/HTTP transports
-                if isinstance(self, SSEClient| StreamableHttpClient):
+                if isinstance(self, SSEClient | StreamableHttpClient):
                     logger.warning(f"Connection lost during tool call '{tool_name}': {error_type}: {error_msg}")
 
                     try:

--- a/integrations/mcp/tests/test_mcp_integration.py
+++ b/integrations/mcp/tests/test_mcp_integration.py
@@ -135,15 +135,30 @@ if __name__ == "__main__":
             if os.path.exists(server_script_path):
                 os.remove(server_script_path)
 
-    @pytest.mark.skip
+    @pytest.mark.skipif(
+        (not os.environ.get("OPENAI_API_KEY") and not os.environ.get("BRAVE_API_KEY"))
+        or (sys.platform == "win32")
+        or (sys.platform == "darwin"),
+        reason="OPENAI_API_KEY or BRAVE_API_KEY not set, or running on Windows or macOS",
+    )
     def test_mcp_brave_search(self, mcp_tool_cleanup):
         """Test using an MCPTool in a pipeline with OpenAI."""
 
         # Create an MCPTool for the brave_web_search operation
         server_info = StdioServerInfo(
             command="docker",
-            args=["run", "-i", "--rm", "-e", f"BRAVE_API_KEY={os.environ.get('BRAVE_API_KEY')}", "mcp/brave-search"],
-            env=None,
+            args=[
+                "run",
+                "-i",
+                "--rm",
+                "-e", "BRAVE_MCP_TRANSPORT",
+                "-e", "BRAVE_API_KEY",
+                "mcp/brave-search"
+            ],
+            env={
+                "BRAVE_MCP_TRANSPORT": "stdio",
+                "BRAVE_API_KEY": os.environ.get('BRAVE_API_KEY', 'YOUR_API_KEY_HERE'),
+            },
         )
         try:
             tool = MCPTool(name="brave_web_search", server_info=server_info)

--- a/integrations/mcp/tests/test_mcp_integration.py
+++ b/integrations/mcp/tests/test_mcp_integration.py
@@ -135,12 +135,7 @@ if __name__ == "__main__":
             if os.path.exists(server_script_path):
                 os.remove(server_script_path)
 
-    @pytest.mark.skipif(
-        (not os.environ.get("OPENAI_API_KEY") and not os.environ.get("BRAVE_API_KEY"))
-        or (sys.platform == "win32")
-        or (sys.platform == "darwin"),
-        reason="OPENAI_API_KEY or BRAVE_API_KEY not set, or running on Windows or macOS",
-    )
+    @pytest.mark.skip
     def test_mcp_brave_search(self, mcp_tool_cleanup):
         """Test using an MCPTool in a pipeline with OpenAI."""
 

--- a/integrations/mcp/tests/test_mcp_integration.py
+++ b/integrations/mcp/tests/test_mcp_integration.py
@@ -147,17 +147,10 @@ if __name__ == "__main__":
         # Create an MCPTool for the brave_web_search operation
         server_info = StdioServerInfo(
             command="docker",
-            args=[
-                "run",
-                "-i",
-                "--rm",
-                "-e", "BRAVE_MCP_TRANSPORT",
-                "-e", "BRAVE_API_KEY",
-                "mcp/brave-search"
-            ],
+            args=["run", "-i", "--rm", "-e", "BRAVE_MCP_TRANSPORT", "-e", "BRAVE_API_KEY", "mcp/brave-search"],
             env={
                 "BRAVE_MCP_TRANSPORT": "stdio",
-                "BRAVE_API_KEY": os.environ.get('BRAVE_API_KEY', 'YOUR_API_KEY_HERE'),
+                "BRAVE_API_KEY": os.environ.get("BRAVE_API_KEY", "YOUR_API_KEY_HERE"),
             },
         )
         try:

--- a/integrations/mcp/tests/test_mcp_server_info.py
+++ b/integrations/mcp/tests/test_mcp_server_info.py
@@ -144,6 +144,7 @@ class TestMCPServerInfo:
             "timeout": 45,
             "max_retries": 3,
             "base_delay": 1.0,
+            "max_delay": 30.0,
         }
 
         # Test from_dict - Secret is properly deserialized
@@ -174,6 +175,7 @@ class TestMCPServerInfo:
             },
             "max_retries": 3,
             "base_delay": 1.0,
+            "max_delay": 30.0,
         }
 
         # Test from_dict - Secret env vars are properly deserialized, plain strings stay as-is
@@ -209,6 +211,7 @@ class TestMCPServerInfo:
             },
             "max_retries": 3,
             "base_delay": 1.0,
+            "max_delay": 30.0,
         }
         new_info = StdioServerInfo.from_dict(info_dict)
         assert len(new_info.env) == 2

--- a/integrations/mcp/tests/test_mcp_server_info.py
+++ b/integrations/mcp/tests/test_mcp_server_info.py
@@ -142,6 +142,8 @@ class TestMCPServerInfo:
             "url": "http://example.com/mcp",
             "token": {"type": "env_var", "env_vars": ["TEST_TOKEN"], "strict": True},
             "timeout": 45,
+            "max_retries": 3,
+            "base_delay": 1.0,
         }
 
         # Test from_dict - Secret is properly deserialized
@@ -170,6 +172,8 @@ class TestMCPServerInfo:
                 "PUBLIC_VAR": "public_value",
                 "SECRET_VAR": {"type": "env_var", "env_vars": ["SECRET_VAR"], "strict": True},
             },
+            "max_retries": 3,
+            "base_delay": 1.0,
         }
 
         # Test from_dict - Secret env vars are properly deserialized, plain strings stay as-is
@@ -203,6 +207,8 @@ class TestMCPServerInfo:
                 "SECRET_VAR1": {"type": "env_var", "env_vars": ["SECRET_VAR1"], "strict": True},
                 "SECRET_VAR2": {"type": "env_var", "env_vars": ["SECRET_VAR2"], "strict": True},
             },
+            "max_retries": 3,
+            "base_delay": 1.0,
         }
         new_info = StdioServerInfo.from_dict(info_dict)
         assert len(new_info.env) == 2

--- a/integrations/mcp/tests/test_mcp_timeout_reconnection.py
+++ b/integrations/mcp/tests/test_mcp_timeout_reconnection.py
@@ -11,6 +11,7 @@ This validates the complete reconnection flow with real SSEClient connections.
 """
 
 import json
+import logging
 import os
 import socket
 import subprocess
@@ -19,11 +20,10 @@ import tempfile
 import time
 
 import pytest
-from mcp.server.fastmcp import FastMCP
 
 from haystack_integrations.tools.mcp import MCPTool, SSEServerInfo
 
-from .mcp_memory_transport import InMemoryServerInfo
+logger = logging.getLogger(__name__)
 
 
 class TestMCPTimeoutReconnection:
@@ -34,11 +34,11 @@ class TestMCPTimeoutReconnection:
     def test_real_sse_reconnection_after_server_restart(self):
         """
         Test reconnection works with real SSE server that gets restarted.
-        
+
         Simulates SSE timeout (normally 5-10 mins) by killing/restarting server.
         Validates automatic reconnection with real SSEClient (not InMemoryClient).
         """
-        
+
         def find_free_port():
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind(("", 0))
@@ -47,15 +47,16 @@ class TestMCPTimeoutReconnection:
         def wait_for_server_ready(port, max_attempts=10):
             """Wait for server to accept connections."""
             import socket
-            for attempt in range(max_attempts):
+
+            for _attempt in range(max_attempts):
                 try:
                     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                         s.settimeout(1)
-                        result = s.connect_ex(('127.0.0.1', port))
+                        result = s.connect_ex(("127.0.0.1", port))
                         if result == 0:
                             return True
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Server connection attempt failed: {e}")
                 time.sleep(0.5)
             return False
 
@@ -63,7 +64,8 @@ class TestMCPTimeoutReconnection:
 
         # Create server script
         with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
-            temp_file.write(f"""
+            temp_file.write(
+                f"""
 import sys
 from mcp.server.fastmcp import FastMCP
 
@@ -79,7 +81,8 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Server error: {{e}}", file=sys.stderr)
         sys.exit(1)
-""".encode())
+""".encode()
+            )
             server_script_path = temp_file.name
 
         server_process = None
@@ -87,64 +90,58 @@ if __name__ == "__main__":
         try:
             # Start server
             server_process = subprocess.Popen(
-                ["python", server_script_path], 
-                stdout=subprocess.PIPE, 
-                stderr=subprocess.PIPE, 
-                text=True
+                ["python", server_script_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
-            
+
             if not wait_for_server_ready(port):
                 stdout, stderr = server_process.communicate(timeout=2)
                 pytest.fail(f"Server failed to start on port {port}. stdout: {stdout}, stderr: {stderr}")
-            
-            # Create tool with real SSE connection 
+
+            # Create tool with real SSE connection
             server_info = SSEServerInfo(base_url=f"http://127.0.0.1:{port}")
             tool = MCPTool(name="test_tool", server_info=server_info)
-            
+
             # Test normal operation
             result = tool.invoke(message="first call")
             result_data = json.loads(result)
             assert "Server response: first call" in result_data["content"][0]["text"]
-            
+
             # Kill server to simulate timeout
             server_process.terminate()
             server_process.wait(timeout=5)
             time.sleep(1)
-            
+
             # Restart server
             server_process = subprocess.Popen(
-                ["python", server_script_path], 
-                stdout=subprocess.PIPE, 
-                stderr=subprocess.PIPE, 
-                text=True
+                ["python", server_script_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
-            
+
             if not wait_for_server_ready(port):
                 stdout, stderr = server_process.communicate(timeout=2)
                 pytest.fail(f"Server failed to restart on port {port}. stdout: {stdout}, stderr: {stderr}")
-            
+
             # This should trigger reconnection and succeed
             result = tool.invoke(message="after restart")
             result_data = json.loads(result)
             assert "Server response: after restart" in result_data["content"][0]["text"]
-            
+
         except Exception:
             if server_process and server_process.poll() is None:
                 try:
                     stdout, stderr = server_process.communicate(timeout=2)
-                    print(f"Server stdout: {stdout}")
-                    print(f"Server stderr: {stderr}")
+                    logger.debug(f"Server stdout: {stdout}")
+                    logger.debug(f"Server stderr: {stderr}")
                 except subprocess.TimeoutExpired:
                     server_process.terminate()
             raise
-            
+
         finally:
             if tool:
                 try:
                     tool.close()
-                except Exception:
-                    pass
-                    
+                except Exception as e:
+                    logger.debug(f"Error closing tool: {e}")
+
             if server_process:
                 if server_process.poll() is None:
                     server_process.terminate()
@@ -153,7 +150,6 @@ if __name__ == "__main__":
                     except subprocess.TimeoutExpired:
                         server_process.kill()
                         server_process.wait(timeout=5)
-                        
+
             if os.path.exists(server_script_path):
                 os.remove(server_script_path)
-

--- a/integrations/mcp/tests/test_mcp_timeout_reconnection.py
+++ b/integrations/mcp/tests/test_mcp_timeout_reconnection.py
@@ -46,7 +46,6 @@ class TestMCPTimeoutReconnection:
 
         def wait_for_server_ready(port, max_attempts=10):
             """Wait for server to accept connections."""
-            import socket
 
             for _attempt in range(max_attempts):
                 try:

--- a/integrations/mcp/tests/test_mcp_timeout_reconnection.py
+++ b/integrations/mcp/tests/test_mcp_timeout_reconnection.py
@@ -8,14 +8,44 @@ by killing the server process and then restarting it.
 
 import logging
 import os
+import socket
 import subprocess
+import sys
 import tempfile
 import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from haystack_integrations.tools.mcp import MCPTool, SSEServerInfo
 from haystack_integrations.tools.mcp.mcp_tool import SSEClient
 
 logger = logging.getLogger(__name__)
+
+
+def find_free_port():
+    """Find a free port to use for the test server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_server_ready(port, max_attempts=20, delay=0.5):
+    """Wait for server to accept connections."""
+    for attempt in range(max_attempts):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(1)
+                result = s.connect_ex(("127.0.0.1", port))
+                if result == 0:
+                    logger.debug(f"Server ready on port {port} after {attempt + 1} attempts")
+                    return True
+        except Exception as e:
+            logger.debug(f"Server connection attempt {attempt + 1} failed: {e}")
+        time.sleep(delay)
+
+    logger.warning(f"Server not ready on port {port} after {max_attempts} attempts")
+    return False
 
 
 class TestMCPTimeoutReconnection:
@@ -33,14 +63,51 @@ class TestMCPTimeoutReconnection:
         # Test that parameters are passed through correctly
         assert isinstance(client, SSEClient)
 
+    def test_retry_logic_with_mock(self):
+        """Test retry logic using mocked SSE client (unit test)."""
+        # Create a real SSE client but mock its session and connect method
+        server_info = SSEServerInfo(url="http://localhost:8000/sse", max_retries=2, base_delay=0.1)
+        client = server_info.create_client()
+
+        # Mock the session and connect method
+        mock_session = AsyncMock()
+        client.session = mock_session
+        client.connect = AsyncMock()
+
+        # Create a successful response mock
+        success_response = MagicMock()
+        success_response.isError = False
+        success_response.model_dump_json.return_value = '{"result": "success"}'
+
+        # First call fails with ConnectionError, second call succeeds
+        mock_session.call_tool.side_effect = [ConnectionError("Connection lost"), success_response]
+
+        # Test the retry logic by calling it directly
+        import asyncio
+
+        async def test_call():
+            result = await client.call_tool("test_tool", {"message": "test"})
+            return result
+
+        # Run the async test
+        result = asyncio.run(test_call())
+
+        # Verify the result
+        assert result == '{"result": "success"}'
+
+        # Verify retry behavior
+        assert mock_session.call_tool.call_count == 2  # Initial call + retry
+        assert client.connect.call_count == 1  # Reconnection attempted once
+
     def test_real_sse_reconnection_after_server_restart(self):
         """Test real SSE reconnection by killing and restarting server."""
-        port = 8001
+        port = find_free_port()  # Use dynamic port to avoid conflicts
         server_process = None
         server_script_path = None
+        tool = None
 
         try:
-            # Create server script
+            # Create server script with cross-platform signal handling
             with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
                 temp_file.write(
                     f"""
@@ -48,12 +115,15 @@ import sys
 import signal
 from mcp.server.fastmcp import FastMCP
 
-# Handle shutdown signals gracefully
+# Handle shutdown signals gracefully (cross-platform)
 def signal_handler(signum, frame):
     sys.exit(0)
 
-signal.signal(signal.SIGTERM, signal_handler)
-signal.signal(signal.SIGINT, signal_handler)
+# Only set up signal handlers that exist on the platform
+if hasattr(signal, 'SIGTERM'):
+    signal.signal(signal.SIGTERM, signal_handler)
+if hasattr(signal, 'SIGINT'):
+    signal.signal(signal.SIGINT, signal_handler)
 
 mcp = FastMCP("Reconnection Test Server", host="127.0.0.1", port={port})
 
@@ -63,25 +133,40 @@ def test_tool(message: str) -> str:
 
 if __name__ == "__main__":
     try:
+        print(f"Starting server on port {port}", flush=True)
         mcp.run(transport="sse")
     except (KeyboardInterrupt, SystemExit):
+        print("Server shutting down gracefully", flush=True)
         sys.exit(0)
     except Exception as e:
-        print(f"Server error: {{e}}", file=sys.stderr)
+        print(f"Server error: {{e}}", file=sys.stderr, flush=True)
         sys.exit(1)
 """.encode()
                 )
                 server_script_path = temp_file.name
 
             # Start server
+            logger.debug(f"Starting test server on port {port}")
             server_process = subprocess.Popen(
-                ["python", server_script_path],
+                [sys.executable, server_script_path],  # Use same Python executable
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
             )
-            time.sleep(2)  # Wait for server to start
+
+            # Wait for server to be ready
+            if not wait_for_server_ready(port):
+                # Get server output for debugging
+                try:
+                    stdout, stderr = server_process.communicate(timeout=2)
+                    logger.error(f"Server failed to start. stdout: {stdout}, stderr: {stderr}")
+                except subprocess.TimeoutExpired:
+                    logger.error("Server startup timed out")
+                    server_process.terminate()
+                pytest.fail(f"Server failed to start on port {port}")
 
             # Create tool with custom retry parameters
+            logger.debug(f"Creating MCPTool for server on port {port}")
             tool = MCPTool(
                 name="test_tool",
                 server_info=SSEServerInfo(url=f"http://127.0.0.1:{port}/sse", max_retries=2, base_delay=0.5),
@@ -92,44 +177,67 @@ if __name__ == "__main__":
             assert "Server response: hello" in result
 
             # Kill server to simulate timeout
+            logger.debug("Terminating server to simulate connection loss")
             server_process.terminate()
             try:
-                server_process.wait(timeout=2)
+                server_process.wait(timeout=3)
             except subprocess.TimeoutExpired:
+                logger.debug("Server didn't terminate gracefully, using kill")
                 server_process.kill()
                 server_process.wait(timeout=2)
-            time.sleep(1)
 
             # Restart server
+            logger.debug(f"Restarting server on port {port}")
             server_process = subprocess.Popen(
-                ["python", server_script_path],
+                [sys.executable, server_script_path],  # Use same Python executable
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
             )
-            time.sleep(2)
+
+            # Wait for restarted server to be ready
+            if not wait_for_server_ready(port):
+                # Get server output for debugging
+                try:
+                    stdout, stderr = server_process.communicate(timeout=2)
+                    logger.error(f"Restarted server failed. stdout: {stdout}, stderr: {stderr}")
+                except subprocess.TimeoutExpired:
+                    logger.error("Restarted server startup timed out")
+                    server_process.terminate()
+                pytest.fail(f"Restarted server failed to start on port {port}")
 
             # Second call should trigger reconnection and work
+            logger.debug("Testing reconnection after server restart")
             result = tool.invoke(message="world")
             assert "Server response: world" in result
 
         finally:
+            # Clean up tool
             if tool:
                 try:
                     tool.close()
                 except Exception as e:
                     logger.debug(f"Error closing tool: {e}")
 
+            # Clean up server process
             if server_process:
                 if server_process.poll() is None:
+                    logger.debug("Cleaning up server process")
                     server_process.terminate()
                     try:
-                        server_process.wait(timeout=2)
+                        server_process.wait(timeout=3)
                     except subprocess.TimeoutExpired:
+                        logger.debug("Server didn't terminate gracefully during cleanup, using kill")
                         server_process.kill()
                         try:
                             server_process.wait(timeout=2)
                         except subprocess.TimeoutExpired:
-                            logger.warning("Server process still hanging after kill")
+                            logger.warning("Server process still hanging after kill during cleanup")
 
-            if os.path.exists(server_script_path):
-                os.remove(server_script_path)
+            # Clean up temporary script file
+            if server_script_path and os.path.exists(server_script_path):
+                try:
+                    os.remove(server_script_path)
+                    logger.debug(f"Removed temporary script: {server_script_path}")
+                except Exception as e:
+                    logger.debug(f"Error removing script file: {e}")

--- a/integrations/mcp/tests/test_mcp_timeout_reconnection.py
+++ b/integrations/mcp/tests/test_mcp_timeout_reconnection.py
@@ -6,6 +6,7 @@ Since we can't wait 10 minutes for real timeouts, we simulate disconnections
 by killing the server process and then restarting it.
 """
 
+import asyncio
 import logging
 import os
 import socket
@@ -83,8 +84,6 @@ class TestMCPTimeoutReconnection:
         mock_session.call_tool.side_effect = [ConnectionError("Connection lost"), success_response]
 
         # Test the retry logic by calling it directly
-        import asyncio
-
         async def test_call():
             result = await client.call_tool("test_tool", {"message": "test"})
             return result

--- a/integrations/mcp/tests/test_mcp_timeout_reconnection.py
+++ b/integrations/mcp/tests/test_mcp_timeout_reconnection.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test cases for MCP timeout and reconnection functionality.
+
+Tests automatic reconnection logic for SSE connections that timeout after 5-10 minutes of idle time.
+Since we can't wait that long in tests, we simulate timeouts by killing/restarting the server process.
+This validates the complete reconnection flow with real SSEClient connections.
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from haystack_integrations.tools.mcp import MCPTool, SSEServerInfo
+
+from .mcp_memory_transport import InMemoryServerInfo
+
+
+class TestMCPTimeoutReconnection:
+    """Test automatic reconnection logic for SSE connection timeouts."""
+
+    @pytest.mark.integration
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows subprocess handling differs")
+    def test_real_sse_reconnection_after_server_restart(self):
+        """
+        Test reconnection works with real SSE server that gets restarted.
+        
+        Simulates SSE timeout (normally 5-10 mins) by killing/restarting server.
+        Validates automatic reconnection with real SSEClient (not InMemoryClient).
+        """
+        
+        def find_free_port():
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                return s.getsockname()[1]
+
+        def wait_for_server_ready(port, max_attempts=10):
+            """Wait for server to accept connections."""
+            import socket
+            for attempt in range(max_attempts):
+                try:
+                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                        s.settimeout(1)
+                        result = s.connect_ex(('127.0.0.1', port))
+                        if result == 0:
+                            return True
+                except Exception:
+                    pass
+                time.sleep(0.5)
+            return False
+
+        port = find_free_port()
+
+        # Create server script
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
+            temp_file.write(f"""
+import sys
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("Reconnection Test Server", host="127.0.0.1", port={port})
+
+@mcp.tool()
+def test_tool(message: str) -> str:
+    return f"Server response: {{message}}"
+
+if __name__ == "__main__":
+    try:
+        mcp.run(transport="sse")
+    except Exception as e:
+        print(f"Server error: {{e}}", file=sys.stderr)
+        sys.exit(1)
+""".encode())
+            server_script_path = temp_file.name
+
+        server_process = None
+        tool = None
+        try:
+            # Start server
+            server_process = subprocess.Popen(
+                ["python", server_script_path], 
+                stdout=subprocess.PIPE, 
+                stderr=subprocess.PIPE, 
+                text=True
+            )
+            
+            if not wait_for_server_ready(port):
+                stdout, stderr = server_process.communicate(timeout=2)
+                pytest.fail(f"Server failed to start on port {port}. stdout: {stdout}, stderr: {stderr}")
+            
+            # Create tool with real SSE connection 
+            server_info = SSEServerInfo(base_url=f"http://127.0.0.1:{port}")
+            tool = MCPTool(name="test_tool", server_info=server_info)
+            
+            # Test normal operation
+            result = tool.invoke(message="first call")
+            result_data = json.loads(result)
+            assert "Server response: first call" in result_data["content"][0]["text"]
+            
+            # Kill server to simulate timeout
+            server_process.terminate()
+            server_process.wait(timeout=5)
+            time.sleep(1)
+            
+            # Restart server
+            server_process = subprocess.Popen(
+                ["python", server_script_path], 
+                stdout=subprocess.PIPE, 
+                stderr=subprocess.PIPE, 
+                text=True
+            )
+            
+            if not wait_for_server_ready(port):
+                stdout, stderr = server_process.communicate(timeout=2)
+                pytest.fail(f"Server failed to restart on port {port}. stdout: {stdout}, stderr: {stderr}")
+            
+            # This should trigger reconnection and succeed
+            result = tool.invoke(message="after restart")
+            result_data = json.loads(result)
+            assert "Server response: after restart" in result_data["content"][0]["text"]
+            
+        except Exception:
+            if server_process and server_process.poll() is None:
+                try:
+                    stdout, stderr = server_process.communicate(timeout=2)
+                    print(f"Server stdout: {stdout}")
+                    print(f"Server stderr: {stderr}")
+                except subprocess.TimeoutExpired:
+                    server_process.terminate()
+            raise
+            
+        finally:
+            if tool:
+                try:
+                    tool.close()
+                except Exception:
+                    pass
+                    
+            if server_process:
+                if server_process.poll() is None:
+                    server_process.terminate()
+                    try:
+                        server_process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        server_process.kill()
+                        server_process.wait(timeout=5)
+                        
+            if os.path.exists(server_script_path):
+                os.remove(server_script_path)
+

--- a/integrations/mcp/tests/test_mcp_timeout_reconnection.py
+++ b/integrations/mcp/tests/test_mcp_timeout_reconnection.py
@@ -1,70 +1,49 @@
-# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
-Test cases for MCP timeout and reconnection functionality.
+Tests for MCP timeout and reconnection functionality.
 
-Tests automatic reconnection logic for SSE connections that timeout after 5-10 minutes of idle time.
-Since we can't wait that long in tests, we simulate timeouts by killing/restarting the server process.
-This validates the complete reconnection flow with real SSEClient connections.
+This module tests the automatic reconnection logic for MCP SSE connections.
+Since we can't wait 10 minutes for real timeouts, we simulate disconnections
+by killing the server process and then restarting it.
 """
 
-import json
 import logging
 import os
-import socket
 import subprocess
-import sys
 import tempfile
 import time
 
-import pytest
-
 from haystack_integrations.tools.mcp import MCPTool, SSEServerInfo
+from haystack_integrations.tools.mcp.mcp_tool import SSEClient
 
 logger = logging.getLogger(__name__)
 
 
 class TestMCPTimeoutReconnection:
-    """Test automatic reconnection logic for SSE connection timeouts."""
+    """Test MCP timeout and reconnection functionality."""
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(sys.platform == "win32", reason="Windows subprocess handling differs")
+    def test_configurable_retry_parameters(self):
+        """Test that retry parameters are configurable."""
+        # Test SSE client with custom retry parameters
+        server_info = SSEServerInfo(url="http://localhost:8000/sse", max_retries=5, base_delay=2.0)
+        client = server_info.create_client()
+
+        assert client.max_retries == 5
+        assert client.base_delay == 2.0
+
+        # Test that parameters are passed through correctly
+        assert isinstance(client, SSEClient)
+
     def test_real_sse_reconnection_after_server_restart(self):
-        """
-        Test reconnection works with real SSE server that gets restarted.
+        """Test real SSE reconnection by killing and restarting server."""
+        port = 8001
+        server_process = None
+        server_script_path = None
 
-        Simulates SSE timeout (normally 5-10 mins) by killing/restarting server.
-        Validates automatic reconnection with real SSEClient (not InMemoryClient).
-        """
-
-        def find_free_port():
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(("", 0))
-                return s.getsockname()[1]
-
-        def wait_for_server_ready(port, max_attempts=10):
-            """Wait for server to accept connections."""
-
-            for _attempt in range(max_attempts):
-                try:
-                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                        s.settimeout(1)
-                        result = s.connect_ex(("127.0.0.1", port))
-                        if result == 0:
-                            return True
-                except Exception as e:
-                    logger.debug(f"Server connection attempt failed: {e}")
-                time.sleep(0.5)
-            return False
-
-        port = find_free_port()
-
-        # Create server script
-        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
-            temp_file.write(
-                f"""
+        try:
+            # Create server script
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
+                temp_file.write(
+                    f"""
 import sys
 import signal
 from mcp.server.fastmcp import FastMCP
@@ -91,34 +70,31 @@ if __name__ == "__main__":
         print(f"Server error: {{e}}", file=sys.stderr)
         sys.exit(1)
 """.encode()
-            )
-            server_script_path = temp_file.name
+                )
+                server_script_path = temp_file.name
 
-        server_process = None
-        tool = None
-        try:
             # Start server
             server_process = subprocess.Popen(
-                ["python", server_script_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+                ["python", server_script_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            time.sleep(2)  # Wait for server to start
+
+            # Create tool with custom retry parameters
+            tool = MCPTool(
+                name="test_tool",
+                server_info=SSEServerInfo(url=f"http://127.0.0.1:{port}/sse", max_retries=2, base_delay=0.5),
             )
 
-            if not wait_for_server_ready(port):
-                stdout, stderr = server_process.communicate(timeout=2)
-                pytest.fail(f"Server failed to start on port {port}. stdout: {stdout}, stderr: {stderr}")
-
-            # Create tool with real SSE connection
-            server_info = SSEServerInfo(base_url=f"http://127.0.0.1:{port}")
-            tool = MCPTool(name="test_tool", server_info=server_info)
-
-            # Test normal operation
-            result = tool.invoke(message="first call")
-            result_data = json.loads(result)
-            assert "Server response: first call" in result_data["content"][0]["text"]
+            # First call should work
+            result = tool.invoke(message="hello")
+            assert "Server response: hello" in result
 
             # Kill server to simulate timeout
             server_process.terminate()
             try:
-                server_process.wait(timeout=2)  # Reduced timeout
+                server_process.wait(timeout=2)
             except subprocess.TimeoutExpired:
                 server_process.kill()
                 server_process.wait(timeout=2)
@@ -126,27 +102,15 @@ if __name__ == "__main__":
 
             # Restart server
             server_process = subprocess.Popen(
-                ["python", server_script_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+                ["python", server_script_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
+            time.sleep(2)
 
-            if not wait_for_server_ready(port):
-                stdout, stderr = server_process.communicate(timeout=2)
-                pytest.fail(f"Server failed to restart on port {port}. stdout: {stdout}, stderr: {stderr}")
-
-            # This should trigger reconnection and succeed
-            result = tool.invoke(message="after restart")
-            result_data = json.loads(result)
-            assert "Server response: after restart" in result_data["content"][0]["text"]
-
-        except Exception:
-            if server_process and server_process.poll() is None:
-                try:
-                    stdout, stderr = server_process.communicate(timeout=2)
-                    logger.debug(f"Server stdout: {stdout}")
-                    logger.debug(f"Server stderr: {stderr}")
-                except subprocess.TimeoutExpired:
-                    server_process.terminate()
-            raise
+            # Second call should trigger reconnection and work
+            result = tool.invoke(message="world")
+            assert "Server response: world" in result
 
         finally:
             if tool:
@@ -157,16 +121,13 @@ if __name__ == "__main__":
 
             if server_process:
                 if server_process.poll() is None:
-                    # Try gentle termination first
                     server_process.terminate()
                     try:
-                        server_process.wait(timeout=2)  # Reduced timeout
+                        server_process.wait(timeout=2)
                     except subprocess.TimeoutExpired:
-                        # Force kill if terminate doesn't work
-                        logger.debug("Server didn't terminate gracefully, using kill")
                         server_process.kill()
                         try:
-                            server_process.wait(timeout=2)  # Reduced timeout
+                            server_process.wait(timeout=2)
                         except subprocess.TimeoutExpired:
                             logger.warning("Server process still hanging after kill")
 


### PR DESCRIPTION
## Why:
Fixes critical issue where MCP SSE connections timeout after 5-10 minutes of idle time, causing tool invocations to fail with `anyio.ClosedResourceError` wrapped in unhelpful empty `MCPInvocationError` messages, requiring manual MCPTool recreation.

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/2054

## What:
- Added automatic reconnection logic with exponential backoff to `MCPClient.call_tool()` for SSE/HTTP transports
- Enhanced error handling to provide meaningful messages even when underlying exceptions have empty string representations  
- Created integration test that simulates real SSE timeout scenarios by killing/restarting server processes

## How can it be used:
```python
# Before: Manual recreation required after timeout
try:
    result = tool.invoke(data="some_data")
except MCPInvocationError as e:
    print(e)  # Empty error message: "Failed to invoke tool 'name' with args: {...}, got error: "
    # User had to recreate MCPTool instance manually

# After: Automatic reconnection with clear errors
try:
    result = tool.invoke(data="some_data") 
    # Works transparently even after 10+ minute idle periods
except MCPInvocationError as e:
    print(e)  # Clear message: "Tool 'name' failed and all 3 reconnection attempts failed. ClosedResourceError: Connection closed unexpectedly"
```

## How did you test it:
- Added integration test `test_real_sse_reconnection_after_server_restart` that uses real SSE server processes
- Tested manually in idle itinerary agent that restarts after 10 min
- Tested manually in isolated script with MCPToolset only
- Confirmed existing functionality remains unchanged
