### PR TITLE
fix: error in `ToolCallDelta.index` for parallel tool calling

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -370,13 +370,14 @@ class AnthropicChatGenerator:
 
     @staticmethod
     def _convert_anthropic_chunk_to_streaming_chunk(
-        chunk: RawMessageStreamEvent, component_info: ComponentInfo
+        chunk: RawMessageStreamEvent, component_info: ComponentInfo, tool_call_index: int
     ) -> StreamingChunk:
         """
         Converts an Anthropic StreamEvent to a StreamingChunk.
 
         :param chunk: The Anthropic StreamEvent to convert.
         :param component_info: The component info.
+        :param tool_call_index: The index of the tool call among the tool calls in the message.
         :returns: The StreamingChunk.
         """
         content = ""
@@ -396,7 +397,7 @@ class AnthropicChatGenerator:
             if chunk.content_block.type == "tool_use":
                 tool_calls.append(
                     ToolCallDelta(
-                        index=0,
+                        index=tool_call_index,
                         id=chunk.content_block.id,
                         tool_name=chunk.content_block.name,
                     )
@@ -407,7 +408,7 @@ class AnthropicChatGenerator:
                 content = chunk.delta.text
             elif chunk.delta.type == "input_json_delta":
                 # we assign index=0 because one chunk can have only one ToolCallDelta
-                tool_calls.append(ToolCallDelta(index=0, arguments=chunk.delta.partial_json))
+                tool_calls.append(ToolCallDelta(index=tool_call_index, arguments=chunk.delta.partial_json))
         # end of streaming message
         elif chunk.type == "message_delta":
             finish_reason = FINISH_REASON_MAPPING.get(getattr(chunk.delta, "stop_reason" or ""))
@@ -488,14 +489,19 @@ class AnthropicChatGenerator:
         if not isinstance(response, Message):
             chunks: List[StreamingChunk] = []
             model: Optional[str] = None
+            tool_call_index = -1
             component_info = ComponentInfo.from_component(self)
             for chunk in response:
                 if chunk.type in ["message_start", "content_block_start", "content_block_delta", "message_delta"]:
                     # Extract model from message_start chunks
                     if chunk.type == "message_start":
                         model = chunk.message.model
+                    if chunk.type == "content_block_start" and chunk.content_block.type == "tool_use":
+                        tool_call_index += 1
 
-                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(chunk, component_info)
+                    streaming_chunk = self._convert_anthropic_chunk_to_streaming_chunk(
+                        chunk, component_info, tool_call_index
+                    )
                     chunks.append(streaming_chunk)
                     if streaming_callback:
                         streaming_callback(streaming_chunk)


### PR DESCRIPTION
### Related Issues

- fixes: The arguments for multiple tool calls are not being parsed correctly due to an incorrect indices in `ToolCallDelta`, which triggers a malformed JSON error [here](https://github.com/deepset-ai/haystack/blob/323274e17478394fdc73f9e47c4eeefded3fa657/haystack/components/generators/utils.py#L72)

### Proposed Changes:

[In this discussion](https://github.com/deepset-ai/haystack-core-integrations/pull/2096#discussion_r2251930603), we decided to keep `ToolCallDelta.index = 0`, which caused malformed JSON because all arguments were being assigned to the first `ToolCall` with (index 0).
When [converting streaming chunks](https://github.com/deepset-ai/haystack/blob/323274e17478394fdc73f9e47c4eeefded3fa657/haystack/components/generators/utils.py#L88), we rely on `ToolCallDelta.index` to map tool call arguments to the correct tool across chunks — even if a single chunk contains only one `ToolCallDelta`. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
