### PR TITLE
chore: Fix linting in tests in mistral integration

### DIFF
--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -96,7 +96,7 @@ class TestMistralChatGenerator:
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
             MistralChatGenerator()
 
     def test_init_with_parameters(self):
@@ -191,7 +191,7 @@ class TestMistralChatGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
             MistralChatGenerator.from_dict(data)
 
     def test_handle_stream_response(self):


### PR DESCRIPTION
### Related Issues

[unused-unpacked-variable](https://docs.astral.sh/ruff/rules/unused-unpacked-variable) (RUF059) is the rule here that got stabilized and is no longer in preview in ruff 0.13.0.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
