### PR TITLE
chore: Fix linting in tests for watsonx integration

### DIFF
--- a/integrations/watsonx/tests/test_document_embedder.py
+++ b/integrations/watsonx/tests/test_document_embedder.py
@@ -92,14 +92,14 @@ class TestWatsonXDocumentEmbedder:
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("WATSONX_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
             WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
 
     def test_init_fail_wo_project_id(self, monkeypatch):
         monkeypatch.setenv("WATSONX_API_KEY", "fake-api-key")
         monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
 
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
             WatsonxDocumentEmbedder()
 
     def test_to_dict(self, mock_watsonx):
@@ -165,7 +165,7 @@ class TestWatsonXDocumentEmbedder:
 
     def test_run_wrong_input_format(self, mock_watsonx):
         embedder = WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
-        with pytest.raises(TypeError, match="WatsonxDocumentEmbedder expects a list of Documents as input."):
+        with pytest.raises(TypeError, match=r"WatsonxDocumentEmbedder expects a list of Documents as input\."):
             embedder.run(documents="not a list")  # type: ignore
 
     def test_run_empty_documents(self, mock_watsonx):

--- a/integrations/watsonx/tests/test_text_embedder.py
+++ b/integrations/watsonx/tests/test_text_embedder.py
@@ -80,13 +80,13 @@ class TestWatsonxTextEmbedder:
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("WATSONX_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
             WatsonxTextEmbedder(project_id=Secret.from_env_var("WATSONX_PROJECT_ID"))
 
     def test_init_fail_wo_project_id(self, monkeypatch):
         monkeypatch.setenv("WATSONX_API_KEY", "fake-api-key")
         monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
-        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
             WatsonxTextEmbedder()
 
     def test_to_dict(self, mock_watsonx):
@@ -142,8 +142,8 @@ class TestWatsonxTextEmbedder:
         embedder = WatsonxTextEmbedder(project_id=Secret.from_token("fake-project-id"))
         with pytest.raises(
             TypeError,
-            match="WatsonxTextEmbedder expects a string as an input. In case you want to embed a list of Documents, "
-            "please use the WatsonxDocumentEmbedder.",
+            match=r"WatsonxTextEmbedder expects a string as an input\. In case you want to embed a list of Documents, "
+            r"please use the WatsonxDocumentEmbedder\.",
         ):
             embedder.run(text=[1, 2, 3])
 


### PR DESCRIPTION
### Related Issues

[unused-unpacked-variable](https://docs.astral.sh/ruff/rules/unused-unpacked-variable) (RUF059) is the rule here that got stabilized and is no longer in preview in ruff 0.13.0.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
