### PR TITLE
chore!: azure_ai_search - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/azure_ai_search/pyproject.toml
+++ b/integrations/azure_ai_search/pyproject.toml
@@ -7,7 +7,7 @@ name = "azure-ai-search-haystack"
 dynamic = ["version"]
 description = 'Haystack 2.x Document Store for Azure AI Search'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0", "azure-search-documents>=11.5", "azure-identity"]
+dependencies = ["haystack-ai>=2.22.0", "azure-search-documents>=11.5", "azure-identity"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/azure_ai_search#readme"
@@ -80,7 +79,6 @@ allow-direct-references = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -126,10 +124,6 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 exclude = ["example"]
 

--- a/integrations/azure_ai_search/src/haystack_integrations/components/retrievers/azure_ai_search/bm25_retriever.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/components/retrievers/azure_ai_search/bm25_retriever.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.document_stores.types import FilterPolicy
@@ -21,9 +21,9 @@ class AzureAISearchBM25Retriever:
         self,
         *,
         document_store: AzureAISearchDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
         **kwargs: Any,
     ):
         """
@@ -97,7 +97,7 @@ class AzureAISearchBM25Retriever:
 
     @component.output_types(documents=list[Document])
     def run(
-        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """Retrieve documents from the AzureAISearchDocumentStore.
 

--- a/integrations/azure_ai_search/src/haystack_integrations/components/retrievers/azure_ai_search/embedding_retriever.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/components/retrievers/azure_ai_search/embedding_retriever.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.document_stores.types import FilterPolicy
@@ -21,9 +21,9 @@ class AzureAISearchEmbeddingRetriever:
         self,
         *,
         document_store: AzureAISearchDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
         **kwargs: Any,
     ):
         """
@@ -94,7 +94,7 @@ class AzureAISearchEmbeddingRetriever:
 
     @component.output_types(documents=list[Document])
     def run(
-        self, query_embedding: list[float], filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query_embedding: list[float], filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """Retrieve documents from the AzureAISearchDocumentStore.
 

--- a/integrations/azure_ai_search/src/haystack_integrations/components/retrievers/azure_ai_search/hybrid_retriever.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/components/retrievers/azure_ai_search/hybrid_retriever.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.document_stores.types import FilterPolicy
@@ -21,9 +21,9 @@ class AzureAISearchHybridRetriever:
         self,
         *,
         document_store: AzureAISearchDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
         **kwargs: Any,
     ):
         """
@@ -100,8 +100,8 @@ class AzureAISearchHybridRetriever:
         self,
         query: str,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """Retrieve documents from the AzureAISearchDocumentStore.
 

--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -4,7 +4,7 @@
 
 import logging as python_logging
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import (
@@ -100,8 +100,8 @@ class AzureAISearchDocumentStore:
         azure_endpoint: Secret = Secret.from_env_var("AZURE_AI_SEARCH_ENDPOINT", strict=True),  # noqa: B008
         index_name: str = "default",
         embedding_dimension: int = 768,
-        metadata_fields: Optional[dict[str, Union[SearchField, type]]] = None,
-        vector_search_configuration: Optional[VectorSearch] = None,
+        metadata_fields: dict[str, SearchField | type] | None = None,
+        vector_search_configuration: VectorSearch | None = None,
         include_search_metadata: bool = False,
         **index_creation_kwargs: Any,
     ):
@@ -148,8 +148,8 @@ class AzureAISearchDocumentStore:
 
         For more information on parameters, see the [official Azure AI Search documentation](https://learn.microsoft.com/en-us/azure/search/).
         """
-        self._client: Optional[SearchClient] = None
-        self._index_client: Optional[SearchIndexClient] = None
+        self._client: SearchClient | None = None
+        self._index_client: SearchIndexClient | None = None
         self._index_fields = []  # type: list[Any]  # stores all fields in the final schema of index
         self._api_key = api_key
         self._azure_endpoint = azure_endpoint
@@ -202,7 +202,7 @@ class AzureAISearchDocumentStore:
 
     @staticmethod
     def _normalize_metadata_index_fields(
-        metadata_fields: Optional[dict[str, Union[SearchField, type]]],
+        metadata_fields: dict[str, SearchField | type] | None,
     ) -> dict[str, SearchField]:
         """Create a list of index fields for storing metadata values."""
 
@@ -516,7 +516,7 @@ class AzureAISearchDocumentStore:
         result = self.client.search(search_text=search_text, top=top_k)
         return self._convert_search_result_to_documents(list(result))
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Returns the documents that match the provided filters.
         Filters should be given as a dictionary supporting filtering by metadata. For details on
@@ -567,7 +567,7 @@ class AzureAISearchDocumentStore:
             documents.append(doc)
         return documents
 
-    def _index_exists(self, index_name: Optional[str]) -> bool:
+    def _index_exists(self, index_name: str | None) -> bool:
         """
         Check if the index exists in the Azure AI Search service.
 
@@ -614,7 +614,7 @@ class AzureAISearchDocumentStore:
         query_embedding: list[float],
         *,
         top_k: int = 10,
-        filters: Optional[str] = None,
+        filters: str | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         """
@@ -648,7 +648,7 @@ class AzureAISearchDocumentStore:
         self,
         query: str,
         top_k: int = 10,
-        filters: Optional[str] = None,
+        filters: str | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         """
@@ -681,7 +681,7 @@ class AzureAISearchDocumentStore:
         query: str,
         query_embedding: list[float],
         top_k: int = 10,
-        filters: Optional[str] = None,
+        filters: str | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         """

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -243,7 +243,7 @@ def _assert_documents_are_equal(received: list[Document], expected: list[Documen
     sorted_expected = sorted(expected, key=lambda doc: doc.id)
     assert len(sorted_received) == len(sorted_expected)
 
-    for received_doc, expected_doc in zip(sorted_received, sorted_expected):
+    for received_doc, expected_doc in zip(sorted_received, sorted_expected, strict=True):
         # Compare all attributes except score
         assert received_doc.id == expected_doc.id
         assert received_doc.content == expected_doc.content


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
