### PR TITLE
chore: Weave - move type ignore comment

### DIFF
--- a/integrations/weights_and_biases_weave/src/haystack_integrations/tracing/weave/tracer.py
+++ b/integrations/weights_and_biases_weave/src/haystack_integrations/tracing/weave/tracer.py
@@ -149,14 +149,14 @@ class WeaveTracer(Tracer):
             output={key: coerce_tag_value(value) for key, value in pipeline_output.items()},
         )
 
+    # the current implementation violates the Liskov Substitution Principle by using WeaveSpan instead of Span
+    # unfortunately, it seems hard to fix without rewriting the Tracer
     @contextlib.contextmanager
-    def trace(
+    def trace(  # type: ignore[override]
         self,
         operation_name: str,
         tags: Optional[dict[str, Any]] = None,
-        # the current implementation violates the Liskov Substitution Principle by using WeaveSpan instead of Span
-        # unfortunately, it seems hard to fix without rewriting the Tracer
-        parent_span: Optional[WeaveSpan] = None,  # type: ignore[override]
+        parent_span: Optional[WeaveSpan] = None,
     ) -> Iterator[WeaveSpan]:
         """
         A context manager that creates and manages spans for tracking operations in Weights & Biases Weave.


### PR DESCRIPTION
### Related Issues

Faling mypy: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/19807198701/job/56743227826
We already have a `# type: ignore[override]` comment but the new version of mypy expects this comment to be in a different position

### Proposed Changes:
- move `# type: ignore[override]` comment

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
