### PR TITLE
Add missing config file for Docusaurus sync

### DIFF
--- a/integrations/cometapi/pydoc/config_docusaurus.yml
+++ b/integrations/cometapi/pydoc/config_docusaurus.yml
@@ -1,0 +1,28 @@
+loaders:
+- ignore_when_discovered:
+  - __init__
+  modules:
+  - haystack_integrations.components.generators.cometapi.chat.chat_generator
+  search_path:
+  - ../src
+  type: haystack_pydoc_tools.loaders.CustomPythonLoader
+processors:
+- do_not_filter_modules: false
+  documented_only: true
+  expression: null
+  skip_empty_modules: true
+  type: filter
+- type: smart
+- type: crossref
+renderer:
+  description: Comet API integration for Haystack
+  id: integrations-cometapi
+  markdown:
+    add_member_class_prefix: false
+    add_method_class_prefix: true
+    classdef_code_block: false
+    descriptive_class_title: false
+    descriptive_module_title: true
+    filename: cometapi.md
+  title: Comet API
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer


### PR DESCRIPTION
As title, this simply adds the missing docs config file for Docusaurus sync (should fix [this](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/19260607520)).