### PR TITLE
ci: extend pattern for 'Sync API reference with Docusaurus' workflow

### DIFF
--- a/.github/workflows/CI_docusaurus_sync.yml
+++ b/.github/workflows/CI_docusaurus_sync.yml
@@ -3,7 +3,7 @@ name: Core / Sync API reference with Docusaurus
 on:
   push:
     tags:
-      - "**-v[0-9].[0-9]+.[0-9]+*"
+      - "**-v[0-9]+.[0-9]+.[0-9]+*"
 
   workflow_dispatch: # Activate this workflow manually
     inputs:


### PR DESCRIPTION
### Proposed Changes:
- modify the regex pattern in the workflow to also accept double digits in tags (`integrations/<INTEGRATION_FOLDER_NAME>-v10.0.0`)
 
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
