### PR TITLE
docs: update syntax in mcp docstrings

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -665,7 +665,7 @@ class SSEServerInfo(MCPServerInfo):
 
     :param url: Full URL of the MCP server (including /sse endpoint)
     :param base_url: Base URL of the MCP server (deprecated, use url instead)
-    :param token: Authentication token for the server (optional, generates "Authorization: Bearer {token}" header)
+    :param token: Authentication token for the server (optional, generates "Authorization: Bearer <token>" header)
     :param headers: Custom HTTP headers (optional, takes precedence over token parameter if provided)
     :param timeout: Connection timeout in seconds
     """
@@ -752,7 +752,7 @@ class StreamableHttpServerInfo(MCPServerInfo):
     ```
 
     :param url: Full URL of the MCP server (streamable HTTP endpoint)
-    :param token: Authentication token for the server (optional, generates "Authorization: Bearer {token}" header)
+    :param token: Authentication token for the server (optional, generates "Authorization: Bearer <token>" header)
     :param headers: Custom HTTP headers (optional, takes precedence over token parameter if provided)
     :param timeout: Connection timeout in seconds
     """


### PR DESCRIPTION
### Related Issues

- Failed deployment in https://github.com/deepset-ai/haystack/pull/10037 due to incorrect MDX syntax

### Proposed Changes:

- The curly braces of "token" were a problem for MDX parsing

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
