### PR TITLE
test: Pinecone - relax flaky test

### DIFF
--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -276,7 +276,7 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, WriteDocumentsT
         query_embedding = [0.1] * 768
         most_similar_embedding = [0.8] * 768
         second_best_embedding = [0.8] * 700 + [0.1] * 3 + [0.2] * 65
-        another_embedding = np.random.rand(768).tolist()
+        another_embedding = [0.1] * 384 + [-0.1] * 384
 
         docs = [
             Document(content="Most similar document", embedding=most_similar_embedding),
@@ -287,9 +287,11 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, WriteDocumentsT
         document_store.write_documents(docs)
 
         results = document_store._embedding_retrieval(query_embedding=query_embedding, top_k=2, filters={})
+
         assert len(results) == 2
-        assert results[0].content == "Most similar document"
-        assert results[1].content == "2nd best document"
+        # Pinecone does not seem to guarantee the order of the results
+        assert "Most similar document" in [result.content for result in results]
+        assert "2nd best document" in [result.content for result in results]
 
     def test_close(self, document_store: PineconeDocumentStore):
         document_store._initialize_index()

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -70,7 +70,7 @@ class TestDocumentStoreAsync:
         query_embedding = [0.1] * 768
         most_similar_embedding = [0.8] * 768
         second_best_embedding = [0.8] * 700 + [0.1] * 3 + [0.2] * 65
-        another_embedding = np.random.rand(768).tolist()
+        another_embedding = [-0.1] * 384 + [0.1] * 384
 
         docs = [
             Document(content="Most similar document", embedding=most_similar_embedding),
@@ -83,9 +83,12 @@ class TestDocumentStoreAsync:
         results = await document_store_async._embedding_retrieval_async(
             query_embedding=query_embedding, top_k=2, filters={}
         )
+
         assert len(results) == 2
-        assert results[0].content == "Most similar document"
-        assert results[1].content == "2nd best document"
+
+        # Pinecone does not seem to guarantee the order of the results
+        assert "Most similar document" in [result.content for result in results]
+        assert "2nd best document" in [result.content for result in results]
 
     async def test_close(self, document_store_async: PineconeDocumentStore):
         await document_store_async._initialize_async_index()


### PR DESCRIPTION
### Related Issues

These tests have been failing repeatedly: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/18266359971/job/52001249975

I tried a lot with different combinations of vectors but I realized that while the best vectors are returned, order is not guaranteed ([Pinecone forum](https://community.pinecone.io/t/pinecone-return-results-consistency/5389/2))

### Proposed Changes:
- relax the test to only check that the correct docs are returned (not the order)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
