### PR TITLE
fix: move from gemini-1.5-flash to gemini-2.5-flash

### DIFF
--- a/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
+++ b/integrations/google_ai/tests/generators/chat/test_chat_gemini.py
@@ -105,7 +105,7 @@ class TestGoogleAIGeminiChatGenerator:
                 tools=tools,
             )
         mock_genai_configure.assert_called_once_with(api_key="test")
-        assert gemini._model_name == "gemini-2.0-flash"
+        assert gemini._model_name == "gemini-2.5-flash"
         assert gemini._generation_config == generation_config
         assert gemini._safety_settings == safety_settings
         assert gemini._tools == tools
@@ -120,7 +120,7 @@ class TestGoogleAIGeminiChatGenerator:
             "type": TYPE,
             "init_parameters": {
                 "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "gemini-2.0-flash",
+                "model": "gemini-2.5-flash",
                 "generation_config": None,
                 "safety_settings": None,
                 "streaming_callback": None,
@@ -161,7 +161,7 @@ class TestGoogleAIGeminiChatGenerator:
             "type": TYPE,
             "init_parameters": {
                 "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "gemini-2.0-flash",
+                "model": "gemini-2.5-flash",
                 "generation_config": {
                     "temperature": 0.5,
                     "top_p": 0.5,
@@ -212,7 +212,7 @@ class TestGoogleAIGeminiChatGenerator:
                     "type": TYPE,
                     "init_parameters": {
                         "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                        "model": "gemini-2.0-flash",
+                        "model": "gemini-2.5-flash",
                         "generation_config": None,
                         "safety_settings": None,
                         "streaming_callback": None,
@@ -221,7 +221,7 @@ class TestGoogleAIGeminiChatGenerator:
                 }
             )
 
-        assert gemini._model_name == "gemini-2.0-flash"
+        assert gemini._model_name == "gemini-2.5-flash"
         assert gemini._generation_config is None
         assert gemini._safety_settings is None
         assert gemini._tools is None
@@ -236,7 +236,7 @@ class TestGoogleAIGeminiChatGenerator:
                     "type": TYPE,
                     "init_parameters": {
                         "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                        "model": "gemini-2.0-flash",
+                        "model": "gemini-2.5-flash",
                         "generation_config": {
                             "temperature": 0.5,
                             "top_p": 0.5,
@@ -262,7 +262,7 @@ class TestGoogleAIGeminiChatGenerator:
                 }
             )
 
-        assert gemini._model_name == "gemini-2.0-flash"
+        assert gemini._model_name == "gemini-2.5-flash"
         assert gemini._generation_config == GenerationConfig(
             candidate_count=1,
             stop_sequences=["stop"],
@@ -286,7 +286,7 @@ class TestGoogleAIGeminiChatGenerator:
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
 
         generator = GoogleAIGeminiChatGenerator(
-            model="gemini-2.0-flash",
+            model="gemini-2.5-flash",
             generation_config=GenerationConfig(
                 temperature=0.6,
                 stop_sequences=["stop", "words"],
@@ -308,7 +308,7 @@ class TestGoogleAIGeminiChatGenerator:
                     "type": TYPE,
                     "init_parameters": {
                         "api_key": {"env_vars": ["GOOGLE_API_KEY"], "strict": True, "type": "env_var"},
-                        "model": "gemini-2.0-flash",
+                        "model": "gemini-2.5-flash",
                         "generation_config": {
                             "temperature": 0.6,
                             "stop_sequences": ["stop", "words"],

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -143,7 +143,7 @@ class VertexAIGeminiChatGenerator:
     def __init__(
         self,
         *,
-        model: str = "gemini-1.5-flash",
+        model: str = "gemini-2.5-flash",
         project_id: Optional[str] = None,
         location: Optional[str] = None,
         generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,

--- a/integrations/google_vertex/tests/chat/test_gemini.py
+++ b/integrations/google_vertex/tests/chat/test_gemini.py
@@ -113,7 +113,7 @@ class TestVertexAIGeminiChatGenerator:
             tool_config=tool_config,
         )
         mock_vertexai_init.assert_called()
-        assert gemini._model_name == "gemini-1.5-flash"
+        assert gemini._model_name == "gemini-2.5-flash"
         assert gemini._generation_config == generation_config
         assert gemini._safety_settings == safety_settings
         assert gemini._tools == tools
@@ -126,7 +126,7 @@ class TestVertexAIGeminiChatGenerator:
         assert gemini.to_dict() == {
             "type": "haystack_integrations.components.generators.google_vertex.chat.gemini.VertexAIGeminiChatGenerator",
             "init_parameters": {
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.5-flash",
                 "project_id": None,
                 "location": None,
                 "generation_config": None,
@@ -171,7 +171,7 @@ class TestVertexAIGeminiChatGenerator:
         expected_dict = {
             "type": "haystack_integrations.components.generators.google_vertex.chat.gemini.VertexAIGeminiChatGenerator",
             "init_parameters": {
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.5-flash",
                 "project_id": "TestID123",
                 "location": "TestLocation",
                 "generation_config": {
@@ -225,7 +225,7 @@ class TestVertexAIGeminiChatGenerator:
                 ),
                 "init_parameters": {
                     "project_id": None,
-                    "model": "gemini-1.5-flash",
+                    "model": "gemini-2.5-flash",
                     "generation_config": None,
                     "safety_settings": None,
                     "tools": None,
@@ -234,7 +234,7 @@ class TestVertexAIGeminiChatGenerator:
             }
         )
 
-        assert gemini._model_name == "gemini-1.5-flash"
+        assert gemini._model_name == "gemini-2.5-flash"
         assert gemini._project_id is None
         assert gemini._safety_settings is None
         assert gemini._tools is None
@@ -254,7 +254,7 @@ class TestVertexAIGeminiChatGenerator:
                 "init_parameters": {
                     "project_id": "TestID123",
                     "location": "TestLocation",
-                    "model": "gemini-1.5-flash",
+                    "model": "gemini-2.5-flash",
                     "generation_config": {
                         "temperature": 0.5,
                         "top_p": 0.5,
@@ -288,7 +288,7 @@ class TestVertexAIGeminiChatGenerator:
             }
         )
 
-        assert gemini._model_name == "gemini-1.5-flash"
+        assert gemini._model_name == "gemini-2.5-flash"
         assert gemini._project_id == "TestID123"
         assert gemini._location == "TestLocation"
         assert gemini._safety_settings == {
@@ -666,7 +666,7 @@ class TestVertexAIGeminiChatGenerator:
 
         generator = VertexAIGeminiChatGenerator(
             project_id="TestID123",
-            model="gemini-1.5-flash",
+            model="gemini-2.5-flash",
             generation_config=GenerationConfig(
                 temperature=0.6,
                 stop_sequences=["stop", "words"],
@@ -690,7 +690,7 @@ class TestVertexAIGeminiChatGenerator:
                     ),
                     "init_parameters": {
                         "project_id": "TestID123",
-                        "model": "gemini-1.5-flash",
+                        "model": "gemini-2.5-flash",
                         "generation_config": {
                             "temperature": 0.6,
                             "stop_sequences": ["stop", "words"],


### PR DESCRIPTION
### Related Issues

- fixes #

### Proposed Changes:

Remove deprecated [gemini-1.5-flash](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/1-5-flash) mode and make use of [gemini-2.5-flash](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash) in Google AI and Google Vertex integrations.

### How did you test it?
Run the test suite and validate against `gemini-2.5-flash` model.

### Notes for the reviewer

Didn't have a Google API key. Do you think it should still be fine without that?

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
