### PR TITLE
enhancement: Adopt PEP 585 type hinting (part 4)

### DIFF
--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -81,7 +81,7 @@ typing = "mypy --install-types --non-interactive --explicit-package-bases {args:
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import google.generativeai as genai
 from google.ai.generativelanguage import Content, Part
@@ -146,9 +146,9 @@ class GoogleAIGeminiChatGenerator:
         *,
         api_key: Secret = Secret.from_env_var("GOOGLE_API_KEY"),  # noqa: B008
         model: str = "gemini-2.0-flash",
-        generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
-        safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
-        tools: Optional[List[Tool]] = None,
+        generation_config: Optional[Union[GenerationConfig, dict[str, Any]]] = None,
+        safety_settings: Optional[dict[HarmCategory, HarmBlockThreshold]] = None,
+        tools: Optional[list[Tool]] = None,
         tool_config: Optional[content_types.ToolConfigDict] = None,
         streaming_callback: Optional[StreamingCallbackT] = None,
     ):
@@ -192,7 +192,7 @@ class GoogleAIGeminiChatGenerator:
         self._model = GenerativeModel(self._model_name)
         self._streaming_callback = streaming_callback
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -218,7 +218,7 @@ class GoogleAIGeminiChatGenerator:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GoogleAIGeminiChatGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "GoogleAIGeminiChatGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -255,13 +255,13 @@ class GoogleAIGeminiChatGenerator:
 
         return FunctionDeclaration(name=tool.name, description=tool.description, parameters=parameters)
 
-    @component.output_types(replies=List[ChatMessage])
+    @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: List[ChatMessage],
+        messages: list[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
         *,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[list[Tool]] = None,
     ):
         """
         Generates text based on the provided messages.
@@ -308,13 +308,13 @@ class GoogleAIGeminiChatGenerator:
 
         return {"replies": replies}
 
-    @component.output_types(replies=List[ChatMessage])
+    @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: List[ChatMessage],
+        messages: list[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
         *,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[list[Tool]] = None,
     ):
         """
         Async version of the run method. Generates text based on the provided messages.
@@ -367,7 +367,7 @@ class GoogleAIGeminiChatGenerator:
     @staticmethod
     def _convert_response_to_messages(
         response_body: Union[GenerateContentResponse, AsyncGenerateContentResponse],
-    ) -> List[ChatMessage]:
+    ) -> list[ChatMessage]:
         """
         Converts the Google AI response to a list of `ChatMessage` instances.
 
@@ -408,7 +408,7 @@ class GoogleAIGeminiChatGenerator:
     @staticmethod
     def _stream_response_and_convert_to_messages(
         stream: GenerateContentResponse, streaming_callback: StreamingCallbackT
-    ) -> List[ChatMessage]:
+    ) -> list[ChatMessage]:
         """
         Streams the Google AI response and converts it to a list of `ChatMessage` instances.
 
@@ -461,7 +461,7 @@ class GoogleAIGeminiChatGenerator:
     @staticmethod
     async def _stream_response_and_convert_to_messages_async(
         stream: AsyncGenerateContentResponse, streaming_callback: AsyncStreamingCallbackT
-    ) -> List[ChatMessage]:
+    ) -> list[ChatMessage]:
         """
         Streams the Google AI response and converts it to a list of `ChatMessage` instances.
 

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import google.generativeai as genai
 from google.ai.generativelanguage import Content, Part
@@ -77,8 +77,8 @@ class GoogleAIGeminiGenerator:
         *,
         api_key: Secret = Secret.from_env_var("GOOGLE_API_KEY"),  # noqa: B008
         model: str = "gemini-2.0-flash",
-        generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
-        safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
+        generation_config: Optional[Union[GenerationConfig, dict[str, Any]]] = None,
+        safety_settings: Optional[dict[HarmCategory, HarmBlockThreshold]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
@@ -107,7 +107,7 @@ class GoogleAIGeminiGenerator:
         self._model = GenerativeModel(self.model_name)
         self.streaming_callback = streaming_callback
 
-    def _generation_config_to_dict(self, config: Union[GenerationConfig, Dict[str, Any]]) -> Dict[str, Any]:
+    def _generation_config_to_dict(self, config: Union[GenerationConfig, dict[str, Any]]) -> dict[str, Any]:
         if isinstance(config, dict):
             return config
         return {
@@ -119,7 +119,7 @@ class GoogleAIGeminiGenerator:
             "stop_sequences": config.stop_sequences,
         }
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -142,7 +142,7 @@ class GoogleAIGeminiGenerator:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GoogleAIGeminiGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "GoogleAIGeminiGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -180,7 +180,7 @@ class GoogleAIGeminiGenerator:
             msg = f"Unsupported type {type(part)} for part {part}"
             raise ValueError(msg)
 
-    @component.output_types(replies=List[str])
+    @component.output_types(replies=list[str])
     def run(
         self,
         parts: Variadic[Union[str, ByteStream, Part]],
@@ -212,7 +212,7 @@ class GoogleAIGeminiGenerator:
 
         return {"replies": replies}
 
-    def _get_response(self, response_body: GenerateContentResponse) -> List[str]:
+    def _get_response(self, response_body: GenerateContentResponse) -> list[str]:
         """
         Extracts the responses from the Google AI request.
         :param response_body: The response body from the Google AI request.
@@ -227,7 +227,7 @@ class GoogleAIGeminiGenerator:
 
     def _get_stream_response(
         self, stream: GenerateContentResponse, streaming_callback: Callable[[StreamingChunk], None]
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Extracts the responses from the Google AI streaming response.
         :param stream: The streaming response from the Google AI request.

--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -81,7 +81,7 @@ typing = "mypy --install-types --non-interactive --explicit-package-bases {args:
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/google_vertex/src/haystack_integrations/components/embedders/google_vertex/document_embedder.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/embedders/google_vertex/document_embedder.py
@@ -1,6 +1,6 @@
 import math
 import time
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Optional
 
 import vertexai
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -71,7 +71,7 @@ class VertexAIDocumentEmbedder:
         retries: int = 3,
         progress_bar: bool = True,
         truncate_dim: Optional[int] = None,
-        meta_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[list[str]] = None,
         embedding_separator: str = "\n",
     ) -> None:
         """
@@ -132,7 +132,7 @@ class VertexAIDocumentEmbedder:
         self.embedder = TextEmbeddingModel.from_pretrained(self.model)
         self.task_type = task_type
 
-    def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:
+    def _prepare_texts_to_embed(self, documents: list[Document]) -> list[str]:
         """
         Prepare the texts to embed by concatenating the Document text with the metadata fields to embed.
         """
@@ -145,7 +145,7 @@ class VertexAIDocumentEmbedder:
             texts_to_embed.append(text_to_embed)
         return texts_to_embed
 
-    def get_text_embedding_input(self, batch: List[Document]) -> List[TextEmbeddingInput]:
+    def get_text_embedding_input(self, batch: list[Document]) -> list[TextEmbeddingInput]:
         """
         Converts a batch of Document objects into a list of TextEmbeddingInput objects.
 
@@ -158,7 +158,7 @@ class VertexAIDocumentEmbedder:
         texts_to_embed = self._prepare_texts_to_embed(documents=batch)
         return [TextEmbeddingInput(text=content, task_type=self.task_type) for content in texts_to_embed]
 
-    def embed_batch_by_smaller_batches(self, batch: List[str], subbatch=1) -> List[List[float]]:
+    def embed_batch_by_smaller_batches(self, batch: list[str], subbatch=1) -> list[list[float]]:
         """
         Embeds a batch of text strings by dividing them into smaller sub-batches.
         Args:
@@ -190,7 +190,7 @@ class VertexAIDocumentEmbedder:
 
         return embeddings_batch
 
-    def embed_batch(self, batch: List[str]) -> List[List[float]]:
+    def embed_batch(self, batch: list[str]) -> list[list[float]]:
         """
         Generate embeddings for a batch of text strings.
 
@@ -205,8 +205,8 @@ class VertexAIDocumentEmbedder:
 
         return embeddings
 
-    @component.output_types(documents=List[Document])
-    def run(self, documents: List[Document]):
+    @component.output_types(documents=list[Document])
+    def run(self, documents: list[Document]):
         """
         Processes all documents in batches while adhering to the API's token limit per request.
 
@@ -276,7 +276,7 @@ class VertexAIDocumentEmbedder:
 
         return {"documents": documents}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -300,7 +300,7 @@ class VertexAIDocumentEmbedder:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIDocumentEmbedder":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAIDocumentEmbedder":
         """
         Deserializes the component from a dictionary.
 

--- a/integrations/google_vertex/src/haystack_integrations/components/embedders/google_vertex/text_embedder.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/embedders/google_vertex/text_embedder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import vertexai
 from haystack import Document, component, default_from_dict, default_to_dict, logging
@@ -84,8 +84,8 @@ class VertexAITextEmbedder:
         self.embedder = TextEmbeddingModel.from_pretrained(self.model)
         self.task_type = task_type
 
-    @component.output_types(embedding=List[float])
-    def run(self, text: Union[List[Document], List[str], str]):
+    @component.output_types(embedding=list[float])
+    def run(self, text: Union[list[Document], list[str], str]):
         """
         Processes text in batches while adhering to the API's token limit per request.
 
@@ -106,7 +106,7 @@ class VertexAITextEmbedder:
         embeddings = self.embedder.get_embeddings(text_embed_input)[0].values
         return {"embedding": embeddings}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -121,7 +121,7 @@ class VertexAITextEmbedder:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAITextEmbedder":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAITextEmbedder":
         """
         Deserializes the component from a dictionary.
 

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/captioner.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/captioner.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import vertexai
 from haystack import logging
@@ -68,7 +68,7 @@ class VertexAIImageCaptioner:
 
         self._model = ImageTextModel.from_pretrained(self._model_name)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -80,7 +80,7 @@ class VertexAIImageCaptioner:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIImageCaptioner":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAIImageCaptioner":
         """
         Deserializes the component from a dictionary.
 
@@ -91,7 +91,7 @@ class VertexAIImageCaptioner:
         """
         return default_from_dict(cls, data)
 
-    @component.output_types(captions=List[str])
+    @component.output_types(captions=list[str])
     def run(self, image: ByteStream):
         """Prompts the model to generate captions for the given image.
 

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/chat/gemini.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, AsyncIterable, Dict, Iterable, List, Optional, Union
+from collections.abc import AsyncIterable, Iterable
+from typing import Any, Optional, Union
 
 from haystack import logging
 from haystack.core.component import component
@@ -146,9 +147,9 @@ class VertexAIGeminiChatGenerator:
         model: str = "gemini-1.5-flash",
         project_id: Optional[str] = None,
         location: Optional[str] = None,
-        generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
-        safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
-        tools: Optional[List[Tool]] = None,
+        generation_config: Optional[Union[GenerationConfig, dict[str, Any]]] = None,
+        safety_settings: Optional[dict[HarmCategory, HarmBlockThreshold]] = None,
+        tools: Optional[list[Tool]] = None,
         tool_config: Optional[ToolConfig] = None,
         streaming_callback: Optional[StreamingCallbackT] = None,
     ):
@@ -205,14 +206,14 @@ class VertexAIGeminiChatGenerator:
         )
 
     @staticmethod
-    def _generation_config_to_dict(config: Union[GenerationConfig, Dict[str, Any]]) -> Dict[str, Any]:
+    def _generation_config_to_dict(config: Union[GenerationConfig, dict[str, Any]]) -> dict[str, Any]:
         """Converts the GenerationConfig object to a dictionary."""
         if isinstance(config, dict):
             return config
         return config.to_dict()
 
     @staticmethod
-    def _tool_config_to_dict(tool_config: ToolConfig) -> Dict[str, Any]:
+    def _tool_config_to_dict(tool_config: ToolConfig) -> dict[str, Any]:
         """Serializes the ToolConfig object into a dictionary."""
         mode = tool_config._gapic_tool_config.function_calling_config.mode
         allowed_function_names = tool_config._gapic_tool_config.function_calling_config.allowed_function_names
@@ -223,7 +224,7 @@ class VertexAIGeminiChatGenerator:
 
         return config_dict
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -250,7 +251,7 @@ class VertexAIGeminiChatGenerator:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIGeminiChatGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAIGeminiChatGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -260,7 +261,7 @@ class VertexAIGeminiChatGenerator:
             Deserialized component.
         """
 
-        def _tool_config_from_dict(config_dict: Dict[str, Any]) -> ToolConfig:
+        def _tool_config_from_dict(config_dict: dict[str, Any]) -> ToolConfig:
             """Deserializes the ToolConfig object from a dictionary."""
             function_calling_config = config_dict["function_calling_config"]
             return ToolConfig(
@@ -280,7 +281,7 @@ class VertexAIGeminiChatGenerator:
         return default_from_dict(cls, data)
 
     @staticmethod
-    def _convert_to_vertex_tools(tools: List[Tool]) -> List[VertexTool]:
+    def _convert_to_vertex_tools(tools: list[Tool]) -> list[VertexTool]:
         """
         Converts a list of Haystack `Tool` to a list of Vertex `Tool` objects.
 
@@ -301,13 +302,13 @@ class VertexAIGeminiChatGenerator:
             )
         return [VertexTool(function_declarations=function_declarations)]
 
-    @component.output_types(replies=List[ChatMessage])
+    @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: List[ChatMessage],
+        messages: list[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
         *,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[list[Tool]] = None,
     ):
         """
         :param messages:
@@ -360,13 +361,13 @@ class VertexAIGeminiChatGenerator:
 
         return {"replies": replies}
 
-    @component.output_types(replies=List[ChatMessage])
+    @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: List[ChatMessage],
+        messages: list[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
         *,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[list[Tool]] = None,
     ):
         """
         Async version of the run method. Generates text based on the provided messages.
@@ -424,14 +425,14 @@ class VertexAIGeminiChatGenerator:
         return {"replies": replies}
 
     @staticmethod
-    def _convert_response_to_messages(response_body: GenerationResponse) -> List[ChatMessage]:
+    def _convert_response_to_messages(response_body: GenerationResponse) -> list[ChatMessage]:
         """
         Converts the Google Vertex AI response to a list of `ChatMessage` instances.
 
         :param response_body: The response from Google AI request.
         :returns: List of `ChatMessage` instances.
         """
-        replies: List[ChatMessage] = []
+        replies: list[ChatMessage] = []
 
         usage_metadata = response_body.usage_metadata
         openai_usage = {
@@ -464,7 +465,7 @@ class VertexAIGeminiChatGenerator:
 
     def _stream_response_and_convert_to_messages(
         self, stream: Iterable[GenerationResponse], streaming_callback: StreamingCallbackT
-    ) -> List[ChatMessage]:
+    ) -> list[ChatMessage]:
         """
         Streams the Google Vertex AI response and converts it to a list of `ChatMessage` instances.
 
@@ -518,7 +519,7 @@ class VertexAIGeminiChatGenerator:
     @staticmethod
     async def _stream_response_and_convert_to_messages_async(
         stream: AsyncIterable[GenerationResponse], streaming_callback: AsyncStreamingCallbackT
-    ) -> List[ChatMessage]:
+    ) -> list[ChatMessage]:
         """
         Streams the Google Vertex AI response and converts it to a list of `ChatMessage` instances.
 

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/code_generator.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/code_generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import vertexai
 from haystack import logging
@@ -71,7 +71,7 @@ class VertexAICodeGenerator:
 
         self._model = CodeGenerationModel.from_pretrained(self._model_name)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -83,7 +83,7 @@ class VertexAICodeGenerator:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAICodeGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAICodeGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -94,7 +94,7 @@ class VertexAICodeGenerator:
         """
         return default_from_dict(cls, data)
 
-    @component.output_types(replies=List[str])
+    @component.output_types(replies=list[str])
     def run(self, prefix: str, suffix: Optional[str] = None):
         """
         Generate code using a Google Vertex AI model.

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/gemini.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from collections.abc import Iterable
+from typing import Any, Callable, Optional, Union
 
 from haystack import logging
 from haystack.core.component import component
@@ -64,8 +65,8 @@ class VertexAIGeminiGenerator:
         model: str = "gemini-2.0-flash",
         project_id: Optional[str] = None,
         location: Optional[str] = None,
-        generation_config: Optional[Union[GenerationConfig, Dict[str, Any]]] = None,
-        safety_settings: Optional[Dict[HarmCategory, HarmBlockThreshold]] = None,
+        generation_config: Optional[Union[GenerationConfig, dict[str, Any]]] = None,
+        safety_settings: Optional[dict[HarmCategory, HarmBlockThreshold]] = None,
         system_instruction: Optional[Union[str, ByteStream, Part]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
@@ -118,7 +119,7 @@ class VertexAIGeminiGenerator:
             system_instruction=self._system_instruction,
         )
 
-    def _generation_config_to_dict(self, config: Union[GenerationConfig, Dict[str, Any]]) -> Dict[str, Any]:
+    def _generation_config_to_dict(self, config: Union[GenerationConfig, dict[str, Any]]) -> dict[str, Any]:
         if isinstance(config, dict):
             return config
         return {
@@ -130,7 +131,7 @@ class VertexAIGeminiGenerator:
             "stop_sequences": config._raw_generation_config.stop_sequences,
         }
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -155,7 +156,7 @@ class VertexAIGeminiGenerator:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIGeminiGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAIGeminiGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -182,7 +183,7 @@ class VertexAIGeminiGenerator:
             msg = f"Unsupported type {type(part)} for part {part}"
             raise ValueError(msg)
 
-    @component.output_types(replies=List[str])
+    @component.output_types(replies=list[str])
     def run(
         self,
         parts: Variadic[Union[str, ByteStream, Part]],
@@ -211,7 +212,7 @@ class VertexAIGeminiGenerator:
 
         return {"replies": replies}
 
-    def _get_response(self, response_body: GenerationResponse) -> List[str]:
+    def _get_response(self, response_body: GenerationResponse) -> list[str]:
         """
         Extracts the responses from the Vertex AI response.
 
@@ -228,7 +229,7 @@ class VertexAIGeminiGenerator:
 
     def _get_stream_response(
         self, stream: Iterable[GenerationResponse], streaming_callback: Callable[[StreamingChunk], None]
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Extracts the responses from the Vertex AI streaming response.
 
@@ -236,7 +237,7 @@ class VertexAIGeminiGenerator:
         :param streaming_callback: The handler for the streaming response.
         :returns: A list of string responses.
         """
-        streaming_chunks: List[StreamingChunk] = []
+        streaming_chunks: list[StreamingChunk] = []
 
         for chunk in stream:
             streaming_chunk = StreamingChunk(content=chunk.text, meta=chunk.to_dict())

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/image_generator.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/image_generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import vertexai
 from haystack import logging
@@ -61,7 +61,7 @@ class VertexAIImageGenerator:
 
         self._model = ImageGenerationModel.from_pretrained(self._model_name)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -73,7 +73,7 @@ class VertexAIImageGenerator:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIImageGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAIImageGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -84,7 +84,7 @@ class VertexAIImageGenerator:
         """
         return default_from_dict(cls, data)
 
-    @component.output_types(images=List[ByteStream])
+    @component.output_types(images=list[ByteStream])
     def run(self, prompt: str, negative_prompt: Optional[str] = None):
         """Produces images based on the given prompt.
 

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/question_answering.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/question_answering.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import vertexai
 from haystack import logging
@@ -61,7 +61,7 @@ class VertexAIImageQA:
 
         self._model = ImageTextModel.from_pretrained(self._model_name)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -73,7 +73,7 @@ class VertexAIImageQA:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIImageQA":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAIImageQA":
         """
         Deserializes the component from a dictionary.
 
@@ -84,7 +84,7 @@ class VertexAIImageQA:
         """
         return default_from_dict(cls, data)
 
-    @component.output_types(replies=List[str])
+    @component.output_types(replies=list[str])
     def run(self, image: ByteStream, question: str):
         """Prompts model to answer a question about an image.
 

--- a/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/text_generator.py
+++ b/integrations/google_vertex/src/haystack_integrations/components/generators/google_vertex/text_generator.py
@@ -1,6 +1,6 @@
 import importlib
 from dataclasses import fields
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import vertexai
 from haystack import logging
@@ -71,7 +71,7 @@ class VertexAITextGenerator:
 
         self._model = TextGenerationModel.from_pretrained(self._model_name)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -94,7 +94,7 @@ class VertexAITextGenerator:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "VertexAITextGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "VertexAITextGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -111,7 +111,7 @@ class VertexAITextGenerator:
             )
         return default_from_dict(cls, data)
 
-    @component.output_types(replies=List[str], safety_attributes=Dict[str, float], citations=List[Dict[str, Any]])
+    @component.output_types(replies=list[str], safety_attributes=dict[str, float], citations=list[dict[str, Any]])
     def run(self, prompt: str):
         """Prompts the model to generate text.
 

--- a/integrations/google_vertex/tests/test_document_embedder.py
+++ b/integrations/google_vertex/tests/test_document_embedder.py
@@ -28,9 +28,10 @@ def mock_vertex_init_and_model():
     """
     Fixture to mock vertexai.init and TextEmbeddingModel.from_pretrained
     """
-    with patch("vertexai.init") as mock_init, patch(
-        "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-    ) as mock_from_pretrained:
+    with (
+        patch("vertexai.init") as mock_init,
+        patch("vertexai.language_models.TextEmbeddingModel.from_pretrained") as mock_from_pretrained,
+    ):
         mock_embedder = MagicMock(spec=TextEmbeddingModel)
         mock_embedder.get_embeddings.return_value = [MockTextEmbeddingResponse([0.1] * 768)]
         mock_embedder.count_tokens.return_value = MockCountTokensResponse(total_tokens=10)

--- a/integrations/google_vertex/tests/test_text_embedder.py
+++ b/integrations/google_vertex/tests/test_text_embedder.py
@@ -20,9 +20,10 @@ def mock_vertex_init_and_model():
     """
     Fixture to mock vertexai.init and TextEmbeddingModel.from_pretrained
     """
-    with patch("vertexai.init") as mock_init, patch(
-        "vertexai.language_models.TextEmbeddingModel.from_pretrained"
-    ) as mock_from_pretrained:
+    with (
+        patch("vertexai.init") as mock_init,
+        patch("vertexai.language_models.TextEmbeddingModel.from_pretrained") as mock_from_pretrained,
+    ):
         mock_embedder = MagicMock(spec=TextEmbeddingModel)
         # Simulate returning a list with one response object for get_embeddings
         mock_embedder.get_embeddings.return_value = [MockTextEmbeddingResponse([0.1] * 768)]

--- a/integrations/hanlp/pyproject.toml
+++ b/integrations/hanlp/pyproject.toml
@@ -83,12 +83,12 @@ module = [
 ignore_missing_imports = true
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py39"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/hanlp/src/haystack_integrations/components/preprocessors/hanlp/chinese_document_splitter.py
+++ b/integrations/hanlp/src/haystack_integrations/components/preprocessors/hanlp/chinese_document_splitter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
+from typing import Any, Callable, Literal, Optional
 
 from haystack import Document, component, logging
 from haystack.core.serialization import default_from_dict, default_to_dict
@@ -149,7 +149,7 @@ class ChineseDocumentSplitter:
             raise ValueError(msg)
 
     @component.output_types(documents=list[Document])
-    def run(self, documents: List[Document]) -> Dict[str, List[Document]]:
+    def run(self, documents: list[Document]) -> dict[str, list[Document]]:
         """
         Split documents into smaller chunks.
 
@@ -175,7 +175,7 @@ class ChineseDocumentSplitter:
             self.chinese_tokenizer = hanlp.load(hanlp.pretrained.tok.FINE_ELECTRA_SMALL_ZH)
         self.split_sent = hanlp.load(hanlp.pretrained.eos.UD_CTB_EOS_MUL)
 
-    def _split_by_character(self, doc: Document) -> List[Document]:
+    def _split_by_character(self, doc: Document) -> list[Document]:
         """
         Define a function to handle Chinese clauses
 
@@ -202,7 +202,7 @@ class ChineseDocumentSplitter:
         )
 
     # Define a function to handle Chinese clauses
-    def chinese_sentence_split(self, text: str) -> List[Dict[str, Any]]:
+    def chinese_sentence_split(self, text: str) -> list[dict[str, Any]]:
         """
         Split Chinese text into sentences.
 
@@ -223,7 +223,7 @@ class ChineseDocumentSplitter:
 
         return results
 
-    def _split_document(self, doc: Document) -> List[Document]:
+    def _split_document(self, doc: Document) -> list[Document]:
         if self.split_by == "sentence" or self.respect_sentence_boundary:
             return self._split_by_hanlp_sentence(doc)
 
@@ -233,8 +233,8 @@ class ChineseDocumentSplitter:
         return self._split_by_character(doc)
 
     def _concatenate_sentences_based_on_word_amount(
-        self, sentences: List[str], split_length: int, split_overlap: int, granularity: str
-    ) -> Tuple[List[str], List[int], List[int]]:
+        self, sentences: list[str], split_length: int, split_overlap: int, granularity: str
+    ) -> tuple[list[str], list[int], list[int]]:
         """
         Groups the sentences into chunks of `split_length` words while respecting sentence boundaries.
 
@@ -251,11 +251,11 @@ class ChineseDocumentSplitter:
         chunk_word_count = 0
         chunk_starting_page_number = 1
         chunk_start_idx = 0
-        current_chunk: List[str] = []
+        current_chunk: list[str] = []
 
         # output lists
         split_start_page_numbers = []
-        list_of_splits: List[List[str]] = []
+        list_of_splits: list[list[str]] = []
         split_start_indices = []
 
         for sentence_idx, sentence in enumerate(sentences):
@@ -305,7 +305,7 @@ class ChineseDocumentSplitter:
 
         return text_splits, split_start_page_numbers, split_start_indices
 
-    def _split_by_hanlp_sentence(self, doc: Document) -> List[Document]:
+    def _split_by_hanlp_sentence(self, doc: Document) -> list[Document]:
         """
         Split Chinese text into sentences.
 
@@ -342,8 +342,8 @@ class ChineseDocumentSplitter:
         return split_docs
 
     def _concatenate_units(
-        self, elements: List[str], split_length: int, split_overlap: int, split_threshold: int
-    ) -> Tuple[List[str], List[int], List[int]]:
+        self, elements: list[str], split_length: int, split_overlap: int, split_threshold: int
+    ) -> tuple[list[str], list[int], list[int]]:
         """
         Concatenates the elements into parts of split_length units.
 
@@ -364,9 +364,9 @@ class ChineseDocumentSplitter:
         # Otherwise, proceed as before
         step = split_length - split_overlap
         step = max(step, 1)
-        text_splits: List[str] = []
-        splits_pages: List[int] = []
-        splits_start_idxs: List[int] = []
+        text_splits: list[str] = []
+        splits_pages: list[int] = []
+        splits_start_idxs: list[int] = []
         cur_start_idx = 0
         cur_page = 1
         segments = windowed(elements, n=split_length, step=step)
@@ -399,12 +399,12 @@ class ChineseDocumentSplitter:
         return text_splits, splits_pages, splits_start_idxs
 
     def _create_docs_from_splits(
-        self, text_splits: List[str], splits_pages: List[int], splits_start_idxs: List[int], meta: Dict[str, Any]
-    ) -> List[Document]:
+        self, text_splits: list[str], splits_pages: list[int], splits_start_idxs: list[int], meta: dict[str, Any]
+    ) -> list[Document]:
         """
         Creates Document objects from splits enriching them with page number and the metadata of the original document.
         """
-        documents: List[Document] = []
+        documents: list[Document] = []
 
         for i, (txt, split_idx) in enumerate(zip(text_splits, splits_start_idxs)):
             copied_meta = deepcopy(meta)
@@ -460,7 +460,7 @@ class ChineseDocumentSplitter:
                 overlapping_range = (0, overlapping_range[1] - overlapping_range[0])
                 previous_doc.meta["_split_overlap"].append({"doc_id": current_doc.id, "range": overlapping_range})
 
-    def _number_of_sentences_to_keep(self, sentences: List[str], split_length: int, split_overlap: int) -> int:
+    def _number_of_sentences_to_keep(self, sentences: list[str], split_length: int, split_overlap: int) -> int:
         """
         Returns the number of sentences to keep in the next chunk based on the `split_overlap` and `split_length`.
 
@@ -486,7 +486,7 @@ class ChineseDocumentSplitter:
                 break
         return num_sentences_to_keep
 
-    def _split_by_function(self, doc: Document) -> List[Document]:
+    def _split_by_function(self, doc: Document) -> list[Document]:
         """
         Split a document using a custom splitting function.
 
@@ -515,7 +515,7 @@ class ChineseDocumentSplitter:
             meta=metadata,
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
         """
@@ -533,7 +533,7 @@ class ChineseDocumentSplitter:
         return serialized
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ChineseDocumentSplitter":
+    def from_dict(cls, data: dict[str, Any]) -> "ChineseDocumentSplitter":
         """
         Deserializes the component from a dictionary.
         """

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -79,7 +79,7 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
+++ b/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 from urllib.parse import quote
 
 import requests
@@ -67,7 +67,7 @@ class JinaReaderConnector:
             mode = JinaReaderMode.from_str(mode)
         self.mode = mode
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
         :returns:
@@ -81,7 +81,7 @@ class JinaReaderConnector:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "JinaReaderConnector":
+    def from_dict(cls, data: dict[str, Any]) -> "JinaReaderConnector":
         """
         Deserializes the component from a dictionary.
         :param data:
@@ -103,8 +103,8 @@ class JinaReaderConnector:
         document = Document(content=content, meta=data)
         return document
 
-    @component.output_types(documents=List[Document])
-    def run(self, query: str, headers: Optional[Dict[str, str]] = None) -> Dict[str, List[Document]]:
+    @component.output_types(documents=list[Document])
+    def run(self, query: str, headers: Optional[dict[str, str]] = None) -> dict[str, list[Document]]:
         """
         Process the query/URL using the Jina AI reader service.
 

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import requests
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -43,7 +43,7 @@ class JinaDocumentEmbedder:
         suffix: str = "",
         batch_size: int = 32,
         progress_bar: bool = True,
-        meta_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[list[str]] = None,
         embedding_separator: str = "\n",
         task: Optional[str] = None,
         dimensions: Optional[int] = None,
@@ -95,13 +95,13 @@ class JinaDocumentEmbedder:
         self.dimensions = dimensions
         self.late_chunking = late_chunking
 
-    def _get_telemetry_data(self) -> Dict[str, Any]:
+    def _get_telemetry_data(self) -> dict[str, Any]:
         """
         Data that is sent to Posthog for usage analytics.
         """
         return {"model": self.model_name}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
         :returns:
@@ -128,7 +128,7 @@ class JinaDocumentEmbedder:
         return default_to_dict(self, **kwargs)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "JinaDocumentEmbedder":
+    def from_dict(cls, data: dict[str, Any]) -> "JinaDocumentEmbedder":
         """
         Deserializes the component from a dictionary.
         :param data:
@@ -139,7 +139,7 @@ class JinaDocumentEmbedder:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:
+    def _prepare_texts_to_embed(self, documents: list[Document]) -> list[str]:
         """
         Prepare the texts to embed by concatenating the Document text with the metadata fields to embed.
         """
@@ -156,8 +156,8 @@ class JinaDocumentEmbedder:
         return texts_to_embed
 
     def _embed_batch(
-        self, texts_to_embed: List[str], batch_size: int, parameters: Optional[Dict] = None
-    ) -> Tuple[List[List[float]], Dict[str, Any]]:
+        self, texts_to_embed: list[str], batch_size: int, parameters: Optional[dict] = None
+    ) -> tuple[list[list[float]], dict[str, Any]]:
         """
         Embed a list of texts in batches.
         """
@@ -189,8 +189,8 @@ class JinaDocumentEmbedder:
 
         return all_embeddings, metadata
 
-    @component.output_types(documents=List[Document], meta=Dict[str, Any])
-    def run(self, documents: List[Document]) -> Dict[str, Any]:
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    def run(self, documents: list[Document]) -> dict[str, Any]:
         """
         Compute the embeddings for a list of Documents.
 
@@ -208,7 +208,7 @@ class JinaDocumentEmbedder:
             raise TypeError(msg)
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
-        parameters: Dict[str, Any] = {}
+        parameters: dict[str, Any] = {}
         if self.task is not None:
             parameters["task"] = self.task
         if self.dimensions is not None:

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/document_image_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/document_image_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import replace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import requests
 from haystack import Document, component, default_from_dict, default_to_dict, logging
@@ -60,7 +60,7 @@ class JinaDocumentImageEmbedder:
         file_path_meta_field: str = "file_path",
         root_path: Optional[str] = None,
         embedding_dimension: Optional[int] = None,
-        image_size: Optional[Tuple[int, int]] = None,
+        image_size: Optional[tuple[int, int]] = None,
         batch_size: int = 5,
     ):
         """
@@ -103,13 +103,13 @@ class JinaDocumentImageEmbedder:
             }
         )
 
-    def _get_telemetry_data(self) -> Dict[str, Any]:
+    def _get_telemetry_data(self) -> dict[str, Any]:
         """
         Data that is sent to Posthog for usage analytics.
         """
         return {"model": self.model_name}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -128,7 +128,7 @@ class JinaDocumentImageEmbedder:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "JinaDocumentImageEmbedder":
+    def from_dict(cls, data: dict[str, Any]) -> "JinaDocumentImageEmbedder":
         """
         Deserializes the component from a dictionary.
 
@@ -140,7 +140,7 @@ class JinaDocumentImageEmbedder:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    def _extract_images_to_embed(self, documents: List[Document]) -> List[str]:
+    def _extract_images_to_embed(self, documents: list[Document]) -> list[str]:
         """
         Validates the input documents and extracts the images to embed in the format expected by the Jina API.
 
@@ -166,8 +166,8 @@ class JinaDocumentImageEmbedder:
             documents=documents, file_path_meta_field=self.file_path_meta_field, root_path=self.root_path
         )
 
-        images_to_embed: List[Optional[str]] = [None] * len(documents)
-        pdf_page_infos: List[_PDFPageInfo] = []
+        images_to_embed: list[Optional[str]] = [None] * len(documents)
+        pdf_page_infos: list[_PDFPageInfo] = []
 
         for doc_idx, image_source_info in enumerate(images_source_info):
             if image_source_info["mime_type"] == "application/pdf":
@@ -204,8 +204,8 @@ class JinaDocumentImageEmbedder:
         # tested above that image is not None, but mypy doesn't know that
         return images_to_embed  # type: ignore[return-value]
 
-    @component.output_types(documents=List[Document])
-    def run(self, documents: List[Document]) -> Dict[str, List[Document]]:
+    @component.output_types(documents=list[Document])
+    def run(self, documents: list[Document]) -> dict[str, list[Document]]:
         """
         Embed a list of image documents.
 
@@ -229,7 +229,7 @@ class JinaDocumentImageEmbedder:
             batch_images = images_to_embed[i : i + self.batch_size]
 
             # Prepare request parameters
-            parameters: Dict[str, Any] = {}
+            parameters: dict[str, Any] = {}
             if self.embedding_dimension is not None:
                 parameters["dimensions"] = self.embedding_dimension
 

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/text_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/text_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import requests
 from haystack import component, default_from_dict, default_to_dict
@@ -82,19 +82,19 @@ class JinaTextEmbedder:
         self.dimensions = dimensions
         self.late_chunking = late_chunking
 
-    def _get_telemetry_data(self) -> Dict[str, Any]:
+    def _get_telemetry_data(self) -> dict[str, Any]:
         """
         Data that is sent to Posthog for usage analytics.
         """
         return {"model": self.model_name}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
         :returns:
             Dictionary with serialized data.
         """
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "api_key": self.api_key.to_dict(),
             "model": self.model_name,
             "prefix": self.prefix,
@@ -110,7 +110,7 @@ class JinaTextEmbedder:
         return default_to_dict(self, **kwargs)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "JinaTextEmbedder":
+    def from_dict(cls, data: dict[str, Any]) -> "JinaTextEmbedder":
         """
         Deserializes the component from a dictionary.
         :param data:
@@ -121,8 +121,8 @@ class JinaTextEmbedder:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    @component.output_types(embedding=List[float], meta=Dict[str, Any])
-    def run(self, text: str) -> Dict[str, Any]:
+    @component.output_types(embedding=list[float], meta=dict[str, Any])
+    def run(self, text: str) -> dict[str, Any]:
         """
         Embed a string.
 
@@ -141,7 +141,7 @@ class JinaTextEmbedder:
 
         text_to_embed = self.prefix + text + self.suffix
 
-        parameters: Dict[str, Any] = {}
+        parameters: dict[str, Any] = {}
         if self.task is not None:
             parameters["task"] = self.task
         if self.dimensions is not None:

--- a/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
+++ b/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import requests
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -70,7 +70,7 @@ class JinaRanker:
             }
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
         :returns:
@@ -85,7 +85,7 @@ class JinaRanker:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "JinaRanker":
+    def from_dict(cls, data: dict[str, Any]) -> "JinaRanker":
         """
         Deserializes the component from a dictionary.
         :param data:
@@ -96,17 +96,17 @@ class JinaRanker:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    def _get_telemetry_data(self) -> Dict[str, Any]:
+    def _get_telemetry_data(self) -> dict[str, Any]:
         """
         Data that is sent to Posthog for usage analytics.
         """
         return {"model": self.model}
 
-    @component.output_types(documents=List[Document])
+    @component.output_types(documents=list[Document])
     def run(
         self,
         query: str,
-        documents: List[Document],
+        documents: list[Document],
         top_k: Optional[int] = None,
         score_threshold: Optional[float] = None,
     ):
@@ -155,7 +155,7 @@ class JinaRanker:
 
         results = resp["results"]
 
-        ranked_docs: List[Document] = []
+        ranked_docs: list[Document] = []
         for result in results:
             index = result["index"]
             relevance_score = result["relevance_score"]

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -82,7 +82,7 @@ allow-direct-references = true
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import httpx
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
@@ -124,7 +124,7 @@ class LangfuseConnector:
         span_handler: Optional[SpanHandler] = None,
         *,
         host: Optional[str] = None,
-        langfuse_client_kwargs: Optional[Dict[str, Any]] = None,
+        langfuse_client_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Initialize the LangfuseConnector component.
@@ -172,7 +172,7 @@ class LangfuseConnector:
         tracing.enable_tracing(self.tracer)
 
     @component.output_types(name=str, trace_url=str, trace_id=str)
-    def run(self, invocation_context: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def run(self, invocation_context: Optional[dict[str, Any]] = None) -> dict[str, str]:
         """
         Runs the LangfuseConnector component.
 
@@ -191,7 +191,7 @@ class LangfuseConnector:
         )
         return {"name": self.name, "trace_url": self.tracer.get_trace_url(), "trace_id": self.tracer.get_trace_id()}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.
 
@@ -218,7 +218,7 @@ class LangfuseConnector:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "LangfuseConnector":
+    def from_dict(cls, data: dict[str, Any]) -> "LangfuseConnector":
         """
         Deserialize this component from a dictionary.
 

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -6,11 +6,12 @@ import contextlib
 import os
 from abc import ABC, abstractmethod
 from collections import Counter
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Iterator, List, Literal, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 from haystack import default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ChatMessage
@@ -42,11 +43,11 @@ ObservationSpanType = Literal["tool", "agent", "retriever", "embedding", "genera
 
 # External session metadata for trace correlation (Haystack system)
 # Stores trace_id, user_id, session_id, tags, version for root trace creation
-tracing_context_var: ContextVar[Dict[Any, Any]] = ContextVar("tracing_context")
+tracing_context_var: ContextVar[dict[Any, Any]] = ContextVar("tracing_context")
 
 # Internal span execution hierarchy for our tracer
 # Manages parent-child relationships and prevents cross-request span interleaving
-span_stack_var: ContextVar[Optional[List["LangfuseSpan"]]] = ContextVar("span_stack", default=None)
+span_stack_var: ContextVar[Optional[list["LangfuseSpan"]]] = ContextVar("span_stack", default=None)
 
 
 class LangfuseSpan(Span):
@@ -63,7 +64,7 @@ class LangfuseSpan(Span):
         `langfuse.get_client().start_as_current_observation`.
         """
         self._span = context_manager.__enter__()
-        self._data: Dict[str, Any] = {}
+        self._data: dict[str, Any] = {}
         self._context_manager = context_manager
 
     def set_tag(self, key: str, value: Any) -> None:
@@ -114,7 +115,7 @@ class LangfuseSpan(Span):
         """
         return self._span
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         """
         Return the data associated with the span.
 
@@ -122,7 +123,7 @@ class LangfuseSpan(Span):
         """
         return self._data
 
-    def get_correlation_data_for_logs(self) -> Dict[str, Any]:
+    def get_correlation_data_for_logs(self) -> dict[str, Any]:
         return {}
 
 
@@ -149,7 +150,7 @@ class SpanContext:
     name: str
     operation_name: str
     component_type: Optional[str]
-    tags: Dict[str, Any]
+    tags: dict[str, Any]
     parent_span: Optional[Span]
     trace_name: str = "Haystack"
     public: bool = False
@@ -231,14 +232,14 @@ class SpanHandler(ABC):
         pass
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SpanHandler":
+    def from_dict(cls, data: dict[str, Any]) -> "SpanHandler":
         return default_from_dict(cls, data)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return default_to_dict(self)
 
 
-def _sanitize_usage_data(usage: Dict[str, Any]) -> Dict[str, Any]:
+def _sanitize_usage_data(usage: dict[str, Any]) -> dict[str, Any]:
     """
     Sanitize usage data for Langfuse by flattening to a single-level dictionary.
 
@@ -253,9 +254,9 @@ def _sanitize_usage_data(usage: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(usage, dict):
         return {}
 
-    sanitized: Dict[str, Any] = {}
+    sanitized: dict[str, Any] = {}
 
-    def _flatten(data: Dict[str, Any], prefix: str = "") -> None:
+    def _flatten(data: dict[str, Any], prefix: str = "") -> None:
         """Recursively flatten nested dictionaries."""
         for key, value in data.items():
             full_key = f"{prefix}.{key}" if prefix else key
@@ -354,7 +355,7 @@ class DefaultSpanHandler(SpanHandler):
             span.raw_span().update_trace(input=coerced_input, output=coerced_output)
         # special case for ToolInvoker (to update the span name to be: `original_component_name - [tool_names]`)
         if component_type == "ToolInvoker":
-            tool_names: List[str] = []
+            tool_names: list[str] = []
             messages = span.get_data().get(_COMPONENT_INPUT_KEY, {}).get("messages", [])
             for message in messages:
                 if isinstance(message, ChatMessage) and message.tool_calls:
@@ -424,7 +425,7 @@ class LangfuseTracer(Tracer):
             )
         self._tracer = tracer
         # Keep _context as deprecated shim to avoid AttributeError if anyone uses it
-        self._context: List[LangfuseSpan] = []
+        self._context: list[LangfuseSpan] = []
         self._name = name
         self._public = public
         self.enforce_flush = os.getenv(HAYSTACK_LANGFUSE_ENFORCE_FLUSH_ENV_VAR, "true").lower() == "true"
@@ -433,7 +434,7 @@ class LangfuseTracer(Tracer):
 
     @contextlib.contextmanager
     def trace(
-        self, operation_name: str, tags: Optional[Dict[str, Any]] = None, parent_span: Optional[Span] = None
+        self, operation_name: str, tags: Optional[dict[str, Any]] = None, parent_span: Optional[Span] = None
     ) -> Iterator[Span]:
         tags = tags or {}
         span_name = tags.get(_COMPONENT_NAME_KEY, operation_name)

--- a/integrations/langfuse/tests/test_tracing.py
+++ b/integrations/langfuse/tests/test_tracing.py
@@ -5,7 +5,7 @@
 import json
 import os
 import time
-from typing import Any, Dict, List
+from typing import Any
 from urllib.parse import urlparse
 
 import pytest
@@ -137,8 +137,8 @@ def test_tracing_with_sub_pipelines():
             self.sub_pipeline = Pipeline()
             self.sub_pipeline.add_component("llm", OpenAIChatGenerator())
 
-        @component.output_types(replies=List[ChatMessage])
-        def run(self, messages: List[ChatMessage]) -> Dict[str, Any]:
+        @component.output_types(replies=list[ChatMessage])
+        def run(self, messages: list[ChatMessage]) -> dict[str, Any]:
             return {"replies": self.sub_pipeline.run(data={"llm": {"messages": messages}})["llm"]["replies"]}
 
     @component
@@ -149,8 +149,8 @@ def test_tracing_with_sub_pipelines():
             self.sub_pipeline.add_component("sub_llm", SubGenerator())
             self.sub_pipeline.connect("prompt_builder.prompt", "sub_llm.messages")
 
-        @component.output_types(replies=List[ChatMessage])
-        def run(self, messages: List[ChatMessage]) -> Dict[str, Any]:
+        @component.output_types(replies=list[ChatMessage])
+        def run(self, messages: list[ChatMessage]) -> dict[str, Any]:
             return {
                 "replies": self.sub_pipeline.run(
                     data={"prompt_builder": {"template": messages, "template_variables": {"location": "Berlin"}}}

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -92,7 +92,7 @@ known-first-party = ["haystack_integrations"]
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -1,6 +1,7 @@
 import json
+from collections.abc import Iterator
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message
@@ -42,7 +43,7 @@ from llama_cpp.llama_tokenizer import LlamaHFTokenizer
 
 logger = logging.getLogger(__name__)
 
-FINISH_REASON_MAPPING: Dict[str, FinishReason] = {
+FINISH_REASON_MAPPING: dict[str, FinishReason] = {
     "stop": "stop",
     "length": "length",
     "tool_calls": "tool_calls",
@@ -124,7 +125,7 @@ def _convert_message_to_llamacpp_format(message: ChatMessage) -> ChatCompletionR
             result["content"] = text_contents[0]
 
         if tool_calls:
-            llamacpp_tool_calls: List[ChatCompletionMessageToolCall] = []
+            llamacpp_tool_calls: list[ChatCompletionMessageToolCall] = []
             for tc in tool_calls:
                 if tc.id is None:
                     msg = "`ToolCall` must have a non-null `id` attribute to be used with llama.cpp."
@@ -193,8 +194,8 @@ class LlamaCppChatGenerator:
         model: str,
         n_ctx: Optional[int] = 0,
         n_batch: Optional[int] = 512,
-        model_kwargs: Optional[Dict[str, Any]] = None,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
         *,
         tools: Optional[ToolsType] = None,
         streaming_callback: Optional[StreamingCallbackT] = None,
@@ -278,7 +279,7 @@ class LlamaCppChatGenerator:
 
         self._model = Llama(**kwargs)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -300,7 +301,7 @@ class LlamaCppChatGenerator:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "LlamaCppChatGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "LlamaCppChatGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -319,15 +320,15 @@ class LlamaCppChatGenerator:
             )
         return default_from_dict(cls, data)
 
-    @component.output_types(replies=List[ChatMessage])
+    @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: List[ChatMessage],
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        messages: list[ChatMessage],
+        generation_kwargs: Optional[dict[str, Any]] = None,
         *,
         tools: Optional[ToolsType] = None,
         streaming_callback: Optional[StreamingCallbackT] = None,
-    ) -> Dict[str, List[ChatMessage]]:
+    ) -> dict[str, list[ChatMessage]]:
         """
         Run the text generation model on the given list of ChatMessages.
 
@@ -359,7 +360,7 @@ class LlamaCppChatGenerator:
         flattened_tools = flatten_tools_or_toolsets(tools)
         _check_duplicate_tool_names(flattened_tools)
 
-        llamacpp_tools: List[ChatCompletionTool] = []
+        llamacpp_tools: list[ChatCompletionTool] = []
         if flattened_tools:
             for t in flattened_tools:
                 llamacpp_tools.append(
@@ -408,7 +409,7 @@ class LlamaCppChatGenerator:
         response_stream: Iterator[CreateChatCompletionStreamResponse],
         streaming_callback: SyncStreamingCallbackT,
         component_info: ComponentInfo,
-    ) -> Dict[str, List[ChatMessage]]:
+    ) -> dict[str, list[ChatMessage]]:
         """
         Take streaming responses from llama.cpp, convert to Haystack StreamingChunk objects, stream them,
         and finally convert them to a ChatMessage.
@@ -434,7 +435,7 @@ class LlamaCppChatGenerator:
 
             if chunk.get("choices") and len(chunk["choices"]) > 0:
                 choice = chunk["choices"][0]
-                delta: Union[ChatCompletionStreamResponseDelta, ChatCompletionStreamResponseDeltaEmpty, Dict] = (
+                delta: Union[ChatCompletionStreamResponseDelta, ChatCompletionStreamResponseDeltaEmpty, dict] = (
                     choice.get("delta", {})
                 )
 

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from haystack import component, logging
 
@@ -30,8 +30,8 @@ class LlamaCppGenerator:
         model: str,
         n_ctx: Optional[int] = 0,
         n_batch: Optional[int] = 512,
-        model_kwargs: Optional[Dict[str, Any]] = None,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         :param model: The path of a quantized model for text generation, for example, "zephyr-7b-beta.Q4_0.gguf".
@@ -68,10 +68,10 @@ class LlamaCppGenerator:
         if self.model is None:
             self.model = Llama(**self.model_kwargs)
 
-    @component.output_types(replies=List[str], meta=List[Dict[str, Any]])
+    @component.output_types(replies=list[str], meta=list[dict[str, Any]])
     def run(
-        self, prompt: str, generation_kwargs: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Union[List[str], List[Dict[str, Any]]]]:
+        self, prompt: str, generation_kwargs: Optional[dict[str, Any]] = None
+    ) -> dict[str, Union[list[str], list[dict[str, Any]]]]:
         """
         Run the text generation model on the given prompt.
 

--- a/integrations/llama_stack/pyproject.toml
+++ b/integrations/llama_stack/pyproject.toml
@@ -73,7 +73,7 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
+++ b/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -60,12 +60,12 @@ class LlamaStackChatGenerator(OpenAIChatGenerator):
         api_base_url: str = "http://localhost:8321/v1/openai/v1",
         organization: Optional[str] = None,
         streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
         timeout: Optional[int] = None,
         tools: Optional[ToolsType] = None,
         tools_strict: bool = False,
         max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[Dict[str, Any]] = None,
+        http_client_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Creates an instance of LlamaStackChatGenerator. To use this chat generator,
@@ -129,7 +129,7 @@ class LlamaStackChatGenerator(OpenAIChatGenerator):
             http_client_kwargs=http_client_kwargs,
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.
 
@@ -152,7 +152,7 @@ class LlamaStackChatGenerator(OpenAIChatGenerator):
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "LlamaStackChatGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "LlamaStackChatGenerator":
         """
         Deserialize this component from a dictionary.
 

--- a/integrations/meta_llama/pyproject.toml
+++ b/integrations/meta_llama/pyproject.toml
@@ -75,7 +75,7 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
+++ b/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from haystack import component, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -61,7 +61,7 @@ class MetaLlamaChatGenerator(OpenAIChatGenerator):
         model: str = "Llama-4-Scout-17B-16E-Instruct-FP8",
         streaming_callback: Optional[StreamingCallbackT] = None,
         api_base_url: Optional[str] = "https://api.llama.com/compat/v1/",
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
         tools: Optional[ToolsType] = None,
     ):
         """
@@ -134,7 +134,7 @@ class MetaLlamaChatGenerator(OpenAIChatGenerator):
             api_args.pop("response_format")
         return api_args
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.
 

--- a/integrations/mistral/examples/indexing_ocr_pipeline.py
+++ b/integrations/mistral/examples/indexing_ocr_pipeline.py
@@ -9,7 +9,6 @@
 # You can customize the ImageAnnotation and DocumentAnnotation schemas below
 # to extract different structured information from your documents.
 
-from typing import List
 
 from haystack import Pipeline
 from haystack.components.writers import DocumentWriter
@@ -34,8 +33,8 @@ class ImageAnnotation(BaseModel):
 # Define schema for structured document annotations
 class DocumentAnnotation(BaseModel):
     language: str = Field(..., description="Primary language of the document")
-    urls: List[str] = Field(..., description="URLs found in the document")
-    topics: List[str] = Field(..., description="Main topics covered in the document")
+    urls: list[str] = Field(..., description="URLs found in the document")
+    topics: list[str] = Field(..., description="Main topics covered in the document")
 
 
 # Initialize document store

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -78,7 +78,7 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
+++ b/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
@@ -1,7 +1,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Optional, Union
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.components.converters.utils import (
@@ -103,7 +103,7 @@ class MistralOCRDocumentConverter:
         api_key: Secret = Secret.from_env_var("MISTRAL_API_KEY"),
         model: str = "mistral-ocr-2505",
         include_image_base64: bool = False,
-        pages: Optional[List[int]] = None,
+        pages: Optional[list[int]] = None,
         image_limit: Optional[int] = None,
         image_min_size: Optional[int] = None,
         cleanup_uploaded_files: bool = True,
@@ -141,7 +141,7 @@ class MistralOCRDocumentConverter:
         # Initialize Mistral client
         self.client = Mistral(api_key=self.api_key.resolve_value())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -160,7 +160,7 @@ class MistralOCRDocumentConverter:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "MistralOCRDocumentConverter":
+    def from_dict(cls, data: dict[str, Any]) -> "MistralOCRDocumentConverter":
         """
         Deserializes the component from a dictionary.
 
@@ -172,14 +172,14 @@ class MistralOCRDocumentConverter:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    @component.output_types(documents=List[Document], raw_mistral_response=List[Dict[str, Any]])
+    @component.output_types(documents=list[Document], raw_mistral_response=list[dict[str, Any]])
     def run(
         self,
-        sources: List[Union[str, Path, ByteStream, DocumentURLChunk, FileChunk, ImageURLChunk]],
-        meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-        bbox_annotation_schema: Optional[Type[BaseModel]] = None,
-        document_annotation_schema: Optional[Type[BaseModel]] = None,
-    ) -> Dict[str, Any]:
+        sources: list[Union[str, Path, ByteStream, DocumentURLChunk, FileChunk, ImageURLChunk]],
+        meta: Optional[Union[dict[str, Any], list[dict[str, Any]]]] = None,
+        bbox_annotation_schema: Optional[type[BaseModel]] = None,
+        document_annotation_schema: Optional[type[BaseModel]] = None,
+    ) -> dict[str, Any]:
         """
         Extract text from documents using Mistral OCR.
 
@@ -260,11 +260,11 @@ class MistralOCRDocumentConverter:
     def _process_single_source(
         self,
         source: Union[str, Path, ByteStream, DocumentURLChunk, FileChunk, ImageURLChunk],
-        user_metadata: Dict[str, Any],
+        user_metadata: dict[str, Any],
         bbox_annotation_format: Optional[Any],
         document_annotation_format: Optional[Any],
-        document_annotation_schema: Optional[Type[BaseModel]],
-    ) -> tuple[Optional[Document], Optional[Dict[str, Any]], Optional[str]]:
+        document_annotation_schema: Optional[type[BaseModel]],
+    ) -> tuple[Optional[Document], Optional[dict[str, Any]], Optional[str]]:
         """
         Process a single source and return the document, raw response, and file_id if uploaded.
 
@@ -312,7 +312,7 @@ class MistralOCRDocumentConverter:
             )
             return (None, None, uploaded_file_id)
 
-    def _cleanup_uploaded_files(self, file_ids: List[str]) -> None:
+    def _cleanup_uploaded_files(self, file_ids: list[str]) -> None:
         """
         Delete uploaded files from Mistral storage.
 
@@ -370,8 +370,8 @@ class MistralOCRDocumentConverter:
     def _process_ocr_response(
         self,
         ocr_response: OCRResponse,
-        user_metadata: Dict[str, Any],
-        document_annotation_schema: Optional[Type[BaseModel]],
+        user_metadata: dict[str, Any],
+        document_annotation_schema: Optional[type[BaseModel]],
     ) -> Document:
         """
         Convert an OCR response from Mistral API into a single Haystack Document.

--- a/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
+++ b/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from haystack import component, default_to_dict
 from haystack.components.embedders import OpenAIDocumentEmbedder
@@ -39,12 +39,12 @@ class MistralDocumentEmbedder(OpenAIDocumentEmbedder):
         suffix: str = "",
         batch_size: int = 32,
         progress_bar: bool = True,
-        meta_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[list[str]] = None,
         embedding_separator: str = "\n",
         *,
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[Dict[str, Any]] = None,
+        http_client_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Creates a MistralDocumentEmbedder component.
@@ -98,7 +98,7 @@ class MistralDocumentEmbedder(OpenAIDocumentEmbedder):
         self.timeout = timeout
         self.max_retries = max_retries
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 

--- a/integrations/mistral/src/haystack_integrations/components/embedders/mistral/text_embedder.py
+++ b/integrations/mistral/src/haystack_integrations/components/embedders/mistral/text_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from haystack import component, default_to_dict
 from haystack.components.embedders import OpenAITextEmbedder
@@ -38,7 +38,7 @@ class MistralTextEmbedder(OpenAITextEmbedder):
         *,
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[Dict[str, Any]] = None,
+        http_client_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Creates an MistralTextEmbedder component.
@@ -80,7 +80,7 @@ class MistralTextEmbedder(OpenAITextEmbedder):
         self.timeout = timeout
         self.max_retries = max_retries
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from haystack import component, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -65,12 +65,12 @@ class MistralChatGenerator(OpenAIChatGenerator):
         model: str = "mistral-small-latest",
         streaming_callback: Optional[StreamingCallbackT] = None,
         api_base_url: Optional[str] = "https://api.mistral.ai/v1",
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
         tools: Optional[ToolsType] = None,
         *,
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[Dict[str, Any]] = None,
+        http_client_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Creates an instance of MistralChatGenerator. Unless specified otherwise in the `model`, this is for Mistral's
@@ -155,7 +155,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
             api_args.pop("response_format")
         return api_args
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.
 

--- a/integrations/mistral/tests/test_ocr_document_converter.py
+++ b/integrations/mistral/tests/test_ocr_document_converter.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -320,7 +319,7 @@ class TestMistralOCRDocumentConverter:
         # Define annotation schema
         class DocumentAnnotation(BaseModel):
             language: str = Field(..., description="Document language")
-            topics: List[str] = Field(..., description="Main topics")
+            topics: list[str] = Field(..., description="Main topics")
 
         # Create mock response with document annotation
         mock_page = MagicMock()

--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -80,7 +80,7 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -45,7 +45,7 @@ class MongoDBAtlasEmbeddingRetriever:
         self,
         *,
         document_store: MongoDBAtlasDocumentStore,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: Optional[dict[str, Any]] = None,
         top_k: int = 10,
         filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
     ):
@@ -72,7 +72,7 @@ class MongoDBAtlasEmbeddingRetriever:
             filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -88,7 +88,7 @@ class MongoDBAtlasEmbeddingRetriever:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "MongoDBAtlasEmbeddingRetriever":
+    def from_dict(cls, data: dict[str, Any]) -> "MongoDBAtlasEmbeddingRetriever":
         """
         Deserializes the component from a dictionary.
 
@@ -106,13 +106,13 @@ class MongoDBAtlasEmbeddingRetriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
-    @component.output_types(documents=List[Document])
+    @component.output_types(documents=list[Document])
     def run(
         self,
-        query_embedding: List[float],
-        filters: Optional[Dict[str, Any]] = None,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
         top_k: Optional[int] = None,
-    ) -> Dict[str, List[Document]]:
+    ) -> dict[str, list[Document]]:
         """
         Retrieve documents from the MongoDBAtlasDocumentStore, based on the provided embedding similarity.
 
@@ -134,13 +134,13 @@ class MongoDBAtlasEmbeddingRetriever:
         )
         return {"documents": docs}
 
-    @component.output_types(documents=List[Document])
+    @component.output_types(documents=list[Document])
     async def run_async(
         self,
-        query_embedding: List[float],
-        filters: Optional[Dict[str, Any]] = None,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
         top_k: Optional[int] = None,
-    ) -> Dict[str, List[Document]]:
+    ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents from the MongoDBAtlasDocumentStore, based on the provided embedding
         similarity.

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -43,7 +43,7 @@ class MongoDBAtlasFullTextRetriever:
         self,
         *,
         document_store: MongoDBAtlasDocumentStore,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: Optional[dict[str, Any]] = None,
         top_k: int = 10,
         filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
     ):
@@ -69,7 +69,7 @@ class MongoDBAtlasFullTextRetriever:
             filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -85,7 +85,7 @@ class MongoDBAtlasFullTextRetriever:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "MongoDBAtlasFullTextRetriever":
+    def from_dict(cls, data: dict[str, Any]) -> "MongoDBAtlasFullTextRetriever":
         """
         Deserializes the component from a dictionary.
 
@@ -100,17 +100,17 @@ class MongoDBAtlasFullTextRetriever:
 
         return default_from_dict(cls, data)
 
-    @component.output_types(documents=List[Document])
+    @component.output_types(documents=list[Document])
     def run(
         self,
-        query: Union[str, List[str]],
-        fuzzy: Optional[Dict[str, int]] = None,
+        query: Union[str, list[str]],
+        fuzzy: Optional[dict[str, int]] = None,
         match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[Dict[str, Dict]] = None,
+        score: Optional[dict[str, dict]] = None,
         synonyms: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: Optional[dict[str, Any]] = None,
         top_k: int = 10,
-    ) -> Dict[str, List[Document]]:
+    ) -> dict[str, list[Document]]:
         """
         Retrieve documents from the MongoDBAtlasDocumentStore by full-text search.
 
@@ -150,17 +150,17 @@ class MongoDBAtlasFullTextRetriever:
 
         return {"documents": docs}
 
-    @component.output_types(documents=List[Document])
+    @component.output_types(documents=list[Document])
     async def run_async(
         self,
-        query: Union[str, List[str]],
-        fuzzy: Optional[Dict[str, int]] = None,
+        query: Union[str, list[str]],
+        fuzzy: Optional[dict[str, int]] = None,
         match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[Dict[str, Dict]] = None,
+        score: Optional[dict[str, dict]] = None,
         synonyms: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: Optional[dict[str, Any]] = None,
         top_k: int = 10,
-    ) -> Dict[str, List[Document]]:
+    ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents from the MongoDBAtlasDocumentStore by full-text search.
 

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import re
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from haystack import default_from_dict, default_to_dict, logging
 from haystack.dataclasses.document import Document
@@ -229,7 +229,7 @@ class MongoDBAtlasDocumentStore:
             database = self._connection_async[self.database_name]
             self._collection_async = database[self.collection_name]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -246,7 +246,7 @@ class MongoDBAtlasDocumentStore:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "MongoDBAtlasDocumentStore":
+    def from_dict(cls, data: dict[str, Any]) -> "MongoDBAtlasDocumentStore":
         """
         Deserializes the component from a dictionary.
 
@@ -278,7 +278,7 @@ class MongoDBAtlasDocumentStore:
         assert self._collection_async is not None
         return await self._collection_async.count_documents({})
 
-    def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
+    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
         """
         Returns the documents that match the filters provided.
 
@@ -294,7 +294,7 @@ class MongoDBAtlasDocumentStore:
         documents = list(self._collection.find(filters))
         return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
-    async def filter_documents_async(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
+    async def filter_documents_async(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
         """
         Asynchronously returns the documents that match the filters provided.
 
@@ -310,7 +310,7 @@ class MongoDBAtlasDocumentStore:
         documents = await self._collection_async.find(filters).to_list()
         return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
-    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE) -> int:
+    def write_documents(self, documents: list[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE) -> int:
         """
         Writes documents into the MongoDB Atlas collection.
 
@@ -332,7 +332,7 @@ class MongoDBAtlasDocumentStore:
             policy = DuplicatePolicy.FAIL
 
         mongo_documents = [self._haystack_doc_to_mongo_doc(doc) for doc in documents]
-        operations: List[Union[UpdateOne, InsertOne, ReplaceOne]]
+        operations: list[Union[UpdateOne, InsertOne, ReplaceOne]]
         written_docs = len(documents)
 
         if policy == DuplicatePolicy.SKIP:
@@ -353,7 +353,7 @@ class MongoDBAtlasDocumentStore:
         return written_docs
 
     async def write_documents_async(
-        self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE
+        self, documents: list[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE
     ) -> int:
         """
         Writes documents into the MongoDB Atlas collection.
@@ -377,7 +377,7 @@ class MongoDBAtlasDocumentStore:
 
         mongo_documents = [self._haystack_doc_to_mongo_doc(doc) for doc in documents]
 
-        operations: List[Union[UpdateOne, InsertOne, ReplaceOne]]
+        operations: list[Union[UpdateOne, InsertOne, ReplaceOne]]
         written_docs = len(documents)
 
         if policy == DuplicatePolicy.SKIP:
@@ -399,7 +399,7 @@ class MongoDBAtlasDocumentStore:
 
         return written_docs
 
-    def delete_documents(self, document_ids: List[str]) -> None:
+    def delete_documents(self, document_ids: list[str]) -> None:
         """
         Deletes all documents with a matching document_ids from the document store.
 
@@ -411,7 +411,7 @@ class MongoDBAtlasDocumentStore:
             return
         self._collection.delete_many(filter={"id": {"$in": document_ids}})
 
-    async def delete_documents_async(self, document_ids: List[str]) -> None:
+    async def delete_documents_async(self, document_ids: list[str]) -> None:
         """
         Asynchronously deletes all documents with a matching document_ids from the document store.
 
@@ -423,7 +423,7 @@ class MongoDBAtlasDocumentStore:
             return
         await self._collection_async.delete_many(filter={"id": {"$in": document_ids}})
 
-    def delete_by_filter(self, filters: Dict[str, Any]) -> int:
+    def delete_by_filter(self, filters: dict[str, Any]) -> int:
         """
         Deletes all documents that match the provided filters.
 
@@ -448,7 +448,7 @@ class MongoDBAtlasDocumentStore:
             msg = f"Failed to delete documents by filter from MongoDB Atlas: {e!s}"
             raise DocumentStoreError(msg) from e
 
-    async def delete_by_filter_async(self, filters: Dict[str, Any]) -> int:
+    async def delete_by_filter_async(self, filters: dict[str, Any]) -> int:
         """
         Asynchronously deletes all documents that match the provided filters.
 
@@ -473,7 +473,7 @@ class MongoDBAtlasDocumentStore:
             msg = f"Failed to delete documents by filter from MongoDB Atlas: {e!s}"
             raise DocumentStoreError(msg) from e
 
-    def update_by_filter(self, filters: Dict[str, Any], meta: Dict[str, Any]) -> int:
+    def update_by_filter(self, filters: dict[str, Any], meta: dict[str, Any]) -> int:
         """
         Updates the metadata of all documents that match the provided filters.
 
@@ -502,7 +502,7 @@ class MongoDBAtlasDocumentStore:
             msg = f"Failed to update documents by filter in MongoDB Atlas: {e!s}"
             raise DocumentStoreError(msg) from e
 
-    async def update_by_filter_async(self, filters: Dict[str, Any], meta: Dict[str, Any]) -> int:
+    async def update_by_filter_async(self, filters: dict[str, Any], meta: dict[str, Any]) -> int:
         """
         Asynchronously updates the metadata of all documents that match the provided filters.
 
@@ -635,10 +635,10 @@ class MongoDBAtlasDocumentStore:
 
     def _embedding_retrieval(
         self,
-        query_embedding: List[float],
-        filters: Optional[Dict[str, Any]] = None,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
         top_k: int = 10,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """
         Find the documents that are most similar to the provided `query_embedding` by using a vector similarity metric.
 
@@ -657,7 +657,7 @@ class MongoDBAtlasDocumentStore:
 
         filters = _normalize_filters(filters) if filters else {}
 
-        pipeline: List[Dict[str, Any]] = [
+        pipeline: list[dict[str, Any]] = [
             {
                 "$vectorSearch": {
                     "index": self.vector_search_index,
@@ -686,8 +686,8 @@ class MongoDBAtlasDocumentStore:
         return documents
 
     async def _embedding_retrieval_async(
-        self, query_embedding: List[float], filters: Optional[Dict[str, Any]] = None, top_k: int = 10
-    ) -> List[Document]:
+        self, query_embedding: list[float], filters: Optional[dict[str, Any]] = None, top_k: int = 10
+    ) -> list[Document]:
         """
         Asynchronously find the documents that are most similar to the provided `query_embedding` by using a vector
         similarity metric.
@@ -707,7 +707,7 @@ class MongoDBAtlasDocumentStore:
 
         filters = _normalize_filters(filters) if filters else {}
 
-        pipeline: List[Dict[str, Any]] = [
+        pipeline: list[dict[str, Any]] = [
             {
                 "$vectorSearch": {
                     "index": self.vector_search_index,
@@ -738,14 +738,14 @@ class MongoDBAtlasDocumentStore:
 
     def _fulltext_retrieval(
         self,
-        query: Union[str, List[str]],
-        fuzzy: Optional[Dict[str, int]] = None,
+        query: Union[str, list[str]],
+        fuzzy: Optional[dict[str, int]] = None,
         match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[Dict[str, Dict]] = None,
+        score: Optional[dict[str, dict]] = None,
         synonyms: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: Optional[dict[str, Any]] = None,
         top_k: int = 10,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """
         Retrieve documents similar to the provided `query` using a full-text search.
 
@@ -792,7 +792,7 @@ class MongoDBAtlasDocumentStore:
         filters = _normalize_filters(filters) if filters else {}
 
         # Build the text search options
-        text_search: Dict[str, Any] = {"path": self.content_field or "content", "query": query}
+        text_search: dict[str, Any] = {"path": self.content_field or "content", "query": query}
         if match_criteria:
             text_search["matchCriteria"] = match_criteria
         if synonyms:
@@ -803,7 +803,7 @@ class MongoDBAtlasDocumentStore:
             text_search["score"] = score
 
         # Define the pipeline for MongoDB aggregation
-        pipeline: List[Dict[str, Any]] = [
+        pipeline: list[dict[str, Any]] = [
             {
                 "$search": {
                     "index": self.full_text_search_index,
@@ -831,14 +831,14 @@ class MongoDBAtlasDocumentStore:
 
     async def _fulltext_retrieval_async(
         self,
-        query: Union[str, List[str]],
-        fuzzy: Optional[Dict[str, int]] = None,
+        query: Union[str, list[str]],
+        fuzzy: Optional[dict[str, int]] = None,
         match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[Dict[str, Dict]] = None,
+        score: Optional[dict[str, dict]] = None,
         synonyms: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: Optional[dict[str, Any]] = None,
         top_k: int = 10,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """
         Asynchronously retrieve documents similar to the provided `query` using a full-text search asynchronously.
 
@@ -885,7 +885,7 @@ class MongoDBAtlasDocumentStore:
         filters = _normalize_filters(filters) if filters else {}
 
         # Build the text search options
-        text_search: Dict[str, Any] = {"path": self.content_field or "content", "query": query}
+        text_search: dict[str, Any] = {"path": self.content_field or "content", "query": query}
         if match_criteria:
             text_search["matchCriteria"] = match_criteria
         if synonyms:
@@ -896,7 +896,7 @@ class MongoDBAtlasDocumentStore:
             text_search["score"] = score
 
         # Define the pipeline for MongoDB aggregation
-        pipeline: List[Dict[str, Any]] = [
+        pipeline: list[dict[str, Any]] = [
             {
                 "$search": {
                     "index": self.full_text_search_index,
@@ -923,7 +923,7 @@ class MongoDBAtlasDocumentStore:
 
         return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
-    def _mongo_doc_to_haystack_doc(self, mongo_doc: Dict[str, Any]) -> Document:
+    def _mongo_doc_to_haystack_doc(self, mongo_doc: dict[str, Any]) -> Document:
         """
         Converts the dictionary coming out of MongoDB into a Haystack document
 
@@ -937,7 +937,7 @@ class MongoDBAtlasDocumentStore:
             mongo_doc["embedding"] = mongo_doc.pop(self.embedding_field, None)
         return Document.from_dict(mongo_doc)
 
-    def _haystack_doc_to_mongo_doc(self, haystack_doc: Document) -> Dict[str, Any]:
+    def _haystack_doc_to_mongo_doc(self, haystack_doc: Document) -> dict[str, Any]:
         """
         Parses a Haystack Document to a MongoDB document.
 

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/filters.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/filters.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
 from haystack.errors import FilterError
 
 UNSUPPORTED_TYPES_FOR_COMPARISON = (list,)
 
 
-def _normalize_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_filters(filters: dict[str, Any]) -> dict[str, Any]:
     """
     Converts Haystack filters to MongoDB filters.
     """
@@ -26,7 +26,7 @@ def _normalize_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
     return _parse_logical_condition(filters)
 
 
-def _parse_logical_condition(condition: Dict[str, Any]) -> Dict[str, Any]:
+def _parse_logical_condition(condition: dict[str, Any]) -> dict[str, Any]:
     if "operator" not in condition:
         msg = f"'operator' key missing in {condition}"
         raise FilterError(msg)
@@ -56,7 +56,7 @@ def _parse_logical_condition(condition: Dict[str, Any]) -> Dict[str, Any]:
     raise FilterError(msg)
 
 
-def _parse_comparison_condition(condition: Dict[str, Any]) -> Dict[str, Any]:
+def _parse_comparison_condition(condition: dict[str, Any]) -> dict[str, Any]:
     field: str = condition["field"]
     if "operator" not in condition:
         msg = f"'operator' key missing in {condition}"
@@ -70,11 +70,11 @@ def _parse_comparison_condition(condition: Dict[str, Any]) -> Dict[str, Any]:
     return COMPARISON_OPERATORS[operator](field, value)
 
 
-def _equal(field: str, value: Any) -> Dict[str, Any]:
+def _equal(field: str, value: Any) -> dict[str, Any]:
     return {field: {"$eq": value}}
 
 
-def _not_equal(field: str, value: Any) -> Dict[str, Any]:
+def _not_equal(field: str, value: Any) -> dict[str, Any]:
     return {field: {"$ne": value}}
 
 
@@ -90,12 +90,12 @@ def _validate_type_for_comparison(value: Any) -> None:
             raise FilterError(msg) from exc
 
 
-def _greater_than(field: str, value: Any) -> Dict[str, Any]:
+def _greater_than(field: str, value: Any) -> dict[str, Any]:
     _validate_type_for_comparison(value)
     return {field: {"$gt": value}}
 
 
-def _greater_than_equal(field: str, value: Any) -> Dict[str, Any]:
+def _greater_than_equal(field: str, value: Any) -> dict[str, Any]:
     if value is None:
         # we want {field: {"$gte": null}} to return an empty result
         # $gte with null values in MongoDB returns a non-empty result, while $gt aligns with our expectations
@@ -105,12 +105,12 @@ def _greater_than_equal(field: str, value: Any) -> Dict[str, Any]:
     return {field: {"$gte": value}}
 
 
-def _less_than(field: str, value: Any) -> Dict[str, Any]:
+def _less_than(field: str, value: Any) -> dict[str, Any]:
     _validate_type_for_comparison(value)
     return {field: {"$lt": value}}
 
 
-def _less_than_equal(field: str, value: Any) -> Dict[str, Any]:
+def _less_than_equal(field: str, value: Any) -> dict[str, Any]:
     if value is None:
         # we want {field: {"$lte": null}} to return an empty result
         # $lte with null values in MongoDB returns a non-empty result, while $lt aligns with our expectations
@@ -120,7 +120,7 @@ def _less_than_equal(field: str, value: Any) -> Dict[str, Any]:
     return {field: {"$lte": value}}
 
 
-def _not_in(field: str, value: Any) -> Dict[str, Any]:
+def _not_in(field: str, value: Any) -> dict[str, Any]:
     if not isinstance(value, list):
         msg = f"{field}'s value must be a list when using 'not in' comparator in Pinecone"
         raise FilterError(msg)
@@ -128,7 +128,7 @@ def _not_in(field: str, value: Any) -> Dict[str, Any]:
     return {field: {"$nin": value}}
 
 
-def _in(field: str, value: Any) -> Dict[str, Any]:
+def _in(field: str, value: Any) -> dict[str, Any]:
     if not isinstance(value, list):
         msg = f"{field}'s value must be a list when using 'in' comparator in Pinecone"
         raise FilterError(msg)

--- a/integrations/mongodb_atlas/tests/test_embedding_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_embedding_retrieval.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-from typing import List
 
 import pytest
 from haystack.document_stores.errors import DocumentStoreError
@@ -65,7 +64,7 @@ class TestEmbeddingRetrieval:
             vector_search_index="cosine_index",
             full_text_search_index="full_text_index",
         )
-        query_embedding: List[float] = []
+        query_embedding: list[float] = []
         with pytest.raises(ValueError):
             document_store._embedding_retrieval(query_embedding=query_embedding)
 

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -4,7 +4,7 @@
 
 import os
 from time import sleep
-from typing import List, Union
+from typing import Union
 from unittest.mock import MagicMock
 
 import pytest
@@ -157,7 +157,7 @@ class TestFullTextRetrieval:
         assert results[0].score >= results[1].score
 
     @pytest.mark.parametrize("query", ["", []])
-    def test_empty_query_raises_value_error(self, query: Union[str, List], document_store: MongoDBAtlasDocumentStore):
+    def test_empty_query_raises_value_error(self, query: Union[str, list], document_store: MongoDBAtlasDocumentStore):
         with pytest.raises(ValueError):
             document_store._fulltext_retrieval(query=query)
 

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval_async.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval_async.py
@@ -4,7 +4,7 @@
 
 import os
 from time import sleep
-from typing import List, Union
+from typing import Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -116,7 +116,7 @@ class TestFullTextRetrieval:
 
     @pytest.mark.parametrize("query", ["", []])
     async def test_empty_query_raises_value_error_async(
-        self, query: Union[str, List], document_store: MongoDBAtlasDocumentStore
+        self, query: Union[str, list], document_store: MongoDBAtlasDocumentStore
     ):
         with pytest.raises(ValueError):
             await document_store._fulltext_retrieval_async(query=query)

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -82,7 +82,7 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -4,7 +4,7 @@
 
 import os
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -45,7 +45,7 @@ class NvidiaDocumentEmbedder:
         suffix: str = "",
         batch_size: int = 32,
         progress_bar: bool = True,
-        meta_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[list[str]] = None,
         embedding_separator: str = "\n",
         truncate: Optional[Union[EmbeddingTruncateMode, str]] = None,
         timeout: Optional[float] = None,
@@ -156,7 +156,7 @@ class NvidiaDocumentEmbedder:
         if not self.model:
             self.default_model()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -179,14 +179,14 @@ class NvidiaDocumentEmbedder:
         )
 
     @property
-    def available_models(self) -> List[Model]:
+    def available_models(self) -> list[Model]:
         """
         Get a list of available models that work with NvidiaDocumentEmbedder.
         """
         return self.backend.models() if self.backend else []
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "NvidiaDocumentEmbedder":
+    def from_dict(cls, data: dict[str, Any]) -> "NvidiaDocumentEmbedder":
         """
         Deserializes the component from a dictionary.
 
@@ -200,7 +200,7 @@ class NvidiaDocumentEmbedder:
             deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:
+    def _prepare_texts_to_embed(self, documents: list[Document]) -> list[str]:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
@@ -213,8 +213,8 @@ class NvidiaDocumentEmbedder:
 
         return texts_to_embed
 
-    def _embed_batch(self, texts_to_embed: List[str], batch_size: int) -> Tuple[List[List[float]], Dict[str, Any]]:
-        all_embeddings: List[List[float]] = []
+    def _embed_batch(self, texts_to_embed: list[str], batch_size: int) -> tuple[list[list[float]], dict[str, Any]]:
+        all_embeddings: list[list[float]] = []
         usage_prompt_tokens = 0
         usage_total_tokens = 0
 
@@ -233,8 +233,8 @@ class NvidiaDocumentEmbedder:
 
         return all_embeddings, {"usage": {"prompt_tokens": usage_prompt_tokens, "total_tokens": usage_total_tokens}}
 
-    @component.output_types(documents=List[Document], meta=Dict[str, Any])
-    def run(self, documents: List[Document]) -> Dict[str, Union[List[Document], Dict[str, Any]]]:
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    def run(self, documents: list[Document]) -> dict[str, Union[list[Document], dict[str, Any]]]:
         """
         Embed a list of Documents.
 

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -4,7 +4,7 @@
 
 import os
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -146,7 +146,7 @@ class NvidiaTextEmbedder:
             else:
                 self.default_model()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -165,14 +165,14 @@ class NvidiaTextEmbedder:
         )
 
     @property
-    def available_models(self) -> List[Model]:
+    def available_models(self) -> list[Model]:
         """
         Get a list of available models that work with NvidiaTextEmbedder.
         """
         return self.backend.models() if self.backend else []
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "NvidiaTextEmbedder":
+    def from_dict(cls, data: dict[str, Any]) -> "NvidiaTextEmbedder":
         """
         Deserializes the component from a dictionary.
 
@@ -186,8 +186,8 @@ class NvidiaTextEmbedder:
             deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    @component.output_types(embedding=List[float], meta=Dict[str, Any])
-    def run(self, text: str) -> Dict[str, Union[List[float], Dict[str, Any]]]:
+    @component.output_types(embedding=list[float], meta=dict[str, Any])
+    def run(self, text: str) -> dict[str, Union[list[float], dict[str, Any]]]:
         """
         Embed a string.
 

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/chat/chat_generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/chat/chat_generator.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from haystack import component, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -55,11 +55,11 @@ class NvidiaChatGenerator(OpenAIChatGenerator):
         model: str = "meta/llama-3.1-8b-instruct",
         streaming_callback: Optional[StreamingCallbackT] = None,
         api_base_url: Optional[str] = os.getenv("NVIDIA_API_URL", DEFAULT_API_URL),
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
         tools: Optional[ToolsType] = None,
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[Dict[str, Any]] = None,
+        http_client_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Creates an instance of NvidiaChatGenerator.
@@ -126,7 +126,7 @@ class NvidiaChatGenerator(OpenAIChatGenerator):
             http_client_kwargs=http_client_kwargs,
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.
 

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
@@ -4,7 +4,7 @@
 
 import os
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils.auth import Secret, deserialize_secrets_inplace
@@ -47,7 +47,7 @@ class NvidiaGenerator:
         model: Optional[str] = None,
         api_url: str = os.getenv("NVIDIA_API_URL", DEFAULT_API_URL),
         api_key: Optional[Secret] = Secret.from_env_var("NVIDIA_API_KEY"),
-        model_arguments: Optional[Dict[str, Any]] = None,
+        model_arguments: Optional[dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         """
@@ -134,7 +134,7 @@ class NvidiaGenerator:
             else:
                 self.default_model()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -150,14 +150,14 @@ class NvidiaGenerator:
         )
 
     @property
-    def available_models(self) -> List[Model]:
+    def available_models(self) -> list[Model]:
         """
         Get a list of available models that work with ChatNVIDIA.
         """
         return self.backend.models() if self.backend else []
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "NvidiaGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "NvidiaGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -170,8 +170,8 @@ class NvidiaGenerator:
         deserialize_secrets_inplace(init_params, ["api_key"])
         return default_from_dict(cls, data)
 
-    @component.output_types(replies=List[str], meta=List[Dict[str, Any]])
-    def run(self, prompt: str) -> Dict[str, Union[List[str], List[Dict[str, Any]]]]:
+    @component.output_types(replies=list[str], meta=list[dict[str, Any]])
+    def run(self, prompt: str) -> dict[str, Union[list[str], list[dict[str, Any]]]]:
         """
         Queries the model with the provided prompt.
 

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -4,7 +4,7 @@
 
 import os
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -54,7 +54,7 @@ class NvidiaRanker:
         top_k: int = 5,
         query_prefix: str = "",
         document_prefix: str = "",
-        meta_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[list[str]] = None,
         embedding_separator: str = "\n",
         timeout: Optional[float] = None,
     ):
@@ -122,7 +122,7 @@ class NvidiaRanker:
     def class_name(cls) -> str:
         return "NvidiaRanker"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize the ranker to a dictionary.
 
@@ -143,7 +143,7 @@ class NvidiaRanker:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "NvidiaRanker":
+    def from_dict(cls, data: dict[str, Any]) -> "NvidiaRanker":
         """
         Deserialize the ranker from a dictionary.
 
@@ -162,7 +162,7 @@ class NvidiaRanker:
         :raises ValueError: If the API key is required for hosted NVIDIA NIMs.
         """
         if not self._initialized:
-            model_kwargs: Dict[str, Any] = {}
+            model_kwargs: dict[str, Any] = {}
             if self.truncate is not None:
                 model_kwargs.update(truncate=str(self.truncate))
             self.backend = NimBackend(
@@ -179,7 +179,7 @@ class NvidiaRanker:
                     self.model = self.backend.model
             self._initialized = True
 
-    def _prepare_documents_to_embed(self, documents: List[Document]) -> List[str]:
+    def _prepare_documents_to_embed(self, documents: list[Document]) -> list[str]:
         document_texts = []
         for doc in documents:
             meta_values_to_embed = [
@@ -191,13 +191,13 @@ class NvidiaRanker:
             document_texts.append(self.document_prefix + text_to_embed)
         return document_texts
 
-    @component.output_types(documents=List[Document])
+    @component.output_types(documents=list[Document])
     def run(
         self,
         query: str,
-        documents: List[Document],
+        documents: list[Document],
         top_k: Optional[int] = None,
-    ) -> Dict[str, List[Document]]:
+    ) -> dict[str, list[Document]]:
         """
         Rank a list of documents based on a given query.
 

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
@@ -4,7 +4,7 @@
 
 import os
 import warnings
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Literal, Optional, Union
 
 import requests
 from haystack import logging
@@ -26,7 +26,7 @@ class NimBackend:
         model_type: Optional[Literal["chat", "embedding", "ranking"]] = None,
         model: Optional[str] = None,
         api_key: Optional[Secret] = Secret.from_env_var("NVIDIA_API_KEY"),
-        model_kwargs: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[dict[str, Any]] = None,
         client: Optional[Union[str, Client]] = None,
         timeout: Optional[float] = None,
     ):
@@ -73,7 +73,7 @@ class NimBackend:
             timeout = float(os.environ.get("NVIDIA_TIMEOUT", REQUEST_TIMEOUT))
         self.timeout = timeout
 
-    def embed(self, texts: List[str]) -> Tuple[List[List[float]], Dict[str, Any]]:
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], dict[str, Any]]:
         url = f"{self.api_url}/embeddings"
 
         try:
@@ -98,7 +98,7 @@ class NimBackend:
 
         return embeddings, {"usage": data["usage"]}
 
-    def generate(self, prompt: str) -> Tuple[List[str], List[Dict[str, Any]]]:
+    def generate(self, prompt: str) -> tuple[list[str], list[dict[str, Any]]]:
         # We're using the chat completion endpoint as the NIM API doesn't support
         # the /completions endpoint. So both the non-chat and chat generator will use this.
         # This is the same for local containers and the cloud API.
@@ -151,7 +151,7 @@ class NimBackend:
 
         return replies, meta
 
-    def models(self) -> List[Model]:
+    def models(self) -> list[Model]:
         url = f"{self.api_url}/models"
 
         res = self.session.get(
@@ -174,7 +174,7 @@ class NimBackend:
             raise ValueError(msg)
         return models
 
-    def rank(self, query_text: str, document_texts: List[str]) -> List[Dict[str, Any]]:
+    def rank(self, query_text: str, document_texts: list[str]) -> list[dict[str, Any]]:
         url = self.api_url
 
         try:

--- a/integrations/nvidia/tests/conftest.py
+++ b/integrations/nvidia/tests/conftest.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import pytest
 from haystack.utils import Secret
@@ -12,7 +12,7 @@ from haystack_integrations.utils.nvidia import Model, NimBackend
 
 
 class MockBackend(NimBackend):
-    def __init__(self, model: str, api_key: Optional[Secret] = None, model_kwargs: Optional[Dict[str, Any]] = None):
+    def __init__(self, model: str, api_key: Optional[Secret] = None, model_kwargs: Optional[dict[str, Any]] = None):
         api_key = api_key or Secret.from_env_var("NVIDIA_API_KEY")
         super().__init__(api_url="", model=model, api_key=api_key, model_kwargs=model_kwargs or {})
 
@@ -24,7 +24,7 @@ class MockBackend(NimBackend):
     def models(self):
         return [Model(id="aa")]
 
-    def generate(self) -> Tuple[List[str], List[Dict[str, Any]]]:
+    def generate(self) -> tuple[list[str], list[dict[str, Any]]]:
         return (
             ["This is a mocked response."],
             [{"role": "assistant", "usage": {"prompt_tokens": 5, "total_tokens": 10, "completion_tokens": 5}}],


### PR DESCRIPTION
### Related Issues

- part of the fix for [#2136](https://github.com/deepset-ai/haystack-core-integrations/issues/2136)

### Proposed Changes:

- Update ruff version to `py39` compatible with Python 3.9
- Replace the use of `typing` module with collections in the Python standard library
- Updated integrations: GoogleAI, Google Vertex, HaNLP, Jina, Langfuse, LlamaCpp, Llama Stack, Meta Llama, Mistral, MongoDB, Nvidia

### How did you test it?

CI
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
