### PR TITLE
chore!: cohere - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -7,7 +7,7 @@ name = "cohere-haystack"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.19.0", "cohere>=5.17.0"]
+dependencies = ["haystack-ai>=2.22.0", "cohere>=5.17.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"
@@ -79,7 +78,6 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -125,10 +123,6 @@ ignore = [
   # Misc
   "B008",
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -45,9 +45,9 @@ class CohereDocumentEmbedder:
         timeout: float = 120.0,
         batch_size: int = 32,
         progress_bar: bool = True,
-        meta_fields_to_embed: Optional[list[str]] = None,
+        meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
-        embedding_type: Optional[EmbeddingTypes] = None,
+        embedding_type: EmbeddingTypes | None = None,
     ):
         """
         :param api_key: the Cohere API key.
@@ -167,7 +167,7 @@ class CohereDocumentEmbedder:
         return texts_to_embed
 
     @component.output_types(documents=list[Document], meta=dict[str, Any])
-    def run(self, documents: list[Document]) -> dict[str, Union[list[Document], dict[str, Any]]]:
+    def run(self, documents: list[Document]) -> dict[str, list[Document] | dict[str, Any]]:
         """Embed a list of `Documents`.
 
         :param documents: documents to embed.
@@ -195,13 +195,13 @@ class CohereDocumentEmbedder:
             self.embedding_type,
         )
 
-        for doc, embeddings in zip(documents, all_embeddings):
+        for doc, embeddings in zip(documents, all_embeddings, strict=True):
             doc.embedding = embeddings
 
         return {"documents": documents, "meta": metadata}
 
     @component.output_types(documents=list[Document], meta=dict[str, Any])
-    async def run_async(self, documents: list[Document]) -> dict[str, Union[list[Document], dict[str, Any]]]:
+    async def run_async(self, documents: list[Document]) -> dict[str, list[Document] | dict[str, Any]]:
         """
         Embed a list of `Documents` asynchronously.
 
@@ -228,7 +228,7 @@ class CohereDocumentEmbedder:
             embedding_type=self.embedding_type,
         )
 
-        for doc, embeddings in zip(documents, all_embeddings):
+        for doc, embeddings in zip(documents, all_embeddings, strict=True):
             doc.embedding = embeddings
 
         return {"documents": documents, "meta": metadata}

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_image_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_image_embedder.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import replace
-from typing import Any, Optional
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.components.converters.image.image_utils import (
@@ -63,13 +63,13 @@ class CohereDocumentImageEmbedder:
         self,
         *,
         file_path_meta_field: str = "file_path",
-        root_path: Optional[str] = None,
-        image_size: Optional[tuple[int, int]] = None,
+        root_path: str | None = None,
+        image_size: tuple[int, int] | None = None,
         api_key: Secret = Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
         model: str = "embed-v4.0",
         api_base_url: str = "https://api.cohere.com",
         timeout: float = 120.0,
-        embedding_dimension: Optional[int] = None,
+        embedding_dimension: int | None = None,
         embedding_type: EmbeddingTypes = EmbeddingTypes.FLOAT,
         progress_bar: bool = True,
     ) -> None:
@@ -205,7 +205,7 @@ class CohereDocumentImageEmbedder:
                 )
                 raise ValueError(msg)
 
-        images_to_embed: list[Optional[str]] = [None] * len(documents)
+        images_to_embed: list[str | None] = [None] * len(documents)
         pdf_page_infos: list[_PDFPageInfo] = []
 
         for doc_idx, image_source_info in enumerate(images_source_info):
@@ -259,7 +259,9 @@ class CohereDocumentImageEmbedder:
         embeddings = []
 
         # The Cohere API only supports passing one image at a time
-        for doc, image in tqdm(zip(documents, images_to_embed), desc="Embedding images", disable=not self.progress_bar):
+        for doc, image in tqdm(
+            zip(documents, images_to_embed, strict=True), desc="Embedding images", disable=not self.progress_bar
+        ):
             try:
                 response = self._client.embed(
                     model=self.model,
@@ -276,7 +278,7 @@ class CohereDocumentImageEmbedder:
             embeddings.append(embedding)
 
         docs_with_embeddings = []
-        for doc, emb in zip(documents, embeddings):
+        for doc, emb in zip(documents, embeddings, strict=True):
             # we store this information for later inspection
             new_meta = {
                 **doc.meta,
@@ -305,7 +307,9 @@ class CohereDocumentImageEmbedder:
         embeddings = []
 
         # The Cohere API only supports passing one image at a time
-        for doc, image in tqdm(zip(documents, images_to_embed), desc="Embedding images", disable=not self.progress_bar):
+        for doc, image in tqdm(
+            zip(documents, images_to_embed, strict=True), desc="Embedding images", disable=not self.progress_bar
+        ):
             try:
                 response = await self._async_client.embed(
                     model=self.model,
@@ -322,7 +326,7 @@ class CohereDocumentImageEmbedder:
             embeddings.append(embedding)
 
         docs_with_embeddings = []
-        for doc, emb in zip(documents, embeddings):
+        for doc, emb in zip(documents, embeddings, strict=True):
             # we store this information for later inspection
             new_meta = {
                 **doc.meta,

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -40,7 +40,7 @@ class CohereTextEmbedder:
         api_base_url: str = "https://api.cohere.com",
         truncate: str = "END",
         timeout: float = 120.0,
-        embedding_type: Optional[EmbeddingTypes] = None,
+        embedding_type: EmbeddingTypes | None = None,
     ):
         """
         :param api_key: the Cohere API key.
@@ -134,7 +134,7 @@ class CohereTextEmbedder:
         return default_from_dict(cls, data)
 
     @component.output_types(embedding=list[float], meta=dict[str, Any])
-    def run(self, text: str) -> dict[str, Union[list[float], dict[str, Any]]]:
+    def run(self, text: str) -> dict[str, list[float] | dict[str, Any]]:
         """
         Embed text.
 
@@ -161,7 +161,7 @@ class CohereTextEmbedder:
         return {"embedding": embedding[0], "meta": metadata}
 
     @component.output_types(embedding=list[float], meta=dict[str, Any])
-    async def run_async(self, text: str) -> dict[str, Union[list[float], dict[str, Any]]]:
+    async def run_async(self, text: str) -> dict[str, list[float] | dict[str, Any]]:
         """
         Asynchronously embed text.
 

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/utils.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/utils.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional
+from typing import Any
 
 from tqdm import tqdm
 
@@ -16,7 +16,7 @@ async def get_async_response(
     model_name: str,
     input_type: str,
     truncate: str,
-    embedding_type: Optional[EmbeddingTypes] = None,
+    embedding_type: EmbeddingTypes | None = None,
 ) -> tuple[list[list[float]], dict[str, Any]]:
     """Embeds a list of texts asynchronously using the Cohere API.
 
@@ -64,7 +64,7 @@ def get_response(
     truncate: str,
     batch_size: int = 32,
     progress_bar: bool = False,
-    embedding_type: Optional[EmbeddingTypes] = None,
+    embedding_type: EmbeddingTypes | None = None,
 ) -> tuple[list[list[float]], dict[str, Any]]:
     """Embeds a list of texts using the Cohere API.
 

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import AsyncIterator, Iterator
-from typing import Any, Literal, Optional, Union, get_args
+from typing import Any, Literal, get_args
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message
@@ -77,7 +77,7 @@ def _format_tool(tool: Tool) -> dict[str, Any]:
 
 def _format_message(
     message: ChatMessage,
-) -> Union[UserChatMessageV2, AssistantChatMessageV2, SystemChatMessageV2, ToolChatMessageV2]:
+) -> UserChatMessageV2 | AssistantChatMessageV2 | SystemChatMessageV2 | ToolChatMessageV2:
     """
     Formats a Haystack ChatMessage into Cohere's chat format.
 
@@ -147,7 +147,7 @@ def _format_message(
                     raise ValueError(msg)
 
         # Build multimodal content following Cohere's API specification
-        content_parts: list[Union[CohereTextContent, ImageUrlContent]] = []
+        content_parts: list[CohereTextContent | ImageUrlContent] = []
         for part in message._content:
             if isinstance(part, TextContent) and part.text:
                 text_content = CohereTextContent(text=part.text)
@@ -234,7 +234,7 @@ def _parse_response(chat_response: ChatResponse, model: str) -> ChatMessage:
 def _convert_cohere_chunk_to_streaming_chunk(
     chunk: StreamedChatResponseV2,
     model: str,
-    component_info: Optional[ComponentInfo] = None,
+    component_info: ComponentInfo | None = None,
     global_index: int = 0,
 ) -> StreamingChunk:
     """
@@ -518,10 +518,10 @@ class CohereChatGenerator:
         self,
         api_key: Secret = Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
         model: str = "command-a-03-2025",
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        api_base_url: Optional[str] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        api_base_url: str | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
         **kwargs: Any,
     ):
         """
@@ -618,9 +618,9 @@ class CohereChatGenerator:
     def run(
         self,
         messages: list[ChatMessage],
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
-        streaming_callback: Optional[StreamingCallbackT] = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
+        streaming_callback: StreamingCallbackT | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Invoke the chat endpoint based on the provided messages and generation parameters.
@@ -685,9 +685,9 @@ class CohereChatGenerator:
     async def run_async(
         self,
         messages: list[ChatMessage],
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
-        streaming_callback: Optional[StreamingCallbackT] = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
+        streaming_callback: StreamingCallbackT | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Asynchronously invoke the chat endpoint based on the provided messages and generation parameters.

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any
 
 from haystack import component, logging
 from haystack.dataclasses import ChatMessage
@@ -33,8 +34,8 @@ class CohereGenerator(CohereChatGenerator):
         self,
         api_key: Secret = Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
         model: str = "command-a-03-2025",
-        streaming_callback: Optional[Callable] = None,
-        api_base_url: Optional[str] = None,
+        streaming_callback: Callable | None = None,
+        api_base_url: str | None = None,
         **kwargs: Any,
     ):
         """
@@ -57,7 +58,7 @@ class CohereGenerator(CohereChatGenerator):
     def run(  # type: ignore[override] # due to incompatible signature with ChatGenerator
         self,
         prompt: str,
-    ) -> dict[str, Union[list[str], list[dict[str, Any]]]]:
+    ) -> dict[str, list[str] | list[dict[str, Any]]]:
         """
         Queries the LLM with the prompts to produce replies.
 
@@ -80,7 +81,7 @@ class CohereGenerator(CohereChatGenerator):
     async def run_async(  # type: ignore[override] # due to incompatible signature with ChatGenerator
         self,
         prompt: str,
-    ) -> dict[str, Union[list[str], list[dict[str, Any]]]]:
+    ) -> dict[str, list[str] | list[dict[str, Any]]]:
         """
         Queries the LLM asynchronously with the prompts to produce replies.
         :param prompt: the prompt to be sent to the generative model.

--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -37,7 +37,7 @@ class CohereRanker:
         top_k: int = 10,
         api_key: Secret = Secret.from_env_var(["COHERE_API_KEY", "CO_API_KEY"]),
         api_base_url: str = "https://api.cohere.com",
-        meta_fields_to_embed: Optional[list[str]] = None,
+        meta_fields_to_embed: list[str] | None = None,
         meta_data_separator: str = "\n",
         max_tokens_per_doc: int = 4096,
     ):
@@ -120,7 +120,7 @@ class CohereRanker:
         return concatenated_input_list
 
     @component.output_types(documents=list[Document])
-    def run(self, query: str, documents: list[Document], top_k: Optional[int] = None) -> dict[str, list[Document]]:
+    def run(self, query: str, documents: list[Document], top_k: int | None = None) -> dict[str, list[Document]]:
         """
         Use the Cohere Reranker to re-rank the list of documents based on the query.
 
@@ -160,7 +160,7 @@ class CohereRanker:
         indices = [output.index for output in response.results]
         scores = [output.relevance_score for output in response.results]
         sorted_docs = []
-        for idx, score in zip(indices, scores):
+        for idx, score in zip(indices, scores, strict=True):
             doc = documents[idx]
             doc.score = score
             sorted_docs.append(documents[idx])

--- a/integrations/cohere/tests/test_chat_generator_chunks.py
+++ b/integrations/cohere/tests/test_chat_generator_chunks.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,7 +9,7 @@ from haystack_integrations.components.generators.cohere.chat.chat_generator impo
 )
 
 
-def create_mock_cohere_chunk(chunk_type: str, index: Optional[int] = None, **kwargs):
+def create_mock_cohere_chunk(chunk_type: str, index: int | None = None, **kwargs):
     """aux function to create properly configured mock Cohere chunks"""
     chunk = MagicMock()
     chunk.type = chunk_type
@@ -370,7 +369,7 @@ class TestCohereChunkConversion:
         # TODO: the indexes are not correctly checked because of missing global_index
         # all the streaming chunks have index 0, but the expected indexes increase with tool calls.
 
-        for cohere_chunk, haystack_chunk in zip(cohere_chunks, expected_streaming_chunks):
+        for cohere_chunk, haystack_chunk in zip(cohere_chunks, expected_streaming_chunks, strict=True):
             stream_chunk = _convert_cohere_chunk_to_streaming_chunk(
                 chunk=cohere_chunk,
                 model="command-a-03-2025",

--- a/integrations/cohere/tests/test_document_embedder.py
+++ b/integrations/cohere/tests/test_document_embedder.py
@@ -168,7 +168,7 @@ class TestCohereDocumentEmbedder:
 
         assert result["meta"] == {"api_version": "1.0"}
 
-        for doc, doc_with_embedding, embedding in zip(docs, result["documents"], embeddings):
+        for doc, doc_with_embedding, embedding in zip(docs, result["documents"], embeddings, strict=True):
             assert doc_with_embedding.content == doc.content
             assert doc_with_embedding.meta == doc.meta
             assert doc_with_embedding.embedding == embedding
@@ -190,7 +190,7 @@ class TestCohereDocumentEmbedder:
 
         assert result["meta"] == {"api_version": "1.0"}
 
-        for doc, doc_with_embedding, embedding in zip(docs, result["documents"], embeddings):
+        for doc, doc_with_embedding, embedding in zip(docs, result["documents"], embeddings, strict=True):
             assert doc_with_embedding.content == doc.content
             assert doc_with_embedding.meta == doc.meta
             assert doc_with_embedding.embedding == embedding

--- a/integrations/cohere/tests/test_document_image_embedder.py
+++ b/integrations/cohere/tests/test_document_image_embedder.py
@@ -244,7 +244,7 @@ class TestCohereDocumentImageEmbedder:
 
         assert isinstance(result["documents"], list)
         assert len(result["documents"]) == len(documents)
-        for doc, new_doc in zip(documents, result["documents"]):
+        for doc, new_doc in zip(documents, result["documents"], strict=True):
             assert doc.embedding is None
             assert new_doc is not doc
             assert isinstance(new_doc, Document)
@@ -306,7 +306,7 @@ class TestCohereDocumentImageEmbedder:
 
         assert isinstance(result["documents"], list)
         assert len(result["documents"]) == len(documents)
-        for doc, new_doc in zip(documents, result["documents"]):
+        for doc, new_doc in zip(documents, result["documents"], strict=True):
             assert doc.embedding is None
             assert new_doc is not doc
             assert isinstance(new_doc, Document)
@@ -357,7 +357,7 @@ class TestCohereDocumentImageEmbedder:
 
         result = embedder.run(documents=documents)
         assert len(result["documents"]) == len(documents)
-        for doc, new_doc in zip(documents, result["documents"]):
+        for doc, new_doc in zip(documents, result["documents"], strict=True):
             assert doc.embedding is None
             assert new_doc is not doc
             assert isinstance(new_doc, Document)
@@ -388,7 +388,7 @@ class TestCohereDocumentImageEmbedder:
 
         result = await embedder.run_async(documents=documents)
         assert len(result["documents"]) == len(documents)
-        for doc, new_doc in zip(documents, result["documents"]):
+        for doc, new_doc in zip(documents, result["documents"], strict=True):
             assert doc.embedding is None
             assert new_doc is not doc
             assert isinstance(new_doc, Document)


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
