### PR TITLE
chore!: mongodb_atlas - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -7,7 +7,7 @@ name = "mongodb-atlas-haystack"
 dynamic = ["version"]
 description = "An integration of MongoDB Atlas with Haystack"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.11.0",
+  "haystack-ai>=2.22.0",
   "pymongo[srv]>=4.13.0"
 ]
 
@@ -80,7 +79,6 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -128,10 +126,6 @@ ignore = [
   "PLR0915",
   # Allow assert statements
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -45,9 +45,9 @@ class MongoDBAtlasEmbeddingRetriever:
         self,
         *,
         document_store: MongoDBAtlasDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         Create the MongoDBAtlasDocumentStore component.
@@ -110,8 +110,8 @@ class MongoDBAtlasEmbeddingRetriever:
     def run(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents from the MongoDBAtlasDocumentStore, based on the provided embedding similarity.
@@ -138,8 +138,8 @@ class MongoDBAtlasEmbeddingRetriever:
     async def run_async(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents from the MongoDBAtlasDocumentStore, based on the provided embedding

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -43,9 +43,9 @@ class MongoDBAtlasFullTextRetriever:
         self,
         *,
         document_store: MongoDBAtlasDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         :param document_store: An instance of MongoDBAtlasDocumentStore.
@@ -103,12 +103,12 @@ class MongoDBAtlasFullTextRetriever:
     @component.output_types(documents=list[Document])
     def run(
         self,
-        query: Union[str, list[str]],
-        fuzzy: Optional[dict[str, int]] = None,
-        match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[dict[str, dict]] = None,
-        synonyms: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        query: str | list[str],
+        fuzzy: dict[str, int] | None = None,
+        match_criteria: Literal["any", "all"] | None = None,
+        score: dict[str, dict] | None = None,
+        synonyms: str | None = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
     ) -> dict[str, list[Document]]:
         """
@@ -153,12 +153,12 @@ class MongoDBAtlasFullTextRetriever:
     @component.output_types(documents=list[Document])
     async def run_async(
         self,
-        query: Union[str, list[str]],
-        fuzzy: Optional[dict[str, int]] = None,
-        match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[dict[str, dict]] = None,
-        synonyms: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        query: str | list[str],
+        fuzzy: dict[str, int] | None = None,
+        match_criteria: Literal["any", "all"] | None = None,
+        score: dict[str, dict] | None = None,
+        synonyms: str | None = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
     ) -> dict[str, list[Document]]:
         """

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import re
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from haystack import default_from_dict, default_to_dict, logging
 from haystack.dataclasses.document import Document
@@ -105,10 +105,10 @@ class MongoDBAtlasDocumentStore:
         self.full_text_search_index = full_text_search_index
         self.embedding_field = embedding_field
         self.content_field = content_field
-        self._connection: Optional[MongoClient] = None
-        self._connection_async: Optional[AsyncMongoClient] = None
-        self._collection: Optional[Collection] = None
-        self._collection_async: Optional[AsyncCollection] = None
+        self._connection: MongoClient | None = None
+        self._connection_async: AsyncMongoClient | None = None
+        self._collection: Collection | None = None
+        self._collection_async: AsyncCollection | None = None
 
     def __del__(self) -> None:
         """
@@ -118,7 +118,7 @@ class MongoDBAtlasDocumentStore:
             self._connection.close()
 
     @property
-    def connection(self) -> Union[AsyncMongoClient, MongoClient]:
+    def connection(self) -> AsyncMongoClient | MongoClient:
         if self._connection:
             return self._connection
         if self._connection_async:
@@ -127,7 +127,7 @@ class MongoDBAtlasDocumentStore:
         raise DocumentStoreError(msg)
 
     @property
-    def collection(self) -> Union[AsyncCollection, Collection]:
+    def collection(self) -> AsyncCollection | Collection:
         if self._collection:
             return self._collection
         if self._collection_async:
@@ -278,7 +278,7 @@ class MongoDBAtlasDocumentStore:
         assert self._collection_async is not None
         return await self._collection_async.count_documents({})
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Returns the documents that match the filters provided.
 
@@ -294,7 +294,7 @@ class MongoDBAtlasDocumentStore:
         documents = list(self._collection.find(filters))
         return [self._mongo_doc_to_haystack_doc(doc) for doc in documents]
 
-    async def filter_documents_async(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    async def filter_documents_async(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Asynchronously returns the documents that match the filters provided.
 
@@ -332,7 +332,7 @@ class MongoDBAtlasDocumentStore:
             policy = DuplicatePolicy.FAIL
 
         mongo_documents = [self._haystack_doc_to_mongo_doc(doc) for doc in documents]
-        operations: list[Union[UpdateOne, InsertOne, ReplaceOne]]
+        operations: list[UpdateOne | InsertOne | ReplaceOne]
         written_docs = len(documents)
 
         if policy == DuplicatePolicy.SKIP:
@@ -377,7 +377,7 @@ class MongoDBAtlasDocumentStore:
 
         mongo_documents = [self._haystack_doc_to_mongo_doc(doc) for doc in documents]
 
-        operations: list[Union[UpdateOne, InsertOne, ReplaceOne]]
+        operations: list[UpdateOne | InsertOne | ReplaceOne]
         written_docs = len(documents)
 
         if policy == DuplicatePolicy.SKIP:
@@ -636,7 +636,7 @@ class MongoDBAtlasDocumentStore:
     def _embedding_retrieval(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
     ) -> list[Document]:
         """
@@ -686,7 +686,7 @@ class MongoDBAtlasDocumentStore:
         return documents
 
     async def _embedding_retrieval_async(
-        self, query_embedding: list[float], filters: Optional[dict[str, Any]] = None, top_k: int = 10
+        self, query_embedding: list[float], filters: dict[str, Any] | None = None, top_k: int = 10
     ) -> list[Document]:
         """
         Asynchronously find the documents that are most similar to the provided `query_embedding` by using a vector
@@ -738,12 +738,12 @@ class MongoDBAtlasDocumentStore:
 
     def _fulltext_retrieval(
         self,
-        query: Union[str, list[str]],
-        fuzzy: Optional[dict[str, int]] = None,
-        match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[dict[str, dict]] = None,
-        synonyms: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        query: str | list[str],
+        fuzzy: dict[str, int] | None = None,
+        match_criteria: Literal["any", "all"] | None = None,
+        score: dict[str, dict] | None = None,
+        synonyms: str | None = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
     ) -> list[Document]:
         """
@@ -831,12 +831,12 @@ class MongoDBAtlasDocumentStore:
 
     async def _fulltext_retrieval_async(
         self,
-        query: Union[str, list[str]],
-        fuzzy: Optional[dict[str, int]] = None,
-        match_criteria: Optional[Literal["any", "all"]] = None,
-        score: Optional[dict[str, dict]] = None,
-        synonyms: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        query: str | list[str],
+        fuzzy: dict[str, int] | None = None,
+        match_criteria: Literal["any", "all"] | None = None,
+        score: dict[str, dict] | None = None,
+        synonyms: str | None = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
     ) -> list[Document]:
         """

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval.py
@@ -4,7 +4,6 @@
 
 import os
 from time import sleep
-from typing import Union
 from unittest.mock import MagicMock
 
 import pytest
@@ -157,7 +156,7 @@ class TestFullTextRetrieval:
         assert results[0].score >= results[1].score
 
     @pytest.mark.parametrize("query", ["", []])
-    def test_empty_query_raises_value_error(self, query: Union[str, list], document_store: MongoDBAtlasDocumentStore):
+    def test_empty_query_raises_value_error(self, query: str | list, document_store: MongoDBAtlasDocumentStore):
         with pytest.raises(ValueError):
             document_store._fulltext_retrieval(query=query)
 

--- a/integrations/mongodb_atlas/tests/test_fulltext_retrieval_async.py
+++ b/integrations/mongodb_atlas/tests/test_fulltext_retrieval_async.py
@@ -4,7 +4,6 @@
 
 import os
 from time import sleep
-from typing import Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -116,7 +115,7 @@ class TestFullTextRetrieval:
 
     @pytest.mark.parametrize("query", ["", []])
     async def test_empty_query_raises_value_error_async(
-        self, query: Union[str, list], document_store: MongoDBAtlasDocumentStore
+        self, query: str | list, document_store: MongoDBAtlasDocumentStore
     ):
         with pytest.raises(ValueError):
             await document_store._fulltext_retrieval_async(query=query)


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
