### PR TITLE
chore!: amazon_bedrock - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -7,7 +7,7 @@ name = "amazon-bedrock-haystack"
 dynamic = ["version"]
 description = 'An integration of AWS S3 and Bedrock as a Downloader and Generator components.'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.19.0", "boto3>=1.28.57", "aioboto3>=14.0.0"]
+dependencies = ["haystack-ai>=2.22.0", "boto3>=1.28.57", "aioboto3>=14.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_bedrock#readme"
@@ -92,7 +91,6 @@ module = [
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -139,10 +137,6 @@ ignore = [
   "ARG001",
   "ARG002",
   "ARG005",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/amazon_bedrock/src/haystack_integrations/common/amazon_bedrock/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/common/amazon_bedrock/utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Union
+from typing import Any
 
 import aioboto3
 import boto3
@@ -20,14 +20,14 @@ AWS_CONFIGURATION_KEYS = [
 
 
 def get_aws_session(
-    aws_access_key_id: Optional[str] = None,
-    aws_secret_access_key: Optional[str] = None,
-    aws_session_token: Optional[str] = None,
-    aws_region_name: Optional[str] = None,
-    aws_profile_name: Optional[str] = None,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: str | None = None,
+    aws_session_token: str | None = None,
+    aws_region_name: str | None = None,
+    aws_profile_name: str | None = None,
     async_mode: bool = False,
     **kwargs: Any,
-) -> Union[boto3.Session, aioboto3.Session]:
+) -> boto3.Session | aioboto3.Session:
     """
     Creates an AWS Session with the given parameters.
     Checks if the provided AWS credentials are valid and can be used to connect to AWS.

--- a/integrations/amazon_bedrock/src/haystack_integrations/common/s3/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/common/s3/utils.py
@@ -6,7 +6,6 @@ import os
 from dataclasses import dataclass
 from http import HTTPStatus
 from pathlib import Path
-from typing import Optional
 
 from boto3.session import Session
 from botocore.config import Config
@@ -23,9 +22,9 @@ class S3Storage:
         self,
         s3_bucket: str,
         session: Session,
-        s3_prefix: Optional[str] = None,
-        endpoint_url: Optional[str] = None,
-        config: Optional[Config] = None,
+        s3_prefix: str | None = None,
+        endpoint_url: str | None = None,
+        config: Config | None = None,
     ) -> None:
         """
         Initializes the S3Storage object with the provided parameters.

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any
 
 from botocore.config import Config
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -29,20 +30,20 @@ class S3Downloader:
     def __init__(
         self,
         *,
-        aws_access_key_id: Optional[Secret] = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
-        aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
+        aws_access_key_id: Secret | None = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
-        aws_session_token: Optional[Secret] = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Optional[Secret] = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
-        aws_profile_name: Optional[Secret] = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
-        boto3_config: Optional[dict[str, Any]] = None,
-        file_root_path: Optional[str] = None,
-        file_extensions: Optional[list[str]] = None,
+        aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
+        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
+        boto3_config: dict[str, Any] | None = None,
+        file_root_path: str | None = None,
+        file_extensions: list[str] | None = None,
         file_name_meta_key: str = "file_name",
         max_workers: int = 32,
         max_cache_size: int = 100,
-        s3_key_generation_function: Optional[Callable[[Document], str]] = None,
+        s3_key_generation_function: Callable[[Document], str] | None = None,
     ) -> None:
         """
         Initializes the `S3Downloader` with the provided parameters.
@@ -104,9 +105,9 @@ class S3Downloader:
         self.file_name_meta_key = file_name_meta_key
         self.s3_key_generation_function = s3_key_generation_function
 
-        self._storage: Optional[S3Storage] = None
+        self._storage: S3Storage | None = None
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         self._session = get_aws_session(
@@ -169,7 +170,7 @@ class S3Downloader:
             if Path(doc.meta.get(self.file_name_meta_key, "")).suffix.lower() in self.file_extensions
         ]
 
-    def _download_file(self, document: Document) -> Optional[Document]:
+    def _download_file(self, document: Document) -> Document | None:
         """
         Download a single file from AWS S3 Bucket to local filesystem.
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any
 
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -50,18 +50,18 @@ class AmazonBedrockDocumentEmbedder:
     def __init__(
         self,
         model: str,
-        aws_access_key_id: Optional[Secret] = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
-        aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
+        aws_access_key_id: Secret | None = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
-        aws_session_token: Optional[Secret] = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Optional[Secret] = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
-        aws_profile_name: Optional[Secret] = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
+        aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
+        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
         batch_size: int = 32,
         progress_bar: bool = True,
-        meta_fields_to_embed: Optional[list[str]] = None,
+        meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
-        boto3_config: Optional[dict[str, Any]] = None,
+        boto3_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -115,7 +115,7 @@ class AmazonBedrockDocumentEmbedder:
         self.boto3_config = boto3_config
         self.kwargs = kwargs
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         try:
@@ -186,7 +186,7 @@ class AmazonBedrockDocumentEmbedder:
             )
             all_embeddings.extend(embeddings_list)
 
-        for doc, emb in zip(documents, all_embeddings):
+        for doc, emb in zip(documents, all_embeddings, strict=True):
             doc.embedding = emb
 
         return documents
@@ -214,7 +214,7 @@ class AmazonBedrockDocumentEmbedder:
             embedding = response_body["embedding"]
             all_embeddings.append(embedding)
 
-        for doc, emb in zip(documents, all_embeddings):
+        for doc, emb in zip(documents, all_embeddings, strict=True):
             doc.embedding = emb
 
         return documents

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_image_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_image_embedder.py
@@ -4,7 +4,7 @@
 
 import json
 from dataclasses import replace
-from typing import Any, Optional
+from typing import Any
 
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -68,18 +68,18 @@ class AmazonBedrockDocumentImageEmbedder:
         self,
         *,
         model: str,
-        aws_access_key_id: Optional[Secret] = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
-        aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
+        aws_access_key_id: Secret | None = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
-        aws_session_token: Optional[Secret] = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Optional[Secret] = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
-        aws_profile_name: Optional[Secret] = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
+        aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
+        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
         file_path_meta_field: str = "file_path",
-        root_path: Optional[str] = None,
-        image_size: Optional[tuple[int, int]] = None,
+        root_path: str | None = None,
+        image_size: tuple[int, int] | None = None,
         progress_bar: bool = True,
-        boto3_config: Optional[dict[str, Any]] = None,
+        boto3_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -144,7 +144,7 @@ class AmazonBedrockDocumentImageEmbedder:
                 raise ValueError(msg)
             self.embedding_types = embedding_types
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         try:
@@ -288,7 +288,7 @@ class AmazonBedrockDocumentImageEmbedder:
 
         docs_with_embeddings = []
 
-        for doc, emb in zip(documents, embeddings):
+        for doc, emb in zip(documents, embeddings, strict=True):
             # we store this information for later inspection
             new_meta = {
                 **doc.meta,

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any
 
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -43,14 +43,14 @@ class AmazonBedrockTextEmbedder:
     def __init__(
         self,
         model: str,
-        aws_access_key_id: Optional[Secret] = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
-        aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
+        aws_access_key_id: Secret | None = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
-        aws_session_token: Optional[Secret] = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Optional[Secret] = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
-        aws_profile_name: Optional[Secret] = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
-        boto3_config: Optional[dict[str, Any]] = None,
+        aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
+        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
+        boto3_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -94,7 +94,7 @@ class AmazonBedrockTextEmbedder:
         self.boto3_config = boto3_config
         self.kwargs = kwargs
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         try:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/adapters.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from botocore.eventstream import EventStream
 from haystack.dataclasses import StreamingChunk, SyncStreamingCallbackT
@@ -19,7 +19,7 @@ class BedrockModelAdapter(ABC):
         It will be overridden by the corresponding parameter in the `model_kwargs` if it is present.
     """
 
-    def __init__(self, model_kwargs: dict[str, Any], max_length: Optional[int]) -> None:
+    def __init__(self, model_kwargs: dict[str, Any], max_length: int | None) -> None:
         self.model_kwargs = model_kwargs
         self.max_length = max_length
 
@@ -115,7 +115,7 @@ class AnthropicClaudeAdapter(BedrockModelAdapter):
     :param max_length: Maximum length of generated text
     """
 
-    def __init__(self, model_kwargs: dict[str, Any], max_length: Optional[int]) -> None:
+    def __init__(self, model_kwargs: dict[str, Any], max_length: int | None) -> None:
         self.use_messages_api = model_kwargs.get("use_messages_api", True)
         self.include_thinking = model_kwargs.get("include_thinking", True)
         self.thinking_tag = model_kwargs.get("thinking_tag", "thinking")
@@ -175,7 +175,7 @@ class AnthropicClaudeAdapter(BedrockModelAdapter):
             if self.include_thinking and len(thinking) == len(texts):
                 texts = [
                     f"{self.thinking_tag_start}{thinking}{self.thinking_tag_end}{text}"
-                    for text, thinking in zip(texts, thinking)
+                    for text, thinking in zip(texts, thinking, strict=True)
                 ]
             return texts
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import aioboto3
 from botocore.config import Config
@@ -147,19 +147,19 @@ class AmazonBedrockChatGenerator:
     def __init__(
         self,
         model: str,
-        aws_access_key_id: Optional[Secret] = Secret.from_env_var(["AWS_ACCESS_KEY_ID"], strict=False),  # noqa: B008
-        aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
+        aws_access_key_id: Secret | None = Secret.from_env_var(["AWS_ACCESS_KEY_ID"], strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
             ["AWS_SECRET_ACCESS_KEY"], strict=False
         ),
-        aws_session_token: Optional[Secret] = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
-        aws_region_name: Optional[Secret] = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
-        aws_profile_name: Optional[Secret] = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        boto3_config: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        aws_session_token: Secret | None = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
+        aws_region_name: Secret | None = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
+        generation_kwargs: dict[str, Any] | None = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        boto3_config: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
         *,
-        guardrail_config: Optional[dict[str, str]] = None,
+        guardrail_config: dict[str, str] | None = None,
     ) -> None:
         """
         Initializes the `AmazonBedrockChatGenerator` with the provided parameters. The parameters are passed to the
@@ -225,7 +225,7 @@ class AmazonBedrockChatGenerator:
         _validate_guardrail_config(guardrail_config=guardrail_config, streaming=streaming_callback is not None)
         self.guardrail_config = guardrail_config
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         config = Config(
@@ -252,7 +252,7 @@ class AmazonBedrockChatGenerator:
             raise AmazonBedrockConfigurationError(msg) from exception
 
         self.generation_kwargs = generation_kwargs or {}
-        self.async_session: Optional[aioboto3.Session] = None
+        self.async_session: aioboto3.Session | None = None
 
     def _get_async_session(self) -> aioboto3.Session:
         """
@@ -341,11 +341,11 @@ class AmazonBedrockChatGenerator:
     def _prepare_request_params(
         self,
         messages: list[ChatMessage],
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
         requires_async: bool = False,
-    ) -> tuple[dict[str, Any], Optional[StreamingCallbackT]]:
+    ) -> tuple[dict[str, Any], StreamingCallbackT | None]:
         """
         Prepares and formats parameters required to call the Amazon Bedrock Converse API.
 
@@ -423,9 +423,9 @@ class AmazonBedrockChatGenerator:
     def run(
         self,
         messages: list[ChatMessage],
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Executes a synchronous inference call to the Amazon Bedrock model using the Converse API.
@@ -484,9 +484,9 @@ class AmazonBedrockChatGenerator:
     async def run_async(
         self,
         messages: list[ChatMessage],
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Executes an asynchronous inference call to the Amazon Bedrock model using the Converse API.

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from botocore.eventstream import EventStream
 from haystack import logging
@@ -40,7 +40,7 @@ FINISH_REASON_MAPPING: dict[str, FinishReason] = {
 
 
 # Haystack to Bedrock util methods
-def _format_tools(tools: Optional[list[Tool]] = None) -> Optional[dict[str, Any]]:
+def _format_tools(tools: list[Tool] | None = None) -> dict[str, Any] | None:
     """
     Format Haystack Tool(s) to Amazon Bedrock toolConfig format.
 
@@ -454,7 +454,7 @@ def _convert_event_to_streaming_chunk(
     return streaming_chunk
 
 
-def _process_reasoning_contents(chunks: list[StreamingChunk]) -> Optional[ReasoningContent]:
+def _process_reasoning_contents(chunks: list[StreamingChunk]) -> ReasoningContent | None:
     """
     Process reasoning contents from a list of StreamingChunk objects into the Bedrock expected format.
 
@@ -613,7 +613,7 @@ async def _parse_streaming_response_async(
     return [reply]
 
 
-def _validate_guardrail_config(guardrail_config: Optional[dict[str, str]] = None, streaming: bool = False) -> None:
+def _validate_guardrail_config(guardrail_config: dict[str, str] | None = None, streaming: bool = False) -> None:
     """
     Validate the guardrail configuration.
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -1,7 +1,8 @@
 import json
 import re
 import warnings
-from typing import Any, Callable, ClassVar, Literal, Optional, Union, get_args
+from collections.abc import Callable
+from typing import Any, ClassVar, Literal, get_args
 
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -95,18 +96,18 @@ class AmazonBedrockGenerator:
     def __init__(
         self,
         model: str,
-        aws_access_key_id: Optional[Secret] = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
-        aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
+        aws_access_key_id: Secret | None = Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
-        aws_session_token: Optional[Secret] = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Optional[Secret] = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
-        aws_profile_name: Optional[Secret] = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
-        max_length: Optional[int] = None,
-        truncate: Optional[bool] = None,
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        boto3_config: Optional[dict[str, Any]] = None,
-        model_family: Optional[MODEL_FAMILIES] = None,
+        aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
+        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
+        max_length: int | None = None,
+        truncate: bool | None = None,
+        streaming_callback: Callable[[StreamingChunk], None] | None = None,
+        boto3_config: dict[str, Any] | None = None,
+        model_family: MODEL_FAMILIES | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -156,7 +157,7 @@ class AmazonBedrockGenerator:
         self.kwargs = kwargs
         self.model_family = model_family
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         try:
@@ -187,9 +188,9 @@ class AmazonBedrockGenerator:
     def run(
         self,
         prompt: str,
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-    ) -> dict[str, Union[list[str], dict[str, Any]]]:
+        streaming_callback: Callable[[StreamingChunk], None] | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+    ) -> dict[str, list[str] | dict[str, Any]]:
         """
         Generates a list of string response to the given prompt.
 
@@ -240,7 +241,7 @@ class AmazonBedrockGenerator:
         return {"replies": replies, "meta": metadata}
 
     @classmethod
-    def get_model_adapter(cls, model: str, model_family: Optional[str] = None) -> type[BedrockModelAdapter]:
+    def get_model_adapter(cls, model: str, model_family: str | None = None) -> type[BedrockModelAdapter]:
         """
         Gets the model adapter for the given model.
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from botocore.exceptions import ClientError
 from haystack import Document, component, default_from_dict, default_to_dict, logging
@@ -60,15 +60,15 @@ class AmazonBedrockRanker:
         self,
         model: str = "cohere.rerank-v3-5:0",
         top_k: int = 10,
-        aws_access_key_id: Optional[Secret] = Secret.from_env_var(["AWS_ACCESS_KEY_ID"], strict=False),  # noqa: B008
-        aws_secret_access_key: Optional[Secret] = Secret.from_env_var(  # noqa: B008
+        aws_access_key_id: Secret | None = Secret.from_env_var(["AWS_ACCESS_KEY_ID"], strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
             ["AWS_SECRET_ACCESS_KEY"], strict=False
         ),
-        aws_session_token: Optional[Secret] = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
-        aws_region_name: Optional[Secret] = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
-        aws_profile_name: Optional[Secret] = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
-        max_chunks_per_doc: Optional[int] = None,
-        meta_fields_to_embed: Optional[list[str]] = None,
+        aws_session_token: Secret | None = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
+        aws_region_name: Secret | None = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
+        max_chunks_per_doc: int | None = None,
+        meta_fields_to_embed: list[str] | None = None,
         meta_data_separator: str = "\n",
     ) -> None:
         if not model:
@@ -103,7 +103,7 @@ class AmazonBedrockRanker:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.meta_data_separator = meta_data_separator
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         try:
@@ -177,7 +177,7 @@ class AmazonBedrockRanker:
         return concatenated_input_list
 
     @component.output_types(documents=list[Document])
-    def run(self, query: str, documents: list[Document], top_k: Optional[int] = None) -> dict[str, list[Document]]:
+    def run(self, query: str, documents: list[Document], top_k: int | None = None) -> dict[str, list[Document]]:
         """
         Use the Amazon Bedrock Reranker to re-rank the list of documents based on the query.
 
@@ -201,7 +201,7 @@ class AmazonBedrockRanker:
         if not documents:
             return {"documents": []}
 
-        def resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+        def resolve_secret(secret: Secret | None) -> str | None:
             return secret.resolve_value() if secret else None
 
         region = resolve_secret(self.aws_region_name)

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from haystack import Pipeline
@@ -169,7 +169,7 @@ class TestAmazonBedrockChatGenerator:
         assert generator.to_dict() == expected_dict
 
     @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 1000}])
-    def test_from_dict(self, mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]):
+    def test_from_dict(self, mock_boto3_session: Any, boto3_config: dict[str, Any] | None):
         """
         Test that the from_dict method returns the correct object
         """

--- a/integrations/amazon_bedrock/tests/test_document_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_document_embedder.py
@@ -1,6 +1,6 @@
 import io
 import os
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -66,7 +66,7 @@ class TestAmazonBedrockDocumentEmbedder:
             )
 
     @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 1000}])
-    def test_to_dict(self, mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]):
+    def test_to_dict(self, mock_boto3_session: Any, boto3_config: dict[str, Any] | None):
         embedder = AmazonBedrockDocumentEmbedder(
             model="cohere.embed-english-v3",
             input_type="search_document",
@@ -94,7 +94,7 @@ class TestAmazonBedrockDocumentEmbedder:
         assert embedder.to_dict() == expected_dict
 
     @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 1000}])
-    def test_from_dict(self, mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]):
+    def test_from_dict(self, mock_boto3_session: Any, boto3_config: dict[str, Any] | None):
         data = {
             "type": TYPE,
             "init_parameters": {

--- a/integrations/amazon_bedrock/tests/test_document_image_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_document_image_embedder.py
@@ -1,7 +1,7 @@
 import glob
 import io
 import os
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -62,7 +62,7 @@ class TestAmazonBedrockDocumentImageEmbedder:
             )
 
     @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 1000}])
-    def test_to_dict(self, mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]):
+    def test_to_dict(self, mock_boto3_session: Any, boto3_config: dict[str, Any] | None):
         embedder = AmazonBedrockDocumentImageEmbedder(
             model="cohere.embed-english-v3",
             embedding_types=["float"],
@@ -90,7 +90,7 @@ class TestAmazonBedrockDocumentImageEmbedder:
         assert embedder.to_dict() == expected_dict
 
     @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 1000}])
-    def test_from_dict(self, mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]):
+    def test_from_dict(self, mock_boto3_session: Any, boto3_config: dict[str, Any] | None):
         data = {
             "type": TYPE,
             "init_parameters": {
@@ -243,7 +243,7 @@ class TestAmazonBedrockDocumentImageEmbedder:
 
         assert isinstance(result["documents"], list)
         assert len(result["documents"]) == len(documents)
-        for doc, new_doc in zip(documents, result["documents"]):
+        for doc, new_doc in zip(documents, result["documents"], strict=True):
             assert doc.embedding is None
             assert new_doc is not doc
             assert isinstance(new_doc, Document)
@@ -276,7 +276,7 @@ class TestAmazonBedrockDocumentImageEmbedder:
 
         assert isinstance(result["documents"], list)
         assert len(result["documents"]) == len(documents)
-        for doc, new_doc in zip(documents, result["documents"]):
+        for doc, new_doc in zip(documents, result["documents"], strict=True):
             assert doc.embedding is None
             assert new_doc is not doc
             assert isinstance(new_doc, Document)

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -21,7 +21,7 @@ from haystack_integrations.components.generators.amazon_bedrock.adapters import 
 
 
 @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 1000}])
-def test_to_dict(mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]):
+def test_to_dict(mock_boto3_session: Any, boto3_config: dict[str, Any] | None):
     """
     Test that the to_dict method returns the correct dictionary without aws credentials
     """
@@ -50,7 +50,7 @@ def test_to_dict(mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]
 
 
 @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 1000}])
-def test_from_dict(mock_boto3_session: Any, boto3_config: Optional[dict[str, Any]]):
+def test_from_dict(mock_boto3_session: Any, boto3_config: dict[str, Any] | None):
     """
     Test that the from_dict method returns the correct object
     """
@@ -161,7 +161,7 @@ def test_constructor_with_empty_model():
         ("mistral.mistral-medium-v8:0", MistralAdapter),  # artificial
     ],
 )
-def test_get_model_adapter(model: str, expected_model_adapter: Optional[type[BedrockModelAdapter]]):
+def test_get_model_adapter(model: str, expected_model_adapter: type[BedrockModelAdapter] | None):
     """
     Test that the correct model adapter is returned for a given model
     """
@@ -182,7 +182,7 @@ def test_get_model_adapter(model: str, expected_model_adapter: Optional[type[Bed
     ],
 )
 def test_get_model_adapter_with_model_family(
-    model_family: str, expected_model_adapter: Optional[type[BedrockModelAdapter]]
+    model_family: str, expected_model_adapter: type[BedrockModelAdapter] | None
 ):
     """
     Test that the correct model adapter is returned for a given model model_family

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -63,7 +63,7 @@ class TestS3Downloader:
         assert d.file_extensions == [".pdf", ".txt"]
 
     @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 10}])
-    def test_to_dict(self, mock_boto3_session: Any, tmp_path, boto3_config: Optional[dict[str, Any]]):
+    def test_to_dict(self, mock_boto3_session: Any, tmp_path, boto3_config: dict[str, Any] | None):
         d = S3Downloader(file_root_path=str(tmp_path), boto3_config=boto3_config)
         expected = {
             "type": TYPE,
@@ -84,7 +84,7 @@ class TestS3Downloader:
         assert d.to_dict() == expected
 
     @pytest.mark.parametrize("boto3_config", [None, {"read_timeout": 10}])
-    def test_from_dict(self, mock_boto3_session: Any, tmp_path, boto3_config: Optional[dict[str, Any]]):
+    def test_from_dict(self, mock_boto3_session: Any, tmp_path, boto3_config: dict[str, Any] | None):
         data = {
             "type": TYPE,
             "init_parameters": {


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes:
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.

---
