### PR TITLE
ci: set actor of automated PRs as a reviewer

### DIFF
--- a/.github/workflows/CI_docusaurus_sync.yml
+++ b/.github/workflows/CI_docusaurus_sync.yml
@@ -118,3 +118,4 @@ jobs:
             docs-website
           body: |
             This PR syncs the Core Integrations API reference (${{ env.INTEGRATION_NAME }}) on Docusaurus. Just approve and merge it.
+          reviewers: "${{ github.actor }}"

--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -83,4 +83,5 @@ jobs:
             A good changelog diff simply lists these latest changes on top of the CHANGELOG.md file.
             If there are some diffs that seem out of place, please adjust the CHANGELOG.md file manually.
             Either way, please merge this PR as soon as possible.
+          reviewers: "${{ github.actor }}"
 


### PR DESCRIPTION
### Related Issues

Twin PR of https://github.com/deepset-ai/haystack/pull/10212. See it for details.

### Proposed Changes:
- modify all usages of create-pull-request action to include the actor as a reviewer
- this works because the actual committer is the GitHub bot so the committer is different from the reviewer

### How did you test it?
Tested in https://github.com/deepset-ai/haystack/pull/10212

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
