### PR TITLE
feat: `MistralChatGenerator` update tools param to ToolsType

### DIFF
--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 from haystack import component, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
-from haystack.tools import ToolsType
+from haystack.tools import ToolsType, serialize_tools_or_toolset
 from haystack.utils import serialize_callable
 from haystack.utils.auth import Secret
 from openai.lib._pydantic import to_strict_json_schema
@@ -108,8 +108,8 @@ class MistralChatGenerator(OpenAIChatGenerator):
                 - For structured outputs with streaming,
                   the `response_format` must be a JSON schema and not a Pydantic model.
         :param tools:
-            A list of tools or a Toolset for which the model can prepare calls. This parameter can accept either a
-            list of `Tool` objects or a `Toolset` instance.
+            A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
+            Each tool should have a unique name.
         :param timeout:
             The timeout for the Mistral API call. If not set, it defaults to either the `OPENAI_TIMEOUT`
             environment variable, or 30 seconds.
@@ -190,7 +190,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
             api_base_url=self.api_base_url,
             generation_kwargs=generation_kwargs,
             api_key=self.api_key.to_dict(),
-            tools=[tool.to_dict() for tool in self.tools] if self.tools else None,
+            tools=serialize_tools_or_toolset(self.tools),
             timeout=self.timeout,
             max_retries=self.max_retries,
             http_client_kwargs=self.http_client_kwargs,

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -9,7 +9,7 @@ from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.components.tools import ToolInvoker
 from haystack.dataclasses import ChatMessage, ChatRole, ComponentInfo, StreamingChunk, ToolCall, ToolCallDelta
-from haystack.tools import Tool
+from haystack.tools import Tool, Toolset
 from haystack.utils.auth import Secret
 from openai import OpenAIError
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
@@ -47,6 +47,11 @@ def weather(city: str):
     return f"The weather in {city} is sunny and 32°C"
 
 
+def population(city: str):
+    """Get population for a given city."""
+    return f"The population of {city} is 2.1 million"
+
+
 @pytest.fixture
 def tools():
     tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
@@ -58,6 +63,25 @@ def tools():
     )
 
     return [tool]
+
+
+@pytest.fixture
+def mixed_tools():
+    """Fixture that returns a mixed list of Tool and Toolset."""
+    weather_tool = Tool(
+        name="weather",
+        description="useful to determine the weather in a given location",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        function=weather,
+    )
+    population_tool = Tool(
+        name="population",
+        description="useful to determine the population of a given location",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        function=population,
+    )
+    toolset = Toolset([population_tool])
+    return [weather_tool, toolset]
 
 
 @pytest.fixture
@@ -227,6 +251,27 @@ class TestMistralChatGenerator:
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
             MistralChatGenerator.from_dict(data)
+
+    def test_init_with_mixed_tools(self, monkeypatch):
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
+
+        weather_tool = Tool(
+            name="weather",
+            description="Weather lookup",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=weather,
+        )
+        population_tool = Tool(
+            name="population",
+            description="Population lookup",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=population,
+        )
+        toolset = Toolset([population_tool])
+
+        component = MistralChatGenerator(tools=[weather_tool, toolset])
+
+        assert component.tools == [weather_tool, toolset]
 
     def test_handle_stream_response(self):
         mistral_chunks = [
@@ -741,3 +786,48 @@ class TestMistralChatGenerator:
         assert loaded_generator.tools[0].name == generator.tools[0].name
         assert loaded_generator.tools[0].description == generator.tools[0].description
         assert loaded_generator.tools[0].parameters == generator.tools[0].parameters
+
+    @pytest.mark.skipif(
+        not os.environ.get("MISTRAL_API_KEY", None),
+        reason="Export an env var called MISTRAL_API_KEY containing the Mistral API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_with_mixed_tools(self, mixed_tools):
+        """
+        Integration test that verifies MistralChatGenerator works with mixed Tool and Toolset.
+        This tests that the LLM can correctly invoke tools from both a standalone Tool and a Toolset.
+        """
+        initial_messages = [
+            ChatMessage.from_user("What's the weather like in Paris and what is the population of Berlin?")
+        ]
+        component = MistralChatGenerator(tools=mixed_tools)
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) > 0, "No replies received"
+
+        # Find the message with tool calls
+        tool_call_message = None
+        for message in results["replies"]:
+            if message.tool_calls:
+                tool_call_message = message
+                break
+
+        assert tool_call_message is not None, "No message with tool call found"
+        assert isinstance(tool_call_message, ChatMessage), "Tool message is not a ChatMessage instance"
+        assert ChatMessage.is_from(tool_call_message, ChatRole.ASSISTANT), "Tool message is not from the assistant"
+
+        tool_calls = tool_call_message.tool_calls
+        assert len(tool_calls) == 2, f"Expected 2 tool calls, got {len(tool_calls)}"
+
+        # Verify we got calls to both weather and population tools
+        tool_names = {tc.tool_name for tc in tool_calls}
+        assert "weather" in tool_names, "Expected 'weather' tool call"
+        assert "population" in tool_names, "Expected 'population' tool call"
+
+        # Verify tool call details
+        for tool_call in tool_calls:
+            assert tool_call.id, "Tool call does not contain value for 'id' key"
+            assert tool_call.tool_name in ["weather", "population"]
+            assert "city" in tool_call.arguments
+            assert tool_call.arguments["city"] in ["Paris", "Berlin"]
+            assert tool_call_message.meta["finish_reason"] == "tool_calls"


### PR DESCRIPTION
## Why:
Adopts Haystack's `ToolsType` to enable flexible tool composition, developers can now mix individual `Tool` objects and `Toolset` instances in a single list

part of:
- https://github.com/deepset-ai/haystack-core-integrations/issues/2409

## What:
- Updated `tools` parameter from `Union[List[Tool], Toolset]` to `ToolsType` in constructor and all methods
- Replaced manual tool serialization with `serialize_tools_or_toolset()` utility
- Updated docstring to match pattern from other PRs
- Added tests for mixed tool collection initialization and request parameter formatting

## How can it be used:

```python
from haystack.tools import Tool, Toolset
from haystack_integrations.components.generators.mistral import MistralChatGenerator

weather_tool = Tool(name="weather", ...)
population_toolset = Toolset([...])

# NEW: Mix Tool and Toolset freely
generator = MistralChatGenerator(tools=[weather_tool, population_toolset])
```

## How did you test it:
- Unit tests verify mixed tool initialization and correct Mistral tool formatting
- Backward compatibility validated for existing patterns (list of tools, single toolset)
- Integration test `test_live_run_with_mixed_tools()` demonstrates end-to-end LLM tool invocation from mixed collections

## Notes for the reviewer:
- Centralizes tool normalization logic with `serialize_tools_or_toolset()`—eliminates duplicate handling code
- Fully backward compatible; no migration needed
- Added integration test `test_live_run_with_mixed_tools()` demonstrates end-to-end LLM tool invocation from mixed collections