### PR TITLE
docs: fix hanlp markdown filenames

### DIFF
--- a/integrations/hanlp/pydoc/config.yml
+++ b/integrations/hanlp/pydoc/config.yml
@@ -26,4 +26,4 @@ renderer:
     descriptive_module_title: true
     add_method_class_prefix: true
     add_member_class_prefix: false
-    filename: _readme_github.md
+    filename: _readme_hanlp.md

--- a/integrations/hanlp/pydoc/config_docusaurus.yml
+++ b/integrations/hanlp/pydoc/config_docusaurus.yml
@@ -23,6 +23,6 @@ renderer:
     classdef_code_block: false
     descriptive_class_title: false
     descriptive_module_title: true
-    filename: github.md
+    filename: hanlp.md
   title: HanLP
   type: haystack_pydoc_tools.renderers.DocusaurusRenderer


### PR DESCRIPTION
### Issues

- Hanlp API docs were overwriting the Github API docs with the same filename

### Proposed Changes:

- Fixing pydoc config for Hanlp integration to have its own filename
- Github pydoc config is correct and should remain the same

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
