### PR TITLE
ci: increase Ollama retry timeout to improve stability

### DIFF
--- a/.github/workflows/llama_stack.yml
+++ b/.github/workflows/llama_stack.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install and run Ollama Server as inference provider (needed for Llama Stack Server)
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 2
+          timeout_minutes: 4
           max_attempts: 3
           command: |
             curl -fsSL https://ollama.com/install.sh | sh

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install and run Ollama
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 2
+          timeout_minutes: 4
           max_attempts: 3
           command: |
             curl -fsSL https://ollama.com/install.sh | sh


### PR DESCRIPTION
### Related Issues

Lately, there have been several failures of `nick-fields/retry@v3` action. See for example https://github.com/deepset-ai/haystack-core-integrations/actions/runs/18481357645/job/52656519560

There's an open issue with this action: https://github.com/nick-fields/retry/issues/124

This action retries a command in case of failures (it works) and timeouts (it sometimes fails when trying to kill the child process).

While some users have created their own retry actions/scripts, I think that for the moment we can still use this action, acknowledging that it can be unreliable for timeouts. Our commands already implement their own timeout mechanisms.
I think it's worth keeping it because the retry mechanism works (and has been executed several times) when commands fail for reasons unrelated to `nick-fields/retry` timeouts.

### Proposed Changes:
- increase timeouts in `nick-fields/retry@v3` action action to make timeouts unlikely.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
