### PR TITLE
chore!: langfuse - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -7,14 +7,13 @@ name = "langfuse-haystack"
 dynamic = ["version"]
 description = "Langfuse integration for Haystack"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -22,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.17.1", "langfuse>=3.3.1, <4.0.0"]
+dependencies = ["haystack-ai>=2.22.0", "langfuse>=3.3.1, <4.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"
@@ -82,7 +81,6 @@ allow-direct-references = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -127,10 +125,6 @@ ignore = [
   "PLR0915",
   # Asserts
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
@@ -118,13 +118,13 @@ class LangfuseConnector:
         self,
         name: str,
         public: bool = False,
-        public_key: Optional[Secret] = Secret.from_env_var("LANGFUSE_PUBLIC_KEY"),  # noqa: B008
-        secret_key: Optional[Secret] = Secret.from_env_var("LANGFUSE_SECRET_KEY"),  # noqa: B008
-        httpx_client: Optional[httpx.Client] = None,
-        span_handler: Optional[SpanHandler] = None,
+        public_key: Secret | None = Secret.from_env_var("LANGFUSE_PUBLIC_KEY"),  # noqa: B008
+        secret_key: Secret | None = Secret.from_env_var("LANGFUSE_SECRET_KEY"),  # noqa: B008
+        httpx_client: httpx.Client | None = None,
+        span_handler: SpanHandler | None = None,
         *,
-        host: Optional[str] = None,
-        langfuse_client_kwargs: Optional[dict[str, Any]] = None,
+        host: str | None = None,
+        langfuse_client_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
         Initialize the LangfuseConnector component.
@@ -172,7 +172,7 @@ class LangfuseConnector:
         tracing.enable_tracing(self.tracer)
 
     @component.output_types(name=str, trace_url=str, trace_id=str)
-    def run(self, invocation_context: Optional[dict[str, Any]] = None) -> dict[str, str]:
+    def run(self, invocation_context: dict[str, Any] | None = None) -> dict[str, str]:
         """
         Runs the LangfuseConnector component.
 

--- a/integrations/langfuse/tests/test_tracer.py
+++ b/integrations/langfuse/tests/test_tracer.py
@@ -6,7 +6,6 @@ import asyncio
 import datetime
 import logging
 import sys
-from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -107,7 +106,7 @@ class MockLangfuseClient:
 
 
 class CustomSpanHandler(DefaultSpanHandler):
-    def handle(self, span: LangfuseSpan, component_type: Optional[str]) -> None:
+    def handle(self, span: LangfuseSpan, component_type: str | None) -> None:
         if component_type == "OpenAIChatGenerator":
             output = span.get_data().get(_COMPONENT_OUTPUT_KEY, {})
             replies = output.get("replies", [])


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
