### PR TITLE
chore!: remove deprecated `BedrockRanker` (use `AmazonBedrockRanker` instead)

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/__init__.py
@@ -1,3 +1,3 @@
-from .ranker import AmazonBedrockRanker, BedrockRanker
+from .ranker import AmazonBedrockRanker
 
-__all__ = ["AmazonBedrockRanker", "BedrockRanker"]
+__all__ = ["AmazonBedrockRanker"]

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any, Dict, List, Optional
 
 from botocore.exceptions import ClientError
@@ -265,20 +264,3 @@ class AmazonBedrockRanker:
         except Exception as exception:
             msg = f"Error during Amazon Bedrock API call: {exception}"
             raise AmazonBedrockInferenceError(msg) from exception
-
-
-class BedrockRanker(AmazonBedrockRanker):
-    """
-    Deprecated alias for AmazonBedrockRanker.
-    This class will be removed in a future version.
-    Please use AmazonBedrockRanker instead.
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "BedrockRanker is deprecated and will be removed in a future version. "
-            "Please use AmazonBedrockRanker instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -7,7 +7,7 @@ from haystack.utils import Secret
 from haystack_integrations.common.amazon_bedrock.errors import (
     AmazonBedrockInferenceError,
 )
-from haystack_integrations.components.rankers.amazon_bedrock import AmazonBedrockRanker, BedrockRanker
+from haystack_integrations.components.rankers.amazon_bedrock import AmazonBedrockRanker
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def test_amazon_bedrock_ranker_initialization(mock_aws_session):
 
 
 def test_bedrock_ranker_run(mock_aws_session):
-    ranker = BedrockRanker(
+    ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",
         top_k=2,
         aws_access_key_id=Secret.from_token("test_access_key"),


### PR DESCRIPTION
### Related Issues

- `BedrockRanker` was introduced by mistake
- `AmazonBedrockRanker` exists from #1732 (May 2025)
- `BedrockRanker` is an alias for `AmazonBedrockRanker` and is deprecated (every time it's initialized, you see a warning)

### Proposed Changes:
- remove deprecated `BedrockRanker`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
