### PR TITLE
fix: make Llama Stack integration compatible with Haystack 2.17.1

### DIFF
--- a/.github/workflows/llama_stack.yml
+++ b/.github/workflows/llama_stack.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Test Llama Stack Server
+      - name: Run Llama Stack Server
         env:
           OLLAMA_INFERENCE_MODEL: llama3.2:3b
           OLLAMA_URL: http://localhost:11434

--- a/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
+++ b/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
@@ -2,14 +2,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# ruff: noqa: E402  # Module level import not at top of file: needed for the workaround below
+
 from typing import Any, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import StreamingCallbackT
 from haystack.tools import Tool, Toolset, deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
 from haystack.utils import deserialize_callable, serialize_callable
 from haystack.utils.auth import Secret
+
+# NOTE: Temporary workaround
+# Llama Stack only supports openai<1.100.0 where the ChatCompletionMessageCustomToolCall is not available.
+# Haystack assumes that the ChatCompletionMessageCustomToolCall is available, so we need to inject a dummy class.
+from openai.types import chat
+
+
+class ChatCompletionMessageCustomToolCall:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+if not hasattr(chat, "ChatCompletionMessageCustomToolCall"):
+    chat.ChatCompletionMessageCustomToolCall = ChatCompletionMessageCustomToolCall
+
+from haystack.components.generators.chat import OpenAIChatGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
+++ b/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
@@ -24,7 +24,7 @@ class ChatCompletionMessageCustomToolCall:
 
 
 if not hasattr(chat, "ChatCompletionMessageCustomToolCall"):
-    chat.ChatCompletionMessageCustomToolCall = ChatCompletionMessageCustomToolCall
+    chat.ChatCompletionMessageCustomToolCall = ChatCompletionMessageCustomToolCall  # type: ignore[attr-defined]
 
 from haystack.components.generators.chat import OpenAIChatGenerator
 

--- a/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
+++ b/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
@@ -18,9 +18,7 @@ from haystack.utils.auth import Secret
 from openai.types import chat
 
 
-class ChatCompletionMessageCustomToolCall:
-    def __init__(self, *args, **kwargs):
-        pass
+class ChatCompletionMessageCustomToolCall: ...
 
 
 if not hasattr(chat, "ChatCompletionMessageCustomToolCall"):


### PR DESCRIPTION
### Related Issues

- failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/17142378128/job/48632156231#step:10:57
- in Haystack 2.17.1 we use `openai.types.chat.ChatCompletionMessageCustomToolCall`, while Llama Stack pins openai to a previous version (https://github.com/llamastack/llama-stack/pull/3192)

### Proposed Changes:
- inject a dummy `openai.types.chat.ChatCompletionMessageCustomToolCall`
  - this prevents the import error
  - we don't need to make the change in Haystack, which would then require another bugfix release

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
