### PR TITLE
test: use Python 3.10 in tests instead of 3.9 - pt. 2

### DIFF
--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -32,11 +32,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.13"
           - os: windows-latest
-            python-version: "3.9"
+            python-version: "3.10"
           - os: windows-latest
             python-version: "3.13"
 

--- a/.github/workflows/meta_llama.yml
+++ b/.github/workflows/meta_llama.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.13']
+        python-version: ["3.10", "3.13"]
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.13']
+        python-version: ["3.10", "3.13"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
### Related Issues

Follow up of #2616. I forgot some updates.

### Proposed Changes:
- test remaining core-integrations with Python 3.10 instead of 3.9

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
