### PR TITLE
feat: allow `OpenSearch` embedders to query a different `DocumentStore` at runtime

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -154,14 +154,15 @@ class OpenSearchEmbeddingRetriever:
         top_k: Optional[int] = None,
         custom_query: Optional[Dict[str, Any]] = None,
         efficient_filtering: Optional[bool] = None,
+        document_store: Optional[OpenSearchDocumentStore] = None,
     ) -> Dict[str, List[Document]]:
         """
         Retrieve documents using a vector similarity metric.
 
         :param query_embedding: Embedding of the query.
         :param filters: Filters applied when fetching documents from the Document Store.
-            Filters are applied during the approximate kNN search to ensure the Retriever
-              returns `top_k` matching documents.
+            Filters are applied during the approximate kNN search to ensure the Retriever returns `top_k` matching
+            documents.
             The way runtime filters are applied depends on the `filter_policy` selected when initializing the Retriever.
         :param top_k: Maximum number of documents to return.
         :param custom_query: A custom OpenSearch query containing a mandatory `$query_embedding` and an
@@ -206,6 +207,7 @@ class OpenSearchEmbeddingRetriever:
 
         :param efficient_filtering: If `True`, the filter will be applied during the approximate kNN search.
             This is only supported for knn engines "faiss" and "lucene" and does not work with the default "nmslib".
+        :param document_store: Optional instance of OpenSearchDocumentStore to use with the Retriever.
 
         :returns:
             Dictionary with key "documents" containing the retrieved Documents.
@@ -224,8 +226,17 @@ class OpenSearchEmbeddingRetriever:
 
         docs: List[Document] = []
 
+        if document_store is not None:
+            if not isinstance(document_store, OpenSearchDocumentStore):
+                msg = "document_store must be an instance of OpenSearchDocumentStore"
+                raise ValueError(msg)
+            doc_store = document_store
+        else:
+            doc_store = self._document_store
+
+
         try:
-            docs = self._document_store._embedding_retrieval(
+            docs = doc_store._embedding_retrieval(
                 query_embedding=query_embedding,
                 filters=filters,
                 top_k=top_k,
@@ -253,6 +264,7 @@ class OpenSearchEmbeddingRetriever:
         top_k: Optional[int] = None,
         custom_query: Optional[Dict[str, Any]] = None,
         efficient_filtering: Optional[bool] = None,
+        document_store: Optional[OpenSearchDocumentStore] = None,
     ) -> Dict[str, List[Document]]:
         """
         Asynchronously retrieve documents using a vector similarity metric.
@@ -305,6 +317,7 @@ class OpenSearchEmbeddingRetriever:
 
         :param efficient_filtering: If `True`, the filter will be applied during the approximate kNN search.
             This is only supported for knn engines "faiss" and "lucene" and does not work with the default "nmslib".
+        :param document_store: Optional instance of OpenSearchDocumentStore to use with the Retriever.
 
         :returns:
             Dictionary with key "documents" containing the retrieved Documents.
@@ -323,8 +336,16 @@ class OpenSearchEmbeddingRetriever:
 
         docs: List[Document] = []
 
+        if document_store is not None:
+            if not isinstance(document_store, OpenSearchDocumentStore):
+                msg = "document_store must be an instance of OpenSearchDocumentStore"
+                raise ValueError(msg)
+            doc_store = document_store
+        else:
+            doc_store = self._document_store
+
         try:
-            docs = await self._document_store._embedding_retrieval_async(
+            docs = await doc_store._embedding_retrieval_async(
                 query_embedding=query_embedding,
                 filters=filters,
                 top_k=top_k,

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -87,7 +87,7 @@ class OpenSearchDocumentStore:
         Creates a new OpenSearchDocumentStore instance.
 
         The ``embeddings_dim``, ``method``, ``mappings``, and ``settings`` arguments are only used if the index does not
-        exists and needs to be created. If the index already exists, its current configurations will be used.
+        exist and needs to be created. If the index already exists, its current configurations will be used.
 
         For more information on connection parameters, see the [official OpenSearch documentation](https://opensearch.org/docs/latest/clients/python-low-level/#connecting-to-opensearch)
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
