### PR TITLE
fix: Update OpenRouterChatGenerator to work with `haystack-ai>=2.18.0`

### DIFF
--- a/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
+++ b/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
@@ -199,5 +199,5 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             **openai_tools,
             "extra_body": {**generation_kwargs},
             "extra_headers": {**extra_headers},
-            "openai_endpoint": "create"
+            "openai_endpoint": "create",
         }


### PR DESCRIPTION
### Related Issues

- fixes failing CI

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

- Update the `_prepare_api_call` to include `openai_endpoint="create"` to preserve previous behavior. We will use issue https://github.com/deepset-ai/haystack/issues/9761 to determine we should also support the `parse` endpoint.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
