### PR TITLE
feat: expose refresh parameter in ElasticsearchDocumentStore and OpenSearchDocumentStore

### DIFF
--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import random
-import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -525,8 +523,7 @@ class TestDocumentStore(DocumentStoreBaseTests):
         document_store.write_documents(docs)
         assert document_store.count_documents() == 2
 
-        document_store.delete_all_documents(recreate_index=False)
-        time.sleep(2)  # need to wait for the deletion to be reflected in count_documents
+        document_store.delete_all_documents(recreate_index=False, refresh=True)
         assert document_store.count_documents() == 0
 
         new_doc = Document(id="3", content="New document after delete all")
@@ -547,8 +544,9 @@ class TestDocumentStore(DocumentStoreBaseTests):
         assert document_store.count_documents() == 3
 
         # Delete documents with category="A"
-        deleted_count = document_store.delete_by_filter(filters={"field": "category", "operator": "==", "value": "A"})
-        time.sleep(2)  # wait for deletion to be reflected
+        deleted_count = document_store.delete_by_filter(
+            filters={"field": "category", "operator": "==", "value": "A"}, refresh=True
+        )
         assert deleted_count == 2
         assert document_store.count_documents() == 1
 
@@ -568,9 +566,10 @@ class TestDocumentStore(DocumentStoreBaseTests):
 
         # Update status for category="A" documents
         updated_count = document_store.update_by_filter(
-            filters={"field": "category", "operator": "==", "value": "A"}, meta={"status": "published"}
+            filters={"field": "category", "operator": "==", "value": "A"},
+            meta={"status": "published"},
+            refresh=True,
         )
-        time.sleep(2)  # wait for update to be reflected
         assert updated_count == 2
 
         # Verify the updates
@@ -803,9 +802,7 @@ class TestElasticsearchDocumentStoreAsync:
         await document_store.write_documents_async(docs)
         assert await document_store.count_documents_async() == 2
 
-        await document_store.delete_all_documents_async(recreate_index=False)
-        # Need to wait for the deletion to be reflected in count_documents
-        await asyncio.sleep(2)
+        await document_store.delete_all_documents_async(recreate_index=False, refresh=True)
         assert await document_store.count_documents_async() == 0
 
         new_doc = Document(id="3", content="New document after delete all")
@@ -824,9 +821,8 @@ class TestElasticsearchDocumentStoreAsync:
 
         # Delete documents with category="A"
         deleted_count = await document_store.delete_by_filter_async(
-            filters={"field": "category", "operator": "==", "value": "A"}
+            filters={"field": "category", "operator": "==", "value": "A"}, refresh=True
         )
-        await asyncio.sleep(2)  # wait for deletion to be reflected
 
         assert deleted_count == 2
         assert await document_store.count_documents_async() == 1
@@ -848,9 +844,10 @@ class TestElasticsearchDocumentStoreAsync:
 
         # Update status for category="A" documents
         updated_count = await document_store.update_by_filter_async(
-            filters={"field": "category", "operator": "==", "value": "A"}, meta={"status": "published"}
+            filters={"field": "category", "operator": "==", "value": "A"},
+            meta={"status": "published"},
+            refresh=True,
         )
-        await asyncio.sleep(2)  # wait for update to be reflected
         assert updated_count == 2
 
         # Verify the updates

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import random
-import time
 from unittest.mock import patch
 
 import pytest
@@ -511,8 +510,7 @@ class TestDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsT
         document_store.write_documents(docs)
         assert document_store.count_documents() == 2
 
-        document_store.delete_all_documents(recreate_index=False)
-        time.sleep(2)  # need to wait for the deletion to be reflected in count_documents
+        document_store.delete_all_documents(recreate_index=False, refresh=True)
         assert document_store.count_documents() == 0
 
         new_doc = Document(id="3", content="New document after delete all")
@@ -534,9 +532,8 @@ class TestDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsT
 
         # Delete documents with category="A"
         deleted_count = document_store.delete_by_filter(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}
+            filters={"field": "meta.category", "operator": "==", "value": "A"}, refresh=True
         )
-        time.sleep(2)  # wait for deletion to be reflected
         assert deleted_count == 2
         assert document_store.count_documents() == 1
 
@@ -556,9 +553,10 @@ class TestDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsT
 
         # Update status for category="A" documents
         updated_count = document_store.update_by_filter(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}, meta={"status": "published"}
+            filters={"field": "meta.category", "operator": "==", "value": "A"},
+            meta={"status": "published"},
+            refresh=True,
         )
-        time.sleep(2)  # wait for update to be reflected
         assert updated_count == 2
 
         # Verify the updates

--- a/integrations/opensearch/tests/test_document_store_async.py
+++ b/integrations/opensearch/tests/test_document_store_async.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import time
-
 import pytest
 from haystack.dataclasses import Document
 
@@ -289,9 +287,7 @@ class TestDocumentStoreAsync:
         await document_store.write_documents_async(docs)
         assert await document_store.count_documents_async() == 2
 
-        await document_store.delete_all_documents_async(recreate_index=False)
-        # need to wait for the deletion to be reflected in count_documents
-        time.sleep(2)
+        await document_store.delete_all_documents_async(recreate_index=False, refresh=True)
         assert await document_store.count_documents_async() == 0
 
         new_doc = Document(id="3", content="New document after delete all")
@@ -313,9 +309,8 @@ class TestDocumentStoreAsync:
 
         # Delete documents with category="A"
         deleted_count = await document_store.delete_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}
+            filters={"field": "meta.category", "operator": "==", "value": "A"}, refresh=True
         )
-        time.sleep(2)  # wait for deletion to be reflected
         assert deleted_count == 2
         assert await document_store.count_documents_async() == 1
 
@@ -335,9 +330,10 @@ class TestDocumentStoreAsync:
 
         # Update status for category="A" documents
         updated_count = await document_store.update_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}, meta={"status": "published"}
+            filters={"field": "meta.category", "operator": "==", "value": "A"},
+            meta={"status": "published"},
+            refresh=True,
         )
-        time.sleep(2)  # wait for update to be reflected
         assert updated_count == 2
 
         # Verify the updates


### PR DESCRIPTION
## Related Issues
Closes #2065

## Description
This PR exposes the `refresh` parameter to relevant methods in `ElasticsearchDocumentStore` and `OpenSearchDocumentStore`, allowing users to control when index changes become visible to search operations.

## Motivation
Both Elasticsearch and OpenSearch are "near real-time" search engines where changes are not immediately visible after write/update/delete operations. Previously, users had to use `time.sleep()` workarounds to ensure consistency. This change exposes the underlying `refresh` parameter, giving users explicit control over this behavior.

## Changes
New `RefreshType` parameter added to the following methods in both document stores:

| Method | Default Value |
|--------|---------------|
| `write_documents` / `write_documents_async` | `"wait_for"` |
| `delete_documents` / `delete_documents_async` | `"wait_for"` |
| `delete_all_documents` / `delete_all_documents_async` | `True` |
| `delete_by_filter` / `delete_by_filter_async` | `"wait_for"` |
| `update_by_filter` / `update_by_filter_async` | `"wait_for"` |

**Parameter values:**
- `True`: Force refresh immediately after the operation
- `False`: Do not refresh (better performance for bulk operations)
- `"wait_for"`: Wait for the next refresh cycle (default, ensures read-your-writes consistency)

## Test Updates
Updated integration tests to use `refresh=True` instead of `time.sleep()`, making tests more reliable and faster.

## Additional Fixes
- Fixed `delete_all_documents_async` in OpenSearch to set `wait_for_completion=True` (matching Elasticsearch behavior), ensuring the async delete operation completes before returning
- Added file-level `# ruff: noqa: FBT001, FBT002` comment to OpenSearch to match Elasticsearch's linting configuration
- Removed unused `asyncio` import from Elasticsearch tests

## How was this tested?
- Existing integration tests updated to use the new `refresh` parameter
- All tests pass with the new implementation

## Checklist
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I added the docstrings to document new functions and parameters
