### PR TITLE
fix: Pin openai to `<=1.99.2` avoid errors in Llama Stack integration

### DIFF
--- a/integrations/llama_stack/pyproject.toml
+++ b/integrations/llama_stack/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.14", "llama-stack==0.2.14", "openai<=1.99.2"]
+dependencies = ["haystack-ai>=2.14", "llama-stack==0.2.14", "openai<=1.99.1"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/llama-stack#readme"

--- a/integrations/llama_stack/pyproject.toml
+++ b/integrations/llama_stack/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.14", "llama-stack==0.2.14"]
+dependencies = ["haystack-ai>=2.14", "llama-stack==0.2.14", "openai<=1.99.2"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/llama-stack#readme"


### PR DESCRIPTION
### Related Issues

- fixes failures due to openai's release of 1.99.3

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

We pin openai here since we are already pinning llama-stack so even when they fix the issue we won't be able to benefit from it unless we also unpin llama stack.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
