### PR TITLE
ci: Try using nohup to serve ollama

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -46,7 +46,7 @@ jobs:
           max_attempts: 3
           command: |
             curl -fsSL https://ollama.com/install.sh | sh
-            ollama serve &
+            nohup ollama serve > ollama.log 2>&1 &
 
             # Check if the service is up and running with a timeout of 60 seconds
             timeout=60


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Use `nohup` when serving ollama to increase stability of tests.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
