### PR TITLE
fix: make `MCPInvocationError` compatible with `haystack-ai>=2.18.0`

### DIFF
--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.8.0",
-    "haystack-ai>=2.13.0",
+    "haystack-ai>=2.18.0",
     "exceptiongroup",  # Backport of ExceptionGroup for Python < 3.11
     "httpx"  # HTTP client library used for SSE connections
 ]

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -193,8 +193,7 @@ class MCPInvocationError(ToolInvocationError):
         :param tool_name: Name of the tool that was being invoked
         :param tool_args: Arguments that were passed to the tool
         """
-        super().__init__(message)
-        self.tool_name = tool_name
+        super().__init__(message=message, tool_name=tool_name)
         self.tool_args = tool_args or {}
 
 


### PR DESCRIPTION
### Related Issues
- type errors: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/17931910943/job/50990651428
- in https://github.com/deepset-ai/haystack/pull/9774, `ToolInvocationError` was changed and is now incompatible with `MCPInvocationError`


### Proposed Changes:
- adapt `MCPInvocationError`
- pin `haystack-ai>=2.18.0` (I don't particularly like to pin the new version of Haystack, but haven't found backward compatible solutions)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
