### PR TITLE
chore: Update togetherai default model

### DIFF
--- a/integrations/togetherai/src/haystack_integrations/components/generators/togetherai/chat/chat_generator.py
+++ b/integrations/togetherai/src/haystack_integrations/components/generators/togetherai/chat/chat_generator.py
@@ -53,7 +53,7 @@ class TogetherAIChatGenerator(OpenAIChatGenerator):
     >>{'replies': [ChatMessage(_content='Natural Language Processing (NLP) is a branch of artificial intelligence
     >>that focuses on enabling computers to understand, interpret, and generate human language in a way that is
     >>meaningful and useful.', _role=<ChatRole.ASSISTANT: 'assistant'>, _name=None,
-    >>_meta={'model': 'meta-llama/Llama-4-Scout-17B-16E-Instruct-FP8', 'index': 0, 'finish_reason': 'stop',
+    >>_meta={'model': 'deepseek-ai/DeepSeek-V3', 'index': 0, 'finish_reason': 'stop',
     >>'usage': {'prompt_tokens': 15, 'completion_tokens': 36, 'total_tokens': 51}})]}
     ```
     """
@@ -62,7 +62,7 @@ class TogetherAIChatGenerator(OpenAIChatGenerator):
         self,
         *,
         api_key: Secret = Secret.from_env_var("TOGETHER_API_KEY"),
-        model: str = "meta-llama/Llama-4-Scout-17B-16E-Instruct-FP8",
+        model: str = "deepseek-ai/DeepSeek-V3",
         streaming_callback: Optional[StreamingCallbackT] = None,
         api_base_url: Optional[str] = "https://api.together.xyz/v1",
         generation_kwargs: Optional[dict[str, Any]] = None,
@@ -73,7 +73,7 @@ class TogetherAIChatGenerator(OpenAIChatGenerator):
     ):
         """
         Creates an instance of TogetherAIChatGenerator. Unless specified otherwise,
-        the default model is `meta-llama/Llama-4-Scout-17B-16E-Instruct-FP8`.
+        the default model is `deepseek-ai/DeepSeek-V3`.
 
         :param api_key:
             The Together API key.

--- a/integrations/togetherai/src/haystack_integrations/components/generators/togetherai/generator.py
+++ b/integrations/togetherai/src/haystack_integrations/components/generators/togetherai/generator.py
@@ -34,7 +34,7 @@ class TogetherAIGenerator(TogetherAIChatGenerator):
     def __init__(
         self,
         api_key: Secret = Secret.from_env_var("TOGETHER_API_KEY"),
-        model: str = "meta-llama/Llama-4-Scout-17B-16E-Instruct-FP8",
+        model: str = "deepseek-ai/DeepSeek-V3",
         api_base_url: Optional[str] = "https://api.together.xyz/v1",
         streaming_callback: Optional[StreamingCallbackT] = None,
         system_prompt: Optional[str] = None,
@@ -43,7 +43,8 @@ class TogetherAIGenerator(TogetherAIChatGenerator):
         max_retries: Optional[int] = None,
     ):
         """
-        Initialize the TogetherAIGenerator.
+        Initialize the TogetherAIGenerator. Unless specified otherwise,
+        the default model is `deepseek-ai/DeepSeek-V3`.
 
         :param api_key: The Together API key.
         :param model: The name of the model to use.

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -103,7 +103,7 @@ def mock_chat_completion():
     with patch("openai.resources.chat.completions.Completions.create") as mock_chat_completion_create:
         completion = ChatCompletion(
             id="foo",
-            model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            model="deepseek-ai/DeepSeek-V3",
             object="chat.completion",
             choices=[
                 Choice(
@@ -126,7 +126,7 @@ class TestTogetherAIChatGenerator:
         monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = TogetherAIChatGenerator(api_key=Secret.from_env_var("ENV_VAR"))
         assert component.client.api_key == "test-api-key"
-        assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        assert component.model == "deepseek-ai/DeepSeek-V3"
         assert component.api_base_url == "https://api.together.xyz/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
@@ -161,7 +161,7 @@ class TestTogetherAIChatGenerator:
 
         expected_params = {
             "api_key": {"env_vars": ["TOGETHER_API_KEY"], "strict": True, "type": "env_var"},
-            "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            "model": "deepseek-ai/DeepSeek-V3",
             "streaming_callback": None,
             "api_base_url": "https://api.together.xyz/v1",
             "generation_kwargs": {},
@@ -242,7 +242,7 @@ class TestTogetherAIChatGenerator:
             ),
             "init_parameters": {
                 "api_key": {"env_vars": ["TOGETHER_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                "model": "deepseek-ai/DeepSeek-V3",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -253,7 +253,7 @@ class TestTogetherAIChatGenerator:
             },
         }
         component = TogetherAIChatGenerator.from_dict(data)
-        assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        assert component.model == "deepseek-ai/DeepSeek-V3"
         assert component.streaming_callback is print_streaming_chunk
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -271,7 +271,7 @@ class TestTogetherAIChatGenerator:
             ),
             "init_parameters": {
                 "api_key": {"env_vars": ["TOGETHER_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo ",
+                "model": "deepseek-ai/DeepSeek-V3 ",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -322,7 +322,7 @@ class TestTogetherAIChatGenerator:
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
-        assert "meta-llama/Llama-3.3-70B-Instruct-Turbo" in message.meta["model"]
+        assert "deepseek-ai/DeepSeek-V3" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
     @pytest.mark.skipif(
@@ -358,7 +358,7 @@ class TestTogetherAIChatGenerator:
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
 
-        assert "meta-llama/Llama-3.3-70B-Instruct-Turbo" in message.meta["model"]
+        assert "deepseek-ai/DeepSeek-V3" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
         assert callback.counter > 1
@@ -585,7 +585,7 @@ class TestTogetherAIChatGenerator:
                     "type": "haystack_integrations.components.generators.togetherai.chat.chat_generator.TogetherAIChatGenerator",  # noqa: E501
                     "init_parameters": {
                         "api_key": {"type": "env_var", "env_vars": ["ENV_VAR"], "strict": True},
-                        "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                        "model": "deepseek-ai/DeepSeek-V3",
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.together.xyz/v1",
                         "generation_kwargs": {"temperature": 0.7},
@@ -666,7 +666,7 @@ class TestTogetherAIChatGenerator:
         toolset = Toolset([population_tool])
 
         generator = TogetherAIChatGenerator(
-            model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            model="deepseek-ai/DeepSeek-V3",
             tools=[weather_tool, toolset],
         )
 
@@ -746,7 +746,7 @@ class TestChatCompletionChunkConversion:
                     ChoiceChunk(delta=ChoiceDelta(content="", role="assistant"), index=0, native_finish_reason=None)
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -771,7 +771,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -795,7 +795,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -819,7 +819,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -843,7 +843,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -867,7 +867,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -892,7 +892,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 service_tier=None,
                 system_fingerprint="fp_34a54ae93c",
@@ -919,7 +919,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -943,7 +943,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -967,7 +967,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -991,7 +991,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -1007,7 +1007,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 system_fingerprint="fp_34a54ae93c",
                 provider="OpenAI",
@@ -1022,7 +1022,7 @@ class TestChatCompletionChunkConversion:
                     )
                 ],
                 created=1750162525,
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                model="deepseek-ai/DeepSeek-V3",
                 object="chat.completion.chunk",
                 usage=CompletionUsage(
                     completion_tokens=42,
@@ -1052,7 +1052,7 @@ class TestChatCompletionChunkConversion:
         assert result.tool_calls[1].arguments == {"city": "Berlin"}
 
         # Verify meta information
-        assert result.meta["model"] == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        assert result.meta["model"] == "deepseek-ai/DeepSeek-V3"
         assert result.meta["finish_reason"] == "tool_calls"
         assert result.meta["index"] == 0
         assert result.meta["completion_start_time"] is not None

--- a/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
@@ -60,7 +60,7 @@ def mock_async_chat_completion():
     ) as mock_chat_completion_create:
         completion = ChatCompletion(
             id="foo",
-            model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            model="deepseek-ai/DeepSeek-V3",
             object="chat.completion",
             choices=[
                 Choice(
@@ -136,7 +136,7 @@ class TestTogetherAIChatGeneratorAsync:
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
-        assert "meta-llama/Llama-3.3-70B-Instruct-Turbo" in message.meta["model"]
+        assert "deepseek-ai/DeepSeek-V3" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
     @pytest.mark.skipif(
@@ -162,7 +162,7 @@ class TestTogetherAIChatGeneratorAsync:
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
 
-        assert "meta-llama/Llama-3.3-70B-Instruct-Turbo" in message.meta["model"]
+        assert "deepseek-ai/DeepSeek-V3" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
         assert counter > 1

--- a/integrations/togetherai/tests/test_togetherai_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_generator.py
@@ -27,7 +27,7 @@ def mock_chat_completion():
     with patch("openai.resources.chat.completions.Completions.create") as mock_chat_completion_create:
         completion = ChatCompletion(
             id="foo",
-            model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            model="deepseek-ai/DeepSeek-V3",
             object="chat.completion",
             choices=[
                 Choice(
@@ -54,7 +54,7 @@ class TestTogetherAIGenerator:
         monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
         component = TogetherAIGenerator()
         assert component.client.api_key == "test-api-key"
-        assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        assert component.model == "deepseek-ai/DeepSeek-V3"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.client.timeout == 30
@@ -70,7 +70,7 @@ class TestTogetherAIGenerator:
         monkeypatch.setenv("OPENAI_MAX_RETRIES", "10")
         component = TogetherAIGenerator(
             api_key=Secret.from_token("test-api-key"),
-            model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            model="deepseek-ai/DeepSeek-V3",
             streaming_callback=print_streaming_chunk,
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
@@ -78,7 +78,7 @@ class TestTogetherAIGenerator:
             max_retries=1,
         )
         assert component.client.api_key == "test-api-key"
-        assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        assert component.model == "deepseek-ai/DeepSeek-V3"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
         assert component.client.timeout == 40.0
@@ -95,7 +95,7 @@ class TestTogetherAIGenerator:
             "type": "haystack_integrations.components.generators.togetherai.generator.TogetherAIGenerator",
             "init_parameters": {
                 "api_key": {"env_vars": ["TOGETHER_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                "model": "deepseek-ai/DeepSeek-V3",
                 "streaming_callback": None,
                 "system_prompt": None,
                 "api_base_url": "https://api.together.xyz/v1",
@@ -221,7 +221,7 @@ class TestTogetherAIGenerator:
         assert "Paris" in response
 
         metadata = results["meta"][0]
-        assert "meta-llama/Llama-3.3-70B-Instruct-Turbo" in metadata["model"]
+        assert "deepseek-ai/DeepSeek-V3" in metadata["model"]
         assert metadata["finish_reason"] == "stop"
 
         assert "usage" in metadata
@@ -281,7 +281,7 @@ class TestTogetherAIGenerator:
 
         # Metadata validation
         metadata = results["meta"][0]
-        assert "meta-llama/Llama-3.3-70B-Instruct-Turbo" in metadata["model"]
+        assert "deepseek-ai/DeepSeek-V3" in metadata["model"]
         assert metadata["finish_reason"] == "stop"
 
         # Basic usage validation


### PR DESCRIPTION
## Why:
Updates the default model for Together AI generators to `deepseek-ai/DeepSeek-V3`, replacing the previous default `meta-llama/llama-3.3-70b-instruct`. Deepseek has 10x more burned tokens according to this usage [stat](https://openrouter.ai/models?fmt=cards&providers=Together&order=top-weekly).

## What:
- Updated default model parameter in `TogetherAIChatGenerator` from `meta-llama/Llama-3.3-70B-Instruct-Turbo` to `deepseek-ai/DeepSeek-V3`
- Updated default model parameter in `TogetherAIGenerator` to match the chat generator
- Updated docstrings in both generator classes to reflect the new default model

## How can it be used:
```python
from haystack_integrations.components.generators.togetherai import TogetherAIChatGenerator
from haystack.dataclasses import ChatMessage

# Uses deepseek-ai/DeepSeek-V3 by default
generator = TogetherAIChatGenerator()
response = generator.run([ChatMessage.from_user("Hello!")])

# Or explicitly specify a different model
generator = TogetherAIChatGenerator(model="meta-llama/Llama-3.3-70B-Instruct-Turbo")
```

## How did you test it:
- Updated all unit test assertions to expect the new default model
- Updated mock fixtures to use the new model name
- Verified integration tests pass with the new default
- Confirmed all docstrings accurately reflect the change

## Notes for the reviewer:
The model choice was based on usage data from this PR. All tests and documentation have been updated to ensure consistency across the codebase.