### PR TITLE
chore!: anthropic - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -7,7 +7,7 @@ name = "anthropic-haystack"
 dynamic = ["version"]
 description = 'An integration of Anthropic Claude models into the Haystack framework.'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.19.0", "anthropic>=0.47.0"]
+dependencies = ["haystack-ai>=2.22.0", "anthropic>=0.47.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/anthropic#readme"
@@ -77,7 +76,6 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -125,10 +123,6 @@ ignore = [
   "ARG001",
   "ARG002",
   "ARG005",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, ClassVar, Optional, Union
+from typing import Any, ClassVar
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message
@@ -113,13 +113,13 @@ class AnthropicChatGenerator:
         self,
         api_key: Secret = Secret.from_env_var("ANTHROPIC_API_KEY"),  # noqa: B008
         model: str = "claude-sonnet-4-5",
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
         ignore_tools_thinking_messages: bool = True,
-        tools: Optional[ToolsType] = None,
+        tools: ToolsType | None = None,
         *,
-        timeout: Optional[float] = None,
-        max_retries: Optional[int] = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
     ):
         """
         Creates an instance of AnthropicChatGenerator.
@@ -229,8 +229,8 @@ class AnthropicChatGenerator:
     def _prepare_request_params(
         self,
         messages: list[ChatMessage],
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
     ) -> tuple[list[TextBlockParam], list[MessageParam], dict[str, Any], list[ToolParam]]:
         """
         Prepare the parameters for the Anthropic API request.
@@ -277,8 +277,8 @@ class AnthropicChatGenerator:
 
     def _process_response(
         self,
-        response: Union[Message, Stream[RawMessageStreamEvent]],
-        streaming_callback: Optional[SyncStreamingCallbackT] = None,
+        response: Message | Stream[RawMessageStreamEvent],
+        streaming_callback: SyncStreamingCallbackT | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Process the response from the Anthropic API.
@@ -291,7 +291,7 @@ class AnthropicChatGenerator:
         # we cannot use isinstance(Stream)
         if not isinstance(response, Message):
             chunks: list[StreamingChunk] = []
-            model: Optional[str] = None
+            model: str | None = None
             tool_call_index = -1
             input_tokens = None
             component_info = ComponentInfo.from_component(self)
@@ -345,7 +345,7 @@ class AnthropicChatGenerator:
     async def _process_response_async(
         self,
         response: Any,
-        streaming_callback: Optional[AsyncStreamingCallbackT] = None,
+        streaming_callback: AsyncStreamingCallbackT | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Process the response from the Anthropic API asynchronously.
@@ -359,7 +359,7 @@ class AnthropicChatGenerator:
         # workaround for https://github.com/DataDog/dd-trace-py/issues/12562
         if not isinstance(response, Message):
             chunks: list[StreamingChunk] = []
-            model: Optional[str] = None
+            model: str | None = None
             tool_call_index = -1
             input_tokens = None
             component_info = ComponentInfo.from_component(self)
@@ -418,9 +418,9 @@ class AnthropicChatGenerator:
     def run(
         self,
         messages: list[ChatMessage],
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Invokes the Anthropic API with the given messages and generation kwargs.
@@ -460,9 +460,9 @@ class AnthropicChatGenerator:
     async def run_async(
         self,
         messages: list[ChatMessage],
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Async version of the run method. Invokes the Anthropic API with the given messages and generation kwargs.

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/utils.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, Union, cast, get_args
+from typing import Any, Literal, cast, get_args
 
 from haystack.dataclasses.chat_message import (
     ChatMessage,
@@ -46,14 +46,12 @@ FINISH_REASON_MAPPING: dict[str, FinishReason] = {
 def _update_anthropic_message_with_tool_call_results(
     tool_call_results: list[ToolCallResult],
     content: list[
-        Union[
-            TextBlockParam,
-            ToolUseBlockParam,
-            ToolResultBlockParam,
-            ImageBlockParam,
-            ThinkingBlockParam,
-            RedactedThinkingBlockParam,
-        ]
+        TextBlockParam
+        | ToolUseBlockParam
+        | ToolResultBlockParam
+        | ImageBlockParam
+        | ThinkingBlockParam
+        | RedactedThinkingBlockParam
     ],
 ) -> None:
     """
@@ -130,14 +128,12 @@ def _convert_messages_to_anthropic_format(
             continue
 
         content: list[
-            Union[
-                TextBlockParam,
-                ToolUseBlockParam,
-                ToolResultBlockParam,
-                ImageBlockParam,
-                ThinkingBlockParam,
-                RedactedThinkingBlockParam,
-            ]
+            TextBlockParam
+            | ToolUseBlockParam
+            | ToolResultBlockParam
+            | ImageBlockParam
+            | ThinkingBlockParam
+            | RedactedThinkingBlockParam
         ] = []
 
         # Handle multimodal content (text and images) preserving order
@@ -222,7 +218,7 @@ def _convert_messages_to_anthropic_format(
 
         # Anthropic only supports assistant and user roles in messages. User role is also used for tool messages.
         # System messages are passed separately.
-        role: Union[Literal["assistant"], Literal["user"]] = "user"
+        role: Literal["assistant"] | Literal["user"] = "user"
         if message._role == ChatRole.ASSISTANT:
             role = "assistant"
 
@@ -358,7 +354,7 @@ def _convert_anthropic_chunk_to_streaming_chunk(
     )
 
 
-def _process_reasoning_contents(chunks: list[StreamingChunk]) -> Optional[ReasoningContent]:
+def _process_reasoning_contents(chunks: list[StreamingChunk]) -> ReasoningContent | None:
     """
     Process reasoning contents from a list of StreamingChunk objects into the Anthropic expected format.
 

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import StreamingChunk
@@ -70,13 +71,13 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
         region: str,
         project_id: str,
         model: str = "claude-sonnet-4@20250514",
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
+        streaming_callback: Callable[[StreamingChunk], None] | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
         ignore_tools_thinking_messages: bool = True,
-        tools: Optional[ToolsType] = None,
+        tools: ToolsType | None = None,
         *,
-        timeout: Optional[float] = None,
-        max_retries: Optional[int] = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
     ):
         """
         Creates an instance of AnthropicVertexChatGenerator.


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
