### PR TITLE
test: Replace deprecated `gemini-1.5` model with `gemini-2.0-flash` in Google GenAI test

### DIFF
--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -972,7 +972,7 @@ class TestGoogleGenAIChatGenerator:
         """
         Integration test to verify that thinking configuration fails fast with unsupported models.
         """
-        # gemini-1.5-pro-latest is known to not support thinking
+        # gemini-2.0-flash is known to not support thinking
         chat_messages = [ChatMessage.from_user("Why is the sky blue?")]
         component = GoogleGenAIChatGenerator(model="gemini-2.0-flash", generation_kwargs={"thinking_budget": 1024})
 
@@ -1080,7 +1080,7 @@ class TestAsyncGoogleGenAIChatGenerator:
         """
         # Use a model that does NOT support thinking features
         chat_messages = [ChatMessage.from_user("Why is the sky blue?")]
-        component = GoogleGenAIChatGenerator(model="gemini-1.5-pro-latest", generation_kwargs={"thinking_budget": 1024})
+        component = GoogleGenAIChatGenerator(model="gemini-2.0-flash", generation_kwargs={"thinking_budget": 1024})
 
         # The call should raise a RuntimeError with a helpful message
         with pytest.raises(RuntimeError) as exc_info:
@@ -1089,7 +1089,7 @@ class TestAsyncGoogleGenAIChatGenerator:
         # Verify the error message is helpful and mentions thinking configuration
         error_message = str(exc_info.value)
         assert "Thinking configuration error" in error_message
-        assert "gemini-1.5-pro" in error_message
+        assert "gemini-2.0" in error_message
         assert "thinking_budget" in error_message or "thinking features" in error_message
         assert "Try removing" in error_message or "use a different model" in error_message
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The `gemini-1.5` models have been deprecated (more details [here](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions)). So we update tests to use `gemini-2.0-flash`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
