### PR TITLE
chore!: astra - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/astra/pyproject.toml
+++ b/integrations/astra/pyproject.toml
@@ -7,7 +7,7 @@ name = "astra-haystack"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "Anant Corporation", email = "support@anant.us" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0", "pydantic", "typing_extensions", "astrapy>=1.5.0,<2.0"]
+dependencies = ["haystack-ai>=2.22.0", "pydantic", "typing_extensions", "astrapy>=1.5.0,<2.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/astra#readme"
@@ -77,7 +76,6 @@ disallow_incomplete_defs = true
 allow-direct-references = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -123,10 +121,6 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/astra/src/haystack_integrations/components/retrievers/astra/retriever.py
+++ b/integrations/astra/src/haystack_integrations/components/retrievers/astra/retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
@@ -36,9 +36,9 @@ class AstraEmbeddingRetriever:
     def __init__(
         self,
         document_store: AstraDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         :param document_store: An instance of AstraDocumentStore.
@@ -61,8 +61,8 @@ class AstraEmbeddingRetriever:
     def run(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """Retrieve documents from the AstraDocumentStore.
 

--- a/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/astra_client.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Any, Optional, Union
+from typing import Any
 from warnings import warn
 
 from astrapy import DataAPIClient as AstraDBClient
@@ -22,10 +22,10 @@ CALLER_NAME = "haystack"
 @dataclass
 class Response:
     document_id: str
-    text: Optional[str]
-    values: Optional[list]
-    metadata: Optional[dict]
-    score: Optional[float]
+    text: str | None
+    values: list | None
+    metadata: dict | None
+    score: float | None
 
 
 @dataclass
@@ -48,7 +48,7 @@ class AstraClient:
         collection_name: str,
         embedding_dimension: int,
         similarity_function: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """
         The connection to Astra DB is established and managed through the JSON API.
@@ -149,11 +149,11 @@ class AstraClient:
     def query(
         self,
         *,
-        vector: Optional[list[float]] = None,
-        query_filter: Optional[dict[str, Union[str, float, int, bool, list, dict]]] = None,
-        top_k: Optional[int] = None,
-        include_metadata: Optional[bool] = None,
-        include_values: Optional[bool] = None,
+        vector: list[float] | None = None,
+        query_filter: dict[str, str | float | int | bool | list | dict] | None = None,
+        top_k: int | None = None,
+        include_metadata: bool | None = None,
+        include_values: bool | None = None,
     ) -> QueryResponse:
         """
         Search the Astra index using a query vector.
@@ -323,8 +323,8 @@ class AstraClient:
     def delete(
         self,
         *,
-        ids: Optional[list[str]] = None,
-        filters: Optional[dict[str, Union[str, float, int, bool, list, dict]]] = None,
+        ids: list[str] | None = None,
+        filters: dict[str, str | float | int | bool | list | dict] | None = None,
     ) -> int:
         """Delete documents from the Astra index.
 
@@ -364,7 +364,7 @@ class AstraClient:
     def update(
         self,
         *,
-        filters: dict[str, Union[str, float, int, bool, list, dict]],
+        filters: dict[str, str | float | int | bool | list | dict],
         update: dict[str, Any],
     ) -> int:
         """

--- a/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
@@ -52,7 +52,7 @@ class AstraDocumentStore:
         embedding_dimension: int = 768,
         duplicates_policy: DuplicatePolicy = DuplicatePolicy.NONE,
         similarity: str = "cosine",
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ):
         """
         The connection to Astra DB is established and managed through the JSON API.
@@ -100,7 +100,7 @@ class AstraDocumentStore:
         self.duplicates_policy = duplicates_policy
         self.similarity = similarity
         self.namespace = namespace
-        self._index: Optional[AstraClient] = None
+        self._index: AstraClient | None = None
 
     @property
     def index(self) -> AstraClient:
@@ -177,7 +177,7 @@ class AstraDocumentStore:
 
         batch_size = MAX_BATCH_SIZE
 
-        def _convert_input_document(document: Union[dict, Document]) -> dict[str, Any]:
+        def _convert_input_document(document: dict | Document) -> dict[str, Any]:
             if isinstance(document, Document):
                 document_dict = document.to_dict(flatten=False)
             elif isinstance(document, dict):
@@ -284,7 +284,7 @@ class AstraDocumentStore:
         """
         return self.index.count_documents()
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Returns at most 1000 documents that match the filter.
 
@@ -370,9 +370,7 @@ class AstraDocumentStore:
             raise MissingDocumentError(msg)
         return ret[0]
 
-    def search(
-        self, query_embedding: list[float], top_k: int, filters: Optional[dict[str, Any]] = None
-    ) -> list[Document]:
+    def search(self, query_embedding: list[float], top_k: int, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Perform a search for a list of queries.
 

--- a/integrations/astra/src/haystack_integrations/document_stores/astra/filters.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/filters.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional
+from typing import Any
 
 from haystack.errors import FilterError
 
@@ -20,7 +20,7 @@ def _normalize_filters(filters: dict[str, Any]) -> dict[str, Any]:
     return _parse_logical_condition(filters)
 
 
-def _convert_filters(filters: Optional[dict[str, Any]] = None) -> Optional[dict[str, Any]]:
+def _convert_filters(filters: dict[str, Any] | None = None) -> dict[str, Any] | None:
     """
     Convert haystack filters to astra filter string capturing all boolean operators
     """


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
