### PR TITLE
feat: Add Gemini "Thinking" Support to GoogleGenAIChatGenerator

### DIFF
--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.16.1", "google-genai[aiohttp]>=1.17.0", "jsonref>=1.0.0"]
+dependencies = ["haystack-ai>=2.17.1", "google-genai[aiohttp]>=1.17.0", "jsonref>=1.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_genai#readme"


### PR DESCRIPTION
## Why:
Introduces support for Gemini  "thinking/reasoning" .Models can now show their reasoning process, maintain thought context across multi-turn conversations, and use configurable thinking budgets.

## What:
- Added `thinking_budget` configuration via `generation_kwargs` with model-specific validation
- Implemented parsing of thought parts into `ReasoningContent` objects
- Extended streaming aggregation to handle reasoning deltas while reusing generic aggregator
- Implemented fail-fast error handling for unsupported models
- Added integration tests for thinking feature and error scenarios

## How can it be used:
```python
from haystack_integrations.components.generators.google_genai import GoogleGenAIChatGenerator
from haystack.dataclasses import ChatMessage

# Enable thinking with dynamic or explicit budget
generator = GoogleGenAIChatGenerator(
    model="gemini-2.5-pro",
    generation_kwargs={"thinking_budget": -1}  # -1 for dynamic, or specific token count
)

messages = [ChatMessage.from_user("Explain why the sky is blue")]
response = generator.run(messages=messages)

# Access reasoning content
message = response["replies"][0]
if message.reasonings:
    for reasoning in message.reasonings:
        print(f"Thought: {reasoning.reasoning_text}")

# Check thinking tokens used
print(f"Thinking tokens: {message.meta['usage'].get('thoughts_token_count', 0)}")
```

## How did you test it:
- Added integration tests for thinking feature with gemini-2.5-pro
- Added fail-fast tests for unsupported models  

## Notes for the reviewer:
- `_aggregate_streaming_chunks_with_reasoning` extends the generic aggregator (40 lines vs 78 if duplicated)
- Model detection may need updates as new models are released