### PR TITLE
chore!: cometapi - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/cometapi/pyproject.toml
+++ b/integrations/cometapi/pyproject.toml
@@ -7,7 +7,7 @@ name = "cometapi-haystack"
 dynamic = ["version"]
 description = 'Use Comet API with Haystack to build AI applications with 500+ AI models.'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -26,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.13.2",]
+dependencies = ["haystack-ai>=2.22.0",]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cometapi#readme"
@@ -85,7 +84,6 @@ module = [
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -137,10 +135,6 @@ ignore = [
   "ARG005",
   # Allow function call argument defaults e.g. `Secret.from_env_var`
   "B008",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/cometapi/src/haystack_integrations/components/generators/cometapi/chat/chat_generator.py
+++ b/integrations/cometapi/src/haystack_integrations/components/generators/cometapi/chat/chat_generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import StreamingCallbackT
@@ -34,13 +34,13 @@ class CometAPIChatGenerator(OpenAIChatGenerator):
         *,
         api_key: Secret = Secret.from_env_var("COMET_API_KEY"),
         model: str = "gpt-5-mini",
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        timeout: Optional[int] = None,
-        max_retries: Optional[int] = None,
-        tools: Optional[Union[list[Union[Tool, Toolset]], Toolset]] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        timeout: int | None = None,
+        max_retries: int | None = None,
+        tools: list[Tool | Toolset] | Toolset | None = None,
         tools_strict: bool = False,
-        http_client_kwargs: Optional[dict[str, Any]] = None,
+        http_client_kwargs: dict[str, Any] | None = None,
     ):
         api_base_url = "https://api.cometapi.com/v1"
 


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
