### PR TITLE
test: run integrations tests with Haystack main for AIMLAPI and CometAPI

### DIFF
--- a/.github/workflows/aimlapi.yml
+++ b/.github/workflows/aimlapi.yml
@@ -67,12 +67,13 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      - name: Nightly - run unit tests with Haystack main branch
+      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
+      - name: Nightly - run tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
-          hatch run test:unit
+          hatch run test:cov-retry
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/cometapi.yml
+++ b/.github/workflows/cometapi.yml
@@ -67,12 +67,13 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      - name: Nightly - run unit tests with Haystack main branch
+      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
+      - name: Nightly - run tests with Haystack main branch
         if: github.event_name == 'schedule'
         run: |
           hatch env prune
-          hatch run uv pip install git+https://github.com/deepset-ai/haystack.git@main
-          hatch run test:unit
+          hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
+          hatch run test:cov-retry
 
       - name: Send event to Datadog for nightly failures
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
### Related Issues
AIMLAPI and CometAPI components inherit from `OpenAIChatGenerator`.
For consistency with other integrations, we should test them with Haystack main branch nightly.

### Proposed Changes:
- run integrations tests with Haystack main for AIMLAPI and CometAPI

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
