### PR TITLE
Add `run_async` to all retrievers

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
@@ -108,3 +108,24 @@ class WeaviateBM25Retriever:
         top_k = top_k or self._top_k
         documents = self._document_store._bm25_retrieval(query=query, filters=filters, top_k=top_k)
         return {"documents": documents}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+    ) -> dict[str, list[Document]]:
+        """
+        Asynchronously retrieves documents from Weaviate using the BM25 algorithm.
+
+        :param query:
+            The query text.
+        :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
+                        details.
+        :param top_k:
+            The maximum number of documents to return.
+        """
+        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
+
+        top_k = top_k or self._top_k
+        documents = await self._document_store._bm25_retrieval_async(query=query, filters=filters, top_k=top_k)
+        return {"documents": documents}

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
@@ -143,3 +143,49 @@ class WeaviateEmbeddingRetriever:
             certainty=certainty,
         )
         return {"documents": documents}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        distance: Optional[float] = None,
+        certainty: Optional[float] = None,
+    ) -> dict[str, list[Document]]:
+        """
+        Asynchronously retrieves documents from Weaviate using the vector search.
+
+        :param query_embedding:
+            Embedding of the query.
+        :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
+                        details.
+        :param top_k:
+            The maximum number of documents to return.
+        :param distance:
+            The maximum allowed distance between Documents' embeddings.
+        :param certainty:
+            Normalized distance between the result item and the search vector.
+        :raises ValueError:
+            If both `distance` and `certainty` are provided.
+            See https://weaviate.io/developers/weaviate/api/graphql/search-operators#variables to learn more about
+            `distance` and `certainty` parameters.
+        """
+        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
+        top_k = top_k or self._top_k
+
+        distance = distance or self._distance
+        certainty = certainty or self._certainty
+        if distance is not None and certainty is not None:
+            msg = "Can't use 'distance' and 'certainty' parameters together"
+            raise ValueError(msg)
+
+        documents = await self._document_store._embedding_retrieval_async(
+            query_embedding=query_embedding,
+            filters=filters,
+            top_k=top_k,
+            distance=distance,
+            certainty=certainty,
+        )
+        return {"documents": documents}

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/hybrid_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/hybrid_retriever.py
@@ -174,3 +174,67 @@ class WeaviateHybridRetriever:
             max_vector_distance=max_vector_distance,
         )
         return {"documents": documents}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query: str,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        alpha: Optional[float] = None,
+        max_vector_distance: Optional[float] = None,
+    ) -> dict[str, list[Document]]:
+        """
+        Asynchronously retrieves documents from Weaviate using hybrid search.
+
+        :param query:
+            The query text.
+        :param query_embedding:
+            Embedding of the query.
+        :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
+                        details.
+        :param top_k:
+            The maximum number of documents to return.
+        :param alpha:
+            Blending factor for hybrid retrieval in Weaviate. Must be in the range ``[0.0, 1.0]``.
+
+            Weaviate hybrid search combines keyword (BM25) and vector scores into a single ranking. ``alpha`` controls
+            how much each part contributes to the final score:
+
+            - ``alpha = 0.0``: only keyword (BM25) scoring is used.
+            - ``alpha = 1.0``: only vector similarity scoring is used.
+            - Values in between blend the two; higher values favor the vector score, lower values favor BM25.
+
+            If ``None``, the Weaviate server default is used.
+
+            See the official Weaviate docs on Hybrid Search parameters for more details:
+            `Hybrid search parameters <https://weaviate.io/developers/weaviate/search/hybrid#parameters>`_
+            `Hybrid Search <https://docs.weaviate.io/weaviate/concepts/search/hybrid-search>`_
+        :param max_vector_distance:
+            Optional threshold that restricts the vector part of the hybrid search to candidates within a maximum
+            vector distance. Candidates with a distance larger than this threshold are excluded from the vector portion
+            before blending.
+
+            Use this to prune low-quality vector matches while still benefitting from keyword recall. Leave ``None`` to
+            use Weaviate's default behavior without an explicit cutoff.
+
+            See the official Weaviate docs on Hybrid Search parameters for more details:
+            - `Hybrid search parameters <https://weaviate.io/developers/weaviate/search/hybrid#parameters>`_
+            - `Hybrid Search <https://docs.weaviate.io/weaviate/concepts/search/hybrid-search>`_
+        """
+        filters = apply_filter_policy(self._filter_policy, self._filters, filters)
+        top_k = self._top_k if top_k is None else top_k
+        alpha = self._alpha if alpha is None else alpha
+        max_vector_distance = self._max_vector_distance if max_vector_distance is None else max_vector_distance
+
+        documents = await self._document_store._hybrid_retrieval_async(
+            query=query,
+            query_embedding=query_embedding,
+            filters=filters,
+            top_k=top_k,
+            alpha=alpha,
+            max_vector_distance=max_vector_distance,
+        )
+        return {"documents": documents}

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -145,7 +145,9 @@ class WeaviateDocumentStore:
         self._grpc_port = grpc_port
         self._grpc_secure = grpc_secure
         self._client: Optional[weaviate.WeaviateClient] = None
+        self._async_client: Optional[weaviate.WeaviateAsyncClient] = None
         self._collection: Optional[weaviate.Collection] = None
+        self._async_collection: Optional[weaviate.AsyncCollection] = None
         # Store the connection settings dictionary
         self._collection_settings = collection_settings or {
             "class": "Default",
@@ -211,6 +213,51 @@ class WeaviateDocumentStore:
         return self._client
 
     @property
+    async def async_client(self):
+        if self._async_client:
+            return self._async_client
+
+        if self._url and self._url.endswith((".weaviate.network", ".weaviate.cloud")):
+            # If we detect that the URL is a Weaviate Cloud URL, we use the utility function to connect
+            # instead of using WeaviateAsyncClient directly like in other cases.
+            # Among other things, the utility function takes care of parsing the URL.
+            if not self._auth_client_secret:
+                msg = "Auth credentials are required for Weaviate Cloud Services"
+                raise ValueError(msg)
+            self._async_client = weaviate.use_async_with_weaviate_cloud(
+                self._url,
+                auth_credentials=self._auth_client_secret.resolve_value(),
+                headers=self._additional_headers,
+                additional_config=self._additional_config,
+            )
+        else:
+            # Embedded, local Docker deployment or custom connection.
+            # proxies, timeout_config, trust_env are part of additional_config now
+            # startup_period has been removed
+            self._async_client = weaviate.WeaviateAsyncClient(
+                connection_params=(
+                    weaviate.connect.base.ConnectionParams.from_url(
+                        url=self._url, grpc_port=self._grpc_port, grpc_secure=self._grpc_secure
+                    )
+                    if self._url
+                    else None
+                ),
+                auth_client_secret=self._auth_client_secret.resolve_value() if self._auth_client_secret else None,
+                additional_config=self._additional_config,
+                additional_headers=self._additional_headers,
+                embedded_options=self._embedded_options,
+                skip_init_checks=False,
+            )
+
+        await self._async_client.connect()
+        # Test connection, it will raise an exception if it fails.
+        await self._async_client.collections.list_all(simple=True)
+        if not await self._async_client.collections.exists(self._collection_settings["class"]):
+            await self._async_client.collections.create_from_dict(self._collection_settings)
+
+        return self._async_client
+
+    @property
     def collection(self):
         if self._collection:
             return self._collection
@@ -218,6 +265,15 @@ class WeaviateDocumentStore:
         client = self.client
         self._collection = client.collections.get(self._collection_settings["class"])
         return self._collection
+
+    @property
+    async def async_collection(self):
+        if self._async_collection:
+            return self._async_collection
+
+        async_client = await self.async_client
+        self._async_collection = async_client.collections.get(self._collection_settings["class"])
+        return self._async_collection
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -570,6 +626,24 @@ class WeaviateDocumentStore:
 
         return [self._to_document(doc) for doc in result.objects]
 
+    async def _bm25_retrieval_async(
+        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+    ) -> list[Document]:
+        collection = await self.async_collection
+        config = await collection.config.get()
+        properties = [p.name for p in config.properties]
+        result = await collection.query.bm25(
+            query=query,
+            filters=convert_filters(filters) if filters else None,
+            limit=top_k,
+            include_vector=True,
+            query_properties=["content"],
+            return_properties=properties,
+            return_metadata=["score"],
+        )
+
+        return [self._to_document(doc) for doc in result.objects]
+
     def _embedding_retrieval(
         self,
         query_embedding: list[float],
@@ -596,6 +670,34 @@ class WeaviateDocumentStore:
 
         return [self._to_document(doc) for doc in result.objects]
 
+    async def _embedding_retrieval_async(
+        self,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        distance: Optional[float] = None,
+        certainty: Optional[float] = None,
+    ) -> list[Document]:
+        if distance is not None and certainty is not None:
+            msg = "Can't use 'distance' and 'certainty' parameters together"
+            raise ValueError(msg)
+
+        collection = await self.async_collection
+        config = await collection.config.get()
+        properties = [p.name for p in config.properties]
+        result = await collection.query.near_vector(
+            near_vector=query_embedding,
+            distance=distance,
+            certainty=certainty,
+            include_vector=True,
+            filters=convert_filters(filters) if filters else None,
+            limit=top_k,
+            return_properties=properties,
+            return_metadata=["certainty"],
+        )
+
+        return [self._to_document(doc) for doc in result.objects]
+
     def _hybrid_retrieval(
         self,
         query: str,
@@ -607,6 +709,33 @@ class WeaviateDocumentStore:
     ) -> list[Document]:
         properties = [p.name for p in self.collection.config.get().properties]
         result = self.collection.query.hybrid(
+            query=query,
+            vector=query_embedding,
+            alpha=alpha,
+            filters=convert_filters(filters) if filters else None,
+            limit=top_k,
+            max_vector_distance=max_vector_distance,
+            include_vector=True,
+            query_properties=["content"],
+            return_properties=properties,
+            return_metadata=["score"],
+        )
+
+        return [self._to_document(doc) for doc in result.objects]
+
+    async def _hybrid_retrieval_async(
+        self,
+        query: str,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        alpha: Optional[float] = None,
+        max_vector_distance: Optional[float] = None,
+    ) -> list[Document]:
+        collection = await self.async_collection
+        config = await collection.config.get()
+        properties = [p.name for p in config.properties]
+        result = await collection.query.hybrid(
             query=query,
             vector=query_embedding,
             alpha=alpha,

--- a/integrations/weaviate/tests/test_bm25_retriever_async.py
+++ b/integrations/weaviate/tests/test_bm25_retriever_async.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from haystack_integrations.components.retrievers.weaviate import WeaviateBM25Retriever
+from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
+
+
+@pytest.mark.asyncio
+async def test_run_async_calls_async_retrieval():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    mock_document_store._bm25_retrieval_async = AsyncMock(return_value=[])
+
+    retriever = WeaviateBM25Retriever(document_store=mock_document_store)
+
+    await retriever.run_async(
+        query="test query",
+        filters={"field": "content", "operator": "==", "value": "test"},
+        top_k=5,
+    )
+
+    mock_document_store._bm25_retrieval_async.assert_called_once_with(
+        query="test query",
+        filters={"field": "content", "operator": "==", "value": "test"},
+        top_k=5,
+    )

--- a/integrations/weaviate/tests/test_document_store_async.py
+++ b/integrations/weaviate/tests/test_document_store_async.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from haystack.dataclasses.document import Document
+
+from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
+from haystack_integrations.document_stores.weaviate.document_store import DOCUMENT_COLLECTION_PROPERTIES
+
+
+@pytest.mark.integration
+class TestWeaviateDocumentStoreAsync:
+    @pytest.fixture
+    def document_store(self, request) -> WeaviateDocumentStore:
+        collection_settings = {
+            "class": f"{request.node.name}",
+            "invertedIndexConfig": {"indexNullState": True},
+            "properties": DOCUMENT_COLLECTION_PROPERTIES,
+        }
+        store = WeaviateDocumentStore(
+            url="http://localhost:8080",
+            collection_settings=collection_settings,
+        )
+        yield store
+        store.client.collections.delete(collection_settings["class"])
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval_async(self, document_store):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language"),
+                Document(content="Lisp is a functional programming language"),
+                Document(content="Python is an object oriented programming language"),
+                Document(content="Rust is a systems programming language"),
+            ]
+        )
+
+        result = await document_store._bm25_retrieval_async("functional Haskell", top_k=2)
+
+        assert len(result) <= 2
+        assert any("Haskell" in doc.content for doc in result)
+        assert all(doc.score is not None and doc.score > 0.0 for doc in result)
+
+    @pytest.mark.asyncio
+    async def test_bm25_retrieval_async_with_filters(self, document_store):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language"),
+                Document(content="Lisp is a functional programming language"),
+                Document(content="Python is an object oriented programming language"),
+            ]
+        )
+
+        filters = {"field": "content", "operator": "==", "value": "Haskell"}
+        result = await document_store._bm25_retrieval_async("functional", filters=filters)
+
+        assert len(result) == 1
+        assert "Haskell" in result[0].content
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval_async(self, document_store):
+        document_store.write_documents(
+            [
+                Document(content="The document", embedding=[1.0, 1.0, 1.0, 1.0]),
+                Document(content="Another document", embedding=[0.8, 0.8, 0.8, 1.0]),
+                Document(content="Yet another document", embedding=[0.00001, 0.00001, 0.00001, 0.00002]),
+            ]
+        )
+
+        result = await document_store._embedding_retrieval_async(query_embedding=[1.0, 1.0, 1.0, 1.0], top_k=2)
+
+        assert len(result) == 2
+        assert result[0].content == "The document"
+        assert result[0].score is not None and result[0].score > 0.0
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval_async_with_filters(self, document_store):
+        document_store.write_documents(
+            [
+                Document(content="The document I want", embedding=[1.0, 1.0, 1.0, 1.0]),
+                Document(content="Another document", embedding=[0.8, 0.8, 0.8, 1.0]),
+            ]
+        )
+
+        filters = {"field": "content", "operator": "==", "value": "The document I want"}
+        result = await document_store._embedding_retrieval_async(query_embedding=[1.0, 1.0, 1.0, 1.0], filters=filters)
+
+        assert len(result) == 1
+        assert result[0].content == "The document I want"
+
+    @pytest.mark.asyncio
+    async def test_embedding_retrieval_async_distance_and_certainty_error(self, document_store):
+        with pytest.raises(ValueError, match="Can't use 'distance' and 'certainty' parameters together"):
+            await document_store._embedding_retrieval_async(
+                query_embedding=[1.0, 1.0, 1.0, 1.0], distance=0.5, certainty=0.8
+            )
+
+    @pytest.mark.asyncio
+    async def test_hybrid_retrieval_async(self, document_store):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language", embedding=[1.0, 0.8, 0.2, 0.1]),
+                Document(content="Lisp is a functional programming language", embedding=[0.9, 0.7, 0.3, 0.2]),
+                Document(content="Python is an object oriented language", embedding=[0.1, 0.2, 0.8, 0.9]),
+            ]
+        )
+
+        result = await document_store._hybrid_retrieval_async(
+            query="functional Haskell",
+            query_embedding=[1.0, 0.8, 0.2, 0.1],
+            top_k=2,
+        )
+
+        assert len(result) <= 2
+        assert result[0].content == "Haskell is a functional programming language"
+        assert result[0].score is not None and result[0].score > 0.0
+
+    @pytest.mark.asyncio
+    async def test_hybrid_retrieval_async_with_filters(self, document_store):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language", embedding=[1.0, 0.8, 0.2, 0.1]),
+                Document(content="Lisp is a functional programming language", embedding=[0.9, 0.7, 0.3, 0.2]),
+            ]
+        )
+
+        filters = {"field": "content", "operator": "==", "value": "Haskell is a functional programming language"}
+        result = await document_store._hybrid_retrieval_async(
+            query="functional",
+            query_embedding=[1.0, 0.8, 0.2, 0.1],
+            filters=filters,
+        )
+
+        assert len(result) == 1
+        assert result[0].content == "Haskell is a functional programming language"
+
+    @pytest.mark.asyncio
+    async def test_hybrid_retrieval_async_with_alpha(self, document_store):
+        document_store.write_documents(
+            [
+                Document(content="Haskell is a functional programming language", embedding=[1.0, 0.8, 0.2, 0.1]),
+                Document(content="Python is an object oriented language", embedding=[0.1, 0.2, 0.8, 0.9]),
+            ]
+        )
+
+        # Test with alpha=0.0 (pure BM25)
+        result_bm25 = await document_store._hybrid_retrieval_async(
+            query="functional",
+            query_embedding=[1.0, 0.8, 0.2, 0.1],
+            alpha=0.0,
+        )
+        assert len(result_bm25) > 0
+        assert result_bm25[0].score > 0.0
+
+        # Test with alpha=1.0 (pure vector search)
+        result_vector = await document_store._hybrid_retrieval_async(
+            query="functional",
+            query_embedding=[1.0, 0.8, 0.2, 0.1],
+            alpha=1.0,
+        )
+        assert len(result_vector) > 0
+        assert result_vector[0].score > 0.0

--- a/integrations/weaviate/tests/test_embedding_retriever_async.py
+++ b/integrations/weaviate/tests/test_embedding_retriever_async.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from haystack_integrations.components.retrievers.weaviate import WeaviateEmbeddingRetriever
+from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
+
+
+@pytest.mark.asyncio
+async def test_run_async_calls_async_retrieval():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    mock_document_store._embedding_retrieval_async = AsyncMock(return_value=[])
+
+    retriever = WeaviateEmbeddingRetriever(document_store=mock_document_store)
+
+    await retriever.run_async(
+        query_embedding=[0.1, 0.2, 0.3],
+        filters={"field": "content", "operator": "==", "value": "test"},
+        top_k=5,
+        distance=0.5,
+    )
+
+    mock_document_store._embedding_retrieval_async.assert_called_once_with(
+        query_embedding=[0.1, 0.2, 0.3],
+        filters={"field": "content", "operator": "==", "value": "test"},
+        top_k=5,
+        distance=0.5,
+        certainty=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_async_distance_and_certainty_error():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    retriever = WeaviateEmbeddingRetriever(document_store=mock_document_store)
+
+    with pytest.raises(ValueError, match="Can't use 'distance' and 'certainty' parameters together"):
+        await retriever.run_async(query_embedding=[0.1, 0.2, 0.3], distance=0.5, certainty=0.8)

--- a/integrations/weaviate/tests/test_hybrid_retriever_async.py
+++ b/integrations/weaviate/tests/test_hybrid_retriever_async.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from haystack_integrations.components.retrievers.weaviate import WeaviateHybridRetriever
+from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
+
+
+@pytest.mark.asyncio
+async def test_run_async_calls_async_retrieval():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    mock_document_store._hybrid_retrieval_async = AsyncMock(return_value=[])
+
+    retriever = WeaviateHybridRetriever(document_store=mock_document_store)
+
+    await retriever.run_async(
+        query="test query",
+        query_embedding=[0.1, 0.2, 0.3],
+        filters={"field": "content", "operator": "==", "value": "test"},
+        top_k=5,
+        alpha=0.7,
+        max_vector_distance=0.5,
+    )
+
+    mock_document_store._hybrid_retrieval_async.assert_called_once_with(
+        query="test query",
+        query_embedding=[0.1, 0.2, 0.3],
+        filters={"field": "content", "operator": "==", "value": "test"},
+        top_k=5,
+        alpha=0.7,
+        max_vector_distance=0.5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_async_with_init_parameters():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    mock_document_store._hybrid_retrieval_async = AsyncMock(return_value=[])
+
+    retriever = WeaviateHybridRetriever(
+        document_store=mock_document_store,
+        top_k=20,
+        alpha=0.3,
+        max_vector_distance=0.9,
+    )
+
+    await retriever.run_async(query="test", query_embedding=[0.1, 0.2, 0.3])
+
+    mock_document_store._hybrid_retrieval_async.assert_called_once_with(
+        query="test",
+        query_embedding=[0.1, 0.2, 0.3],
+        filters={},
+        top_k=20,
+        alpha=0.3,
+        max_vector_distance=0.9,
+    )


### PR DESCRIPTION
### Related Issues

- fixes #1395

### Proposed Changes:

- add `async_client` and `async_collection` in `document_store`
- add `run_async` for `bm25_retriever`,  `embedding_retriever` and `hybrid_retriever`

### How did you test it?

unit tests, integration tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
