### PR TITLE
feat: Add Agent state-mapping parameters to MCPTool

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -925,11 +925,14 @@ class MCPTool(Tool):
         :param outputs_to_string: Optional dictionary defining how tool outputs should be converted into a string.
                                  If the source is provided only the specified output key is sent to the handler.
                                  If the source is omitted the whole tool result is sent to the handler.
+                                 Example: `{"source": "docs", "handler": my_custom_function}`
         :param inputs_from_state: Optional dictionary mapping state keys to tool parameter names.
                                  Example: `{"repository": "repo"}` maps state's "repository" to tool's "repo" parameter.
         :param outputs_to_state: Optional dictionary defining how tool outputs map to keys within state as well as
                                 optional handlers. If the source is provided only the specified output key is sent
                                 to the handler.
+                                Example with source: `{"documents": {"source": "docs", "handler": custom_handler}}`
+                                Example without source: `{"documents": {"handler": custom_handler}}`
         :raises MCPConnectionError: If connection to the server fails
         :raises MCPToolNotFoundError: If no tools are available or the requested tool is not found
         :raises TimeoutError: If connection times out

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -138,20 +138,31 @@ class TestMCPTool:
         server_info = InMemoryServerInfo(server=calculator_mcp._mcp_server)
 
         # Create tool with state-mapping parameters
+        # Map state key "state_a" to tool parameter "a"
         tool = MCPTool(
             name="add",
             server_info=server_info,
             eager_connect=False,
             outputs_to_string={"source": "result", "handler": str},
-            inputs_from_state={"filter": "query_filter"},
+            inputs_from_state={"state_a": "a"},
             outputs_to_state={"result": {"source": "output", "handler": str}},
         )
         mcp_tool_cleanup(tool)
 
         # Verify the parameters are stored correctly
         assert tool._outputs_to_string == {"source": "result", "handler": str}
-        assert tool._inputs_from_state == {"filter": "query_filter"}
+        assert tool._inputs_from_state == {"state_a": "a"}
         assert tool._outputs_to_state == {"result": {"source": "output", "handler": str}}
+
+        # Warm up the tool to trigger schema adjustment
+        tool.warm_up()
+
+        # Verify that "a" was removed from parameters since it's in inputs_from_state
+        assert "a" not in tool.parameters["properties"]
+        assert "a" not in tool.parameters.get("required", [])
+        # Verify that "b" is still present (not removed)
+        assert "b" in tool.parameters["properties"]
+        assert "b" in tool.parameters["required"]
 
     def test_mcp_tool_serde_with_state_mapping(self, mcp_tool_cleanup):
         """Test serialization and deserialization of MCPTool with state-mapping parameters."""
@@ -204,6 +215,57 @@ class TestMCPTool:
             user_input_msg = ChatMessage.from_user(text="What is the time in New York?")
             result = pipeline.run({"agent": {"messages": [user_input_msg]}})
             assert "New York" in result["agent"]["messages"][3].text
+        finally:
+            if tool:
+                tool.close()
+
+    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
+    @pytest.mark.integration
+    def test_agent_with_state_mapping(self):
+        """Test Agent with MCPTool using state-mapping to inject location from state."""
+
+        # Create MCPTool with state-mapping that injects home_city from state as timezone parameter
+        server_info = StdioServerInfo(command="uvx", args=["mcp-server-time", "--local-timezone=Europe/Berlin"])
+        tool = MCPTool(
+            name="get_current_time",
+            server_info=server_info,
+            inputs_from_state={"home_city": "timezone"},  # Inject home_city from state as timezone
+        )
+
+        try:
+            # Build Agent with state schema that includes home_city
+            agent = Agent(
+                chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+                tools=[tool],
+                state_schema={"home_city": {"type": str}},
+            )
+            pipeline = Pipeline()
+            pipeline.add_component("agent", agent)
+
+            # Ask for time without mentioning the location - it should use home_city from state
+            user_input_msg = ChatMessage.from_user(text="What time is it at home?")
+            result = pipeline.run(
+                {
+                    "agent": {
+                        "messages": [user_input_msg],
+                        "home_city": "America/New_York",  # Inject New York as home city
+                    }
+                }
+            )
+
+            # Verify the agent got the time for New York
+            final_message = result["agent"]["messages"][-1].text
+
+            # The response should mention time
+            assert any(keyword in final_message.lower() for keyword in ["time", "o'clock", "am", "pm"]), (
+                f"Expected time in response: {final_message}"
+            )
+
+            # Verify the response mentions New York or Eastern timezone (proving state-mapping injected it)
+            # The user never mentioned location, but timezone info should appear in the response
+            assert any(keyword in final_message for keyword in ["New York", "New_York"]), (
+                f"Expected timezone reference (New York) to confirm state-mapping: {final_message}"
+            )
         finally:
             if tool:
                 tool.close()


### PR DESCRIPTION
## Why:
Enables MCPTool to support Agent state-mapping parameters (`outputs_to_string`, `inputs_from_state`, `outputs_to_state`), allowing easy integration with Agent state for automatic parameter injection and output handling without requiring wrapper functions.

## What:
- Added three state-mapping parameters to `MCPTool.__init__` signature with proper type hints
- Implemented parameter storage and propagation to `Tool` superclass in both eager and lazy connection paths
- Added schema adjustment logic to remove `inputs_from_state` keys from parameters, matching `ComponentTool` behavior
- Extended serialization/deserialization in `to_dict`/`from_dict` to preserve state-mapping configuration
- Added two comprehensive tests: `test_mcp_tool_state_mapping_parameters` and `test_mcp_tool_serde_with_state_mapping`

## How can it be used:
```python
from haystack_integrations.tools.mcp import MCPTool, StreamableHttpServerInfo

# Before: Required wrapper function to use inputs_from_state
server_info = StreamableHttpServerInfo(url="http://localhost:1417/mcp")
mcp_tool = MCPTool(name="mcp_tool", server_info=server_info)

def rag_via_mcp(query: str, filter: dict) -> str:
    return mcp_tool.invoke(query=query, filter=filter)

get_latest_version_tool = Tool(
    name="get_latest_version",
    description="Get the latest Haystack version.",
    parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
    function=rag_via_mcp,
    inputs_from_state={"filter": "filter"}
)

# After: Direct MCPTool usage with state-mapping
mcp_tool = MCPTool(
    name="mcp_tool",
    server_info=StreamableHttpServerInfo(url="http://localhost:1417/mcp"),
    inputs_from_state={"filter": "filter"}  # Automatically inject 'filter' from Agent state
)

# Use directly in Agent
agent = Agent(tools=[mcp_tool], ...)
```

## How did you test it:
- Added `test_mcp_tool_state_mapping_parameters` to verify parameter initialization and storage
- Added `test_mcp_tool_serde_with_state_mapping` to validate serialization/deserialization preserves configuration
- Confirmed backward compatibility with existing MCPTool usage patterns

## Notes for the reviewer:
Pay attention to the schema adjustment logic in lines 985-991 (eager connect) and 1106-1112 (lazy connect via `warm_up`), which removes `inputs_from_state` keys from the JSON schema to match `ComponentTool` behavior. The state-mapping parameters are stored with underscore prefixes (`_outputs_to_string`, etc.) for serialization while being passed directly to the parent `Tool` class.