### PR TITLE
docs: add NvidiaChatGenerator to pydoc configs

### DIFF
--- a/integrations/nvidia/pydoc/config.yml
+++ b/integrations/nvidia/pydoc/config.yml
@@ -7,6 +7,7 @@ loaders:
         "haystack_integrations.components.embedders.nvidia.text_embedder",
         "haystack_integrations.components.embedders.nvidia.truncate",
         "haystack_integrations.components.generators.nvidia.generator",
+        "haystack_integrations.components.generators.nvidia.chat.chat_generator",
         "haystack_integrations.components.rankers.nvidia.ranker",
         "haystack_integrations.components.rankers.nvidia.truncate",
       ]

--- a/integrations/nvidia/pydoc/config_docusaurus.yml
+++ b/integrations/nvidia/pydoc/config_docusaurus.yml
@@ -6,6 +6,7 @@ loaders:
   - haystack_integrations.components.embedders.nvidia.text_embedder
   - haystack_integrations.components.embedders.nvidia.truncate
   - haystack_integrations.components.generators.nvidia.generator
+  - haystack_integrations.components.generators.nvidia.chat.chat_generator
   - haystack_integrations.components.rankers.nvidia.ranker
   - haystack_integrations.components.rankers.nvidia.truncate
   search_path:


### PR DESCRIPTION
### Related Issues
I noticed that this component is missing from pydocs config, so the API reference is not generated

### Proposed Changes:
- add `NvidiaChatGenerator` to pydoc configs

### How did you test it?
Locally generated API reference

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
