### PR TITLE
ci: make changelog push more robust

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -77,5 +77,8 @@ jobs:
           author_email: "accounts@deepset.ai"
           message: "Update the changelog"
           add: ${{ steps.pathfinder.outputs.project_path }}
+          # to avoid that the pushed branch tip is behind its remote counterpart, we need to pull first
+          # see https://github.com/EndBug/add-and-commit/issues/498
+          pull: " "
           push: origin HEAD:main
 


### PR DESCRIPTION
### Related Issues
If someone merges a PR between changelog generation and push, the push operation fails
See for example https://github.com/deepset-ai/haystack-core-integrations/actions/runs/20955468949/job/60218893038

To avoid that, we need to pull before pushing 

### Proposed Changes:
- modify the [GitHub action config](https://github.com/EndBug/add-and-commit) to pull before pushing

### How did you test it?
Haven't tested but will try to keep this monitored.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
