### PR TITLE
chore: Fix tool validation test failures in github integration

### DIFF
--- a/integrations/github/tests/test_file_editor_tool.py
+++ b/integrations/github/tests/test_file_editor_tool.py
@@ -77,7 +77,7 @@ class TestGitHubFileEditorTool:
         tool = GitHubFileEditorTool(
             outputs_to_string={"source": "result", "handler": message_handler},
             inputs_from_state={"repo_state": "repo"},
-            outputs_to_state={"file_content": {"source": "content", "handler": message_handler}},
+            outputs_to_state={"file_content": {"source": "result", "handler": message_handler}},
         )
 
         tool_dict = tool.to_dict()
@@ -88,7 +88,7 @@ class TestGitHubFileEditorTool:
         assert tool_dict["data"]["inputs_from_state"] == {"repo_state": "repo"}
         assert tool_dict["data"]["outputs_to_state"] == {
             "file_content": {
-                "source": "content",
+                "source": "result",
                 "handler": "haystack_integrations.tools.github.utils.message_handler",
             },
         }
@@ -113,7 +113,7 @@ class TestGitHubFileEditorTool:
                 "inputs_from_state": {"repo_state": "repo"},
                 "outputs_to_state": {
                     "file_content": {
-                        "source": "content",
+                        "source": "result",
                         "handler": "haystack_integrations.tools.github.utils.message_handler",
                     },
                 },
@@ -124,7 +124,7 @@ class TestGitHubFileEditorTool:
         assert tool.outputs_to_string["source"] == "result"
         assert tool.outputs_to_string["handler"] == message_handler
         assert tool.inputs_from_state == {"repo_state": "repo"}
-        assert tool.outputs_to_state["file_content"]["source"] == "content"
+        assert tool.outputs_to_state["file_content"]["source"] == "result"
         assert tool.outputs_to_state["file_content"]["handler"] == message_handler
 
     def test_pipeline_serialization(self, monkeypatch):

--- a/integrations/github/tests/test_issue_commenter_tool.py
+++ b/integrations/github/tests/test_issue_commenter_tool.py
@@ -77,7 +77,7 @@ class TestGitHubIssueCommenterTool:
             retry_attempts=3,
             outputs_to_string={"handler": message_handler},
             inputs_from_state={"repository": "repo"},
-            outputs_to_state={"documents": {"source": "docs", "handler": message_handler}},
+            outputs_to_state={"documents": {"source": "success", "handler": message_handler}},
         )
         tool_dict = tool.to_dict()
         assert tool_dict["type"] == "haystack_integrations.tools.github.issue_commenter_tool.GitHubIssueCommenterTool"
@@ -92,7 +92,7 @@ class TestGitHubIssueCommenterTool:
             == "haystack_integrations.tools.github.utils.message_handler"
         )
         assert tool_dict["data"]["inputs_from_state"] == {"repository": "repo"}
-        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "docs"
+        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "success"
         assert (
             tool_dict["data"]["outputs_to_state"]["documents"]["handler"]
             == "haystack_integrations.tools.github.utils.message_handler"
@@ -113,7 +113,7 @@ class TestGitHubIssueCommenterTool:
                 "inputs_from_state": {"repository": "repo"},
                 "outputs_to_state": {
                     "documents": {
-                        "source": "docs",
+                        "source": "success",
                         "handler": "haystack_integrations.tools.github.utils.message_handler",
                     }
                 },
@@ -128,5 +128,5 @@ class TestGitHubIssueCommenterTool:
         assert tool.retry_attempts == 3
         assert tool.outputs_to_string["handler"] == message_handler
         assert tool.inputs_from_state == {"repository": "repo"}
-        assert tool.outputs_to_state["documents"]["source"] == "docs"
+        assert tool.outputs_to_state["documents"]["source"] == "success"
         assert tool.outputs_to_state["documents"]["handler"] == message_handler

--- a/integrations/github/tests/test_issue_viewer_tool.py
+++ b/integrations/github/tests/test_issue_viewer_tool.py
@@ -73,7 +73,7 @@ class TestGitHubIssueViewerTool:
             retry_attempts=3,
             outputs_to_string={"handler": message_handler},
             inputs_from_state={"repository": "repo"},
-            outputs_to_state={"documents": {"source": "docs", "handler": message_handler}},
+            outputs_to_state={"documents": {"source": "documents", "handler": message_handler}},
         )
         tool_dict = tool.to_dict()
         assert tool_dict["type"] == "haystack_integrations.tools.github.issue_viewer_tool.GitHubIssueViewerTool"
@@ -88,7 +88,7 @@ class TestGitHubIssueViewerTool:
             == "haystack_integrations.tools.github.utils.message_handler"
         )
         assert tool_dict["data"]["inputs_from_state"] == {"repository": "repo"}
-        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "docs"
+        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "documents"
         assert (
             tool_dict["data"]["outputs_to_state"]["documents"]["handler"]
             == "haystack_integrations.tools.github.utils.message_handler"
@@ -109,7 +109,7 @@ class TestGitHubIssueViewerTool:
                 "inputs_from_state": {"repository": "repo"},
                 "outputs_to_state": {
                     "documents": {
-                        "source": "docs",
+                        "source": "documents",
                         "handler": "haystack_integrations.tools.github.utils.message_handler",
                     }
                 },
@@ -124,5 +124,5 @@ class TestGitHubIssueViewerTool:
         assert tool.retry_attempts == 3
         assert tool.outputs_to_string["handler"] == message_handler
         assert tool.inputs_from_state == {"repository": "repo"}
-        assert tool.outputs_to_state["documents"]["source"] == "docs"
+        assert tool.outputs_to_state["documents"]["source"] == "documents"
         assert tool.outputs_to_state["documents"]["handler"] == message_handler

--- a/integrations/github/tests/test_pr_creator_tool.py
+++ b/integrations/github/tests/test_pr_creator_tool.py
@@ -74,7 +74,7 @@ class TestGitHubPRCreatorTool:
             raise_on_failure=False,
             outputs_to_string={"handler": message_handler},
             inputs_from_state={"repository": "repo"},
-            outputs_to_state={"documents": {"source": "docs", "handler": message_handler}},
+            outputs_to_state={"documents": {"source": "result", "handler": message_handler}},
         )
         tool_dict = tool.to_dict()
         assert tool_dict["type"] == "haystack_integrations.tools.github.pr_creator_tool.GitHubPRCreatorTool"
@@ -92,7 +92,7 @@ class TestGitHubPRCreatorTool:
             == "haystack_integrations.tools.github.utils.message_handler"
         )
         assert tool_dict["data"]["inputs_from_state"] == {"repository": "repo"}
-        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "docs"
+        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "result"
         assert (
             tool_dict["data"]["outputs_to_state"]["documents"]["handler"]
             == "haystack_integrations.tools.github.utils.message_handler"
@@ -112,7 +112,7 @@ class TestGitHubPRCreatorTool:
                 "inputs_from_state": {"repository": "repo"},
                 "outputs_to_state": {
                     "documents": {
-                        "source": "docs",
+                        "source": "result",
                         "handler": "haystack_integrations.tools.github.utils.message_handler",
                     }
                 },
@@ -126,5 +126,5 @@ class TestGitHubPRCreatorTool:
         assert tool.raise_on_failure is False
         assert tool.outputs_to_string["handler"] == message_handler
         assert tool.inputs_from_state == {"repository": "repo"}
-        assert tool.outputs_to_state["documents"]["source"] == "docs"
+        assert tool.outputs_to_state["documents"]["source"] == "result"
         assert tool.outputs_to_state["documents"]["handler"] == message_handler

--- a/integrations/github/tests/test_repo_forker_tool.py
+++ b/integrations/github/tests/test_repo_forker_tool.py
@@ -70,9 +70,9 @@ class TestGitHubRepoForkerTool:
         tool = GitHubRepoForkerTool(
             github_token=Secret.from_env_var("GITHUB_TOKEN"),
             raise_on_failure=False,
-            outputs_to_string={"source": "docs", "handler": message_handler},
+            outputs_to_string={"source": "repo", "handler": message_handler},
             inputs_from_state={"repository": "repo"},
-            outputs_to_state={"documents": {"source": "docs", "handler": message_handler}},
+            outputs_to_state={"documents": {"source": "repo", "handler": message_handler}},
         )
         tool_dict = tool.to_dict()
         assert tool_dict["type"] == "haystack_integrations.tools.github.repo_forker_tool.GitHubRepoForkerTool"
@@ -90,7 +90,7 @@ class TestGitHubRepoForkerTool:
             == "haystack_integrations.tools.github.utils.message_handler"
         )
         assert tool_dict["data"]["inputs_from_state"] == {"repository": "repo"}
-        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "docs"
+        assert tool_dict["data"]["outputs_to_state"]["documents"]["source"] == "repo"
         assert (
             tool_dict["data"]["outputs_to_state"]["documents"]["handler"]
             == "haystack_integrations.tools.github.utils.message_handler"
@@ -110,7 +110,7 @@ class TestGitHubRepoForkerTool:
                 "inputs_from_state": {"repository": "repo"},
                 "outputs_to_state": {
                     "documents": {
-                        "source": "docs",
+                        "source": "repo",
                         "handler": "haystack_integrations.tools.github.utils.message_handler",
                     }
                 },
@@ -124,5 +124,5 @@ class TestGitHubRepoForkerTool:
         assert tool.raise_on_failure is False
         assert tool.outputs_to_string["handler"] == message_handler
         assert tool.inputs_from_state == {"repository": "repo"}
-        assert tool.outputs_to_state["documents"]["source"] == "docs"
+        assert tool.outputs_to_state["documents"]["source"] == "repo"
         assert tool.outputs_to_state["documents"]["handler"] == message_handler

--- a/integrations/github/tests/test_repo_viewer_tool.py
+++ b/integrations/github/tests/test_repo_viewer_tool.py
@@ -83,7 +83,7 @@ class TestGitHubRepoViewerTool:
         tool = GitHubRepoViewerTool(
             outputs_to_string={"source": "result", "handler": message_handler},
             inputs_from_state={"repo_state": "repo"},
-            outputs_to_state={"file_content": {"source": "content", "handler": message_handler}},
+            outputs_to_state={"file_content": {"source": "documents", "handler": message_handler}},
         )
 
         tool_dict = tool.to_dict()
@@ -94,7 +94,7 @@ class TestGitHubRepoViewerTool:
         assert tool_dict["data"]["inputs_from_state"] == {"repo_state": "repo"}
         assert tool_dict["data"]["outputs_to_state"] == {
             "file_content": {
-                "source": "content",
+                "source": "documents",
                 "handler": "haystack_integrations.tools.github.utils.message_handler",
             },
         }
@@ -120,7 +120,7 @@ class TestGitHubRepoViewerTool:
                 "inputs_from_state": {"repo_state": "repo"},
                 "outputs_to_state": {
                     "file_content": {
-                        "source": "content",
+                        "source": "documents",
                         "handler": "haystack_integrations.tools.github.utils.message_handler",
                     },
                 },
@@ -131,5 +131,5 @@ class TestGitHubRepoViewerTool:
         assert tool.outputs_to_string["source"] == "result"
         assert tool.outputs_to_string["handler"] == message_handler
         assert tool.inputs_from_state == {"repo_state": "repo"}
-        assert tool.outputs_to_state["file_content"]["source"] == "content"
+        assert tool.outputs_to_state["file_content"]["source"] == "documents"
         assert tool.outputs_to_state["file_content"]["handler"] == message_handler


### PR DESCRIPTION
## Why

  Upstream Haystack added tool validation hooks (_get_valid_inputs() and _get_valid_outputs()) to catch typos in inputs_from_state and outputs_to_state at tool construction time. This exposed invalid state mappings in GitHub integration tests.

##  What

  Fixed 12 test cases with invalid outputs_to_state mappings that referenced non-existent output keys:

  - test_file_editor_tool.py: "content" → "result"
  - test_issue_commenter_tool.py: "docs" → "success"
  - test_issue_viewer_tool.py: "docs" → "documents"
  - test_pr_creator_tool.py: "docs" → "result"
  - test_repo_forker_tool.py: "docs" → "repo"
  - test_repo_viewer_tool.py: "content" → "documents"

  Each fix maps state to actual component output keys (e.g., GitHubFileEditor returns {"result": ...}, GitHubIssueCommenter returns {"success": ...}).

##  How can it be used

  Same as before - no API changes, just test fixes.

##  How did you test it

 Ran the test suite

##  Notes for the reviewer

  This is identical to the fix in integrations/mcp (#2654). The validation now catches what were previously silent bugs - tests used invalid output names that would have failed at runtime when state mapping was actually attempted.
