### PR TITLE
feat: `LlamaCppChatGenerator` update tools param to ToolsType

### DIFF
--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.16.1", "llama-cpp-python>=0.2.87"]
+dependencies = ["haystack-ai>=2.19.0", "llama-cpp-python>=0.2.87"]
 
 # On macOS GitHub runners, we use a custom index to download pre-built wheels.
 # Installing from source might fail due to missing dependencies (CMake fails with "OpenMP not found")


### PR DESCRIPTION
## Why:
Adopts Haystack's `ToolsType` to enable flexible tool composition, developers can now mix individual `Tool` objects and `Toolset` instances in a single list

part of:
- https://github.com/deepset-ai/haystack-core-integrations/issues/2409

## What:
- Updated `tools` parameter from `Union[List[Tool], Toolset]` to `ToolsType` in constructor and all methods
- Replaced manual `isinstance(tools, Toolset)` checks with `flatten_tools_or_toolsets()` utility
- Haystack dependency to `2.19.0` for `ToolsType` support
- Added tests for mixed tool collection initialization and request parameter formatting

## How can it be used:

```python
from haystack.tools import Tool, Toolset
from haystack_integrations.components.generators.llama_cpp import LlamaCppChatGenerator

weather_tool = Tool(name="weather", ...)
population_toolset = Toolset([...])

# NEW: Mix Tool and Toolset freely
generator = LlamaCppChatGenerator(tools=[weather_tool, population_toolset])
```

## How did you test it:
- Unit tests verify mixed tool initialization and correct llama.cpp `tools` formatting
- Backward compatibility validated for existing patterns (list of tools, single toolset)

## Notes for the reviewer:
- Centralizes tool normalization logic with `flatten_tools_or_toolsets()`—eliminates duplicate handling code
- Fully backward compatible; no migration needed
- Added integration test `test_run_with_mixed_tools()` demonstrates end-to-end LLM tool invocation from mixed collections