### PR TITLE
test: fix GitHub test

### DIFF
--- a/integrations/github/tests/test_file_editor_tool.py
+++ b/integrations/github/tests/test_file_editor_tool.py
@@ -141,13 +141,13 @@ class TestGitHubFileEditorTool:
 
         pipeline_dict = pipeline.to_dict()
 
-        # Remove http_client_kwargs from both dictionaries if it exists
-        # We don't want to test the http_client_kwargs because Haystack 2.12.0 doesn't have it
-        # Only Haystack 2.13.0+ has it
+        # Remove parameters introduced after haystack-ai==2.12.0 (the minimum supported version)
+        # to maintain compatibility
         if "components" in pipeline_dict:
-            agent_params = pipeline_dict["components"]["agent"]["init_parameters"]["chat_generator"]["init_parameters"]
-            if "http_client_kwargs" in agent_params:
-                del agent_params["http_client_kwargs"]
+            pipeline_dict["components"]["agent"]["init_parameters"]["chat_generator"]["init_parameters"].pop(
+                "http_client_kwargs", None
+            )
+            pipeline_dict["components"]["agent"]["init_parameters"].pop("tool_invoker_kwargs", None)
 
         expected_dict = {
             "metadata": {},

--- a/integrations/github/tests/test_file_editor_tool.py
+++ b/integrations/github/tests/test_file_editor_tool.py
@@ -143,11 +143,14 @@ class TestGitHubFileEditorTool:
 
         # Remove parameters introduced after haystack-ai==2.12.0 (the minimum supported version)
         # to maintain compatibility
-        if "components" in pipeline_dict:
-            pipeline_dict["components"]["agent"]["init_parameters"]["chat_generator"]["init_parameters"].pop(
-                "http_client_kwargs", None
-            )
-            pipeline_dict["components"]["agent"]["init_parameters"].pop("tool_invoker_kwargs", None)
+        try:
+            if "components" in pipeline_dict:
+                pipeline_dict["components"]["agent"]["init_parameters"]["chat_generator"]["init_parameters"].pop(
+                    "http_client_kwargs", None
+                )
+                pipeline_dict["components"]["agent"]["init_parameters"].pop("tool_invoker_kwargs", None)
+        except KeyError:
+            pass
 
         expected_dict = {
             "metadata": {},

--- a/integrations/github/tests/test_file_editor_tool.py
+++ b/integrations/github/tests/test_file_editor_tool.py
@@ -144,11 +144,10 @@ class TestGitHubFileEditorTool:
         # Remove parameters introduced after haystack-ai==2.12.0 (the minimum supported version)
         # to maintain compatibility
         try:
-            if "components" in pipeline_dict:
-                pipeline_dict["components"]["agent"]["init_parameters"]["chat_generator"]["init_parameters"].pop(
-                    "http_client_kwargs", None
-                )
-                pipeline_dict["components"]["agent"]["init_parameters"].pop("tool_invoker_kwargs", None)
+            pipeline_dict["components"]["agent"]["init_parameters"]["chat_generator"]["init_parameters"].pop(
+                "http_client_kwargs", None
+            )
+            pipeline_dict["components"]["agent"]["init_parameters"].pop("tool_invoker_kwargs", None)
         except KeyError:
             pass
 


### PR DESCRIPTION
### Related Issues

- [nightly test failure](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/16610241446/job/46991677919) due to new `tool_invoker_kwargs` parameter introduced in Haystack 2.16.0 for Agent

### Proposed Changes:
- drop the parameter in the serialization test to keep compatibility with Haystack 2.12.0 (minum supported version)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
