### PR TITLE
chore!: pinecone - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -7,7 +7,7 @@ name = "pinecone_haystack"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.11.0",
+  "haystack-ai>=2.22.0",
   "pinecone[asyncio]>=7.0.0",
 ]
 
@@ -88,7 +87,6 @@ allow-direct-references = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -136,10 +134,6 @@ ignore = [
   "PLR0915",
   # Ignore assertions
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -55,9 +55,9 @@ class PineconeEmbeddingRetriever:
         self,
         *,
         document_store: PineconeDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         :param document_store: The Pinecone Document Store.
@@ -114,8 +114,8 @@ class PineconeEmbeddingRetriever:
     def run(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents from the `PineconeDocumentStore`, based on their dense embeddings.
@@ -143,8 +143,8 @@ class PineconeEmbeddingRetriever:
     async def run_async(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents from the `PineconeDocumentStore`, based on their dense embeddings.

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import copy
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from haystack import default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
@@ -41,7 +41,7 @@ class PineconeDocumentStore:
         namespace: str = "default",
         batch_size: int = 100,
         dimension: int = 768,
-        spec: Optional[dict[str, Any]] = None,
+        spec: dict[str, Any] | None = None,
         metric: Literal["cosine", "euclidean", "dotproduct"] = "cosine",
     ):
         """
@@ -73,8 +73,8 @@ class PineconeDocumentStore:
         self.dimension = dimension
         self.index_name = index
 
-        self._index: Optional[_Index] = None
-        self._async_index: Optional[_IndexAsyncio] = None
+        self._index: _Index | None = None
+        self._async_index: _IndexAsyncio | None = None
         self._dummy_vector = [-10.0] * self.dimension
 
     def _initialize_index(self):
@@ -156,7 +156,7 @@ class PineconeDocumentStore:
             self._async_index = None
 
     @staticmethod
-    def _convert_dict_spec_to_pinecone_object(spec: dict[str, Any]) -> Union[ServerlessSpec, PodSpec]:
+    def _convert_dict_spec_to_pinecone_object(spec: dict[str, Any]) -> ServerlessSpec | PodSpec:
         """Convert the spec dictionary to a Pinecone spec object"""
 
         if "serverless" in spec:
@@ -274,7 +274,7 @@ class PineconeDocumentStore:
         # if the operation is successful, result will have the upserted_count attribute
         return result.upserted_count  # type: ignore[union-attr]
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Returns the documents that match the filters provided.
 
@@ -306,7 +306,7 @@ class PineconeDocumentStore:
             )
         return documents
 
-    async def filter_documents_async(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    async def filter_documents_async(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Asynchronously returns the documents that match the filters provided.
 
@@ -540,8 +540,8 @@ class PineconeDocumentStore:
         self,
         query_embedding: list[float],
         *,
-        namespace: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        namespace: str | None = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
     ) -> list[Document]:
         """
@@ -583,8 +583,8 @@ class PineconeDocumentStore:
         self,
         query_embedding: list[float],
         *,
-        namespace: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        namespace: str | None = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
     ) -> list[Document]:
         """

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/filters.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/filters.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional
+from typing import Any
 
 from haystack.errors import FilterError
 
@@ -181,7 +181,7 @@ COMPARISON_OPERATORS = {
 LOGICAL_OPERATORS = {"AND": "$and", "OR": "$or"}
 
 
-def _validate_filters(filters: Optional[dict[str, Any]]) -> None:
+def _validate_filters(filters: dict[str, Any] | None) -> None:
     """
     Helper method to validate filter syntax.
     """

--- a/integrations/pinecone/tests/test_filters.py
+++ b/integrations/pinecone/tests/test_filters.py
@@ -21,7 +21,7 @@ class TestFilters(FilterDocumentsTest):
         assert len(received) == len(expected)
         received.sort(key=lambda x: x.id)
         expected.sort(key=lambda x: x.id)
-        for received_doc, expected_doc in zip(received, expected):
+        for received_doc, expected_doc in zip(received, expected, strict=True):
             assert received_doc.meta == expected_doc.meta
             assert received_doc.content == expected_doc.content
             # unfortunately, Pinecone returns a slightly different embedding


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
