### PR TITLE
ci: allow releasing versions >=10.0.0

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -16,7 +16,7 @@ name: Core / Project release on PyPi
 on:
   push:
     tags:
-      - "**-v[0-9].[0-9]+.[0-9]+*"
+      - "**-v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   release-on-pypi:


### PR DESCRIPTION
### Related Issues
Our Qdrant integration is on version 9.4.0. This means that the next major version would be 10.0.0.

Currently, it's not possible to release it due to limitations in the `tags` filter of our release workflow.
TBH, I tried in the past and the release workflow never triggered.

### Proposed Changes:
- update the `tags` filter pattern according to https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet

### How did you test it?
Hard to test without pushing a tag and creating a new release. I'm confident that this will work.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
