### PR TITLE
chore!: hanlp - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/hanlp/pyproject.toml
+++ b/integrations/hanlp/pyproject.toml
@@ -7,7 +7,7 @@ name = "hanlp-haystack"
 dynamic = ["version"]
 description = 'An integration of Han Language Processing - HanLP as a ChineseDocumentSplitter component.'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.13.1",
+  "haystack-ai>=2.22.0",
   "hanlp>=2.1.1"
 ]
 
@@ -88,7 +87,6 @@ line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -137,10 +135,6 @@ ignore = [
   "ARG005",
   "RUF001",
   "RUF002",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/hanlp/src/haystack_integrations/components/preprocessors/hanlp/chinese_document_splitter.py
+++ b/integrations/hanlp/src/haystack_integrations/components/preprocessors/hanlp/chinese_document_splitter.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Literal
 
 from haystack import Document, component, logging
 from haystack.core.serialization import default_from_dict, default_to_dict
@@ -59,7 +60,7 @@ class ChineseDocumentSplitter:
         split_overlap: int = 200,
         split_threshold: int = 0,
         respect_sentence_boundary: bool = False,
-        splitting_function: Optional[Callable] = None,
+        splitting_function: Callable | None = None,
         granularity: Literal["coarse", "fine"] = "coarse",
     ):
         """
@@ -406,7 +407,7 @@ class ChineseDocumentSplitter:
         """
         documents: list[Document] = []
 
-        for i, (txt, split_idx) in enumerate(zip(text_splits, splits_start_idxs)):
+        for i, (txt, split_idx) in enumerate(zip(text_splits, splits_start_idxs, strict=True)):
             copied_meta = deepcopy(meta)
             copied_meta["page_number"] = splits_pages[i]
             copied_meta["split_id"] = i

--- a/integrations/hanlp/tests/test_chinese_document_splitter.py
+++ b/integrations/hanlp/tests/test_chinese_document_splitter.py
@@ -123,7 +123,7 @@ class TestChineseDocumentSplitter:
         splitter.warm_up()
         result = splitter.run(documents=documents)
         assert len(result["documents"]) == 2
-        for doc, split_doc in zip(documents, result["documents"]):
+        for doc, split_doc in zip(documents, result["documents"], strict=True):
             assert doc.meta.items() <= split_doc.meta.items()
 
     @pytest.mark.integration
@@ -136,7 +136,7 @@ class TestChineseDocumentSplitter:
         splitter.warm_up()
         result = splitter.run(documents=documents)
         assert len(result["documents"]) == 2
-        for doc, split_doc in zip(documents, result["documents"]):
+        for doc, split_doc in zip(documents, result["documents"], strict=True):
             assert doc.id == split_doc.meta["source_id"]
 
     @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
