### PR TITLE
chore: Optimum - unpin torch

### DIFF
--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
   "sentence-transformers>=2.3",
   # tokenizers is a dependency of transformers/sentence-transformers. The following version is the first one which supports Python 3.13.
   "tokenizers>=0.20.2",
-  "torch<2.9.0",  # https://github.com/huggingface/optimum/issues/2374
-  ]
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/optimum#readme"


### PR DESCRIPTION
### Related Issues

This basically reverts #2392.

Compatibility with `torch==2.9.0` was added in https://github.com/huggingface/optimum-onnx/pull/82 and then released: https://github.com/huggingface/optimum-onnx/releases/tag/v0.0.2

### Proposed Changes:
- unpin `torch`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
