### PR TITLE
feat: support flattened generation_kwargs with AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -409,6 +409,22 @@ class TestAmazonBedrockChatGenerator:
             ]
         }
 
+    def test_prepare_request_params_with_flattened_generation_kwargs(self, mock_boto3_session, set_env_variables):
+        generator = AmazonBedrockChatGenerator(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+        request_params, _ = generator._prepare_request_params(
+            messages=[ChatMessage.from_user("What's the capital of France?")],
+            generation_kwargs={
+                "parallel_tool_use": False,
+                "tool_choice_type": "any",
+                "thinking_budget_tokens": 1024,
+            },
+        )
+
+        assert request_params["additionalModelRequestFields"] == {
+            "tool_choice": {"disable_parallel_tool_use": True, "type": "any"},
+            "thinking": {"budget_tokens": 1024, "type": "enabled"},
+        }
+
 
 # In the CI, those tests are skipped if AWS Authentication fails
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:
- support flattened generation_kwargs (and inverse of disable_parallel_tool_use) for better consistency across model providers

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
