### PR TITLE
fix: Migration to recent Langfuse SDK

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -328,7 +328,7 @@ class DefaultSpanHandler(SpanHandler):
         if component_type in _SUPPORTED_GENERATORS:
             meta = span.get_data().get(_COMPONENT_OUTPUT_KEY, {}).get("meta")
             if meta:
-                span.raw_span().update(usage=meta[0].get("usage") or None, model=meta[0].get("model"))
+                span.raw_span().update(usage_details=meta[0].get("usage") or None, model=meta[0].get("model"))
 
         if component_type in _SUPPORTED_CHAT_GENERATORS:
             replies = span.get_data().get(_COMPONENT_OUTPUT_KEY, {}).get("replies")
@@ -342,7 +342,7 @@ class DefaultSpanHandler(SpanHandler):
                         logger.error(f"Failed to parse completion_start_time: {completion_start_time}")
                         completion_start_time = None
                 span.raw_span().update(
-                    usage=meta.get("usage") or None,
+                    usage_details=meta.get("usage") or None,
                     model=meta.get("model"),
                     completion_start_time=completion_start_time,
                 )


### PR DESCRIPTION
### Related Issues

- N/A

### Proposed Changes:

Bug description:
In DefaultSpanHandler.handle, the Langfuse span update call incorrectly used the parameter usage= instead of usage_details=, which is silently ignored for SPAN types in the Langfuse SDK. This caused token usage metrics to be dropped from Langfuse traces.

Fix implemented:
Replaced the incorrect usage= argument with the correct usage_details= when updating Langfuse spans for generator and chat generator components.

Langfuse@3.8.0

### How did you test it?

- unit tests
- manual verification

### Notes for the reviewer

https://python.reference.langfuse.com/langfuse

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I added unit tests and updated the docstrings (WIP)
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
