### PR TITLE
fix!: `GoogleGenAIChatGenerator` - align `finish_reason` between streaming and non-streaming

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -44,7 +44,6 @@ FINISH_REASON_MAPPING: Dict[str, FinishReason] = {
     "PROHIBITED_CONTENT": "content_filter",
     "SPII": "content_filter",
     "IMAGE_SAFETY": "content_filter",
-    "FUNCTION_CALL": "tool_calls",
 }
 
 logger = logging.getLogger(__name__)
@@ -199,7 +198,7 @@ def _convert_google_genai_response_to_chatmessage(response: types.GenerateConten
         tool_calls=tool_calls,
         meta={
             "model": model,
-            "finish_reason": str(finish_reason) if finish_reason else None,
+            "finish_reason": FINISH_REASON_MAPPING.get(finish_reason or ""),
             "usage": {
                 "prompt_tokens": getattr(usage_metadata, "prompt_token_count", 0),
                 "completion_tokens": getattr(usage_metadata, "candidates_token_count", 0),
@@ -433,7 +432,7 @@ class GoogleGenAIChatGenerator:
             component_info=component_info,
             index=index,
             start=start,
-            finish_reason=FINISH_REASON_MAPPING.get(finish_reason) if finish_reason else None,
+            finish_reason=FINISH_REASON_MAPPING.get(finish_reason or ""),
             meta={
                 "received_at": datetime.now(timezone.utc).isoformat(),
                 "model": self._model,


### PR DESCRIPTION
### Related Issues

- fixes #2138

### Proposed Changes:
- use the same mapped `finish_reason` in streaming and non-streaming cases

### How did you test it?
CI, new assertions

### Notes for the reviewer
This is a breaking change and I will release a new major version

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
