### PR TITLE
ci: fix version validation pattern

### DIFF
--- a/.github/utils/validate_version.py
+++ b/.github/utils/validate_version.py
@@ -3,7 +3,7 @@ import requests
 
 # * integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0
 # * integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0.post0 (for post-releases)
-INTEGRATION_VERSION_REGEX = r"integrations/([a-zA-Z_]+)-v([0-9]\.[0-9]+\.[0-9]+(?:\.post[0-9]+)?)"
+INTEGRATION_VERSION_REGEX = r"integrations/([a-zA-Z_]+)-v([0-9]+\.[0-9]+\.[0-9]+(?:\.post[0-9]+)?)"
 
 
 def validate_version_number(tag: str):


### PR DESCRIPTION
### Related Issues
The current regex pattern for validating the version to release does not support minor releases X.Y.Z where X is a double digit number.

Recent failure: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/20950934061/job/60203914443

### Proposed Changes:
- fix the version validation pattern

### How did you test it?
Ran the validation script locally

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
