### PR TITLE
chore!: weaviate - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -7,7 +7,7 @@ name = "weaviate-haystack"
 dynamic = ["version"]
 description = "An integration of Weaviate vector database with Haystack"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.11.0",
+  "haystack-ai>=2.22.0",
   "weaviate-client>=4.9",
   "python-dateutil",
 ]
@@ -81,7 +80,6 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -127,10 +125,6 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
@@ -31,9 +31,9 @@ class WeaviateBM25Retriever:
         self,
         *,
         document_store: WeaviateDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         Create a new instance of WeaviateBM25Retriever.
@@ -90,7 +90,7 @@ class WeaviateBM25Retriever:
 
     @component.output_types(documents=list[Document])
     def run(
-        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """
         Retrieves documents from Weaviate using the BM25 algorithm.
@@ -113,7 +113,7 @@ class WeaviateBM25Retriever:
 
     @component.output_types(documents=list[Document])
     async def run_async(
-        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieves documents from Weaviate using the BM25 algorithm.

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
@@ -21,11 +21,11 @@ class WeaviateEmbeddingRetriever:
         self,
         *,
         document_store: WeaviateDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        distance: Optional[float] = None,
-        certainty: Optional[float] = None,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        distance: float | None = None,
+        certainty: float | None = None,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         Creates a new instance of WeaviateEmbeddingRetriever.
@@ -102,10 +102,10 @@ class WeaviateEmbeddingRetriever:
     def run(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        distance: Optional[float] = None,
-        certainty: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        distance: float | None = None,
+        certainty: float | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieves documents from Weaviate using the vector search.
@@ -150,10 +150,10 @@ class WeaviateEmbeddingRetriever:
     async def run_async(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        distance: Optional[float] = None,
-        certainty: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        distance: float | None = None,
+        certainty: float | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieves documents from Weaviate using the vector search.

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/hybrid_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/hybrid_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import FilterPolicy
@@ -21,11 +21,11 @@ class WeaviateHybridRetriever:
         self,
         *,
         document_store: WeaviateDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        alpha: Optional[float] = None,
-        max_vector_distance: Optional[float] = None,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        alpha: float | None = None,
+        max_vector_distance: float | None = None,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         Creates a new instance of WeaviateHybridRetriever.
@@ -120,10 +120,10 @@ class WeaviateHybridRetriever:
         self,
         query: str,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        alpha: Optional[float] = None,
-        max_vector_distance: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        alpha: float | None = None,
+        max_vector_distance: float | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieves documents from Weaviate using hybrid search.
@@ -190,10 +190,10 @@ class WeaviateHybridRetriever:
         self,
         query: str,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        alpha: Optional[float] = None,
-        max_vector_distance: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        alpha: float | None = None,
+        max_vector_distance: float | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieves documents from Weaviate using hybrid search.

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -6,7 +6,7 @@ import base64
 import datetime
 import json
 from dataclasses import asdict
-from typing import Any, Optional
+from typing import Any
 
 from haystack import logging
 from haystack.core.serialization import default_from_dict, default_to_dict
@@ -86,12 +86,12 @@ class WeaviateDocumentStore:
     def __init__(
         self,
         *,
-        url: Optional[str] = None,
-        collection_settings: Optional[dict[str, Any]] = None,
-        auth_client_secret: Optional[AuthCredentials] = None,
-        additional_headers: Optional[dict] = None,
-        embedded_options: Optional[EmbeddedOptions] = None,
-        additional_config: Optional[AdditionalConfig] = None,
+        url: str | None = None,
+        collection_settings: dict[str, Any] | None = None,
+        auth_client_secret: AuthCredentials | None = None,
+        additional_headers: dict | None = None,
+        embedded_options: EmbeddedOptions | None = None,
+        additional_config: AdditionalConfig | None = None,
         grpc_port: int = 50051,
         grpc_secure: bool = False,
     ):
@@ -145,10 +145,10 @@ class WeaviateDocumentStore:
         self._additional_config = additional_config
         self._grpc_port = grpc_port
         self._grpc_secure = grpc_secure
-        self._client: Optional[weaviate.WeaviateClient] = None
-        self._async_client: Optional[weaviate.WeaviateAsyncClient] = None
-        self._collection: Optional[weaviate.Collection] = None
-        self._async_collection: Optional[weaviate.AsyncCollection] = None
+        self._client: weaviate.WeaviateClient | None = None
+        self._async_client: weaviate.WeaviateAsyncClient | None = None
+        self._collection: weaviate.Collection | None = None
+        self._async_collection: weaviate.AsyncCollection | None = None
         # Store the connection settings dictionary
         self._collection_settings = collection_settings or {
             "class": "Default",
@@ -445,7 +445,7 @@ class WeaviateDocumentStore:
             offset += DEFAULT_QUERY_LIMIT
         return result
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Returns the documents that match the filters provided.
 
@@ -837,7 +837,7 @@ class WeaviateDocumentStore:
             raise DocumentStoreError(msg) from e
 
     def _bm25_retrieval(
-        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> list[Document]:
         properties = [p.name for p in self.collection.config.get().properties]
         result = self.collection.query.bm25(
@@ -853,7 +853,7 @@ class WeaviateDocumentStore:
         return [WeaviateDocumentStore._to_document(doc) for doc in result.objects]
 
     async def _bm25_retrieval_async(
-        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> list[Document]:
         collection = await self.async_collection
         config = await collection.config.get()
@@ -873,10 +873,10 @@ class WeaviateDocumentStore:
     def _embedding_retrieval(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        distance: Optional[float] = None,
-        certainty: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        distance: float | None = None,
+        certainty: float | None = None,
     ) -> list[Document]:
         if distance is not None and certainty is not None:
             msg = "Can't use 'distance' and 'certainty' parameters together"
@@ -899,10 +899,10 @@ class WeaviateDocumentStore:
     async def _embedding_retrieval_async(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        distance: Optional[float] = None,
-        certainty: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        distance: float | None = None,
+        certainty: float | None = None,
     ) -> list[Document]:
         if distance is not None and certainty is not None:
             msg = "Can't use 'distance' and 'certainty' parameters together"
@@ -928,10 +928,10 @@ class WeaviateDocumentStore:
         self,
         query: str,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        alpha: Optional[float] = None,
-        max_vector_distance: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        alpha: float | None = None,
+        max_vector_distance: float | None = None,
     ) -> list[Document]:
         properties = [p.name for p in self.collection.config.get().properties]
         result = self.collection.query.hybrid(
@@ -953,10 +953,10 @@ class WeaviateDocumentStore:
         self,
         query: str,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        alpha: Optional[float] = None,
-        max_vector_distance: Optional[float] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        alpha: float | None = None,
+        max_vector_distance: float | None = None,
     ) -> list[Document]:
         collection = await self.async_collection
         config = await collection.config.get()

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -87,7 +87,7 @@ class TestWeaviateDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDo
         assert len(received) == len(expected)
         received = sorted(received, key=lambda doc: doc.id)
         expected = sorted(expected, key=lambda doc: doc.id)
-        for received_doc, expected_doc in zip(received, expected):
+        for received_doc, expected_doc in zip(received, expected, strict=True):
             received_doc_dict = received_doc.to_dict(flatten=False)
             expected_doc_dict = expected_doc.to_dict(flatten=False)
 


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
