### PR TITLE
chore!: meta_llama - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/meta_llama/pyproject.toml
+++ b/integrations/meta_llama/pyproject.toml
@@ -7,7 +7,7 @@ name = "meta-llama-haystack"
 dynamic = ["version"]
 description = 'Use Llama models via Llama API'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.19.0"]
+dependencies = ["haystack-ai>=2.22.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/meta_llama#readme"
@@ -75,7 +74,6 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -121,10 +119,6 @@ ignore = [
   # Misc
   "B008",
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
+++ b/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional
+from typing import Any
 
 from haystack import component, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -59,10 +59,10 @@ class MetaLlamaChatGenerator(OpenAIChatGenerator):
         *,
         api_key: Secret = Secret.from_env_var("LLAMA_API_KEY"),
         model: str = "Llama-4-Scout-17B-16E-Instruct-FP8",
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        api_base_url: Optional[str] = "https://api.llama.com/compat/v1/",
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        api_base_url: str | None = "https://api.llama.com/compat/v1/",
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
     ):
         """
         Creates an instance of LlamaChatGenerator. Unless specified otherwise in the `model`, this is for Llama's
@@ -117,10 +117,10 @@ class MetaLlamaChatGenerator(OpenAIChatGenerator):
         self,
         *,
         messages: list[ChatMessage],
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        generation_kwargs: Optional[dict[str, Any]] = None,
-        tools: Optional[ToolsType] = None,
-        tools_strict: Optional[bool] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
+        tools_strict: bool | None = None,
     ) -> dict[str, Any]:
         api_args = super(MetaLlamaChatGenerator, self)._prepare_api_call(  # noqa: UP008
             messages=messages,


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI. Test are expected to fail due to rate limits.

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
