### PR TITLE
fix: Weave - pin gql

### DIFF
--- a/integrations/weights_and_biases_weave/pyproject.toml
+++ b/integrations/weights_and_biases_weave/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "weave>=0.51.33", "gql>=3.3.0, <4"]
+dependencies = ["haystack-ai", "weave>=0.51.33", "gql>=3.5.0, <4"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"


### PR DESCRIPTION
### Related Issues

- nightly tests failures: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/17055914061/job/48353442250
- this happens because Weave is not compatible with `gql>=4.0.0` (GraphQL python client): https://github.com/wandb/weave/issues/5288

### Proposed Changes:
- temporarily pin `gql`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
