### PR TITLE
fix: Add optional `aiohttp` to google-genai integration

### DIFF
--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -26,7 +26,12 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.16.1", "google-genai>=1.17.0", "jsonref>=1.0.0"]
+dependencies = [
+  "haystack-ai>=2.16.1",
+  "google-genai>=1.17.0",
+  "jsonref>=1.0.0",
+  "aiohttp",  # This dep was used in google-genai 1.29.0, but not added to their requirements
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_genai#readme"

--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -26,12 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = [
-  "haystack-ai>=2.16.1",
-  "google-genai>=1.17.0",
-  "jsonref>=1.0.0",
-  "aiohttp>=3.0.0",
-]
+dependencies = ["haystack-ai>=2.16.1", "google-genai[aiohttp]>=1.17.0", "jsonref>=1.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_genai#readme"

--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "haystack-ai>=2.16.1",
   "google-genai>=1.17.0",
   "jsonref>=1.0.0",
-  "aiohttp",  # This dep was used in google-genai 1.29.0, but not added to their requirements
+  "aiohttp>=3.0.0",
 ]
 
 [project.urls]

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -604,7 +604,7 @@ class GoogleGenAIChatGenerator:
             chat_messages = messages[1:]
 
         # Convert messages to Google Gen AI Content format
-        contents: List[types.ContentUnion] = []
+        contents: List[types.ContentUnionDict] = []
         for msg in chat_messages:
             contents.append(_convert_message_to_google_genai_format(msg))
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add the optional `aiohttp` dependency which was recently used more often in google's update to google-genai in version 2.19.0 (released on August 6th).  See diff [here](https://github.com/googleapis/python-genai/compare/v1.28.0...v1.29.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40)

Previously we were able to run the async client without the optional dependency (<1.29.0) but now it is required so we add it.

It's listed as an optional dependency in their pyproject.toml
```
[project.optional-dependencies]
aiohttp = ["aiohttp<4.0.0"]
```


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
