### PR TITLE
docs: fix docstrings to avoid errors in API reference generation

### DIFF
--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -118,15 +118,17 @@ class AzureAISearchDocumentStore:
 
             These fields are automatically added when creating the search index.
             Example:
-                metadata_fields={
-                    "Title": SearchField(
-                        name="Title",
-                        type="Edm.String",
-                        searchable=True,
-                        filterable=True
-                    ),
-                    "Pages": int
-                }
+            ```python
+            metadata_fields={
+                "Title": SearchField(
+                    name="Title",
+                    type="Edm.String",
+                    searchable=True,
+                    filterable=True
+                ),
+                "Pages": int
+            }
+            ```
         :param vector_search_configuration: Configuration option related to vector search.
             Default configuration uses the HNSW algorithm with cosine similarity to handle vector searches.
 

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
@@ -115,7 +115,7 @@ class GoogleGenAIDocumentEmbedder:
             Separator used to concatenate the metadata fields to the document text.
         :param config:
             A dictionary of keyword arguments to configure embedding content configuration `types.EmbedContentConfig`.
-            If not specified, it defaults to {"task_type": "SEMANTIC_SIMILARITY"}.
+            If not specified, it defaults to `{"task_type": "SEMANTIC_SIMILARITY"}`.
             For more information, see the [Google AI Task types](https://ai.google.dev/gemini-api/docs/embeddings#task-types).
         """
         self._api_key = api_key

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
@@ -104,7 +104,7 @@ class GoogleGenAITextEmbedder:
             A string to add at the end of each text to embed.
         :param config:
             A dictionary of keyword arguments to configure embedding content configuration `types.EmbedContentConfig`.
-            If not specified, it defaults to {"task_type": "SEMANTIC_SIMILARITY"}.
+            If not specified, it defaults to `{"task_type": "SEMANTIC_SIMILARITY"}`.
             For more information, see the [Google AI Task types](https://ai.google.dev/gemini-api/docs/embeddings#task-types).
         """
 

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -958,7 +958,7 @@ class MCPTool(Tool):
         active connection is not maintained.
 
         :returns: Dictionary with serialized data in the format:
-                  {"type": fully_qualified_class_name, "data": {parameters}}
+                  `{"type": fully_qualified_class_name, "data": {parameters}}`
         """
         serialized = {
             "name": self.name,

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -61,7 +61,7 @@ class NvidiaDocumentEmbedder:
             API key for the NVIDIA NIM.
         :param api_url:
             Custom API URL for the NVIDIA NIM.
-            Format for API URL is http://host:port
+            Format for API URL is `http://host:port`
         :param prefix:
             A string to add to the beginning of each text.
         :param suffix:

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -58,7 +58,7 @@ class NvidiaTextEmbedder:
             API key for the NVIDIA NIM.
         :param api_url:
             Custom API URL for the NVIDIA NIM.
-            Format for API URL is http://host:port
+            Format for API URL is `http://host:port`
         :param prefix:
             A string to add to the beginning of each text.
         :param suffix:

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -105,7 +105,7 @@ class OpenSearchDocumentStore:
             for more information. If None, it uses the embedding_dim and method arguments to create default mappings.
             Defaults to None
         :param settings: The settings of the index to be created. Please see the [official OpenSearch docs](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#index-settings)
-            for more information. Defaults to {"index.knn": True}
+            for more information. Defaults to `{"index.knn": True}`.
         :param create_index: Whether to create the index if it doesn't exist. Defaults to True
         :param http_auth: http_auth param passed to the underlying connection class.
             For basic authentication with default connection class `Urllib3HttpConnection` this can be


### PR DESCRIPTION
### Proposed Changes:
- fix docstrings to avoid errors in API reference generation with Docusaurus

### How did you test it?
I tried generating and serving docs with Docusaurus. After these fixes, it works correctly.\\

Test failure is unrelated.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
