### PR TITLE
chore!: chroma - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -7,7 +7,7 @@ name = "chroma-haystack"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "John Doe", email = "jd@example.com" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0", "chromadb>=1.0.2"]
+dependencies = ["haystack-ai>=2.22.0", "chromadb>=1.0.2"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma#readme"
@@ -78,7 +77,6 @@ disallow_incomplete_defs = true
 allow-direct-references = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -128,10 +126,6 @@ ignore = [
   "ARG002",
   # Allow assertions
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 exclude = ["example"]
 

--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
@@ -48,9 +48,9 @@ class ChromaQueryTextRetriever:
     def __init__(
         self,
         document_store: ChromaDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         :param document_store: an instance of `ChromaDocumentStore`.
@@ -69,8 +69,8 @@ class ChromaQueryTextRetriever:
     def run(
         self,
         query: str,
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, Any]:
         """
         Run the retriever on the given input data.
@@ -94,8 +94,8 @@ class ChromaQueryTextRetriever:
     async def run_async(
         self,
         query: str,
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, Any]:
         """
         Asynchronously run the retriever on the given input data.
@@ -161,9 +161,9 @@ class ChromaEmbeddingRetriever:
     def __init__(
         self,
         document_store: ChromaDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         :param document_store: an instance of `ChromaDocumentStore`.
@@ -182,8 +182,8 @@ class ChromaEmbeddingRetriever:
     def run(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, Any]:
         """
         Run the retriever on the given input data.
@@ -209,8 +209,8 @@ class ChromaEmbeddingRetriever:
     async def run_async(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, Any]:
         """
         Asynchronously run the retriever on the given input data.

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, cast
 
 import chromadb
 from chromadb.api.models.AsyncCollection import AsyncCollection
@@ -36,12 +36,12 @@ class ChromaDocumentStore:
         self,
         collection_name: str = "documents",
         embedding_function: str = "default",
-        persist_path: Optional[str] = None,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
+        persist_path: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
         distance_function: Literal["l2", "cosine", "ip"] = "l2",
-        metadata: Optional[dict] = None,
-        client_settings: Optional[dict[str, Any]] = None,
+        metadata: dict | None = None,
+        client_settings: dict[str, Any] | None = None,
         **embedding_function_params: Any,
     ):
         """
@@ -97,8 +97,8 @@ class ChromaDocumentStore:
         self._host = host
         self._port = port
 
-        self._collection: Optional[chromadb.Collection] = None
-        self._async_collection: Optional[AsyncCollection] = None
+        self._collection: chromadb.Collection | None = None
+        self._async_collection: AsyncCollection | None = None
 
     def _ensure_initialized(self):
         if not self._collection:
@@ -208,7 +208,7 @@ class ChromaDocumentStore:
                 )
 
     @staticmethod
-    def _prepare_get_kwargs(filters: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def _prepare_get_kwargs(filters: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Prepare kwargs for Chroma get operations.
         """
@@ -226,7 +226,7 @@ class ChromaDocumentStore:
         return kwargs
 
     @staticmethod
-    def _prepare_query_kwargs(filters: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def _prepare_query_kwargs(filters: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Prepare kwargs for Chroma query operations.
         """
@@ -264,7 +264,7 @@ class ChromaDocumentStore:
 
         return value
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Returns the documents that match the filters provided.
 
@@ -282,7 +282,7 @@ class ChromaDocumentStore:
 
         return self._get_result_to_documents(result)
 
-    async def filter_documents_async(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    async def filter_documents_async(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Asynchronously returns the documents that match the filters provided.
 
@@ -353,7 +353,7 @@ class ChromaDocumentStore:
         return ids_to_update, updated_metadata
 
     @staticmethod
-    def _convert_document_to_chroma(doc: Document) -> Optional[dict[str, Any]]:
+    def _convert_document_to_chroma(doc: Document) -> dict[str, Any] | None:
         """
         Converts a Haystack Document to a Chroma document.
         """
@@ -755,7 +755,7 @@ class ChromaDocumentStore:
         self,
         queries: list[str],
         top_k: int,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
     ) -> list[list[Document]]:
         """
         Search the documents in the store using the provided text queries.
@@ -781,7 +781,7 @@ class ChromaDocumentStore:
         self,
         queries: list[str],
         top_k: int,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
     ) -> list[list[Document]]:
         """
         Asynchronously search the documents in the store using the provided text queries.
@@ -809,7 +809,7 @@ class ChromaDocumentStore:
         self,
         query_embeddings: list[list[float]],
         top_k: int,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
     ) -> list[list[Document]]:
         """
         Perform vector search on the stored document, pass the embeddings of the queries instead of their text.
@@ -837,7 +837,7 @@ class ChromaDocumentStore:
         self,
         query_embeddings: list[list[float]],
         top_k: int,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
     ) -> list[list[Document]]:
         """
         Asynchronously perform vector search on the stored document, pass the embeddings of the queries instead of

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/filters.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/filters.py
@@ -4,7 +4,7 @@
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from chromadb.api.types import WhereDocument, validate_where, validate_where_document
 
@@ -38,8 +38,8 @@ class ChromaFilter:
     """
 
     ids: list[str]
-    where: Optional[dict[str, Any]]
-    where_document: Optional[dict[str, Any]]
+    where: dict[str, Any] | None
+    where_document: dict[str, Any] | None
 
 
 def _convert_filters(filters: dict[str, Any]) -> ChromaFilter:

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -64,7 +64,7 @@ class TestDocumentStore(CountDocumentsTest, DeleteDocumentsTest, FilterDocuments
         received.sort(key=operator.attrgetter("id"))
         expected.sort(key=operator.attrgetter("id"))
 
-        for doc_received, doc_expected in zip(received, expected):
+        for doc_received, doc_expected in zip(received, expected, strict=True):
             assert doc_received.content == doc_expected.content
             assert doc_received.meta == doc_expected.meta
 

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -47,7 +47,7 @@ class TestDocumentStoreAsync:
         received.sort(key=operator.attrgetter("id"))
         expected.sort(key=operator.attrgetter("id"))
 
-        for doc_received, doc_expected in zip(received, expected):
+        for doc_received, doc_expected in zip(received, expected, strict=True):
             assert doc_received.content == doc_expected.content
             assert doc_received.meta == doc_expected.meta
 


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
