### PR TITLE
fix: LangfuseTracer is not thread-safe, causing mixed traces in async environments

### DIFF
--- a/integrations/langfuse/README.md
+++ b/integrations/langfuse/README.md
@@ -91,11 +91,43 @@ response = pipe.run(
 print(response["llm"]["replies"][0])
 print(response["tracer"]["trace_url"])
 print(response["tracer"]["trace_id"])
+
+# Using session_id to group related traces
+response = pipe.run(
+    data={"prompt_builder": {"template_variables": {"location": "Paris"}, "template": messages}},
+    tracer={"session_id": "user_123_conversation_456"}
+)
+print(response["llm"]["replies"][0])
+print(response["tracer"]["trace_url"])
+print(response["tracer"]["trace_id"])
 ```
 
 In this example, we add the `LangfuseConnector` to the pipeline with the name "tracer". 
 Each run of the pipeline produces one trace viewable on the Langfuse website with a specific URL. 
 The trace captures the entire execution context, including the prompts, completions, and metadata.
+
+### Using Session IDs
+
+You can group related traces together by passing a `session_id` when running the pipeline. This is useful for:
+- **Multi-turn conversations**: Group all messages in a chat session
+- **Workflow tracking**: Group all operations in a user workflow
+- **Debugging**: Correlate related traces across different pipeline runs
+
+```python
+# Group traces by user session
+response = pipe.run(
+    data={"prompt_builder": {"template_variables": {"location": "Tokyo"}, "template": messages}},
+    tracer={"session_id": "user_123_session_456"}
+)
+
+# Group traces by workflow
+response = pipe.run(
+    data={"prompt_builder": {"template_variables": {"location": "London"}, "template": messages}},
+    tracer={"session_id": "workflow_789_step_2"}
+)
+```
+
+All traces with the same `session_id` will be grouped together in the Langfuse UI, making it easier to analyze related operations.
 
 ## Trace Visualization
 

--- a/integrations/langfuse/README.md
+++ b/integrations/langfuse/README.md
@@ -94,8 +94,10 @@ print(response["tracer"]["trace_id"])
 
 # Using session_id to group related traces
 response = pipe.run(
-    data={"prompt_builder": {"template_variables": {"location": "Paris"}, "template": messages}},
-    tracer={"session_id": "user_123_conversation_456"}
+    data={
+        "prompt_builder": {"template_variables": {"location": "Paris"}, "template": messages},
+        "tracer": {"session_id": "user_123_conversation_456"},
+    }
 )
 print(response["llm"]["replies"][0])
 print(response["tracer"]["trace_url"])
@@ -116,14 +118,18 @@ You can group related traces together by passing a `session_id` when running the
 ```python
 # Group traces by user session
 response = pipe.run(
-    data={"prompt_builder": {"template_variables": {"location": "Tokyo"}, "template": messages}},
-    tracer={"session_id": "user_123_session_456"}
+    data={
+        "prompt_builder": {"template_variables": {"location": "Tokyo"}, "template": messages},
+        "tracer": {"session_id": "user_123_session_456"},
+    }
 )
 
 # Group traces by workflow
 response = pipe.run(
-    data={"prompt_builder": {"template_variables": {"location": "London"}, "template": messages}},
-    tracer={"session_id": "workflow_789_step_2"}
+    data={
+        "prompt_builder": {"template_variables": {"location": "London"}, "template": messages},
+        "tracer": {"session_id": "workflow_789_step_2"},
+    }
 )
 ```
 

--- a/integrations/langfuse/example/basic_rag.py
+++ b/integrations/langfuse/example/basic_rag.py
@@ -60,7 +60,11 @@ if __name__ == "__main__":
 
     pipeline = get_pipeline(document_store)
     question = "What does Rhodes Statue look like?"
-    response = pipeline.run({"text_embedder": {"text": question}, "prompt_builder": {"question": question}})
+    response = pipeline.run({
+        "text_embedder": {"text": question}, 
+        "prompt_builder": {"question": question},
+        "tracer": {"session_id": "rag_session_001"}
+    })
 
     print(response["llm"]["replies"][0])
     print(response["tracer"]["trace_url"])

--- a/integrations/langfuse/example/chat.py
+++ b/integrations/langfuse/example/chat.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
             },
             "tracer": {
                 "invocation_context": {"some_key": "some_value"},
+                "session_id": "user_123_chat_session",
             },
         }
     )

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -116,15 +116,20 @@ class LangfuseConnector:
         **Using Sessions to Group Related Traces:**
 
         ```python
-        # Create a connector with a session ID to group all related traces
-        tracer = LangfuseConnector(
-            name="Agent Workflow",
-            session_id="user_123_workflow_456"
+        # Create a connector
+        tracer = LangfuseConnector(name="Agent Workflow")
+
+        # Pass session_id at runtime to group related traces
+        response = tracer.run(session_id="user_123_workflow_456")
+
+        # Or when used in a pipeline
+        response = pipeline.run(
+            data={"your_data": "value"},
+            tracer={"session_id": "user_123_workflow_456"}
         )
 
-        # All traces created by this connector will use the same session_id
-        # Langfuse will automatically group them as one session in the UI
-        # This is useful for complex workflows with multiple agents or pipelines
+        # All traces with the same session_id will be grouped together
+        # in the Langfuse UI, making it easier to correlate related operations
         ```
     """
 
@@ -162,9 +167,6 @@ class LangfuseConnector:
         :param langfuse_client_kwargs: Optional custom configuration for the Langfuse client. This is a dictionary
             containing any additional configuration options for the Langfuse client. See the Langfuse documentation
             for more details on available configuration options.
-        :param session_id: Optional session ID to group multiple traces together. If provided, all traces created
-            by this connector will be grouped under the same session in Langfuse, making it easier to correlate
-            related operations (e.g., all agents in a workflow).
         """
         self.name = name
         self.public = public

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -116,16 +116,16 @@ class LangfuseConnector:
         **Using Sessions to Group Related Traces:**
 
         ```python
-        # Create a connector
+        # Create a connector and add it to the pipeline first
         tracer = LangfuseConnector(name="Agent Workflow")
+        pipeline.add_component("tracer", tracer)
 
         # Pass session_id at runtime to group related traces
-        response = tracer.run(session_id="user_123_workflow_456")
-
-        # Or when used in a pipeline
         response = pipeline.run(
-            data={"your_data": "value"},
-            tracer={"session_id": "user_123_workflow_456"}
+            data={
+                "your_data": "value",
+                "tracer": {"session_id": "user_123_workflow_456"},
+            }
         )
 
         # All traces with the same session_id will be grouped together

--- a/integrations/langfuse/tests/conftest.py
+++ b/integrations/langfuse/tests/conftest.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+
+# Enable content tracing for tests - must be set before importing haystack modules
+os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
+
+from haystack_integrations.tracing.langfuse.tracer import (
+    tracing_context_var,
+    span_stack_var,
+    root_trace_client_var,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing_globals():
+    """Ensure tracing-related ContextVars are clean for every test.
+
+    This prevents cross-test contamination where roots/spans leak via ContextVars
+    or per-task stacks, causing order-dependent flakiness.
+    """
+    token_ctx = tracing_context_var.set({})
+    token_stack = span_stack_var.set(None)
+    token_root = root_trace_client_var.set(None)
+    try:
+        yield
+    finally:
+        tracing_context_var.reset(token_ctx)
+        span_stack_var.reset(token_stack)
+        root_trace_client_var.reset(token_root)
+
+

--- a/integrations/langfuse/tests/test_langfuse_connector.py
+++ b/integrations/langfuse/tests/test_langfuse_connector.py
@@ -69,6 +69,7 @@ class TestLangfuseConnector:
                 "span_handler": None,
                 "host": None,
                 "langfuse_client_kwargs": None,
+                "session_id": None,
             },
         }
 
@@ -111,6 +112,7 @@ class TestLangfuseConnector:
                 },
                 "host": "https://example.com",
                 "langfuse_client_kwargs": {"timeout": 30.0},
+                "session_id": None,
             },
         }
 
@@ -136,6 +138,7 @@ class TestLangfuseConnector:
                 "span_handler": None,
                 "host": None,
                 "langfuse_client_kwargs": None,
+                "session_id": None,
             },
         }
         langfuse_connector = LangfuseConnector.from_dict(data)
@@ -146,6 +149,7 @@ class TestLangfuseConnector:
         assert langfuse_connector.span_handler is None
         assert langfuse_connector.host is None
         assert langfuse_connector.langfuse_client_kwargs is None
+        assert langfuse_connector.session_id is None
 
     def test_from_dict_with_params(self, monkeypatch):
         monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
@@ -175,6 +179,7 @@ class TestLangfuseConnector:
                 },
                 "host": "https://example.com",
                 "langfuse_client_kwargs": {"timeout": 30.0},
+                "session_id": None,
             },
         }
 
@@ -186,6 +191,7 @@ class TestLangfuseConnector:
         assert isinstance(langfuse_connector.span_handler, CustomSpanHandler)
         assert langfuse_connector.host == "https://example.com"
         assert langfuse_connector.langfuse_client_kwargs == {"timeout": 30.0}
+        assert langfuse_connector.session_id is None
 
     def test_pipeline_serialization(self, monkeypatch):
         # Set test env vars


### PR DESCRIPTION
## Why:
**Purpose:** Fixes a race condition where spans from concurrent pipeline runs become intertwined, corrupting tracing data and making debugging unreliable in production web server environments.

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/2140

## What:
- Replaced instance-level `self._context` list with `ContextVar` for thread-safe span stack management
- Updated `LangfuseTracer.trace()` method to use context-local span storage
- Modified `current_span()` method to read from context-local state
- Added module-level `span_context_var` ContextVar for isolated span contexts per execution thread
- Fixed support for session IDs as well

## How can it be used:
Nothing changes in client code except that we don't corrupt traces in concurrent async pipelines. All existing usage patterns continue to work exactly as before, but now with proper thread safety.

## How did you test it:
- Added unit tests verifying context isolation between concurrent tracer instances
- Verified that spans are properly isolated per execution context
- Tested examples in examples directory and itinerary agent
- Ran existing test suite to ensure no regressions in single-threaded scenarios

## Notes for the reviewer:
@LastRemote would you please test this branch on your use case