### PR TITLE
chore!: weights_and_biases_weave - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/weights_and_biases_weave/pyproject.toml
+++ b/integrations/weights_and_biases_weave/pyproject.toml
@@ -7,7 +7,7 @@ name = "weave-haystack"
 dynamic = ["version"]
 description = "An integration of Weights & Biases Weave tracer with Haystack"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "weave>=0.52.7"]
+dependencies = ["haystack-ai>=2.22.0", "weave>=0.52.7"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"
@@ -74,7 +73,6 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -120,10 +118,6 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/weights_and_biases_weave/src/haystack_integrations/components/connectors/weave/weave_connector.py
+++ b/integrations/weights_and_biases_weave/src/haystack_integrations/components/connectors/weave/weave_connector.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
 
@@ -71,7 +71,7 @@ class WeaveConnector:
 
     """
 
-    def __init__(self, pipeline_name: str, weave_init_kwargs: Optional[dict[str, Any]] = None) -> None:
+    def __init__(self, pipeline_name: str, weave_init_kwargs: dict[str, Any] | None = None) -> None:
         """
         Initialize WeaveConnector.
 
@@ -80,7 +80,7 @@ class WeaveConnector:
         """
         self.pipeline_name = pipeline_name
         self.weave_init_kwargs = weave_init_kwargs or {}
-        self.tracer: Optional[WeaveTracer] = None
+        self.tracer: WeaveTracer | None = None
 
     def warm_up(self) -> None:
         """Initialize the WeaveTracer."""


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
