### PR TITLE
enhancement: Adopt PEP 585 type hinting (part 6)

### DIFF
--- a/integrations/aimlapi/pyproject.toml
+++ b/integrations/aimlapi/pyproject.toml
@@ -76,7 +76,7 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/aimlapi/src/haystack_integrations/components/generators/aimlapi/chat/chat_generator.py
+++ b/integrations/aimlapi/src/haystack_integrations/components/generators/aimlapi/chat/chat_generator.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from haystack import component, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -65,12 +65,12 @@ class AIMLAPIChatGenerator(OpenAIChatGenerator):
         model: str = "openai/gpt-5-chat-latest",
         streaming_callback: Optional[StreamingCallbackT] = None,
         api_base_url: Optional[str] = "https://api.aimlapi.com/v1",
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
         tools: Optional[ToolsType] = None,
         timeout: Optional[float] = None,
-        extra_headers: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, Any]] = None,
         max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[Dict[str, Any]] = None,
+        http_client_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Creates an instance of AIMLAPIChatGenerator. Unless specified otherwise,
@@ -128,7 +128,7 @@ class AIMLAPIChatGenerator(OpenAIChatGenerator):
         )
         self.extra_headers = extra_headers
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.
 
@@ -154,18 +154,18 @@ class AIMLAPIChatGenerator(OpenAIChatGenerator):
     def _prepare_api_call(
         self,
         *,
-        messages: List[ChatMessage],
+        messages: list[ChatMessage],
         streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
         tools: Optional[ToolsType] = None,
         tools_strict: Optional[bool] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         # update generation kwargs by merging with the generation kwargs passed to the run method
         generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
         extra_headers = {**AIMLAPI_HEADERS, **(self.extra_headers or {})}
 
         # adapt ChatMessage(s) to the format expected by the OpenAI API (AIMLAPI uses the same format)
-        aimlapi_formatted_messages: List[Dict[str, Any]] = [message.to_openai_dict_format() for message in messages]
+        aimlapi_formatted_messages: list[dict[str, Any]] = [message.to_openai_dict_format() for message in messages]
 
         tools_strict = tools_strict if tools_strict is not None else self.tools_strict
         flattened_tools = flatten_tools_or_toolsets(tools or self.tools)

--- a/integrations/amazon_sagemaker/pyproject.toml
+++ b/integrations/amazon_sagemaker/pyproject.toml
@@ -83,7 +83,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/integrations/amazon_sagemaker/src/haystack_integrations/components/generators/amazon_sagemaker/sagemaker.py
+++ b/integrations/amazon_sagemaker/src/haystack_integrations/components/generators/amazon_sagemaker/sagemaker.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Optional, Union
 
 import boto3
 import requests
@@ -56,8 +56,8 @@ class SagemakerGenerator:
         aws_session_token: Optional[Secret] = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
         aws_region_name: Optional[Secret] = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
         aws_profile_name: Optional[Secret] = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
-        aws_custom_attributes: Optional[Dict[str, Any]] = None,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        aws_custom_attributes: Optional[dict[str, Any]] = None,
+        generation_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Instantiates the session with SageMaker.
@@ -114,7 +114,7 @@ class SagemakerGenerator:
             )
             raise AWSConfigurationError(msg) from e
 
-    def _get_telemetry_data(self) -> Dict[str, Any]:
+    def _get_telemetry_data(self) -> dict[str, Any]:
         """
         Returns data that is sent to Posthog for usage analytics.
         :returns: A dictionary with the following keys:
@@ -122,7 +122,7 @@ class SagemakerGenerator:
         """
         return {"model": self.model}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.
 
@@ -142,7 +142,7 @@ class SagemakerGenerator:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SagemakerGenerator":
+    def from_dict(cls, data: dict[str, Any]) -> "SagemakerGenerator":
         """
         Deserializes the component from a dictionary.
 
@@ -191,10 +191,10 @@ class SagemakerGenerator:
             msg = f"Failed to initialize the session with provided AWS credentials: {e}."
             raise AWSConfigurationError(msg) from e
 
-    @component.output_types(replies=List[str], meta=List[Dict[str, Any]])
+    @component.output_types(replies=list[str], meta=list[dict[str, Any]])
     def run(
-        self, prompt: str, generation_kwargs: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Union[List[str], List[Dict[str, Any]]]]:
+        self, prompt: str, generation_kwargs: Optional[dict[str, Any]] = None
+    ) -> dict[str, Union[list[str], list[dict[str, Any]]]]:
         """
         Invoke the text generation inference based on the provided prompt and generation parameters.
 
@@ -222,10 +222,10 @@ class SagemakerGenerator:
                 CustomAttributes=custom_attributes,
             )
             response_json = response.get("Body").read().decode("utf-8")
-            output: Dict[str, Dict[str, Any]] = json.loads(response_json)
+            output: dict[str, dict[str, Any]] = json.loads(response_json)
 
             # The output might be either a list of dictionaries or a single dictionary
-            list_output: List[Dict[str, Any]]
+            list_output: list[dict[str, Any]]
             if output and isinstance(output, dict):
                 list_output = [output]
             elif isinstance(output, list) and all(isinstance(o, dict) for o in output):


### PR DESCRIPTION
### Related Issues

- part of the fix for [#2136](https://github.com/deepset-ai/haystack-core-integrations/issues/2136)

### Proposed Changes:

- Update ruff version to `py39` compatible with Python 3.9
- Replace the use of `typing` module with collections in the Python standard library
- Updated integrations: AIMLAPI, Amazon Sagemaker

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
