### PR TITLE
docs: fix Docusaurus workflow

### DIFF
--- a/.github/workflows/CI_docusaurus_sync.yml
+++ b/.github/workflows/CI_docusaurus_sync.yml
@@ -98,9 +98,11 @@ jobs:
           shutil.copy(artifact_filename, "docs-website/reference/integrations-api/")
 
           # Copy to versioned API reference
-          for element in os.scandir("docs-website/reference_versioned_docs"):
-              if element.is_dir():
-                  shutil.copy(artifact_filename, element.path)
+          for version_dir in os.scandir("docs-website/reference_versioned_docs"):
+              if version_dir.is_dir():
+                  # example: docs-website/reference_versioned_docs/version-2.17/integrations-api
+                  integrations_api_ref_dir = os.path.join(version_dir.path, "integrations-api")
+                  shutil.copy(artifact_filename, integrations_api_ref_dir)
 
           os.remove(artifact_filename)
 


### PR DESCRIPTION
### Related Issues

With the previous version of the workflow, some files have been pushed to the wrong folder: https://github.com/deepset-ai/haystack/blob/main/docs-website/reference_versioned_docs/version-2.17/qdrant.md

### Proposed Changes:
- fix the wrong logic

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
