### PR TITLE
chore: Improve OpenRouter test fragility

### DIFF
--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -421,7 +421,12 @@ class TestOpenRouterChatGenerator:
             assert tool_call.tool_name == "weather"
 
         arguments = [tool_call.arguments for tool_call in tool_calls]
-        assert sorted(arguments, key=lambda x: x["city"]) == [{"city": "Berlin"}, {"city": "Paris"}]
+        # Extract city names and check they contain the expected cities
+        # (LLM may return "Paris, France" or "Berlin, Germany" instead of just city names)
+        cities = [arg["city"].lower() for arg in arguments]
+        assert len(cities) == 2
+        assert any("berlin" in city for city in cities), f"Expected 'berlin' in one of {cities}"
+        assert any("paris" in city for city in cities), f"Expected 'paris' in one of {cities}"
         assert tool_message.meta["finish_reason"] == "tool_calls"
 
     @pytest.mark.skipif(


### PR DESCRIPTION
### Why:
Fixes fragile test that fails when LLM returns city names with country suffixes (e.g., "Paris, France" instead of "Paris").

### What:
- Updated `test_live_run_with_tools_streaming` to use case-insensitive substring matching instead of exact equality
- Test now checks for presence of "berlin" and "paris" in lowercased city names

### How did you test it:
Test passes with both exact city names and extended formats like "Berlin, Germany" and "Paris, France".