### PR TITLE
chore!: fastembed - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -7,7 +7,7 @@ name = "fastembed-haystack"
 dynamic = ["version"]
 description = "Haystack 2.x component to embed strings and Documents using fastembed embedding model"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.0.1", "fastembed>=0.4.2"]
+dependencies = ["haystack-ai>=2.22.0", "fastembed>=0.4.2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"
@@ -75,7 +74,6 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -123,10 +121,6 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from tqdm import tqdm
@@ -17,8 +17,8 @@ class _FastembedEmbeddingBackendFactory:
     @staticmethod
     def get_embedding_backend(
         model_name: str,
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         local_files_only: bool = False,
     ) -> "_FastembedEmbeddingBackend":
         embedding_backend_id = f"{model_name}{cache_dir}{threads}"
@@ -41,8 +41,8 @@ class _FastembedEmbeddingBackend:
     def __init__(
         self,
         model_name: str,
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         local_files_only: bool = False,
     ):
         self.model = TextEmbedding(
@@ -70,10 +70,10 @@ class _FastembedSparseEmbeddingBackendFactory:
     @staticmethod
     def get_embedding_backend(
         model_name: str,
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         local_files_only: bool = False,
-        model_kwargs: Optional[dict[str, Any]] = None,
+        model_kwargs: dict[str, Any] | None = None,
     ) -> "_FastembedSparseEmbeddingBackend":
         embedding_backend_id = f"{model_name}{cache_dir}{threads}{local_files_only}{model_kwargs}"
 
@@ -99,10 +99,10 @@ class _FastembedSparseEmbeddingBackend:
     def __init__(
         self,
         model_name: str,
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         local_files_only: bool = False,
-        model_kwargs: Optional[dict[str, Any]] = None,
+        model_kwargs: dict[str, Any] | None = None,
     ):
         model_kwargs = model_kwargs or {}
 

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_document_embedder.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import replace
-from typing import Any, Optional
+from typing import Any
 
 from haystack import Document, component, default_to_dict
 
@@ -63,15 +63,15 @@ class FastembedDocumentEmbedder:
     def __init__(
         self,
         model: str = "BAAI/bge-small-en-v1.5",
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         prefix: str = "",
         suffix: str = "",
         batch_size: int = 256,
         progress_bar: bool = True,
-        parallel: Optional[int] = None,
+        parallel: int | None = None,
         local_files_only: bool = False,
-        meta_fields_to_embed: Optional[list[str]] = None,
+        meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
     ) -> None:
         """
@@ -107,7 +107,7 @@ class FastembedDocumentEmbedder:
         self.local_files_only = local_files_only
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
-        self.embedding_backend: Optional[_FastembedEmbeddingBackend] = None
+        self.embedding_backend: _FastembedEmbeddingBackend | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -184,7 +184,7 @@ class FastembedDocumentEmbedder:
         )
 
         new_documents = []
-        for doc, emb in zip(documents, embeddings):
+        for doc, emb in zip(documents, embeddings, strict=True):
             new_documents.append(replace(doc, embedding=emb))
 
         return {"documents": new_documents}

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import replace
-from typing import Any, Optional
+from typing import Any
 
 from haystack import Document, component, default_to_dict
 
@@ -62,15 +62,15 @@ class FastembedSparseDocumentEmbedder:
     def __init__(
         self,
         model: str = "prithivida/Splade_PP_en_v1",
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         batch_size: int = 32,
         progress_bar: bool = True,
-        parallel: Optional[int] = None,
+        parallel: int | None = None,
         local_files_only: bool = False,
-        meta_fields_to_embed: Optional[list[str]] = None,
+        meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
-        model_kwargs: Optional[dict[str, Any]] = None,
+        model_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
         Create an FastembedDocumentEmbedder component.
@@ -103,7 +103,7 @@ class FastembedSparseDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
         self.model_kwargs = model_kwargs
-        self.embedding_backend: Optional[_FastembedSparseEmbeddingBackend] = None
+        self.embedding_backend: _FastembedSparseEmbeddingBackend | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -179,7 +179,7 @@ class FastembedSparseDocumentEmbedder:
         )
 
         new_documents = []
-        for doc, emb in zip(documents, embeddings):
+        for doc, emb in zip(documents, embeddings, strict=True):
             new_documents.append(replace(doc, sparse_embedding=emb))
 
         return {"documents": new_documents}

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional
+from typing import Any
 
 from haystack import component, default_to_dict
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
@@ -37,12 +37,12 @@ class FastembedSparseTextEmbedder:
     def __init__(
         self,
         model: str = "prithivida/Splade_PP_en_v1",
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         progress_bar: bool = True,
-        parallel: Optional[int] = None,
+        parallel: int | None = None,
         local_files_only: bool = False,
-        model_kwargs: Optional[dict[str, Any]] = None,
+        model_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
         Create a FastembedSparseTextEmbedder component.
@@ -68,7 +68,7 @@ class FastembedSparseTextEmbedder:
         self.parallel = parallel
         self.local_files_only = local_files_only
         self.model_kwargs = model_kwargs
-        self.embedding_backend: Optional[_FastembedSparseEmbeddingBackend] = None
+        self.embedding_backend: _FastembedSparseEmbeddingBackend | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_text_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional
+from typing import Any
 
 from haystack import component, default_to_dict
 
@@ -33,12 +33,12 @@ class FastembedTextEmbedder:
     def __init__(
         self,
         model: str = "BAAI/bge-small-en-v1.5",
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         prefix: str = "",
         suffix: str = "",
         progress_bar: bool = True,
-        parallel: Optional[int] = None,
+        parallel: int | None = None,
         local_files_only: bool = False,
     ) -> None:
         """
@@ -67,7 +67,7 @@ class FastembedTextEmbedder:
         self.progress_bar = progress_bar
         self.parallel = parallel
         self.local_files_only = local_files_only
-        self.embedding_backend: Optional[_FastembedEmbeddingBackend] = None
+        self.embedding_backend: _FastembedEmbeddingBackend | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
+++ b/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 
@@ -39,12 +39,12 @@ class FastembedRanker:
         self,
         model_name: str = "Xenova/ms-marco-MiniLM-L-6-v2",
         top_k: int = 10,
-        cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
+        cache_dir: str | None = None,
+        threads: int | None = None,
         batch_size: int = 64,
-        parallel: Optional[int] = None,
+        parallel: int | None = None,
         local_files_only: bool = False,
-        meta_fields_to_embed: Optional[list[str]] = None,
+        meta_fields_to_embed: list[str] | None = None,
         meta_data_separator: str = "\n",
     ):
         """
@@ -80,7 +80,7 @@ class FastembedRanker:
         self.local_files_only = local_files_only
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.meta_data_separator = meta_data_separator
-        self._model: Optional[TextCrossEncoder] = None
+        self._model: TextCrossEncoder | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -144,7 +144,7 @@ class FastembedRanker:
         return concatenated_input_list
 
     @component.output_types(documents=list[Document])
-    def run(self, query: str, documents: list[Document], top_k: Optional[int] = None) -> dict[str, list[Document]]:
+    def run(self, query: str, documents: list[Document], top_k: int | None = None) -> dict[str, list[Document]]:
         """
         Returns a list of documents ranked by their similarity to the given query, using FastEmbed.
 
@@ -192,7 +192,7 @@ class FastembedRanker:
         )
 
         # Combine the two lists into a single list of tuples
-        doc_scores = list(zip(documents, scores))
+        doc_scores = list(zip(documents, scores, strict=True))
 
         # Sort the list of tuples by the score in descending order
         sorted_doc_scores = sorted(doc_scores, key=lambda x: x[1], reverse=True)

--- a/integrations/fastembed/tests/test_fastembed_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_document_embedder.py
@@ -262,6 +262,7 @@ class TestFastembedDocumentEmbedder:
             embedding_separator="\n",
         )
         embedder.embedding_backend = MagicMock()
+        embedder.embedding_backend.embed.return_value = [np.random.rand(3, 16).tolist() for _ in range(5)]
 
         documents = [Document(content=f"document-number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
 

--- a/integrations/fastembed/tests/test_fastembed_ranker.py
+++ b/integrations/fastembed/tests/test_fastembed_ranker.py
@@ -4,6 +4,7 @@
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from haystack import Document, default_from_dict
 
@@ -237,6 +238,7 @@ class TestFastembedRanker:
             meta_fields_to_embed=["meta_field"],
         )
         ranker._model = MagicMock()
+        ranker._model.rerank.return_value = [np.random.rand(3, 16).tolist() for _ in range(5)]
 
         documents = [Document(content=f"document-number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
         query = "test"

--- a/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/tests/test_fastembed_sparse_document_embedder.py
@@ -267,7 +267,7 @@ class TestFastembedSparseDocumentEmbedderDoc:
             embedding_separator="\n",
         )
         embedder.embedding_backend = MagicMock()
-
+        embedder.embedding_backend.embed.return_value = [self._generate_mocked_sparse_embedding(3) for _ in range(5)]
         documents = [Document(content=f"document-number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
 
         embedder.run(documents=documents)


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
