### PR TITLE
feat: `S3Downloader` - add configurable suffix to `S3Storage`

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/common/s3/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/common/s3/utils.py
@@ -24,6 +24,7 @@ class S3Storage:
         s3_bucket: str,
         session: Session,
         s3_prefix: Optional[str] = None,
+        s3_suffix: Optional[str] = None,
         endpoint_url: Optional[str] = None,
         config: Optional[Config] = None,
     ) -> None:
@@ -33,16 +34,18 @@ class S3Storage:
         :param s3_bucket: The name of the S3 bucket to download files from.
         :param session: The session to use for the S3 client.
         :param s3_prefix: The optional prefix of the files in the S3 bucket.
-        Can be used to specify folder or naming structure.
+            Can be used to specify folder or naming structure.
             For example, if the file is in the folder "folder/subfolder/file.txt",
             the s3_prefix should be "folder/subfolder/". If the file is in the root of the S3 bucket,
             the s3_prefix should be None.
+        :param s3_suffix: The optional suffix of the files in the S3 bucket.
         :param endpoint_url: The endpoint URL of the S3 bucket to download files from.
         :param config: The configuration to use for the S3 client.
         """
 
         self.s3_bucket = s3_bucket
         self.s3_prefix = s3_prefix
+        self.s3_suffix = s3_suffix
         self.endpoint_url = endpoint_url
         self.session = session
         self.config = config
@@ -65,10 +68,7 @@ class S3Storage:
         or the file cannot be downloaded.
         """
 
-        if self.s3_prefix:
-            s3_key = f"{self.s3_prefix}{key}"
-        else:
-            s3_key = key
+        s3_key = f"{self.s3_prefix or ''}{key}{self.s3_suffix or ''}"
 
         try:
             self._client.download_file(self.s3_bucket, s3_key, str(local_file_path))
@@ -110,10 +110,12 @@ class S3Storage:
             )
             raise ValueError(msg)
         s3_prefix = os.getenv("S3_DOWNLOADER_PREFIX") or None
+        s3_suffix = os.getenv("S3_DOWNLOADER_SUFFIX") or None
         endpoint_url = os.getenv("AWS_ENDPOINT_URL") or None
         return cls(
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
+            s3_suffix=s3_suffix,
             endpoint_url=endpoint_url,
             session=session,
             config=config,

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -163,9 +163,9 @@ class TestS3Downloader:
         not os.environ.get("S3_DOWNLOADER_BUCKET", None),
         reason="Export an env var called `S3_DOWNLOADER_BUCKET` containing the S3 bucket to run this test.",
     )
-    def test_live_run(self, tmp_path):
+    def test_live_run(self, tmp_path, monkeypatch):
         d = S3Downloader(file_root_path=str(tmp_path))
-        os.environ["S3_DOWNLOADER_PREFIX"] = ""
+        monkeypatch.setenv("S3_DOWNLOADER_PREFIX", "")
         S3Downloader.warm_up(d)
 
         docs = [
@@ -200,9 +200,9 @@ class TestS3Downloader:
         not os.environ.get("S3_DOWNLOADER_BUCKET", None),
         reason="Export an env var called `S3_DOWNLOADER_BUCKET` containing the S3 bucket to run this test.",
     )
-    def test_live_run_with_custom_meta_key(self, tmp_path):
+    def test_live_run_with_custom_meta_key(self, tmp_path, monkeypatch):
         d = S3Downloader(file_root_path=str(tmp_path), file_name_meta_key="custom_name")
-        os.environ["S3_DOWNLOADER_PREFIX"] = ""
+        monkeypatch.setenv("S3_DOWNLOADER_PREFIX", "")
         S3Downloader.warm_up(d)
         docs = [
             Document(meta={"custom_name": "text-sample.txt"}),
@@ -216,9 +216,9 @@ class TestS3Downloader:
         not os.environ.get("S3_DOWNLOADER_BUCKET", None),
         reason="Export an env var called `S3_DOWNLOADER_BUCKET` containing the S3 bucket to run this test.",
     )
-    def test_live_run_with_prefix(self, tmp_path):
+    def test_live_run_with_prefix(self, tmp_path, monkeypatch):
         d = S3Downloader(file_root_path=str(tmp_path))
-        os.environ["S3_DOWNLOADER_PREFIX"] = "subfolder/"
+        monkeypatch.setenv("S3_DOWNLOADER_PREFIX", "subfolder/")
 
         S3Downloader.warm_up(d)
         docs = [
@@ -227,3 +227,19 @@ class TestS3Downloader:
         out = d.run(documents=docs)
         assert len(out["documents"]) == 1
         assert out["documents"][0].meta["file_name"] == "employees.json"
+
+    @pytest.mark.integration
+    @pytest.mark.skipif(
+        not os.environ.get("S3_DOWNLOADER_BUCKET", None),
+        reason="Export an env var called `S3_DOWNLOADER_BUCKET` containing the S3 bucket to run this test.",
+    )
+    def test_live_run_with_suffix(self, tmp_path, monkeypatch):
+        d = S3Downloader(file_root_path=str(tmp_path))
+        monkeypatch.setenv("S3_DOWNLOADER_SUFFIX", ".txt")
+        S3Downloader.warm_up(d)
+        docs = [
+            Document(meta={"file_name": "text-sample"}),
+        ]
+        out = d.run(documents=docs)
+        assert len(out["documents"]) == 1
+        assert out["documents"][0].meta["file_name"] == "text-sample"


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
