### PR TITLE
ci: automatically push changelog updates

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -70,23 +70,12 @@ jobs:
             --include-path "${{ steps.pathfinder.outputs.project_path }}/**/*"
             --tag-pattern "${{ steps.pathfinder.outputs.project_path }}-v*"
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+      - name: Commit changelog
+        uses: EndBug/add-and-commit@v9
         with:
-          token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
-          commit-message: "Update changelog for ${{ steps.pathfinder.outputs.project_path }}"
-          branch: update-changelog-${{ steps.pathfinder.outputs.project_path }}
-          base: main
-          title: "docs: update changelog for ${{ steps.pathfinder.outputs.project_path }}"
-          add-paths: |
-            ${{ steps.pathfinder.outputs.project_path }}/CHANGELOG.md
-          body: |
-            This PR updates the changelog for ${{ steps.pathfinder.outputs.project_path }} integration
-            with the latest changes just released on PyPi. Please review the changelog diff below and adjust it
-            if necessary.
-
-            A good changelog diff simply lists these latest changes on top of the CHANGELOG.md file.
-            If there are some diffs that seem out of place, please adjust the CHANGELOG.md file manually.
-            Either way, please merge this PR as soon as possible.
-          reviewers: "${{ github.actor }}"
+          author_name: "HaystackBot"
+          author_email: "accounts@deepset.ai"
+          message: "Update the changelog"
+          add: ${{ steps.pathfinder.outputs.project_path }}
+          push: origin HEAD:main
 


### PR DESCRIPTION
### Related Issues

Manually reviewing the automatically generated Changelog PRs for core integrations isn't very useful.
If the changelog is wrong and we manually fix it, those changes will just be overwritten the next time it's generated.
To avoid spending time in these reviews, I'd switch back to the previous behavior, where Changelog is automatically generated and pushed.


### Proposed Changes:

- automatically push changelog updates (reverts #1328)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
