### PR TITLE
chore!: Upgrade to minimum version of python 3.10

### DIFF
--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
 
     steps:
       - name: Support longpaths
@@ -50,11 +50,11 @@ jobs:
       - name: Install Hatch
         run: pip install --upgrade hatch
       - name: Lint
-        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
       - name: Generate docs
-        if: matrix.python-version == '3.9' && runner.os == 'Linux'
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run docs
 
       - name: Run tests

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -5,9 +5,9 @@ build-backend = "hatchling.build"
 [project]
 name = "deepeval-haystack"
 dynamic = ["version"]
-description = 'An integration of DeepEvla LLM evaluation framework with Haystack'
+description = 'An integration of DeepEval LLM evaluation framework with Haystack'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -77,7 +76,7 @@ module = ["deepeval.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any
 
 from haystack import DeserializationError, component, default_from_dict, default_to_dict
 
@@ -47,12 +48,12 @@ class DeepEvalEvaluator:
 
     _backend_metric: BaseMetric
     # Wrapped for easy mocking.
-    _backend_callable: Callable[[List[LLMTestCase], BaseMetric], EvaluationResult]
+    _backend_callable: Callable[[list[LLMTestCase], BaseMetric], EvaluationResult]
 
     def __init__(
         self,
-        metric: Union[str, DeepEvalMetric],
-        metric_params: Optional[Dict[str, Any]] = None,
+        metric: str | DeepEvalMetric,
+        metric_params: dict[str, Any] | None = None,
     ):
         """
         Construct a new DeepEval evaluator.
@@ -72,8 +73,8 @@ class DeepEvalEvaluator:
         expected_inputs = self.descriptor.input_parameters
         component.set_input_types(self, **expected_inputs)
 
-    @component.output_types(results=List[List[Dict[str, Any]]])
-    def run(self, **inputs: Any) -> Dict[str, Any]:
+    @component.output_types(results=list[list[dict[str, Any]]])
+    def run(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the DeepEval evaluator on the provided inputs.
 
@@ -91,7 +92,7 @@ class DeepEvalEvaluator:
             - `explanation` - An optional explanation of the score.
         """
         InputConverters.validate_input_parameters(self.metric, self.descriptor.input_parameters, inputs)
-        converted_inputs: List[LLMTestCase] = list(self.descriptor.input_converter(**inputs))  # type: ignore
+        converted_inputs: list[LLMTestCase] = list(self.descriptor.input_converter(**inputs))  # type: ignore
 
         results = self._backend_callable(converted_inputs, self._backend_metric)
         converted_results = [
@@ -100,7 +101,7 @@ class DeepEvalEvaluator:
 
         return {"results": converted_results}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -128,7 +129,7 @@ class DeepEvalEvaluator:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "DeepEvalEvaluator":
+    def from_dict(cls, data: dict[str, Any]) -> "DeepEvalEvaluator":
         """
         Deserializes the component from a dictionary.
 
@@ -140,7 +141,7 @@ class DeepEvalEvaluator:
         return default_from_dict(cls, data)
 
     @staticmethod
-    def _invoke_deepeval(test_cases: List[LLMTestCase], metric: BaseMetric) -> EvaluationResult:
+    def _invoke_deepeval(test_cases: list[LLMTestCase], metric: BaseMetric) -> EvaluationResult:
         return evaluate(test_cases=test_cases, metrics=[metric])
 
     def _init_backend(self):

--- a/integrations/deepeval/tests/test_evaluator.py
+++ b/integrations/deepeval/tests/test_evaluator.py
@@ -1,7 +1,6 @@
 import copy
 import os
 from dataclasses import dataclass
-from typing import Dict, Optional
 
 import pytest
 from deepeval.evaluate.types import EvaluationResult, TestResult
@@ -46,8 +45,8 @@ class Unserializable:
 @dataclass(frozen=True)
 class MockResult:
     score: float
-    reason: Optional[str] = None
-    score_breakdown: Optional[Dict[str, float]] = None
+    reason: str | None = None
+    score_breakdown: dict[str, float] | None = None
 
 
 # Only returns results for the passed metrics.
@@ -273,7 +272,7 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params, monk
     assert isinstance(results, type(expected_outputs))
     assert len(results) == len(expected_outputs)
 
-    for r, o in zip(results, expected_outputs):
+    for r, o in zip(results, expected_outputs, strict=True):
         assert len(r) == len(o)
 
         expected = {(name if name is not None else str(metric), score, exp) for name, score, exp in o}


### PR DESCRIPTION
### Related Issues

- fixes failing [tests](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/18859582873/job/53814956580) for deepeval integration 
- Failure was caused by a new release of deepeval introducing a python 3.10 dependency. Since python 3.9 EOL is this month I thought I'd take the opportunity to increase the min version of python to 3.10 for this integration

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
