### PR TITLE
chore!: elasticsearch - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -7,7 +7,7 @@ name = "elasticsearch-haystack"
 dynamic = ["version"]
 description = 'Haystack 2.x Document Store for ElasticSearch'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "Silvano Cerza", email = "silvanocerza@gmail.com" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.4.0",
+  "haystack-ai>=2.22.0",
   "elasticsearch>=8,<9",
   "aiohttp>=3.9.0" # for async support https://elasticsearch-py.readthedocs.io/en/latest/async.html#valueerror-when-initializing-asyncelasticsearch
 ]
@@ -83,7 +82,6 @@ disallow_incomplete_defs = true
 allow-direct-references = true
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -129,10 +127,6 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -47,11 +47,11 @@ class ElasticsearchBM25Retriever:
         self,
         *,
         document_store: ElasticsearchDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
         scale_score: bool = False,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         Initialize ElasticsearchBM25Retriever with an instance ElasticsearchDocumentStore.
@@ -117,7 +117,7 @@ class ElasticsearchBM25Retriever:
 
     @component.output_types(documents=list[Document])
     def run(
-        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents using the BM25 keyword-based algorithm.
@@ -142,7 +142,7 @@ class ElasticsearchBM25Retriever:
 
     @component.output_types(documents=list[Document])
     async def run_async(
-        self, query: str, filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents using the BM25 keyword-based algorithm.

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
@@ -49,10 +49,10 @@ class ElasticsearchEmbeddingRetriever:
         self,
         *,
         document_store: ElasticsearchDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        num_candidates: Optional[int] = None,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+        num_candidates: int | None = None,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
     ):
         """
         Create the ElasticsearchEmbeddingRetriever component.
@@ -115,7 +115,7 @@ class ElasticsearchEmbeddingRetriever:
 
     @component.output_types(documents=list[Document])
     def run(
-        self, query_embedding: list[float], filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query_embedding: list[float], filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents using a vector similarity metric.
@@ -140,7 +140,7 @@ class ElasticsearchEmbeddingRetriever:
 
     @component.output_types(documents=list[Document])
     async def run_async(
-        self, query_embedding: list[float], filters: Optional[dict[str, Any]] = None, top_k: Optional[int] = None
+        self, query_embedding: list[float], filters: dict[str, Any] | None = None, top_k: int | None = None
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents using a vector similarity metric.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -8,7 +8,7 @@
 
 
 from collections.abc import Mapping
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 import numpy as np
 from elastic_transport import NodeConfig
@@ -26,7 +26,7 @@ from .filters import _normalize_filters
 logger = logging.getLogger(__name__)
 
 
-Hosts = Union[str, list[Union[str, Mapping[str, Union[str, int]], NodeConfig]]]
+Hosts = str | list[str | Mapping[str, str | int] | NodeConfig]
 
 # document scores are essentially unbounded and will be scaled to values between 0 and 1 if scale_score is set to
 # True. Scaling uses the expit function (inverse of the logit function) after applying a scaling factor
@@ -77,8 +77,8 @@ class ElasticsearchDocumentStore:
     def __init__(
         self,
         *,
-        hosts: Optional[Hosts] = None,
-        custom_mapping: Optional[dict[str, Any]] = None,
+        hosts: Hosts | None = None,
+        custom_mapping: dict[str, Any] | None = None,
         index: str = "default",
         api_key: Secret = Secret.from_env_var("ELASTIC_API_KEY", strict=False),
         api_key_id: Secret = Secret.from_env_var("ELASTIC_API_KEY_ID", strict=False),
@@ -117,8 +117,8 @@ class ElasticsearchDocumentStore:
         :param **kwargs: Optional arguments that `Elasticsearch` takes.
         """
         self._hosts = hosts
-        self._client: Optional[Elasticsearch] = None
-        self._async_client: Optional[AsyncElasticsearch] = None
+        self._client: Elasticsearch | None = None
+        self._async_client: AsyncElasticsearch | None = None
         self._index = index
         self._api_key = api_key
         self._api_key_id = api_key_id
@@ -193,7 +193,7 @@ class ElasticsearchDocumentStore:
 
             self._initialized = True
 
-    def _handle_auth(self) -> Optional[Union[str, tuple[str, str]]]:
+    def _handle_auth(self) -> str | tuple[str, str] | None:
         """
         Handles authentication for the Elasticsearch client.
 
@@ -213,7 +213,7 @@ class ElasticsearchDocumentStore:
 
         """
 
-        api_key: Optional[Union[str, tuple[str, str]]]  # make the type checker happy
+        api_key: str | tuple[str, str] | None  # make the type checker happy
 
         api_key_resolved = self._api_key.resolve_value()
         api_key_id_resolved = self._api_key_id.resolve_value()
@@ -359,7 +359,7 @@ class ElasticsearchDocumentStore:
 
         return documents
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         The main query method for the document store. It retrieves all documents that match the filters.
 
@@ -377,7 +377,7 @@ class ElasticsearchDocumentStore:
         documents = self._search_documents(query=query)
         return documents
 
-    async def filter_documents_async(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    async def filter_documents_async(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Asynchronously retrieves all documents that match the filters.
 
@@ -850,7 +850,7 @@ class ElasticsearchDocumentStore:
         self,
         query: str,
         *,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
         scale_score: bool = False,
@@ -904,7 +904,7 @@ class ElasticsearchDocumentStore:
         self,
         query: str,
         *,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
         scale_score: bool = False,
@@ -960,9 +960,9 @@ class ElasticsearchDocumentStore:
         self,
         query_embedding: list[float],
         *,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        num_candidates: Optional[int] = None,
+        num_candidates: int | None = None,
     ) -> list[Document]:
         """
         Retrieves documents using dense vector similarity search.
@@ -999,9 +999,9 @@ class ElasticsearchDocumentStore:
         self,
         query_embedding: list[float],
         *,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        num_candidates: Optional[int] = None,
+        num_candidates: int | None = None,
     ) -> list[Document]:
         """
         Asynchronously retrieves documents using dense vector similarity search.


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
