### PR TITLE
docs: fix `MistralOCRDocumentConverter` docstring

### DIFF
--- a/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
+++ b/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
@@ -202,7 +202,7 @@ class MistralOCRDocumentConverter:
                 - `content`: All pages joined with form feed (\\f) separators in markdown format.
                   When using bbox_annotation_schema, image tags will be enriched with your defined descriptions.
                 - `meta`: Aggregated metadata dictionary with structure:
-                  {"source_page_count": int, "source_total_images": int, "source_*": any}.
+                  `{"source_page_count": int, "source_total_images": int, "source_*": any}`.
                   If document_annotation_schema was provided, all annotation fields are unpacked
                   with 'source_' prefix (e.g., source_language, source_chapter_titles, source_urls).
             - `raw_mistral_response`:


### PR DESCRIPTION
### Related Issues

Failing Docusaurus build: "Could not parse expression with acorn"

### Proposed Changes:
- fix problematic docstring

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
