### PR TITLE
feat: `TogetherAIChatGenerator` update tools param to ToolsType

### DIFF
--- a/integrations/together_ai/pyproject.toml
+++ b/integrations/together_ai/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.17.1"]
+dependencies = ["haystack-ai>=2.19.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/together_ai#readme"

--- a/integrations/together_ai/src/haystack_integrations/components/generators/together_ai/chat/chat_generator.py
+++ b/integrations/together_ai/src/haystack_integrations/components/generators/together_ai/chat/chat_generator.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 from haystack import component, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import StreamingCallbackT
-from haystack.tools import Tool, Toolset
+from haystack.tools import ToolsType
 from haystack.utils import serialize_callable
 from haystack.utils.auth import Secret
 
@@ -64,7 +64,7 @@ class TogetherAIChatGenerator(OpenAIChatGenerator):
         streaming_callback: Optional[StreamingCallbackT] = None,
         api_base_url: Optional[str] = "https://api.together.xyz/v1",
         generation_kwargs: Optional[Dict[str, Any]] = None,
-        tools: Optional[Union[List[Tool], Toolset]] = None,
+        tools: Optional[ToolsType] = None,
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
         http_client_kwargs: Optional[Dict[str, Any]] = None,
@@ -99,8 +99,8 @@ class TogetherAIChatGenerator(OpenAIChatGenerator):
             - `safe_prompt`: Whether to inject a safety prompt before all conversations.
             - `random_seed`: The seed to use for random sampling.
         :param tools:
-            A list of tools or a Toolset for which the model can prepare calls. This parameter can accept either a
-            list of `Tool` objects or a `Toolset` instance.
+            A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
+            Each tool should have a unique name.
         :param timeout:
             The timeout for the Together AI API call.
         :param max_retries:

--- a/integrations/together_ai/tests/test_together_ai_chat_generator.py
+++ b/integrations/together_ai/tests/test_together_ai_chat_generator.py
@@ -8,7 +8,7 @@ from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.components.tools import ToolInvoker
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
-from haystack.tools import Tool
+from haystack.tools import Tool, Toolset
 from haystack.utils.auth import Secret
 from openai import OpenAIError
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
@@ -45,6 +45,11 @@ def weather(city: str):
     return f"The weather in {city} is sunny and 32°C"
 
 
+def population(city: str):
+    """Get population for a given city."""
+    return f"The population of {city} is 2.2 million"
+
+
 @pytest.fixture
 def tools():
     tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
@@ -56,6 +61,25 @@ def tools():
     )
 
     return [tool]
+
+
+@pytest.fixture
+def mixed_tools():
+    """Fixture that returns a mixed list of Tool and Toolset."""
+    weather_tool = Tool(
+        name="weather",
+        description="useful to determine the weather in a given location",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        function=weather,
+    )
+    population_tool = Tool(
+        name="population",
+        description="useful to determine the population of a given location",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        function=population,
+    )
+    toolset = Toolset([population_tool])
+    return [weather_tool, toolset]
 
 
 @pytest.fixture
@@ -528,6 +552,98 @@ class TestTogetherAIChatGenerator:
         assert loaded_generator.tools[0].name == generator.tools[0].name
         assert loaded_generator.tools[0].description == generator.tools[0].description
         assert loaded_generator.tools[0].parameters == generator.tools[0].parameters
+
+    def test_init_with_mixed_tools(self, monkeypatch):
+        """Test that TogetherAIChatGenerator can be initialized with mixed Tool and Toolset."""
+        monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
+
+        def tool_fn(city: str) -> str:
+            return city
+
+        weather_tool = Tool(
+            name="weather",
+            description="Weather lookup",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=tool_fn,
+        )
+        population_tool = Tool(
+            name="population",
+            description="Population lookup",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=tool_fn,
+        )
+        toolset = Toolset([population_tool])
+
+        generator = TogetherAIChatGenerator(
+            model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            tools=[weather_tool, toolset],
+        )
+
+        assert generator.tools == [weather_tool, toolset]
+
+    @pytest.mark.skipif(
+        not os.environ.get("TOGETHER_API_KEY", None),
+        reason="Export an env var called TOGETHER_API_KEY containing the Together AI API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_with_mixed_tools(self, mixed_tools):
+        """
+        Integration test that verifies TogetherAIChatGenerator works with mixed Tool and Toolset.
+        This tests that the LLM can correctly invoke tools from both a standalone Tool and a Toolset.
+        """
+        initial_messages = [
+            ChatMessage.from_user("What's the weather like in Paris and what is the population of Berlin?")
+        ]
+        component = TogetherAIChatGenerator(model="meta-llama/Llama-3.3-70B-Instruct-Turbo", tools=mixed_tools)
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) > 0, "No replies received"
+
+        # Find the message with tool calls
+        tool_call_message = None
+        for message in results["replies"]:
+            if message.tool_calls:
+                tool_call_message = message
+                break
+
+        assert tool_call_message is not None, "No message with tool call found"
+        assert isinstance(tool_call_message, ChatMessage), "Tool message is not a ChatMessage instance"
+        assert ChatMessage.is_from(tool_call_message, ChatRole.ASSISTANT), "Tool message is not from the assistant"
+
+        tool_calls = tool_call_message.tool_calls
+        assert len(tool_calls) == 2, f"Expected 2 tool calls, got {len(tool_calls)}"
+
+        # Verify we got calls to both weather and population tools
+        tool_names = {tc.tool_name for tc in tool_calls}
+        assert "weather" in tool_names, "Expected 'weather' tool call"
+        assert "population" in tool_names, "Expected 'population' tool call"
+
+        # Verify tool call details
+        for tool_call in tool_calls:
+            assert tool_call.id, "Tool call does not contain value for 'id' key"
+            assert tool_call.tool_name in ["weather", "population"]
+            assert "city" in tool_call.arguments
+            assert tool_call.arguments["city"] in ["Paris", "Berlin"]
+            assert tool_call_message.meta["finish_reason"] == "tool_calls"
+
+        # Mock the response we'd get from ToolInvoker
+        tool_result_messages = []
+        for tool_call in tool_calls:
+            if tool_call.tool_name == "weather":
+                result = "The weather in Paris is sunny and 32°C"
+            else:  # population
+                result = "The population of Berlin is 2.2 million"
+            tool_result_messages.append(ChatMessage.from_tool(tool_result=result, origin=tool_call))
+
+        new_messages = [*initial_messages, tool_call_message, *tool_result_messages]
+        results = component.run(new_messages)
+
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_call
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
+        assert "berlin" in final_message.text.lower()
 
 
 class TestChatCompletionChunkConversion:


### PR DESCRIPTION
## Why:
Adopts Haystack's `ToolsType` to enable flexible tool composition, developers can now mix individual `Tool` objects and `Toolset` instances in a single list

part of:
- https://github.com/deepset-ai/haystack-core-integrations/issues/2409

## What:
- Updated `tools` parameter from `Union[List[Tool], Toolset]` to `ToolsType` in constructor and all methods
- Replaced manual `isinstance(tools, Toolset)` checks with `flatten_tools_or_toolsets()` utility
- Haystack dependency to `2.19.0` for `ToolsType` support
- Added tests for mixed tool collection initialization and request parameter formatting

## How can it be used:

```python
from haystack.tools import Tool, Toolset
from haystack_integrations.components.generators.together_ai import TogetherAIChatGenerator

weather_tool = Tool(name="weather", ...)
population_toolset = Toolset([...])

# NEW: Mix Tool and Toolset freely
generator = TogetherAIChatGenerator(tools=[weather_tool, population_toolset])
```

## How did you test it:
- Unit tests verify mixed tool initialization and correct Together AI `toolConfig` formatting
- Backward compatibility validated for existing patterns (list of tools, single toolset)
- Integration test `test_live_run_with_mixed_tools()` demonstrates end-to-end LLM tool invocation from mixed collections

## Notes for the reviewer:
- Centralizes tool normalization logic with `flatten_tools_or_toolsets()`—eliminates duplicate handling code
- Fully backward compatible; no migration needed
- TogetherAIChatGenerator inherits from OpenAIChatGenerator, so it automatically benefits from the parent class's updated tool handling
- Added comprehensive test coverage for mixed tool scenarios specific to Together AI integration