### PR TITLE
docs: sync API reference updates with Docusaurus on integration releases

### DIFF
--- a/.github/workflows/CI_docusaurus_sync.yml
+++ b/.github/workflows/CI_docusaurus_sync.yml
@@ -1,8 +1,6 @@
 name: Core / Sync API reference with Docusaurus
 
 on:
-  # for testing purposes
-  pull_request:
   push:
     tags:
       - "**-v[0-9].[0-9]+.[0-9]+"
@@ -16,9 +14,7 @@ on:
         default: integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0
 
 env:
-  # TAG: ${{ inputs.tag || github.ref_name}}
-  # for testing purposes
-  TAG: integrations/qdrant-v1.0.0
+  TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   generate-api-reference:
@@ -122,4 +118,3 @@ jobs:
             docs-website
           body: |
             This PR syncs the Core Integrations API reference (${{ env.INTEGRATION_NAME }}) on Docusaurus. Just approve and merge it.
-          draft: true


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/132

### Proposed Changes:
- introduce a workflow to update API reference on Haystack when a new version of a core integration is released

### Design choices
- Use `peter-evans/create-pull-request` action which is robust and works well
- Follow recommendation in https://github.com/peter-evans/create-pull-request/issues/1304#issuecomment-1340249429
  - Create two separate jobs: one for API reference generation, the other one for creating a PR in Haystack. This works well because `peter-evans/create-pull-request` works on the repo corresponding to the preceding `actions/checkout`.
  - Use artifacts to temporarily store the generated markdown files. Artifacts are free for public repos.

### How did you test it?
Tested on this PR. Here is an example PR created: https://github.com/deepset-ai/haystack/pull/9917

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
