### PR TITLE
feat: support AWS Bedrock Guardrails in `AmazonBedrockChatGenerator`

### DIFF
--- a/.github/workflows/CI_readme_sync.yml
+++ b/.github/workflows/CI_readme_sync.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U haystack-pydoc-tools hatch
+          pip install -U haystack-pydoc-tools hatch "click<8.3.0"
 
       - name: Get project folder
         id: pathfinder

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -26,7 +26,9 @@ permissions:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
-  AWS_REGION: us-east-1
+  AWS_REGION: "us-east-1"
+  AWS_BEDROCK_GUARDRAIL_ID: ${{ secrets.AWS_BEDROCK_GUARDRAIL_ID }}
+  AWS_BEDROCK_GUARDRAIL_VERSION: "1"
 
 jobs:
   run:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -157,6 +157,8 @@ class AmazonBedrockChatGenerator:
         streaming_callback: Optional[StreamingCallbackT] = None,
         boto3_config: Optional[Dict[str, Any]] = None,
         tools: Optional[Union[List[Tool], Toolset]] = None,
+        *,
+        guardrail_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Initializes the `AmazonBedrockChatGenerator` with the provided parameters. The parameters are passed to the
@@ -203,6 +205,7 @@ class AmazonBedrockChatGenerator:
         self.boto3_config = boto3_config
         _check_duplicate_tool_names(list(tools or []))  # handles Toolset as well
         self.tools = tools
+        self.guardrail_config = guardrail_config
 
         def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
             return secret.resolve_value() if secret else None
@@ -288,6 +291,7 @@ class AmazonBedrockChatGenerator:
             streaming_callback=callback_name,
             boto3_config=self.boto3_config,
             tools=serialize_tools_or_toolset(self.tools),
+            guardrail_config=self.guardrail_config,
         )
 
     @classmethod
@@ -385,6 +389,8 @@ class AmazonBedrockChatGenerator:
             params["toolConfig"] = tool_config
         if additional_fields:
             params["additionalModelRequestFields"] = additional_fields
+        if self.guardrail_config:
+            params["guardrailConfig"] = self.guardrail_config
 
         # overloads that exhaust finite Literals(bool) not treated as exhaustive
         # see https://github.com/python/mypy/issues/14764

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -27,6 +27,7 @@ from haystack_integrations.components.generators.amazon_bedrock.chat.utils impor
     _parse_completion_response,
     _parse_streaming_response,
     _parse_streaming_response_async,
+    _validate_guardrail_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -158,7 +159,7 @@ class AmazonBedrockChatGenerator:
         boto3_config: Optional[Dict[str, Any]] = None,
         tools: Optional[Union[List[Tool], Toolset]] = None,
         *,
-        guardrail_config: Optional[Dict[str, Any]] = None,
+        guardrail_config: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Initializes the `AmazonBedrockChatGenerator` with the provided parameters. The parameters are passed to the
@@ -203,8 +204,11 @@ class AmazonBedrockChatGenerator:
         self.aws_profile_name = aws_profile_name
         self.streaming_callback = streaming_callback
         self.boto3_config = boto3_config
+
         _check_duplicate_tool_names(list(tools or []))  # handles Toolset as well
         self.tools = tools
+
+        _validate_guardrail_config(guardrail_config=guardrail_config, streaming = streaming_callback is not None)
         self.guardrail_config = guardrail_config
 
         def resolve_secret(secret: Optional[Secret]) -> Optional[str]:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -208,7 +208,7 @@ class AmazonBedrockChatGenerator:
         _check_duplicate_tool_names(list(tools or []))  # handles Toolset as well
         self.tools = tools
 
-        _validate_guardrail_config(guardrail_config=guardrail_config, streaming = streaming_callback is not None)
+        _validate_guardrail_config(guardrail_config=guardrail_config, streaming=streaming_callback is not None)
         self.guardrail_config = guardrail_config
 
         def resolve_secret(secret: Optional[Secret]) -> Optional[str]:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -188,6 +188,19 @@ class AmazonBedrockChatGenerator:
             the streaming mode on.
         :param boto3_config: The configuration for the boto3 client.
         :param tools: A list of Tool objects or a Toolset that the model can use. Each tool should have a unique name.
+        :param guardrail_config: Optional configuration for a guardrail that has been created in Amazon Bedrock.
+            This must be provided as a dictionary matching either
+            [GuardrailConfiguration](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GuardrailConfiguration.html).
+            or, in streaming mode (when `streaming_callback` is set),
+            [GuardrailStreamConfiguration](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_GuardrailStreamConfiguration.html).
+            If `trace` is set to `enabled`, the guardrail trace will be included under the `trace` key in the `meta`
+            attribute of the resulting `ChatMessage`.
+            Note: Enabling guardrails in streaming mode may introduce additional latency.
+            To manage this, you can adjust the `streamProcessingMode` parameter.
+            See the
+            [Guardrails Streaming documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-streaming.html)
+            for more information.
+
 
         :raises ValueError: If the model name is empty or None.
         :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly or the model is

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -273,6 +273,11 @@ def _parse_completion_response(response_body: Dict[str, Any], model: str) -> Lis
     :param model: The model ID used for generation, included in message metadata.
     :returns: List of ChatMessage objects containing the assistant's response(s) with appropriate metadata.
     """
+    print("response_body")
+    print(response_body)
+
+    print("---")
+
     replies = []
     if "output" in response_body and "message" in response_body["output"]:
         message = response_body["output"]["message"]
@@ -571,8 +576,6 @@ def _parse_streaming_response(
         tool_calls=reply.tool_calls,
         reasoning=reasoning_content,
     )
-
-
 
     return [reply]
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -612,3 +612,24 @@ async def _parse_streaming_response_async(
         reasoning=reasoning_content,
     )
     return [reply]
+
+
+def _validate_guardrail_config(guardrail_config: Optional[Dict[str, str]] = None, streaming: bool = False) -> None:
+    """
+    Validate the guardrail configuration.
+
+    :param guardrail_config: The guardrail configuration.
+    :param streaming: Whether the streaming is enabled.
+
+    :raises ValueError: If the guardrail configuration is invalid.
+    """
+    if guardrail_config is None:
+        return
+
+    required_fields = {"guardrailIdentifier", "guardrailVersion"}
+    if not required_fields.issubset(guardrail_config):
+        msg = "`guardrailIdentifier` and `guardrailVersion` fields are required in guardrail configuration."
+        raise ValueError(msg)
+    if not streaming and "streamProcessingMode" in guardrail_config:
+        msg = "`streamProcessingMode` field is only supported for streaming (when `streaming_callback` is not None)."
+        raise ValueError(msg)

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -555,8 +555,15 @@ def _parse_streaming_response(
             content_block_idxs.add(content_block_idx)
         streaming_callback(streaming_chunk)
         chunks.append(streaming_chunk)
+
     reply = _convert_streaming_chunks_to_chat_message(chunks=chunks)
+
+    # both the reasoning content and the trace are ignored in _convert_streaming_chunks_to_chat_message
+    # so we need to process them separately
     reasoning_content = _process_reasoning_contents(chunks=chunks)
+    if chunks[-1].meta and "trace" in chunks[-1].meta:
+        reply.meta["trace"] = chunks[-1].meta["trace"]
+
     reply = ChatMessage.from_assistant(
         text=reply.text,
         meta=reply.meta,
@@ -564,6 +571,9 @@ def _parse_streaming_response(
         tool_calls=reply.tool_calls,
         reasoning=reasoning_content,
     )
+
+
+
     return [reply]
 
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -273,10 +273,6 @@ def _parse_completion_response(response_body: Dict[str, Any], model: str) -> Lis
     :param model: The model ID used for generation, included in message metadata.
     :returns: List of ChatMessage objects containing the assistant's response(s) with appropriate metadata.
     """
-    print("response_body")
-    print(response_body)
-
-    print("---")
 
     replies = []
     if "output" in response_body and "message" in response_body["output"]:

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -663,9 +663,8 @@ class TestAmazonBedrockChatGeneratorInference:
         ),
     )
     @pytest.mark.parametrize("streaming_callback", [None, print_streaming_chunk])
-    @pytest.mark.integration
     def test_live_run_with_guardrail(self, streaming_callback):
-        initial_messages = [ChatMessage.from_user("Should I invest in Tesla or Apple?")]
+        messages = [ChatMessage.from_user("Should I invest in Tesla or Apple?")]
         component = AmazonBedrockChatGenerator(
             model="anthropic.claude-3-5-sonnet-20240620-v1:0",
             guardrail_config={
@@ -675,10 +674,10 @@ class TestAmazonBedrockChatGeneratorInference:
             },
             streaming_callback=streaming_callback,
         )
-        results = component.run(messages=initial_messages)
+        results = component.run(messages=messages)
 
         assert results["replies"][0].meta["finish_reason"] == "content_filter"
-        assert results["replies"][0].text == "I'm sorry, I can't answer that question."
+        assert results["replies"][0].text == "Sorry, the model cannot answer this question."
         assert "trace" in results["replies"][0].meta
         assert "guardrail" in results["replies"][0].meta["trace"]
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -123,6 +123,7 @@ class TestAmazonBedrockChatGenerator:
             generation_kwargs={"temperature": 0.7},
             streaming_callback=print_streaming_chunk,
             boto3_config=boto3_config,
+            guardrail_config={"guardrailIdentifier": "test", "guardrailVersion": "test"},
         )
         expected_dict = {
             "type": CLASS_TYPE,
@@ -137,7 +138,7 @@ class TestAmazonBedrockChatGenerator:
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "boto3_config": boto3_config,
                 "tools": None,
-                "guardrail_config": None,
+                "guardrail_config": {"guardrailIdentifier": "test", "guardrailVersion": "test"},
             },
         }
 
@@ -292,6 +293,17 @@ class TestAmazonBedrockChatGenerator:
         )
         assert request_params["messages"] == [{"content": [{"text": "What's the capital of France?"}], "role": "user"}]
         assert request_params["toolConfig"] == top_song_tool_config
+
+    def test_prepare_request_params_guardrail_config(self, mock_boto3_session, set_env_variables):
+        generator = AmazonBedrockChatGenerator(
+            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            guardrail_config={"guardrailIdentifier": "test", "guardrailVersion": "test"},
+        )
+        request_params, _ = generator._prepare_request_params(
+            messages=[ChatMessage.from_user("What's the capital of France?")],
+        )
+        assert request_params["messages"] == [{"content": [{"text": "What's the capital of France?"}], "role": "user"}]
+        assert request_params["guardrailConfig"] == {"guardrailIdentifier": "test", "guardrailVersion": "test"}
 
 
 # In the CI, those tests are skipped if AWS Authentication fails

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -21,6 +21,7 @@ from haystack_integrations.components.generators.amazon_bedrock.chat.utils impor
     _format_tools,
     _parse_completion_response,
     _parse_streaming_response,
+    _validate_guardrail_config,
 )
 
 
@@ -602,6 +603,71 @@ class TestAmazonBedrockChatGeneratorUtils:
             },
         )
         assert replies[0] == expected_message
+
+    def test_extract_replies_with_guardrail(self, mock_boto3_session):
+        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+        trace = {
+            "guardrail": {
+                "inputAssessment": {
+                    "test_guardrail_id": {
+                        "topicPolicy": {
+                            "topics": [
+                                {"name": "Investments topic", "type": "DENY", "action": "BLOCKED", "detected": True}
+                            ]
+                        },
+                        "invocationMetrics": {
+                            "guardrailProcessingLatency": 273,
+                            "usage": {
+                                "topicPolicyUnits": 1,
+                                "contentPolicyUnits": 0,
+                                "wordPolicyUnits": 0,
+                                "sensitiveInformationPolicyUnits": 0,
+                                "sensitiveInformationPolicyFreeUnits": 0,
+                                "contextualGroundingPolicyUnits": 0,
+                                "contentPolicyImageUnits": 0,
+                            },
+                            "guardrailCoverage": {"textCharacters": {"guarded": 48, "total": 48}},
+                        },
+                    }
+                },
+                "actionReason": "Guardrail blocked.",
+            }
+        }
+
+        response_body = {
+            "ResponseMetadata": {
+                "RequestId": "7f2b43ef-fb52-40e4-ab14-8cc1edaf5013",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "date": "Thu, 18 Sep 2025 09:14:48 GMT",
+                    "content-type": "application/json",
+                    "content-length": "835",
+                    "connection": "keep-alive",
+                    "x-amzn-requestid": "7f2b43ef-fb52-40e4-ab14-8cc1edaf5013",
+                },
+                "RetryAttempts": 0,
+            },
+            "output": {
+                "message": {"role": "assistant", "content": [{"text": "Sorry, the model cannot answer this question."}]}
+            },
+            "stopReason": "guardrail_intervened",
+            "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+            "metrics": {"latencyMs": 316},
+            "trace": trace,
+        }
+
+        replies = _parse_completion_response(response_body, model)
+        assert len(replies) == 1
+        assert replies[0].text == "Sorry, the model cannot answer this question."
+        assert replies[0].role == ChatRole.ASSISTANT
+        assert replies[0].meta == {
+            "model": model,
+            "finish_reason": "content_filter",
+            "index": 0,
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "trace": trace,
+        }
 
     def test_process_streaming_response_one_tool_call(self, mock_boto3_session):
         """
@@ -1229,3 +1295,35 @@ class TestAmazonBedrockChatGeneratorUtils:
         assert message._meta["index"] == 0
         assert message._meta["finish_reason"] == "tool_calls"
         assert message._meta["usage"] == {"completion_tokens": 84, "prompt_tokens": 349, "total_tokens": 433}
+
+    def test_validate_guardrail_config_with_valid_configs(self):
+        _validate_guardrail_config(guardrail_config=None, streaming=False)
+        _validate_guardrail_config(
+            guardrail_config={"guardrailIdentifier": "test", "guardrailVersion": "test"}, streaming=False
+        )
+        _validate_guardrail_config(
+            guardrail_config={"guardrailIdentifier": "test", "guardrailVersion": "test"}, streaming=True
+        )
+        _validate_guardrail_config(
+            guardrail_config={
+                "guardrailIdentifier": "test",
+                "guardrailVersion": "test",
+                "streamProcessingMode": "enabled",
+            },
+            streaming=True,
+        )
+
+    def test_validate_guardrail_config_with_invalid_configs(self):
+        with pytest.raises(ValueError, match="`guardrailIdentifier` and `guardrailVersion` fields are required"):
+            _validate_guardrail_config(guardrail_config={"guardrailIdentifier": "test"}, streaming=False)
+        with pytest.raises(ValueError, match="`guardrailIdentifier` and `guardrailVersion` fields are required"):
+            _validate_guardrail_config(guardrail_config={"guardrailVersion": "test"}, streaming=False)
+        with pytest.raises(ValueError, match="`streamProcessingMode` field is only supported for streaming"):
+            _validate_guardrail_config(
+                guardrail_config={
+                    "guardrailIdentifier": "test",
+                    "guardrailVersion": "test",
+                    "streamProcessingMode": "test",
+                },
+                streaming=False,
+            )


### PR DESCRIPTION
### Related Issues

- fixes #1685

### Proposed Changes:

- introduce a `guardrail_config` init parameter to allow users to pass a configuration for a guardrail they have created in Bedrock
- make sure this works properly both in streaming and non-streaming mode
- if available, store the guardrail `trace` in `message.meta`

### How did you test it?
- new unit tests
- new parametrized integration test that references to a guardrail I have created, that blocks investment topics


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
