### PR TITLE
chore: Add Agent pipeline deserialization test

### DIFF
--- a/integrations/mcp/tests/test_mcp_toolset.py
+++ b/integrations/mcp/tests/test_mcp_toolset.py
@@ -7,9 +7,13 @@ import tempfile
 import time
 from unittest.mock import patch
 
+import haystack
+from haystack.dataclasses import ChatMessage
 import pytest
 import pytest_asyncio
 from haystack import logging
+from haystack.core.errors import DeserializationError
+from haystack.core.pipeline import Pipeline
 from haystack.tools import Tool
 
 from haystack_integrations.tools.mcp import MCPToolset
@@ -413,3 +417,79 @@ if __name__ == "__main__":
             # Remove the temporary file
             if os.path.exists(server_script_path):
                 os.remove(server_script_path)
+
+    def test_pipeline_deserialization_fails_without_github_token(self, monkeypatch):
+        """
+        Test that pipeline deserialization + MCPToolset initialization fails when GitHub token is not resolved during deserialization.
+
+        The issue:
+        - Setup: Agent pipeline template with MCPToolset with a token from env var (PERSONAL_ACCESS_TOKEN_GITHUB)
+        - MCPToolset tries to connect immediately during __init__ after validation
+        - Secrets get resolved during validation, after MCPToolset is initialized
+        - Connection fails because token can't be resolved in __init__
+        - Pipeline deserialization fails with DeserializationError
+
+        This test demonstrates why we need warmup for MCPToolset on first use rather than during deserialization.
+        """
+        pipeline_yaml = """
+components:
+  agent:
+    init_parameters:
+      chat_generator:
+        init_parameters:
+          api_base_url:
+          api_key:
+            env_vars:
+            - OPENAI_API_KEY
+            strict: false
+            type: env_var
+          generation_kwargs: {}
+          max_retries:
+          model: gpt-4o
+          organization:
+          streaming_callback:
+          timeout:
+          tools:
+          tools_strict: false
+        type: haystack.components.generators.chat.openai.OpenAIChatGenerator
+      exit_conditions:
+      - text
+      max_agent_steps: 100
+      raise_on_tool_invocation_failure: false
+      state_schema: {}
+      streaming_callback:
+      system_prompt: |-
+        You are an assistant that summarizes latest issues and PRs on a github repository that happened within a certain time frame (e.g. last day or last week). Make sure that you always use the current date as a basis for the time frame. Iterate over issues and PRs where necessary to get a comprehensive overview.
+      tools:
+        data:
+          server_info:
+            type: haystack_integrations.tools.mcp.mcp_tool.StreamableHttpServerInfo
+            url: https://api.githubcopilot.com/mcp/
+            token:
+              env_vars:
+              - PERSONAL_ACCESS_TOKEN_GITHUB
+              strict: true
+              type: env_var
+            timeout: 10
+          tool_names: [get_issue, get_issue_comments, get_latest_release, get_pull_request, get_pull_request_review_comments, get_pull_request_reviews, list_issues, list_pull_requests, list_releases, search_issues, search_pull_requests]
+        type: haystack_integrations.tools.mcp.MCPToolset
+    type: haystack.components.agents.agent.Agent
+
+connections: []
+"""
+        monkeypatch.setenv("PERSONAL_ACCESS_TOKEN_GITHUB", "SOME_OBVIOUSLY_INVALID_TOKEN")
+        # Attempt to deserialize the pipeline - this will fail because MCPToolset
+        # tries to connect immediately and the token isn't available
+        with pytest.raises(haystack.core.errors.DeserializationError):
+            pipe = Pipeline.loads(pipeline_yaml)
+            pipe.run(
+                data={
+                    "agent": {
+                        "messages": [
+                            ChatMessage.from_user(
+                                text="Get comments on https://github.com/deepset-ai/haystack/pull/9849"
+                            )
+                        ]
+                    }
+                }
+            )


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/9807

### Proposed Changes:
Demo how MCPTool/set connect on init and they should delay connect to first tool use/warm_up stage to allow pipelines to set all the required secrets 
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
