### PR TITLE
chore: Add framework name into UserAgent header for bedrock integration

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -137,8 +137,7 @@ class AmazonBedrockDocumentEmbedder:
                 aws_profile_name=resolve_secret(aws_profile_name),
             )
             config = Config(
-                user_agent_extra="x-client-framework:haystack",
-                **(self.boto3_config if self.boto3_config else {})
+                user_agent_extra="x-client-framework:haystack", **(self.boto3_config if self.boto3_config else {})
             )
             self._client = session.client("bedrock-runtime", config=config)
         except Exception as exception:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -138,7 +138,9 @@ class AmazonBedrockDocumentEmbedder:
             )
             config: Optional[Config] = None
             if self.boto3_config:
-                config = Config(**self.boto3_config)
+                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
+            else:
+                config = Config(user_agent_extra="x-client-framework:haystack")
             self._client = session.client("bedrock-runtime", config=config)
         except Exception as exception:
             msg = (

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -136,11 +136,10 @@ class AmazonBedrockDocumentEmbedder:
                 aws_region_name=resolve_secret(aws_region_name),
                 aws_profile_name=resolve_secret(aws_profile_name),
             )
-            config: Optional[Config] = None
-            if self.boto3_config:
-                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
-            else:
-                config = Config(user_agent_extra="x-client-framework:haystack")
+            config = Config(
+                user_agent_extra="x-client-framework:haystack",
+                **(self.boto3_config if self.boto3_config else {})
+            )
             self._client = session.client("bedrock-runtime", config=config)
         except Exception as exception:
             msg = (

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
@@ -115,8 +115,7 @@ class AmazonBedrockTextEmbedder:
                 aws_profile_name=resolve_secret(aws_profile_name),
             )
             config = Config(
-                user_agent_extra="x-client-framework:haystack",
-                **(self.boto3_config if self.boto3_config else {})
+                user_agent_extra="x-client-framework:haystack", **(self.boto3_config if self.boto3_config else {})
             )
             self._client = session.client("bedrock-runtime", config=config)
         except Exception as exception:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
@@ -114,11 +114,10 @@ class AmazonBedrockTextEmbedder:
                 aws_region_name=resolve_secret(aws_region_name),
                 aws_profile_name=resolve_secret(aws_profile_name),
             )
-            config: Optional[Config] = None
-            if self.boto3_config:
-                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
-            else:
-                config = Config(user_agent_extra="x-client-framework:haystack")
+            config = Config(
+                user_agent_extra="x-client-framework:haystack",
+                **(self.boto3_config if self.boto3_config else {})
+            )
             self._client = session.client("bedrock-runtime", config=config)
         except Exception as exception:
             msg = (

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
@@ -116,7 +116,9 @@ class AmazonBedrockTextEmbedder:
             )
             config: Optional[Config] = None
             if self.boto3_config:
-                config = Config(**self.boto3_config)
+                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
+            else:
+                config = Config(user_agent_extra="x-client-framework:haystack")
             self._client = session.client("bedrock-runtime", config=config)
         except Exception as exception:
             msg = (

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -215,7 +215,9 @@ class AmazonBedrockChatGenerator:
 
         config: Optional[Config] = None
         if self.boto3_config:
-            config = Config(**self.boto3_config)
+            config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
+        else:
+            config = Config(user_agent_extra="x-client-framework:haystack")
 
         try:
             # sync session
@@ -226,6 +228,7 @@ class AmazonBedrockChatGenerator:
                 aws_region_name=resolve_secret(aws_region_name),
                 aws_profile_name=resolve_secret(aws_profile_name),
             )
+
             self.client = session.client("bedrock-runtime", config=config)
 
         except Exception as exception:
@@ -498,7 +501,12 @@ class AmazonBedrockChatGenerator:
             session = self._get_async_session()
             # Note: https://aioboto3.readthedocs.io/en/latest/usage.html
             # we need to create a new client for each request
-            async with session.client("bedrock-runtime", config=self.boto3_config) as async_client:
+            config = None
+            if self.boto3_config:
+                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
+            else:
+                config = Config(user_agent_extra="x-client-framework:haystack")
+            async with session.client("bedrock-runtime", config=config) as async_client:
                 if callback:
                     response = await async_client.converse_stream(**params)
                     response_stream: EventStream = response.get("stream")

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -499,11 +499,9 @@ class AmazonBedrockChatGenerator:
             session = self._get_async_session()
             # Note: https://aioboto3.readthedocs.io/en/latest/usage.html
             # we need to create a new client for each request
-            config = None
-            if self.boto3_config:
-                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
-            else:
-                config = Config(user_agent_extra="x-client-framework:haystack")
+            config = Config(
+                user_agent_extra="x-client-framework:haystack", **(self.boto3_config if self.boto3_config else {})
+            )
             async with session.client("bedrock-runtime", config=config) as async_client:
                 if callback:
                     response = await async_client.converse_stream(**params)

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -213,11 +213,10 @@ class AmazonBedrockChatGenerator:
         def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
             return secret.resolve_value() if secret else None
 
-        config: Optional[Config] = None
-        if self.boto3_config:
-            config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
-        else:
-            config = Config(user_agent_extra="x-client-framework:haystack")
+        config = Config(
+            user_agent_extra="x-client-framework:haystack",
+            **(self.boto3_config if self.boto3_config else {})
+        )
 
         try:
             # sync session

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -214,8 +214,7 @@ class AmazonBedrockChatGenerator:
             return secret.resolve_value() if secret else None
 
         config = Config(
-            user_agent_extra="x-client-framework:haystack",
-            **(self.boto3_config if self.boto3_config else {})
+            user_agent_extra="x-client-framework:haystack", **(self.boto3_config if self.boto3_config else {})
         )
 
         try:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -167,11 +167,10 @@ class AmazonBedrockGenerator:
                 aws_region_name=resolve_secret(aws_region_name),
                 aws_profile_name=resolve_secret(aws_profile_name),
             )
-            config: Optional[Config] = None
-            if self.boto3_config:
-                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
-            else:
-                config = Config(user_agent_extra="x-client-framework:haystack")
+            config = Config(
+                user_agent_extra="x-client-framework:haystack",
+                **(self.boto3_config if self.boto3_config else {})
+            )
             self.client = session.client("bedrock-runtime", config=config)
         except Exception as exception:
             msg = (

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -168,8 +168,7 @@ class AmazonBedrockGenerator:
                 aws_profile_name=resolve_secret(aws_profile_name),
             )
             config = Config(
-                user_agent_extra="x-client-framework:haystack",
-                **(self.boto3_config if self.boto3_config else {})
+                user_agent_extra="x-client-framework:haystack", **(self.boto3_config if self.boto3_config else {})
             )
             self.client = session.client("bedrock-runtime", config=config)
         except Exception as exception:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -169,7 +169,9 @@ class AmazonBedrockGenerator:
             )
             config: Optional[Config] = None
             if self.boto3_config:
-                config = Config(**self.boto3_config)
+                config = Config(**self.boto3_config, user_agent_extra="x-client-framework:haystack")
+            else:
+                config = Config(user_agent_extra="x-client-framework:haystack")
             self.client = session.client("bedrock-runtime", config=config)
         except Exception as exception:
             msg = (


### PR DESCRIPTION
### Related Issues

This PR adds the framework name into User-Agent header of Bedrock API call

### Proposed Changes:

This change only append the framework name `haystack` into the User-Agent header field for Bedrock API call, which can be used to collect the usage. Similar change had been made to other framework such as [langchain](https://github.com/langchain-ai/langchain-aws/pull/558)

### How did you test it?

Run through all tests. 

### Notes for the reviewer


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
