### PR TITLE
feat: Adding optional keepalive parameter to Ollama embedders

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
@@ -32,6 +32,7 @@ class OllamaDocumentEmbedder:
         url: str = "http://localhost:11434",
         generation_kwargs: Optional[Dict[str, Any]] = None,
         timeout: int = 120,
+        keep_alive: Optional[Union[float, str]] = None,
         prefix: str = "",
         suffix: str = "",
         progress_bar: bool = True,
@@ -50,6 +51,14 @@ class OllamaDocumentEmbedder:
             [Ollama docs](https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values).
         :param timeout:
             The number of seconds before throwing a timeout error from the Ollama API.
+        :param keep_alive:
+            The option that controls how long the model will stay loaded into memory following the request.
+            If not set, it will use the default value from the Ollama (5 minutes).
+            The value can be set to:
+            - a duration string (such as "10m" or "24h")
+            - a number in seconds (such as 3600)
+            - any negative number which will keep the model loaded in memory (e.g. -1 or "-1m")
+            - '0' which will unload the model immediately after generating a response.
         :param prefix:
             A string to add at the beginning of each text.
         :param suffix:
@@ -63,6 +72,7 @@ class OllamaDocumentEmbedder:
         :param batch_size:
             Number of documents to process at once.
         """
+        self.keep_alive = keep_alive
         self.timeout = timeout
         self.generation_kwargs = generation_kwargs or {}
         self.url = url
@@ -125,7 +135,7 @@ class OllamaDocumentEmbedder:
             range(0, len(texts_to_embed), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
         ):
             batch = texts_to_embed[i : i + batch_size]
-            result = self._client.embed(model=self.model, input=batch, options=generation_kwargs)
+            result = self._client.embed(model=self.model, input=batch, options=generation_kwargs, keep_alive=self.keep_alive)
             all_embeddings.extend(result["embeddings"])
 
         return all_embeddings
@@ -145,6 +155,7 @@ class OllamaDocumentEmbedder:
                 model=self.model,
                 input=batch,
                 options=generation_kwargs,
+                keep_alive=self.keep_alive,
             )
             for batch in batches
         ]

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
@@ -27,6 +27,7 @@ class OllamaTextEmbedder:
         url: str = "http://localhost:11434",
         generation_kwargs: Optional[Dict[str, Any]] = None,
         timeout: int = 120,
+        keep_alive: Optional[Union[float, str]] = None,
     ):
         """
         :param model:
@@ -39,7 +40,16 @@ class OllamaTextEmbedder:
             [Ollama docs](https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values).
         :param timeout:
             The number of seconds before throwing a timeout error from the Ollama API.
+        :param keep_alive:
+            The option that controls how long the model will stay loaded into memory following the request.
+            If not set, it will use the default value from the Ollama (5 minutes).
+            The value can be set to:
+            - a duration string (such as "10m" or "24h")
+            - a number in seconds (such as 3600)
+            - any negative number which will keep the model loaded in memory (e.g. -1 or "-1m")
+            - '0' which will unload the model immediately after generating a response.
         """
+        self.keep_alive = keep_alive
         self.timeout = timeout
         self.generation_kwargs = generation_kwargs or {}
         self.url = url
@@ -65,7 +75,7 @@ class OllamaTextEmbedder:
             - `embedding`: The computed embeddings
             - `meta`: The metadata collected during the embedding process
         """
-        result = self._client.embeddings(model=self.model, prompt=text, options=generation_kwargs).model_dump()
+        result = self._client.embeddings(model=self.model, prompt=text, options=generation_kwargs, keep_alive=self.keep_alive).model_dump()
         result["meta"] = {"model": self.model}
 
         return result
@@ -87,7 +97,7 @@ class OllamaTextEmbedder:
             - `embedding`: The computed embeddings
             - `meta`: The metadata collected during the embedding process
         """
-        response = await self._async_client.embeddings(model=self.model, prompt=text, options=generation_kwargs)
+        response = await self._async_client.embeddings(model=self.model, prompt=text, options=generation_kwargs, keep_alive=self.keep_alive)
         result = response.model_dump()
         result["meta"] = {"model": self.model}
 

--- a/integrations/ollama/tests/test_document_embedder.py
+++ b/integrations/ollama/tests/test_document_embedder.py
@@ -9,6 +9,7 @@ class TestOllamaDocumentEmbedder:
     def test_init_defaults(self):
         embedder = OllamaDocumentEmbedder()
 
+        assert embedder.keep_alive is None
         assert embedder.timeout == 120
         assert embedder.generation_kwargs == {}
         assert embedder.url == "http://localhost:11434"
@@ -20,8 +21,10 @@ class TestOllamaDocumentEmbedder:
             url="http://my-custom-endpoint:11434",
             generation_kwargs={"temperature": 0.5},
             timeout=3000,
+            keep_alive="10m",
         )
 
+        assert embedder.keep_alive == "10m"
         assert embedder.timeout == 3000
         assert embedder.generation_kwargs == {"temperature": 0.5}
         assert embedder.url == "http://my-custom-endpoint:11434"

--- a/integrations/ollama/tests/test_text_embedder.py
+++ b/integrations/ollama/tests/test_text_embedder.py
@@ -8,6 +8,7 @@ class TestOllamaTextEmbedder:
     def test_init_defaults(self):
         embedder = OllamaTextEmbedder()
 
+        assert embedder.keep_alive is None
         assert embedder.timeout == 120
         assert embedder.generation_kwargs == {}
         assert embedder.url == "http://localhost:11434"
@@ -19,8 +20,10 @@ class TestOllamaTextEmbedder:
             url="http://my-custom-endpoint:11434",
             generation_kwargs={"temperature": 0.5},
             timeout=3000,
+            keep_alive="10m",
         )
 
+        assert embedder.keep_alive == "10m"
         assert embedder.timeout == 3000
         assert embedder.generation_kwargs == {"temperature": 0.5}
         assert embedder.url == "http://my-custom-endpoint:11434"


### PR DESCRIPTION
### Related Issues

- fixes #2225

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This change enables `OllamaDocumentEmbedder` and `OllamaTextEmbedder` to accept an optional `keep_alive` parameter to allow for setting how long a model should remain loaded in the Ollama server (same as currently available in `OllamaGenerator` and `OllamaChatGenerator`).

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

1. Ran unit and integration tests: all passed
2. Manual verification in a project currently using Haystack: simply include the new `keep_alive` parameter when instantiating either `OllamaGenerator` or `OllamaChatGenerator`, then check the Ollama server with `ollama ps` to confirm that the value shown for "UNTIL" matches what was specified for `keep_alive`.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

The `.run()` method simply passes `keep_alive` directly to the underlying call to `_client.embeddings()`, so there are no changes to logic.

I only modified the existing unit tests, which confirm that the `keep_alive` attribute matched the value supplied at instantiation; they do not check the Ollama process to see if the keepalive was obeyed.  The integration tests seem to be concerned only with prompt and response, so I did not augment them.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I ~added~ augmented unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
