### PR TITLE
chore: Upgrade langfuse dep, observation types require version>=3.3.1

### DIFF
--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.17.1", "langfuse>=3.3.0, <4.0.0"]
+dependencies = ["haystack-ai>=2.17.1", "langfuse>=3.3.1, <4.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"


### PR DESCRIPTION
To use observation types we need a slightly newer version of langfuse SDK. 
See https://langfuse.com/docs/observability/features/observation-types for more details