### PR TITLE
ci: use ubuntu-slim for lightweight CI jobs

### DIFF
--- a/.github/workflows/CI_check_integration_format.yml
+++ b/.github/workflows/CI_check_integration_format.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/CI_docstring_labeler.yml
+++ b/.github/workflows/CI_docstring_labeler.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout base commit

--- a/.github/workflows/CI_docusaurus_sync.yml
+++ b/.github/workflows/CI_docusaurus_sync.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   generate-api-reference:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       integration_name: ${{ steps.pathfinder.outputs.integration_name }}
 
@@ -61,7 +61,7 @@ jobs:
 
 
   sync-api-reference:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: generate-api-reference
     
     steps:

--- a/.github/workflows/CI_labeler.yml
+++ b/.github/workflows/CI_labeler.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/labeler@v6
       with:

--- a/.github/workflows/CI_project.yml
+++ b/.github/workflows/CI_project.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-to-project:
     name: Add new issues to project for triage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   release-on-pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout
@@ -28,6 +28,11 @@ jobs:
         with:
           token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
           fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install hatch requests

--- a/.github/workflows/CI_stale.yml
+++ b/.github/workflows/CI_stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   makestale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
### Related Issues

- similar to https://github.com/deepset-ai/haystack/pull/10234

### Proposed Changes:
- adopt Ubuntu Slim in some workflows
  - used https://github.com/fchimpan/gh-slimify to identify candidates
  - manually refined this list

### How did you test it?
Haven't tested them specifically, but on Haystack all seem to work well after the migration

### Notes for the reviewer
If something does not work as expected, we'll figure it out in the next few days and revert specific changes.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
