### PR TITLE
feat!: adding `api_token` and `apit_token_id` support to `ElasticSearchDocumentStore`

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -87,8 +87,9 @@ class ElasticsearchDocumentStore:
         For the full list of supported kwargs, see the official Elasticsearch
         [reference](https://elasticsearch-py.readthedocs.io/en/stable/api.html#module-elasticsearch)
 
-        Authentication is provided via Secret objects, which by default are loaded from environment variables. 
-        You can either provide both `api_key_id` and `api_key`, or just `api_key` containing a base64-encoded string of `id:secret`. Secret instances can also be loaded from a token using the `Secret.from_token()` method.
+        Authentication is provided via Secret objects, which by default are loaded from environment variables.
+        You can either provide both `api_key_id` and `api_key`, or just `api_key` containing a base64-encoded string
+        of `id:secret`. Secret instances can also be loaded from a token using the `Secret.from_token()` method.
 
         :param hosts: List of hosts running the Elasticsearch client.
         :param custom_mapping: Custom mapping for the index. If not provided, a default mapping will be used.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -12,7 +12,6 @@ from haystack.dataclasses import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.auth import TokenSecret
 from haystack.version import __version__ as haystack_version
 
 from elasticsearch import AsyncElasticsearch, Elasticsearch, helpers
@@ -42,7 +41,7 @@ class ElasticsearchDocumentStore:
     Usage example (Elastic Cloud):
     ```python
     from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
-    document_store = ElasticsearchDocumentStore(cloud_id="YOUR_CLOUD_ID", api_key="YOUR_API_KEY")
+    document_store = ElasticsearchDocumentStore(api_key_id="YOUR_CLOUD_ID", api_key="YOUR_API_KEY")
     ```
 
     Usage example (self-hosted Elasticsearch instance):
@@ -258,10 +257,8 @@ class ElasticsearchDocumentStore:
             hosts=self._hosts,
             custom_mapping=self._custom_mapping,
             index=self._index,
-            api_key=self._api_key.to_dict() if self._api_key and not isinstance(self._api_key, TokenSecret) else None,
-            api_key_id=self._api_key_id.to_dict()
-            if self._api_key_id and not isinstance(self._api_key, TokenSecret)
-            else None,
+            api_key=self._api_key.to_dict(),
+            api_key_id=self._api_key_id.to_dict(),
             embedding_similarity_function=self._embedding_similarity_function,
             **self._kwargs,
         )
@@ -276,7 +273,7 @@ class ElasticsearchDocumentStore:
         :returns:
             Deserialized component.
         """
-        deserialize_secrets_inplace(data, keys=["ELASTIC_API_KEY", "ELASTIC_API_KEY_ID"])
+        deserialize_secrets_inplace(data, keys=["api_key", "api_key_id"])
         return default_from_dict(cls, data)
 
     def count_documents(self) -> int:

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -203,7 +203,7 @@ class ElasticsearchDocumentStore:
 
         """
 
-        api_key: Optional[Union[str, Tuple[str, str]]] = None  # make the type checker happy
+        api_key: Optional[Union[str, Tuple[str, str]]]  # make the type checker happy
 
         api_key_resolved = self._api_key.resolve_value()
         api_key_id_resolved = self._api_key_id.resolve_value()

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -65,8 +65,8 @@ class ElasticsearchDocumentStore:
         hosts: Optional[Hosts] = None,
         custom_mapping: Optional[Dict[str, Any]] = None,
         index: str = "default",
-        api_key: Secret = Secret.from_env_var("ELASTICSEARCH_API_KEY"),  # noqa: B008
-        api_key_id: Secret = Secret.from_env_var("ELASTICSEARCH_API_KEY_ID"),  # noqa: B008
+        api_key: Optional[Secret] = None,
+        api_key_id: Optional[Secret] = None,
         embedding_similarity_function: Literal["cosine", "dot_product", "l2_norm", "max_inner_product"] = "cosine",
         **kwargs: Any,
     ):
@@ -127,9 +127,11 @@ class ElasticsearchDocumentStore:
             if self.api_key_id and self.api_key:
                 api_key_id_resolved = self.api_key_id.resolve_value()
                 api_key_resolved = self.api_key.resolve_value()
+                """
                 if not api_key_id_resolved or not api_key_resolved:
                     msg = "api_key_id and api_key must be non-empty strings."
                     raise ValueError(msg)
+                """
                 api_key = (api_key_id_resolved, api_key_resolved)
 
             # a base64-encoded string that encodes both id and secret (separated by “:”)

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -215,8 +215,7 @@ class ElasticsearchDocumentStore:
 
         # Scenario 2: only api_key is set, must be a base64-encoded string that encodes id and secret (separated by “:”)
         elif api_key_resolved and not api_key_id_resolved:
-            api_key = self._api_key.resolve_value()
-            return api_key
+            return api_key_resolved
 
         # Error: only api_key_id is found, raise an error
         elif api_key_id_resolved and not api_key_resolved:

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -193,7 +193,7 @@ class ElasticsearchDocumentStore:
         3) There's no authentication, neither api_key nor api_key_id are provided as a Secret nor defined as
            environment variables. In this case, the client will connect without authentication.
 
-        returns:
+        :returns:
             api_key: Optional[Union[str, Tuple[str, str]]]
 
         """

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -87,13 +87,8 @@ class ElasticsearchDocumentStore:
         For the full list of supported kwargs, see the official Elasticsearch
         [reference](https://elasticsearch-py.readthedocs.io/en/stable/api.html#module-elasticsearch)
 
-        Authentication can be provided in 2 ways. As environment variables, both ELASTIC_API_KEY_ID and ELASTIC_API_KEY
-        must be defined or alternatively, only ELASTIC_API_KEY needs to be defined, containing a base64-encoded string
-        that encodes both id and secret (separated by “:”).
-
-        Alternatively, authentication can be provided as a Secret. The api_key_id and api_key parameters are
-        provided as a Secret, or only api_key is provided as a Secret, which is a base64-encoded string that encodes
-        both id and secret (separated by “:”).
+        Authentication is provided via Secret objects, which by default are loaded from environment variables. 
+        You can either provide both `api_key_id` and `api_key`, or just `api_key` containing a base64-encoded string of `id:secret`. Secret instances can also be loaded from a token using the `Secret.from_token()` method.
 
         :param hosts: List of hosts running the Elasticsearch client.
         :param custom_mapping: Custom mapping for the index. If not provided, a default mapping will be used.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -127,11 +127,9 @@ class ElasticsearchDocumentStore:
             if self.api_key_id and self.api_key:
                 api_key_id_resolved = self.api_key_id.resolve_value()
                 api_key_resolved = self.api_key.resolve_value()
-                """
                 if not api_key_id_resolved or not api_key_resolved:
                     msg = "api_key_id and api_key must be non-empty strings."
                     raise ValueError(msg)
-                """
                 api_key = (api_key_id_resolved, api_key_resolved)
 
             # a base64-encoded string that encodes both id and secret (separated by “:”)

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -65,8 +65,8 @@ class ElasticsearchDocumentStore:
         hosts: Optional[Hosts] = None,
         custom_mapping: Optional[Dict[str, Any]] = None,
         index: str = "default",
-        api_key: Secret = Secret.from_env_var("ELASTICSEARCH_API_KEY"), # noqa: B008
-        api_key_id: Secret = Secret.from_env_var("ELASTICSEARCH_API_KEY_ID"),   # noqa: B008
+        api_key: Secret = Secret.from_env_var("ELASTICSEARCH_API_KEY"),  # noqa: B008
+        api_key_id: Secret = Secret.from_env_var("ELASTICSEARCH_API_KEY_ID"),  # noqa: B008
         embedding_similarity_function: Literal["cosine", "dot_product", "l2_norm", "max_inner_product"] = "cosine",
         **kwargs: Any,
     ):

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -131,7 +131,7 @@ class ElasticsearchDocumentStore:
             headers = self._kwargs.pop("headers", {})
             headers["user-agent"] = f"haystack-py-ds/{haystack_version}"
 
-            api_key = self.handle_auth()
+            api_key = self._handle_auth()
 
             # Initialize both sync and async clients
             self._client = Elasticsearch(
@@ -182,7 +182,7 @@ class ElasticsearchDocumentStore:
 
             self._initialized = True
 
-    def handle_auth(self) -> Optional[Union[str, Tuple[str, str]]]:
+    def _handle_auth(self) -> Optional[Union[str, Tuple[str, str]]]:
         """
         Handles authentication for the Elasticsearch client.
 

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -184,12 +184,11 @@ class ElasticsearchDocumentStore:
 
         There are three possible scenarios.
 
-        1) As an environment variables. Both ELASTIC_API_KEY_ID and ELASTIC_API_KEY must be defined, alternatively
-         only ELASTIC_API_KEY can be defined, which is a base64-encoded string that encodes both the id and secret.
-         They can be provided as Secret, the api_key_id and api_key parameters are provided as a Secret.
+        1) Authentication with both api_key and api_key_id, either as Secrets or as environment variables. In this case,
+           use both for authentication.
 
-        2) If only api_key_id is provided, either as a Secret or as an environment variable, fail since api_key_id
-           alone is not enough for authentication.
+        2) Authentication with only api_key, either as a Secret or as an environment variable. In this case, the api_key
+           must be a base64-encoded string that encodes both id and secret <id:secret>.
 
         3) There's no authentication, neither api_key nor api_key_id are provided as a Secret nor defined as
            environment variables. In this case, the client will connect without authentication.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -41,7 +41,10 @@ class ElasticsearchDocumentStore:
     Usage example (Elastic Cloud):
     ```python
     from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
-    document_store = ElasticsearchDocumentStore(api_key_id="YOUR_CLOUD_ID", api_key="YOUR_API_KEY")
+    document_store = ElasticsearchDocumentStore(
+        api_key_id=Secret.from_env_var("ELASTIC_API_KEY_ID", strict=False),
+        api_key=Secret.from_env_var("ELASTIC_API_KEY", strict=False),
+    )
     ```
 
     Usage example (self-hosted Elasticsearch instance):

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Mapping
-from typing import Any, Dict, List, Literal, Optional, Union, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 from elastic_transport import NodeConfig

--- a/integrations/elasticsearch/tests/test_bm25_retriever.py
+++ b/integrations/elasticsearch/tests/test_bm25_retriever.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import Mock, patch
 
 import pytest
@@ -38,6 +39,8 @@ def test_to_dict(_mock_elasticsearch_client):
             "document_store": {
                 "init_parameters": {
                     "hosts": "some fake host",
+                    'api_key': None,
+                    'api_key_id': None,
                     "custom_mapping": None,
                     "index": "default",
                     "embedding_similarity_function": "cosine",

--- a/integrations/elasticsearch/tests/test_bm25_retriever.py
+++ b/integrations/elasticsearch/tests/test_bm25_retriever.py
@@ -39,8 +39,20 @@ def test_to_dict(_mock_elasticsearch_client):
             "document_store": {
                 "init_parameters": {
                     "hosts": "some fake host",
-                    "api_key": None,
-                    "api_key_id": None,
+                    "api_key": {
+                        "env_vars": [
+                            "ELASTIC_API_KEY",
+                        ],
+                        "strict": False,
+                        "type": "env_var",
+                    },
+                    "api_key_id": {
+                        "env_vars": [
+                            "ELASTIC_API_KEY_ID",
+                        ],
+                        "strict": False,
+                        "type": "env_var",
+                    },
                     "custom_mapping": None,
                     "index": "default",
                     "embedding_similarity_function": "cosine",

--- a/integrations/elasticsearch/tests/test_bm25_retriever.py
+++ b/integrations/elasticsearch/tests/test_bm25_retriever.py
@@ -39,8 +39,8 @@ def test_to_dict(_mock_elasticsearch_client):
             "document_store": {
                 "init_parameters": {
                     "hosts": "some fake host",
-                    'api_key': None,
-                    'api_key_id': None,
+                    "api_key": None,
+                    "api_key_id": None,
                     "custom_mapping": None,
                     "index": "default",
                     "embedding_similarity_function": "cosine",

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -13,8 +13,11 @@ from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import DocumentStoreBaseTests
+from haystack.utils import Secret
 
 from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
+
+from haystack.utils.auth import TokenSecret
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
@@ -64,6 +67,8 @@ def test_from_dict(_mock_elasticsearch_client):
             "hosts": "some hosts",
             "custom_mapping": None,
             "index": "default",
+            "api_key": None,
+            "api_key_id": None,
             "embedding_similarity_function": "cosine",
         },
     }
@@ -71,7 +76,158 @@ def test_from_dict(_mock_elasticsearch_client):
     assert document_store._hosts == "some hosts"
     assert document_store._index == "default"
     assert document_store._custom_mapping is None
+    assert document_store.api_key is None
+    assert document_store.api_key_id is None
     assert document_store._embedding_similarity_function == "cosine"
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_to_dict_with_api_keys_env_vars(_mock_elasticsearch_client, monkeypatch):
+    monkeypatch.setenv("ELASTIC_API_KEY", "test-api-key")
+    monkeypatch.setenv("ELASTIC_API_KEY_ID", "test-api-key-id")
+    document_store = ElasticsearchDocumentStore(hosts="https://localhost:9200")
+    document_store.client()
+    res = document_store.to_dict()
+    assert res["init_parameters"]["api_key"] == {
+        'type': 'env_var', 'env_vars': ['ELASTIC_API_KEY'], 'strict': False
+    }
+    assert res["init_parameters"]["api_key_id"] == {
+        'type': 'env_var', 'env_vars': ['ELASTIC_API_KEY_ID'], 'strict': False
+    }
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_to_dict_with_api_keys_as_secret(_mock_elasticsearch_client, monkeypatch):
+    monkeypatch.setenv("ELASTIC_API_KEY", "test-api-key")
+    monkeypatch.setenv("ELASTIC_API_KEY_ID", "test-api-key-id")
+    document_store = ElasticsearchDocumentStore(
+        hosts="https://localhost:9200",
+        api_key=TokenSecret(_token="test-api-key"),
+        api_key_id=TokenSecret(_token="test-api-key-id")
+    )
+    document_store.client()
+    res = document_store.to_dict()
+    assert res["init_parameters"]["api_key"] is None
+    assert res["init_parameters"]["api_key_id"] is None
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_from_dict_with_api_keys_env_vars(_mock_elasticsearch_client):
+    api_key_dict = {'type': 'env_var', 'env_vars': ['ELASTIC_API_KEY'], 'strict': False}
+    api_key_id_dict = {'type': 'env_var', 'env_vars': ['ELASTIC_API_KEY_ID'], 'strict': False}
+
+    data = {
+        "type": "haystack_integrations.document_stores.elasticsearch.document_store.ElasticsearchDocumentStore",
+        "init_parameters": {
+            "hosts": "some hosts",
+            "custom_mapping": None,
+            "index": "default",
+            "api_key": api_key_dict,
+            "api_key_id": api_key_id_dict,
+            "embedding_similarity_function": "cosine",
+        },
+    }
+
+    document_store = ElasticsearchDocumentStore.from_dict(data)
+    assert document_store.api_key == "test_api_key"
+    assert document_store.api_key_id == "test_api_key_id"
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_api_key_validation_only_api_key(_mock_elasticsearch_client):
+    """Test that only api_key can be provided without api_key_id."""
+    api_key = Secret.from_token("test_api_key")
+
+    document_store = ElasticsearchDocumentStore(hosts="testhost", api_key=api_key)
+    document_store.client()
+    assert document_store.api_key == api_key
+    assert document_store.api_key_id is None
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_api_key_validation_only_api_key_id_raises_error(_mock_elasticsearch_client):
+    """Test that providing only api_key_id without api_key raises ValueError."""
+    api_key_id = Secret.from_token("test_api_key_id")
+
+    with pytest.raises(ValueError, match="api_key_id is provided but api_key is missing"):
+        es = ElasticsearchDocumentStore(hosts="testhost", api_key_id=api_key_id)
+        es.client()
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_api_key_validation_empty_strings_raise_error(_mock_elasticsearch_client):
+    """Test that empty strings for api_key and api_key_id raise ValueError."""
+    api_key = Secret.from_token("")
+    api_key_id = Secret.from_token("")
+
+    with pytest.raises(ValueError, match="api_key_id and api_key must be non-empty strings"):
+        ElasticsearchDocumentStore(hosts="testhost", api_key=api_key, api_key_id=api_key_id)
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_api_key_validation_one_empty_string_raises_error(_mock_elasticsearch_client):
+    api_key = Secret.from_token("")
+    api_key_id = Secret.from_token("valid_id")
+
+    with pytest.raises(ValueError, match="api_key_id and api_key must be non-empty strings"):
+        ElasticsearchDocumentStore(hosts="testhost", api_key=api_key, api_key_id=api_key_id)
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.AsyncElasticsearch")
+def test_client_initialization_with_api_key_tuple(_mock_async_es, _mock_es):
+    """Test that api_key is passed as tuple when both api_key_id and api_key are provided."""
+    api_key = Secret.from_token("test_api_key")
+    api_key_id = Secret.from_token("test_api_key_id")
+
+    # Mock the client.info() call to avoid actual connection
+    mock_client = Mock()
+    mock_client.info.return_value = {"version": {"number": "8.0.0"}}
+    _mock_es.return_value = mock_client
+
+    document_store = ElasticsearchDocumentStore(hosts="testhost", api_key=api_key, api_key_id=api_key_id)
+
+    # Access client to trigger initialization
+    _ = document_store.client
+
+    # Check that Elasticsearch was called with the correct api_key tuple
+    _mock_es.assert_called_once()
+    call_args = _mock_es.call_args
+    assert call_args[0][0] == "testhost"  # hosts
+    assert call_args[1]["api_key"] == ("test_api_key_id", "test_api_key")
+
+    # Check that AsyncElasticsearch was called with the same api_key tuple
+    _mock_async_es.assert_called_once()
+    async_call_args = _mock_async_es.call_args
+    assert async_call_args[0][0] == "testhost"  # hosts
+    assert async_call_args[1]["api_key"] == ("test_api_key_id", "test_api_key")
+
+
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.AsyncElasticsearch")
+def test_client_initialization_with_api_key_string(_mock_async_es, _mock_es):
+    """Test that api_key is passed as string when only api_key is provided."""
+    api_key = Secret.from_token("test_api_key")
+
+    # Mock the client.info() call to avoid actual connection
+    mock_client = Mock()
+    mock_client.info.return_value = {"version": {"number": "8.0.0"}}
+    _mock_es.return_value = mock_client
+
+    document_store = ElasticsearchDocumentStore(hosts="testhost", api_key=api_key)
+
+    # Access client to trigger initialization
+    _ = document_store.client
+
+    # Check that Elasticsearch was called with the correct api_key string
+    _mock_es.assert_called_once()
+    call_args = _mock_es.call_args
+    assert call_args[0][0] == "testhost"  # hosts
+    assert call_args[1]["api_key"] == "test_api_key"
+
+    # Check that AsyncElasticsearch was called with the same api_key string
+    _mock_async_es.assert_called_once()
+    async_call_args = _mock_async_es.call_args
+    assert async_call_args[0][0] == "testhost"  # hosts
+    assert async_call_args[1]["api_key"] == "test_api_key"
 
 
 @pytest.mark.integration

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -111,15 +111,14 @@ def test_to_dict_with_api_keys_env_vars(_mock_elasticsearch_client, monkeypatch)
 def test_to_dict_with_api_keys_as_secret(_mock_elasticsearch_client, monkeypatch):
     monkeypatch.setenv("ELASTIC_API_KEY", "test-api-key")
     monkeypatch.setenv("ELASTIC_API_KEY_ID", "test-api-key-id")
-    document_store = ElasticsearchDocumentStore(
-        hosts="https://localhost:9200",
-        api_key=TokenSecret(_token="test-api-key"),
-        api_key_id=TokenSecret(_token="test-api-key-id"),
-    )
-    document_store.client()
-    res = document_store.to_dict()
-    assert res["init_parameters"]["api_key"] is None
-    assert res["init_parameters"]["api_key_id"] is None
+    with pytest.raises(ValueError):
+        document_store = ElasticsearchDocumentStore(
+            hosts="https://localhost:9200",
+            api_key=TokenSecret(_token="test-api-key"),
+            api_key_id=TokenSecret(_token="test-api-key-id"),
+        )
+        document_store.client()
+        _ = document_store.to_dict()
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -48,8 +48,20 @@ def test_to_dict(_mock_elasticsearch_client):
     assert res == {
         "type": "haystack_integrations.document_stores.elasticsearch.document_store.ElasticsearchDocumentStore",
         "init_parameters": {
-            "api_key": None,
-            "api_key_id": None,
+            "api_key": {
+                "env_vars": [
+                    "ELASTIC_API_KEY",
+                ],
+                "strict": False,
+                "type": "env_var",
+            },
+            "api_key_id": {
+                "env_vars": [
+                    "ELASTIC_API_KEY_ID",
+                ],
+                "strict": False,
+                "type": "env_var",
+            },
             "hosts": "some hosts",
             "custom_mapping": None,
             "index": "default",
@@ -136,7 +148,8 @@ def test_api_key_validation_only_api_key(_mock_elasticsearch_client):
     document_store = ElasticsearchDocumentStore(hosts="https://localhost:9200", api_key=api_key)
     document_store.client()
     assert document_store._api_key == api_key
-    assert document_store._api_key_id is None
+    # not passing the api_key_id makes it default to reading from env var
+    assert document_store._api_key_id == Secret.from_env_var("ELASTIC_API_KEY_ID", strict=False)
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -75,8 +75,8 @@ def test_from_dict(_mock_elasticsearch_client):
     assert document_store._hosts == "some hosts"
     assert document_store._index == "default"
     assert document_store._custom_mapping is None
-    assert document_store.api_key is None
-    assert document_store.api_key_id is None
+    assert document_store._api_key is None
+    assert document_store._api_key_id is None
     assert document_store._embedding_similarity_function == "cosine"
 
 
@@ -125,8 +125,8 @@ def test_from_dict_with_api_keys_env_vars(_mock_elasticsearch_client):
     }
 
     document_store = ElasticsearchDocumentStore.from_dict(data)
-    assert document_store.api_key == {"type": "env_var", "env_vars": ["ELASTIC_API_KEY"], "strict": False}
-    assert document_store.api_key_id == {"type": "env_var", "env_vars": ["ELASTIC_API_KEY_ID"], "strict": False}
+    assert document_store._api_key == {"type": "env_var", "env_vars": ["ELASTIC_API_KEY"], "strict": False}
+    assert document_store._api_key_id == {"type": "env_var", "env_vars": ["ELASTIC_API_KEY_ID"], "strict": False}
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
@@ -135,8 +135,8 @@ def test_api_key_validation_only_api_key(_mock_elasticsearch_client):
 
     document_store = ElasticsearchDocumentStore(hosts="https://localhost:9200", api_key=api_key)
     document_store.client()
-    assert document_store.api_key == api_key
-    assert document_store.api_key_id is None
+    assert document_store._api_key == api_key
+    assert document_store._api_key_id is None
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
@@ -179,7 +179,6 @@ def test_client_initialization_with_api_key_tuple(_mock_async_es, _mock_es):
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.AsyncElasticsearch")
 def test_client_initialization_with_api_key_string(_mock_async_es, _mock_es):
-    """Test that api_key is passed as string when only api_key is provided."""
     api_key = Secret.from_token("test_api_key")
 
     # Mock the client.info() call to avoid actual connection

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -167,13 +167,13 @@ def test_client_initialization_with_api_key_tuple(_mock_async_es, _mock_es):
     _mock_es.assert_called_once()
     call_args = _mock_es.call_args
     assert call_args[0][0] == "https://localhost:9200"  # hosts
-    assert call_args[1]["api_key"] == ("test_api_key", "test_api_key_id")
+    assert call_args[1]["api_key"] == ("test_api_key_id", "test_api_key")
 
     # Check that AsyncElasticsearch was called with the same api_key tuple
     _mock_async_es.assert_called_once()
     async_call_args = _mock_async_es.call_args
     assert async_call_args[0][0] == "https://localhost:9200"  # hosts
-    assert async_call_args[1]["api_key"] == ("test_api_key", "test_api_key_id")
+    assert async_call_args[1]["api_key"] == ("test_api_key_id", "test_api_key")
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -46,6 +46,8 @@ def test_to_dict(_mock_elasticsearch_client):
     assert res == {
         "type": "haystack_integrations.document_stores.elasticsearch.document_store.ElasticsearchDocumentStore",
         "init_parameters": {
+            "api_key": None,
+            "api_key_id": None,
             "hosts": "some hosts",
             "custom_mapping": None,
             "index": "default",

--- a/integrations/elasticsearch/tests/test_embedding_retriever.py
+++ b/integrations/elasticsearch/tests/test_embedding_retriever.py
@@ -37,6 +37,8 @@ def test_to_dict(_mock_elasticsearch_client):
         "init_parameters": {
             "document_store": {
                 "init_parameters": {
+                    "api_key": None,
+                    "api_key_id": None,
                     "hosts": "some fake host",
                     "custom_mapping": None,
                     "index": "default",

--- a/integrations/elasticsearch/tests/test_embedding_retriever.py
+++ b/integrations/elasticsearch/tests/test_embedding_retriever.py
@@ -37,8 +37,20 @@ def test_to_dict(_mock_elasticsearch_client):
         "init_parameters": {
             "document_store": {
                 "init_parameters": {
-                    "api_key": None,
-                    "api_key_id": None,
+                    "api_key": {
+                        "env_vars": [
+                            "ELASTIC_API_KEY",
+                        ],
+                        "strict": False,
+                        "type": "env_var",
+                    },
+                    "api_key_id": {
+                        "env_vars": [
+                            "ELASTIC_API_KEY_ID",
+                        ],
+                        "strict": False,
+                        "type": "env_var",
+                    },
                     "hosts": "some fake host",
                     "custom_mapping": None,
                     "index": "default",


### PR DESCRIPTION
### Related Issues

- fixes #2245 

### Proposed Changes:

- Adds API token authentication support to the `ElasticsearchDocumentStore` 
- Supports multiple authentication methods:
   - Environment Variables: Support for ELASTIC_API_KEY and ELASTIC_API_KEY_ID environment variables
   - Secret Objects: Direct parameter support for api_key and api_key_id as Secret objects
   - Base64 Encoded Keys: Support for single base64-encoded API keys containing both ID and secret
   - No Authentication: Graceful fallback to unauthenticated connections when no credentials are provided

### How did you test it?

- unit tests and manual verification
- tested Serialization and Deserialization with env vars
- tes auth with SecretToken string
- test with single API key validation
- error handling, when only API_ID is given and no API_TOKEN


### Notes for the reviewer

- I did test connecting to locally Docker ES setup with auth. We can add it as an integration test, but this involves setting up an ES docker instance and generating API_ID and API_TOKEN on the fly and passing those to the tests. Happy to discuss wether we should setup this or not.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
