### PR TITLE
ci: download pre-built wheels for llama-cpp-python on macOS

### DIFF
--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -40,7 +40,7 @@ jobs:
           - os: windows-latest
             python-version: "3.13"
 
-        # on MacOs, we test with 3.10 and 3.12 because pre-built wheels are only available for these Python versions
+        # on macOS, we test with 3.10 and 3.12 because pre-built wheels are only available for these Python versions
         # and installing from source might fail due to missing dependencies (CMake fails with "OpenMP not found")
           - os: macos-latest
             python-version: "3.10"

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -30,8 +30,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.13"]  
+        include:
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.13"
+
+        # on MacOs, we test with 3.10 and 3.12 because pre-built wheels are only available for these Python versions
+        # and installing from source might fail due to missing dependencies (CMake fails with "OpenMP not found")
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.12"
 
     steps:
       - name: Support longpaths
@@ -50,11 +64,11 @@ jobs:
         run: pip install --upgrade hatch
 
       - name: Lint
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
+        if: matrix.python-version == '3.9' && runner.os == 'Linux'
         run: hatch run docs
 
       - name: Run tests

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.13"]  
+        python-version: ["3.10", "3.13"]  
 
     steps:
       - name: Support longpaths
@@ -50,11 +50,11 @@ jobs:
         run: pip install --upgrade hatch
 
       - name: Lint
-        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
-        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run docs
 
       - name: Run tests

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -28,6 +28,12 @@ classifiers = [
 ]
 dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
 
+[[tool.uv.index]]
+# Optional name for the index.
+name = "llama-cpp-python"
+# Required URL for the index.
+url = "https://abetlen.github.io/llama-cpp-python/whl/metal/"
+
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/llama_cpp#readme"
 Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
 
 [[tool.uv]]
-index-strategy = "unsafe-best-match
+index-strategy = "unsafe-best-match"
 
 [[tool.uv.index]]
 # Optional name for the index.

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -34,7 +34,6 @@ index-strategy = "unsafe-best-match"
 [[tool.uv.index]]
 # Optional name for the index.
 name = "llama-cpp-python"
-index-strategy = "unsafe-best-match
 # Required URL for the index.
 url = "https://abetlen.github.io/llama-cpp-python/whl/metal/"
 

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -28,10 +28,8 @@ classifiers = [
 ]
 dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
 
-[[tool.uv]]
-index-strategy = "unsafe-best-match"
-
 [[tool.uv.index]]
+strategy = "unsafe-best-match"
 # Optional name for the index.
 name = "llama-cpp-python"
 # Required URL for the index.

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -28,13 +28,12 @@ classifiers = [
 ]
 dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
 
+# On MacOs GitHub runners, we use a custom index to download pre-built wheels.
+# Installing from source might fail due to missing dependencies (CMake fails with "OpenMP not found")
 [tool.uv]
-index-strategy = "unsafe-best-match"
-
+index-strategy = "unsafe-best-match"  # this ensures that packages are not only searched in the below index but also in PyPI
 [[tool.uv.index]]
-# Optional name for the index.
-name = "llama-cpp-python"
-# Required URL for the index.
+name = "llama-cpp-python-macos"
 url = "https://abetlen.github.io/llama-cpp-python/whl/metal/"
 
 [project.urls]

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -28,8 +28,10 @@ classifiers = [
 ]
 dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
 
+[tool.uv]
+index-strategy = "unsafe-best-match"
+
 [[tool.uv.index]]
-strategy = "unsafe-best-match"
 # Optional name for the index.
 name = "llama-cpp-python"
 # Required URL for the index.

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
 
-# On MacOs GitHub runners, we use a custom index to download pre-built wheels.
+# On macOS GitHub runners, we use a custom index to download pre-built wheels.
 # Installing from source might fail due to missing dependencies (CMake fails with "OpenMP not found")
 [tool.uv]
 index-strategy = "unsafe-best-match"  # this ensures that packages are not only searched in the below index but also in PyPI

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -28,9 +28,13 @@ classifiers = [
 ]
 dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
 
+[[tool.uv]]
+index-strategy = "unsafe-best-match
+
 [[tool.uv.index]]
 # Optional name for the index.
 name = "llama-cpp-python"
+index-strategy = "unsafe-best-match
 # Required URL for the index.
 url = "https://abetlen.github.io/llama-cpp-python/whl/metal/"
 


### PR DESCRIPTION
### Related Issues
Nightly tests failing on macOS: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/17364348515/job/49288820099
CMake error: OpenMP not found

This likely happens because [new GitHub macOS runners](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/) are not well configured or lack the dependency.

### Proposed Changes:
- Use pre-built wheels on macOS by adding a custom index (llama-cpp-python provides these wheels)
- on macOS, test with Python 3.10 and 3.12 because wheels are only available for python>=3.10, <=3.12

### How did you test it?
CI

### Notes for the reviewer
This would not change things for end users. I have not seen many users reporting issues on this specific topic on llama-cpp-python and I would expect users to be able to install/configure missing system/compilation dependencies.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
