### PR TITLE
chore: revert default model to `command-r-08-2024`

### DIFF
--- a/integrations/cohere/README.md
+++ b/integrations/cohere/README.md
@@ -6,8 +6,6 @@
 - [Integration page](https://haystack.deepset.ai/integrations/cohere)
 - [Changelog](https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/cohere/CHANGELOG.md)
 
----
-
 
 ---
 

--- a/integrations/cohere/examples/cohere_generation.py
+++ b/integrations/cohere/examples/cohere_generation.py
@@ -7,7 +7,7 @@
 #
 # The pipeline workflow:
 # 1. Receives a user message requesting to create a JSON object from "Peter Parker" aka Superman.
-# 2. Processes the message through components to generate a response using Cohere command-r model.
+# 2. Processes the message through components to generate a response using Cohere command-r-08-2024 model.
 # 3. Validates the generated response against a predefined JSON schema for person data.
 # 4. If the response does not meet the schema, the JsonSchemaValidator provides details on how to correct the errors.
 # 4a. The pipeline loops back, using the error information to generate a new JSON object until it satisfies the schema.
@@ -40,7 +40,7 @@ pipe = Pipeline()
 
 # Add components to the pipeline
 pipe.add_component("joiner", BranchJoiner(List[ChatMessage]))
-pipe.add_component("fc_llm", CohereChatGenerator(model="command-r"))
+pipe.add_component("fc_llm", CohereChatGenerator(model="command-r-08-2024"))
 pipe.add_component("validator", JsonSchemaValidator(json_schema=person_schema))
 (pipe.add_component("adapter", OutputAdapter("{{chat_message}}", List[ChatMessage])),)
 # And connect them

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -515,7 +515,7 @@ class CohereChatGenerator:
     def __init__(
         self,
         api_key: Secret = Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
-        model: str = "command-r-plus",
+        model: str = "command-r-08-2024",
         streaming_callback: Optional[StreamingCallbackT] = None,
         api_base_url: Optional[str] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -32,7 +32,7 @@ class CohereGenerator(CohereChatGenerator):
     def __init__(
         self,
         api_key: Secret = Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
-        model: str = "command-r",
+        model: str = "command-r-08-2024",
         streaming_callback: Optional[Callable] = None,
         api_base_url: Optional[str] = None,
         **kwargs: Any,

--- a/integrations/cohere/tests/test_chat_generator.py
+++ b/integrations/cohere/tests/test_chat_generator.py
@@ -152,7 +152,7 @@ class TestCohereChatGenerator:
 
         component = CohereChatGenerator()
         assert component.api_key == Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"])
-        assert component.model == "command-r-plus"
+        assert component.model == "command-r-08-2024"
         assert component.streaming_callback is None
         assert component.api_base_url == "https://api.cohere.com"
         assert not component.generation_kwargs
@@ -190,7 +190,7 @@ class TestCohereChatGenerator:
         assert data == {
             "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model": "command-r-plus",
+                "model": "command-r-08-2024",
                 "streaming_callback": None,
                 "api_key": {
                     "env_vars": ["COHERE_API_KEY", "CO_API_KEY"],
@@ -242,7 +242,7 @@ class TestCohereChatGenerator:
         data = {
             "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model": "command-r-plus",
+                "model": "command-r-08-2024",
                 "api_base_url": "test-base-url",
                 "api_key": {
                     "env_vars": ["ENV_VAR"],
@@ -257,7 +257,7 @@ class TestCohereChatGenerator:
             },
         }
         component = CohereChatGenerator.from_dict(data)
-        assert component.model == "command-r-plus"
+        assert component.model == "command-r-08-2024"
         assert component.streaming_callback is print_streaming_chunk
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {
@@ -271,7 +271,7 @@ class TestCohereChatGenerator:
         data = {
             "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
             "init_parameters": {
-                "model": "command-r-plus",
+                "model": "command-r-08-2024",
                 "api_base_url": "test-base-url",
                 "api_key": {
                     "env_vars": ["COHERE_API_KEY", "CO_API_KEY"],
@@ -303,7 +303,7 @@ class TestCohereChatGenerator:
         )
 
         generator = CohereChatGenerator(
-            model="command-r-plus",
+            model="command-r-08-2024",
             generation_kwargs={"temperature": 0.7},
             streaming_callback=print_streaming_chunk,
             tools=[tool],
@@ -322,7 +322,7 @@ class TestCohereChatGenerator:
                 "generator": {
                     "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",  # noqa: E501
                     "init_parameters": {
-                        "model": "command-r-plus",
+                        "model": "command-r-08-2024",
                         "api_key": {"type": "env_var", "env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True},
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.cohere.com",

--- a/integrations/cohere/tests/test_chat_generator_async.py
+++ b/integrations/cohere/tests/test_chat_generator_async.py
@@ -74,7 +74,7 @@ class TestCohereChatGeneratorAsyncInference:
             function=stock_price,
         )
         initial_messages = [ChatMessage.from_user("What is the current price of AAPL?")]
-        client = CohereChatGenerator(model="command-r")
+        client = CohereChatGenerator(model="command-r-08-2024")
         response = await client.run_async(
             messages=initial_messages,
             tools=[stock_price_tool],
@@ -137,7 +137,7 @@ class TestCohereChatGeneratorAsyncInference:
 
         initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         component = CohereChatGenerator(
-            model="command-r",  # Cohere's model that supports tools
+            model="command-r-08-2024",  # Cohere's model that supports tools
             tools=[weather_tool],
             streaming_callback=print_streaming_chunk_async,
         )

--- a/integrations/cohere/tests/test_generator.py
+++ b/integrations/cohere/tests/test_generator.py
@@ -19,7 +19,7 @@ class TestCohereGenerator:
         monkeypatch.setenv("COHERE_API_KEY", "foo")
         component = CohereGenerator()
         assert component.api_key == Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"])
-        assert component.model == "command-r"
+        assert component.model == "command-r-08-2024"
         assert component.streaming_callback is None
         assert component.api_base_url == COHERE_API_URL
         assert component.model_parameters == {}
@@ -47,7 +47,7 @@ class TestCohereGenerator:
         assert data == {
             "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
             "init_parameters": {
-                "model": "command-r",
+                "model": "command-r-08-2024",
                 "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
                 "streaming_callback": None,
                 "api_base_url": COHERE_API_URL,
@@ -86,7 +86,7 @@ class TestCohereGenerator:
         data = {
             "type": "haystack_integrations.components.generators.cohere.generator.CohereGenerator",
             "init_parameters": {
-                "model": "command-r",
+                "model": "command-r-08-2024",
                 "max_tokens": 10,
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
                 "some_test_param": "test-params",
@@ -97,7 +97,7 @@ class TestCohereGenerator:
         }
         component: CohereGenerator = CohereGenerator.from_dict(data)
         assert component.api_key == Secret.from_env_var("ENV_VAR", strict=False)
-        assert component.model == "command-r"
+        assert component.model == "command-r-08-2024"
         assert component.streaming_callback == print_streaming_chunk
         assert component.api_base_url == "test-base-url"
         assert component.model_parameters == {"max_tokens": 10, "some_test_param": "test-params"}


### PR DESCRIPTION
### Related Issues

Nightly Cohere tests are failing because the current default (`command-r-plus`) has been removed.
https://github.com/deepset-ai/haystack-core-integrations/actions/runs/17782605524/job/50544377520

It looks like `command-r-plus` was accidentally set as the default in #2157. Previously, #1691 had already set the default to `command-r-08-2024`.

**Why `command-r-08-2024`?**
- active model
- mid-level pricing, aligned with our standard Cohere defaults, while `command-r-plus` (removed) and `command-a` (newer) have higher prices

More information:
https://docs.cohere.com/docs/models#command
https://cohere.com/pricing
https://docs.cohere.com/changelog/command-gets-refreshed

### Proposed Changes:

- revert default model to `command-r-08-2024`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
