### PR TITLE
fix: update the API reference path for togetherai 

### DIFF
--- a/integrations/togetherai/pydoc/config.yml
+++ b/integrations/togetherai/pydoc/config.yml
@@ -19,7 +19,7 @@ renderer:
   excerpt: Together AI integration for Haystack
   category_slug: integrations-api
   title: Together AI
-  slug: integrations-together-ai
+  slug: integrations-togetherai
   order: 170
   markdown:
     descriptive_class_title: false


### PR DESCRIPTION
### Related Issues

- Minor inconsistency in path of togetherai integration (uses `together-ai` instead of `togetherai`)

### Proposed Changes:

 Update the config file

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
