### PR TITLE
fix: Update default model to `gemini-2.0-flash` in `GoogleAIGeminiChatGenerator`

### DIFF
--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -87,7 +87,7 @@ class GoogleAIGeminiChatGenerator:
     from haystack_integrations.components.generators.google_ai import GoogleAIGeminiChatGenerator
 
 
-    gemini_chat = GoogleAIGeminiChatGenerator(model="gemini-1.5-flash", api_key=Secret.from_token("<MY_API_KEY>"))
+    gemini_chat = GoogleAIGeminiChatGenerator(model="gemini-2.0-flash", api_key=Secret.from_token("<MY_API_KEY>"))
 
     messages = [ChatMessage.from_user("What is the most interesting thing you know?")]
     res = gemini_chat.run(messages=messages)
@@ -145,7 +145,7 @@ class GoogleAIGeminiChatGenerator:
         self,
         *,
         api_key: Secret = Secret.from_env_var("GOOGLE_API_KEY"),  # noqa: B008
-        model: str = "gemini-1.5-flash",
+        model: str = "gemini-2.0-flash",
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
         safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
         tools: Optional[List[Tool]] = None,

--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -105,7 +105,7 @@ class TestGoogleAIGeminiChatGenerator:
                 tools=tools,
             )
         mock_genai_configure.assert_called_once_with(api_key="test")
-        assert gemini._model_name == "gemini-1.5-flash"
+        assert gemini._model_name == "gemini-2.0-flash"
         assert gemini._generation_config == generation_config
         assert gemini._safety_settings == safety_settings
         assert gemini._tools == tools
@@ -120,7 +120,7 @@ class TestGoogleAIGeminiChatGenerator:
             "type": TYPE,
             "init_parameters": {
                 "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.0-flash",
                 "generation_config": None,
                 "safety_settings": None,
                 "streaming_callback": None,
@@ -161,7 +161,7 @@ class TestGoogleAIGeminiChatGenerator:
             "type": TYPE,
             "init_parameters": {
                 "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.0-flash",
                 "generation_config": {
                     "temperature": 0.5,
                     "top_p": 0.5,
@@ -212,7 +212,7 @@ class TestGoogleAIGeminiChatGenerator:
                     "type": TYPE,
                     "init_parameters": {
                         "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                        "model": "gemini-1.5-flash",
+                        "model": "gemini-2.0-flash",
                         "generation_config": None,
                         "safety_settings": None,
                         "streaming_callback": None,
@@ -221,7 +221,7 @@ class TestGoogleAIGeminiChatGenerator:
                 }
             )
 
-        assert gemini._model_name == "gemini-1.5-flash"
+        assert gemini._model_name == "gemini-2.0-flash"
         assert gemini._generation_config is None
         assert gemini._safety_settings is None
         assert gemini._tools is None
@@ -236,7 +236,7 @@ class TestGoogleAIGeminiChatGenerator:
                     "type": TYPE,
                     "init_parameters": {
                         "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                        "model": "gemini-1.5-flash",
+                        "model": "gemini-2.0-flash",
                         "generation_config": {
                             "temperature": 0.5,
                             "top_p": 0.5,
@@ -262,7 +262,7 @@ class TestGoogleAIGeminiChatGenerator:
                 }
             )
 
-        assert gemini._model_name == "gemini-1.5-flash"
+        assert gemini._model_name == "gemini-2.0-flash"
         assert gemini._generation_config == GenerationConfig(
             candidate_count=1,
             stop_sequences=["stop"],
@@ -286,7 +286,7 @@ class TestGoogleAIGeminiChatGenerator:
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
 
         generator = GoogleAIGeminiChatGenerator(
-            model="gemini-1.5-flash",
+            model="gemini-2.0-flash",
             generation_config=GenerationConfig(
                 temperature=0.6,
                 stop_sequences=["stop", "words"],
@@ -308,7 +308,7 @@ class TestGoogleAIGeminiChatGenerator:
                     "type": TYPE,
                     "init_parameters": {
                         "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                        "model": "gemini-1.5-flash",
+                        "model": "gemini-2.0-flash",
                         "generation_config": {
                             "temperature": 0.6,
                             "stop_sequences": ["stop", "words"],


### PR DESCRIPTION
### Related Issues

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->


The `gemini-1.5` models have been deprecated (more details [here](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions)). So we update the default model to be `gemini-2.0-flash` for the `GoogleAIGeminiChatGenerator` and update the tests to use the new model.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated existing tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
