### PR TITLE
fix: Update AmazonBedrockDocumentEmbedder to not modify Documents in place

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import replace
 from typing import Any
 
 from botocore.config import Config
@@ -186,10 +187,11 @@ class AmazonBedrockDocumentEmbedder:
             )
             all_embeddings.extend(embeddings_list)
 
+        new_documents = []
         for doc, emb in zip(documents, all_embeddings, strict=True):
-            doc.embedding = emb
+            new_documents.append(replace(doc, embedding=emb))
 
-        return documents
+        return new_documents
 
     def _embed_titan(self, documents: list[Document]) -> list[Document]:
         """
@@ -214,10 +216,11 @@ class AmazonBedrockDocumentEmbedder:
             embedding = response_body["embedding"]
             all_embeddings.append(embedding)
 
+        new_documents = []
         for doc, emb in zip(documents, all_embeddings, strict=True):
-            doc.embedding = emb
+            new_documents.append(replace(doc, embedding=emb))
 
-        return documents
+        return new_documents
 
     @component.output_types(documents=list[Document])
     def run(self, documents: list[Document]) -> dict[str, list[Document]]:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Any
 
 from botocore.exceptions import ClientError
@@ -251,8 +252,7 @@ class AmazonBedrockRanker:
                 idx = result["index"]
                 score = result["relevanceScore"]
                 doc = documents[idx]
-                doc.score = score
-                sorted_docs.append(doc)
+                sorted_docs.append(replace(doc, score=score))
 
             return {"documents": sorted_docs}
         except ClientError as client_error:


### PR DESCRIPTION
## Description

partially addresses #2174

Updates `AmazonBedrockDocumentEmbedder` to create new `Document` instances instead of modifying them in place, following the pattern established in Haystack core ([#9693](https://github.com/deepset-ai/haystack/pull/9693)) and recent fixes in FastEmbed (#2678), Optimum (#2675), and Nvidia (#2680) integrations.

## Changes

### Code Changes
- Added `from dataclasses import replace` import
- Updated `_embed_cohere()` method to create new document instances using `replace(doc, embedding=emb)`
- Updated `_embed_titan()` method to create new document instances using `replace(doc, embedding=emb)`

### Test Changes
- Added `test_run_cohere_does_not_modify_original_documents()` to verify Cohere path creates new instances
- Added `test_run_titan_does_not_modify_original_documents()` to verify Titan path creates new instances
- Both tests confirm original documents remain unchanged and new instances contain embeddings

### Documentation
- Updated `CHANGELOG.md` with bug fix entry

## Testing

All tests pass successfully:
- ✅ Format check: `hatch run fmt-check`
- ✅ Type checking: `hatch run test:types`
- ✅ Unit tests: `hatch run test:unit` (213 passed including 2 new immutability tests)

## Notes

- `AmazonBedrockDocumentImageEmbedder` already uses the correct pattern (implemented in #2185)
- No `AmazonBedrockSparseDocumentEmbedder` exists in this integration
- Follows the same immutability pattern as other integrations for consistency across the codebase