### PR TITLE
fix: version validation script should replace underscores with hypens when looking for PyPI packages

### DIFF
--- a/.github/utils/validate_version.py
+++ b/.github/utils/validate_version.py
@@ -18,7 +18,8 @@ def validate_version_number(tag: str):
     print(f"Integration name: {integration_name}")
     print(f"Integration version to release: {version_to_release}")
 
-    integration_package = f"{integration_name}-haystack"
+    # Replace underscores with hyphens to look for the package on PyPi
+    integration_package = f"{integration_name.replace('_', '-')}-haystack"
     print(f"Integration PyPi package: {integration_package}")
 
     # connect to PyPi and check the latest version


### PR DESCRIPTION
### Related Issues
If the tag/folder name is `integrations/google_genai`, the corresponding PyPI package is `google-genai-haystack`.

PyPI is quite robust so it treats in an equivalent way:
- `google-genai-haystack`
- `google_genai_haystack`
- `google_genai-haystack`
- ...

But it's better to use the right name.

### Proposed Changes:
- replace underscores with hyphens when looking for PyPI packages

### How did you test it?
I ran the validation script locally

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
