### PR TITLE
fix: fix version validation to include underscores

### DIFF
--- a/.github/utils/validate_version.py
+++ b/.github/utils/validate_version.py
@@ -11,7 +11,6 @@ def validate_version_number(tag: str):
     """
 
     matches = re.match(INTEGRATION_VERSION_REGEX, tag)
-    print(f"Matches: {matches}")
     if not matches or len(matches.groups()) != 2:
         raise ValueError(f"Invalid tag: {tag}")
 


### PR DESCRIPTION
### Related Issues

Version validation erroneously faling: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/18688747697/job/53288510186

### Proposed Changes:
- incude underscores in valid version tags

### How did you test it?
Local test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
