### PR TITLE
fix: relax model name validation for Bedrock Embedders

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -15,15 +15,6 @@ from haystack_integrations.common.amazon_bedrock.errors import (
 from haystack_integrations.common.amazon_bedrock.utils import get_aws_session
 
 logger = logging.getLogger(__name__)
-
-SUPPORTED_EMBEDDING_MODELS = [
-    "amazon.titan-embed-text-v1",
-    "amazon.titan-embed-text-v2:0",
-    "amazon.titan-embed-image-v1",
-    "cohere.embed-english-v3",
-    "cohere.embed-multilingual-v3",
-    "cohere.embed-v4:0",
-]
 
 
 @component
@@ -58,14 +49,7 @@ class AmazonBedrockDocumentEmbedder:
 
     def __init__(
         self,
-        model: Literal[
-            "amazon.titan-embed-text-v1",
-            "amazon.titan-embed-text-v2:0",
-            "amazon.titan-embed-image-v1",
-            "cohere.embed-english-v3",
-            "cohere.embed-multilingual-v3",
-            "cohere.embed-v4:0",
-        ],
+        model: str,
         aws_access_key_id: Optional[Secret] = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
         aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
             "AWS_SECRET_ACCESS_KEY", strict=False
@@ -90,8 +74,13 @@ class AmazonBedrockDocumentEmbedder:
         constructor. Aside from model, three required parameters are `aws_access_key_id`, `aws_secret_access_key`,
          and `aws_region_name`.
 
-        :param model: The embedding model to use. The model has to be specified in the format outlined in the Amazon
-            Bedrock [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
+        :param model: The embedding model to use.
+            Amazon Titan and Cohere embedding models are supported, for example:
+            "amazon.titan-embed-text-v1", "amazon.titan-embed-text-v2:0", "amazon.titan-embed-image-v1",
+            "cohere.embed-english-v3", "cohere.embed-multilingual-v3", "cohere.embed-v4:0".
+            To find all supported models, refer to the Amazon Bedrock
+            [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) and
+            filter for "embedding", then select models from the Amazon Titan and Cohere series.
         :param aws_access_key_id: AWS access key ID.
         :param aws_secret_access_key: AWS secret access key.
         :param aws_session_token: AWS session token.
@@ -109,11 +98,8 @@ class AmazonBedrockDocumentEmbedder:
         :raises ValueError: If the model is not supported.
         :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly.
         """
-
-        if not model or model not in SUPPORTED_EMBEDDING_MODELS:
-            msg = "Please provide a valid model from the list of supported models: " + ", ".join(
-                SUPPORTED_EMBEDDING_MODELS
-            )
+        if "titan" not in model and "cohere" not in model:
+            msg = f"Model {model} is not supported. Only Amazon Titan and Cohere embedding models are supported."
             raise ValueError(msg)
 
         self.model = model
@@ -254,7 +240,7 @@ class AmazonBedrockDocumentEmbedder:
         elif "titan" in self.model:
             documents_with_embeddings = self._embed_titan(documents=documents)
         else:
-            msg = f"Model {self.model} is not supported. Supported models are: {', '.join(SUPPORTED_EMBEDDING_MODELS)}."
+            msg = f"Model {self.model} is not supported. Only Amazon Titan and Cohere embedding models are supported."
             raise ValueError(msg)
 
         return {"documents": documents_with_embeddings}


### PR DESCRIPTION
### Related Issues

- fixes #2618

### Proposed Changes:
- relax model name validation
  - we now only check if "cohere" or "titan" is present in the model name: we still need this because their APIs are different
  - in case users choose "invalid-cohere-model" (accepted by our init check), they will encounter a runtime failure:  `haystack_integrations.common.amazon_bedrock.errors.AmazonBedrockInferenceError: Could not perform inference for Amazon Bedrock model invalid-cohere-model due to:
An error occurred (ValidationException) when calling the InvokeModel operation: The provided model identifier is invalid.`

### How did you test it?
CI (existing tests for invalid models)

### Notes for the reviewer
We are converting the `model` type hint from `Literal` from `str`, but this is not breaking.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
