### PR TITLE
chore!: pgvector - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -7,7 +7,7 @@ name = "pgvector-haystack"
 dynamic = ["version"]
 description = "An integration of pgvector (vector search extension for Postgres) with Haystack"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0", "pgvector>=0.3.0", "psycopg[binary]"]
+dependencies = ["haystack-ai>=2.22.0", "pgvector>=0.3.0", "psycopg[binary]"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"
@@ -83,7 +82,6 @@ ignore_missing_imports = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -133,10 +131,6 @@ ignore = [
   "B008",
   # ignore assertions
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -62,10 +62,10 @@ class PgvectorEmbeddingRetriever:
         self,
         *,
         document_store: PgvectorDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        vector_function: Optional[Literal["cosine_similarity", "inner_product", "l2_distance"]] = None,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        vector_function: Literal["cosine_similarity", "inner_product", "l2_distance"] | None = None,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         :param document_store: An instance of `PgvectorDocumentStore`.
@@ -137,9 +137,9 @@ class PgvectorEmbeddingRetriever:
     def run(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        vector_function: Optional[Literal["cosine_similarity", "inner_product", "l2_distance"]] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        vector_function: Literal["cosine_similarity", "inner_product", "l2_distance"] | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents from the `PgvectorDocumentStore`, based on their embeddings.
@@ -170,9 +170,9 @@ class PgvectorEmbeddingRetriever:
     async def run_async(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        vector_function: Optional[Literal["cosine_similarity", "inner_product", "l2_distance"]] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        vector_function: Literal["cosine_similarity", "inner_product", "l2_distance"] | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents from the `PgvectorDocumentStore`, based on their embeddings.

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -52,9 +52,9 @@ class PgvectorKeywordRetriever:
         self,
         *,
         document_store: PgvectorDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         :param document_store: An instance of `PgvectorDocumentStore`.
@@ -111,8 +111,8 @@ class PgvectorKeywordRetriever:
     def run(
         self,
         query: str,
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents from the `PgvectorDocumentStore`, based on keywords.
@@ -141,8 +141,8 @@ class PgvectorKeywordRetriever:
     async def run_async(
         self,
         query: str,
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents from the `PgvectorDocumentStore`, based on keywords.

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from itertools import chain
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from haystack.errors import FilterError
 from psycopg.sql import SQL, Composed
@@ -21,7 +21,7 @@ PYTHON_TYPES_TO_PG_TYPES = {
 NO_VALUE = "no_value"
 
 
-def _validate_filters(filters: Optional[dict[str, Any]] = None) -> None:
+def _validate_filters(filters: dict[str, Any] | None = None) -> None:
     """
     Validates the filters provided.
     """

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -154,7 +154,7 @@ def test_halfvec_hnsw_write_documents(document_store_w_halfvec_hnsw_index: Pgvec
     retrieved_docs = document_store_w_halfvec_hnsw_index.filter_documents()
     retrieved_docs.sort(key=lambda x: x.id)
 
-    for original_doc, retrieved_doc in zip(documents, retrieved_docs):
+    for original_doc, retrieved_doc in zip(documents, retrieved_docs, strict=True):
         assert original_doc.id == retrieved_doc.id
         assert original_doc.content == retrieved_doc.content
         assert len(original_doc.embedding) == len(retrieved_doc.embedding)

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -24,7 +24,7 @@ class TestFilters(FilterDocumentsTest):
         assert len(received) == len(expected)
         received.sort(key=lambda x: x.id)
         expected.sort(key=lambda x: x.id)
-        for received_doc, expected_doc in zip(received, expected):
+        for received_doc, expected_doc in zip(received, expected, strict=True):
             # we first compare the embeddings approximately
             if received_doc.embedding is None:
                 assert expected_doc.embedding is None


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
