### PR TITLE
chore!: stackit - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/stackit/pyproject.toml
+++ b/integrations/stackit/pyproject.toml
@@ -7,7 +7,7 @@ name = "stackit-haystack"
 dynamic = ["version"]
 description = 'An integration of STACKIT as a StackitChatGenerator'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.19.0"]
+dependencies = ["haystack-ai>=2.22.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/stackit#readme"
@@ -75,7 +74,6 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -121,10 +119,6 @@ ignore = [
   # Misc
   "B008",
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/stackit/src/haystack_integrations/components/embedders/stackit/document_embedder.py
+++ b/integrations/stackit/src/haystack_integrations/components/embedders/stackit/document_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional
+from typing import Any
 
 from haystack import component, default_to_dict
 from haystack.components.embedders import OpenAIDocumentEmbedder
@@ -34,17 +34,17 @@ class STACKITDocumentEmbedder(OpenAIDocumentEmbedder):
         self,
         model: str,
         api_key: Secret = Secret.from_env_var("STACKIT_API_KEY"),
-        api_base_url: Optional[str] = "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+        api_base_url: str | None = "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
         prefix: str = "",
         suffix: str = "",
         batch_size: int = 32,
         progress_bar: bool = True,
-        meta_fields_to_embed: Optional[list[str]] = None,
+        meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
         *,
-        timeout: Optional[float] = None,
-        max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[dict[str, Any]] = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        http_client_kwargs: dict[str, Any] | None = None,
     ):
         """
         Creates a STACKITDocumentEmbedder component.

--- a/integrations/stackit/src/haystack_integrations/components/embedders/stackit/text_embedder.py
+++ b/integrations/stackit/src/haystack_integrations/components/embedders/stackit/text_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional
+from typing import Any
 
 from haystack import component, default_to_dict
 from haystack.components.embedders import OpenAITextEmbedder
@@ -27,13 +27,13 @@ class STACKITTextEmbedder(OpenAITextEmbedder):
         self,
         model: str,
         api_key: Secret = Secret.from_env_var("STACKIT_API_KEY"),
-        api_base_url: Optional[str] = "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+        api_base_url: str | None = "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
         prefix: str = "",
         suffix: str = "",
         *,
-        timeout: Optional[float] = None,
-        max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[dict[str, Any]] = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        http_client_kwargs: dict[str, Any] | None = None,
     ):
         """
         Creates a STACKITTextEmbedder component.

--- a/integrations/stackit/src/haystack_integrations/components/generators/stackit/chat/chat_generator.py
+++ b/integrations/stackit/src/haystack_integrations/components/generators/stackit/chat/chat_generator.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional
+from typing import Any
 
 from haystack import component, default_to_dict
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -42,13 +42,13 @@ class STACKITChatGenerator(OpenAIChatGenerator):
         self,
         model: str,
         api_key: Secret = Secret.from_env_var("STACKIT_API_KEY"),
-        streaming_callback: Optional[StreamingCallbackT] = None,
-        api_base_url: Optional[str] = "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
-        generation_kwargs: Optional[dict[str, Any]] = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        api_base_url: str | None = "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+        generation_kwargs: dict[str, Any] | None = None,
         *,
-        timeout: Optional[float] = None,
-        max_retries: Optional[int] = None,
-        http_client_kwargs: Optional[dict[str, Any]] = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        http_client_kwargs: dict[str, Any] | None = None,
     ):
         """
         Creates an instance of STACKITChatGenerator class.


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
