### PR TITLE
chore!: opensearch - drop Python 3.9 and use X|Y typing

### DIFF
--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -7,7 +7,7 @@ name = "opensearch-haystack"
 dynamic = ["version"]
 description = 'Haystack 2.x Document Store for OpenSearch'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "deepset", email = "info@deepset.ai" }]
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.14.0",
+  "haystack-ai>=2.22.0",
   "opensearch-py[async]>=2.4.0,<3"]
 
 [project.urls]
@@ -85,7 +84,6 @@ allow-direct-references = true
 
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -133,10 +131,6 @@ ignore = [
   "PLR0915",
   # Ignore asserts
   "S101",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
 ]
 
 [tool.ruff.lint.isort]

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -4,7 +4,7 @@
 
 # ruff: noqa: FBT001  Boolean-typed positional argument in function definition
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
@@ -28,13 +28,13 @@ class OpenSearchBM25Retriever:
         self,
         *,
         document_store: OpenSearchDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
-        fuzziness: Union[int, str] = "AUTO",
+        filters: dict[str, Any] | None = None,
+        fuzziness: int | str = "AUTO",
         top_k: int = 10,
         scale_score: bool = False,
         all_terms_must_match: bool = False,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
-        custom_query: Optional[dict[str, Any]] = None,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
+        custom_query: dict[str, Any] | None = None,
         raise_on_failure: bool = True,
     ):
         """
@@ -158,12 +158,12 @@ class OpenSearchBM25Retriever:
         self,
         *,
         query: str,
-        filters: Optional[dict[str, Any]],
-        all_terms_must_match: Optional[bool],
-        top_k: Optional[int],
-        fuzziness: Optional[Union[str, int]],
-        scale_score: Optional[bool],
-        custom_query: Optional[dict[str, Any]],
+        filters: dict[str, Any] | None,
+        all_terms_must_match: bool | None,
+        top_k: int | None,
+        fuzziness: str | int | None,
+        scale_score: bool | None,
+        custom_query: dict[str, Any] | None,
     ) -> dict[str, Any]:
         filters = apply_filter_policy(self._filter_policy, self._filters, filters)
 
@@ -194,13 +194,13 @@ class OpenSearchBM25Retriever:
     def run(
         self,
         query: str,
-        filters: Optional[dict[str, Any]] = None,
-        all_terms_must_match: Optional[bool] = None,
-        top_k: Optional[int] = None,
-        fuzziness: Optional[Union[int, str]] = None,
-        scale_score: Optional[bool] = None,
-        custom_query: Optional[dict[str, Any]] = None,
-        document_store: Optional[OpenSearchDocumentStore] = None,
+        filters: dict[str, Any] | None = None,
+        all_terms_must_match: bool | None = None,
+        top_k: int | None = None,
+        fuzziness: int | str | None = None,
+        scale_score: bool | None = None,
+        custom_query: dict[str, Any] | None = None,
+        document_store: OpenSearchDocumentStore | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents using BM25 retrieval.
@@ -294,13 +294,13 @@ class OpenSearchBM25Retriever:
     async def run_async(  # pylint: disable=too-many-positional-arguments
         self,
         query: str,
-        filters: Optional[dict[str, Any]] = None,
-        all_terms_must_match: Optional[bool] = None,
-        top_k: Optional[int] = None,
-        fuzziness: Optional[Union[int, str]] = None,
-        scale_score: Optional[bool] = None,
-        custom_query: Optional[dict[str, Any]] = None,
-        document_store: Optional[OpenSearchDocumentStore] = None,
+        filters: dict[str, Any] | None = None,
+        all_terms_must_match: bool | None = None,
+        top_k: int | None = None,
+        fuzziness: int | str | None = None,
+        scale_score: bool | None = None,
+        custom_query: dict[str, Any] | None = None,
+        document_store: OpenSearchDocumentStore | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents using BM25 retrieval.

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -4,7 +4,7 @@
 
 # ruff: noqa: FBT001  Boolean-typed positional argument in function definition
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
@@ -28,10 +28,10 @@ class OpenSearchEmbeddingRetriever:
         self,
         *,
         document_store: OpenSearchDocumentStore,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
-        custom_query: Optional[dict[str, Any]] = None,
+        filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
+        custom_query: dict[str, Any] | None = None,
         raise_on_failure: bool = True,
         efficient_filtering: bool = False,
     ):
@@ -150,11 +150,11 @@ class OpenSearchEmbeddingRetriever:
     def run(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        custom_query: Optional[dict[str, Any]] = None,
-        efficient_filtering: Optional[bool] = None,
-        document_store: Optional[OpenSearchDocumentStore] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        custom_query: dict[str, Any] | None = None,
+        efficient_filtering: bool | None = None,
+        document_store: OpenSearchDocumentStore | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieve documents using a vector similarity metric.
@@ -259,11 +259,11 @@ class OpenSearchEmbeddingRetriever:
     async def run_async(
         self,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]] = None,
-        top_k: Optional[int] = None,
-        custom_query: Optional[dict[str, Any]] = None,
-        efficient_filtering: Optional[bool] = None,
-        document_store: Optional[OpenSearchDocumentStore] = None,
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        custom_query: dict[str, Any] | None = None,
+        efficient_filtering: bool | None = None,
+        document_store: OpenSearchDocumentStore | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously retrieve documents using a vector similarity metric.

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from haystack import Document, Pipeline, default_from_dict, default_to_dict, logging, super_component
 from haystack.components.embedders.types import TextEmbedder
@@ -92,22 +92,22 @@ class OpenSearchHybridRetriever:
         *,
         embedder: TextEmbedder,
         # OpenSearchBM25Retriever
-        filters_bm25: Optional[dict[str, Any]] = None,
-        fuzziness: Union[int, str] = "AUTO",
+        filters_bm25: dict[str, Any] | None = None,
+        fuzziness: int | str = "AUTO",
         top_k_bm25: int = 10,
         scale_score: bool = False,
         all_terms_must_match: bool = False,
-        filter_policy_bm25: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
-        custom_query_bm25: Optional[dict[str, Any]] = None,
+        filter_policy_bm25: str | FilterPolicy = FilterPolicy.REPLACE,
+        custom_query_bm25: dict[str, Any] | None = None,
         # OpenSearchEmbeddingRetriever
-        filters_embedding: Optional[dict[str, Any]] = None,
+        filters_embedding: dict[str, Any] | None = None,
         top_k_embedding: int = 10,
-        filter_policy_embedding: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
-        custom_query_embedding: Optional[dict[str, Any]] = None,
+        filter_policy_embedding: str | FilterPolicy = FilterPolicy.REPLACE,
+        custom_query_embedding: dict[str, Any] | None = None,
         # DocumentJoiner
-        join_mode: Union[str, JoinMode] = JoinMode.RECIPROCAL_RANK_FUSION,
-        weights: Optional[list[float]] = None,
-        top_k: Optional[int] = None,
+        join_mode: str | JoinMode = JoinMode.RECIPROCAL_RANK_FUSION,
+        weights: list[float] | None = None,
+        top_k: int | None = None,
         sort_by_score: bool = True,
         # extra kwargs
         **kwargs: Any,
@@ -242,10 +242,10 @@ class OpenSearchHybridRetriever:
         def run(
             self,
             query: str,
-            filters_bm25: Optional[dict[str, Any]] = None,
-            filters_embedding: Optional[dict[str, Any]] = None,
-            top_k_bm25: Optional[int] = None,
-            top_k_embedding: Optional[int] = None,
+            filters_bm25: dict[str, Any] | None = None,
+            filters_embedding: dict[str, Any] | None = None,
+            top_k_bm25: int | None = None,
+            top_k_embedding: int | None = None,
         ) -> dict[str, list[Document]]: ...
 
     def _create_pipeline(self, data: dict[str, Any]) -> Pipeline:

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/auth.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/auth.py
@@ -27,16 +27,16 @@ class AWSConfigurationError(DocumentStoreError):
     """Exception raised when AWS is not configured correctly"""
 
 
-def _resolve_secret(secret: Optional[Secret]) -> Optional[str]:
+def _resolve_secret(secret: Secret | None) -> str | None:
     return secret.resolve_value() if secret else None
 
 
 def _get_aws_session(
-    aws_access_key_id: Optional[str] = None,
-    aws_secret_access_key: Optional[str] = None,
-    aws_session_token: Optional[str] = None,
-    aws_region_name: Optional[str] = None,
-    aws_profile_name: Optional[str] = None,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: str | None = None,
+    aws_session_token: str | None = None,
+    aws_region_name: str | None = None,
+    aws_profile_name: str | None = None,
     **kwargs: Any,
 ) -> "boto3.Session":
     """
@@ -78,19 +78,19 @@ class AWSAuth:
     the necessary `Urllib3AWSV4SignerAuth` creation steps including boto3 Sessions and boto3 credentials.
     """
 
-    aws_access_key_id: Optional[Secret] = field(
+    aws_access_key_id: Secret | None = field(
         default_factory=lambda: Secret.from_env_var("AWS_ACCESS_KEY_ID", strict=False)
     )
-    aws_secret_access_key: Optional[Secret] = field(
+    aws_secret_access_key: Secret | None = field(
         default_factory=lambda: Secret.from_env_var("AWS_SECRET_ACCESS_KEY", strict=False)
     )
-    aws_session_token: Optional[Secret] = field(
+    aws_session_token: Secret | None = field(
         default_factory=lambda: Secret.from_env_var("AWS_SESSION_TOKEN", strict=False)
     )
-    aws_region_name: Optional[Secret] = field(
+    aws_region_name: Secret | None = field(
         default_factory=lambda: Secret.from_env_var("AWS_DEFAULT_REGION", strict=False)
     )
-    aws_profile_name: Optional[Secret] = field(default_factory=lambda: Secret.from_env_var("AWS_PROFILE", strict=False))
+    aws_profile_name: Secret | None = field(default_factory=lambda: Secret.from_env_var("AWS_PROFILE", strict=False))
     aws_service: str = field(default="es")
 
     def __post_init__(self) -> None:
@@ -106,7 +106,7 @@ class AWSAuth:
         _fields = {}
         for _field in fields(self):
             field_value = getattr(self, _field.name)
-            if _field.type == Optional[Secret]:
+            if _field.type == Secret | None:
                 _fields[_field.name] = field_value.to_dict() if field_value is not None else None
             else:
                 _fields[_field.name] = field_value

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -6,7 +6,7 @@
 
 from collections.abc import Mapping
 from math import exp
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from haystack import default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
@@ -22,7 +22,7 @@ from haystack_integrations.document_stores.opensearch.filters import normalize_f
 logger = logging.getLogger(__name__)
 
 
-Hosts = Union[str, list[Union[str, Mapping[str, Union[str, int]]]]]
+Hosts = str | list[str | Mapping[str, str | int]]
 
 # document scores are essentially unbounded and will be scaled to values between 0 and 1 if scale_score is set to
 # True. Scaling uses the expit function (inverse of the logit function) after applying a scaling factor
@@ -71,22 +71,22 @@ class OpenSearchDocumentStore:
     def __init__(
         self,
         *,
-        hosts: Optional[Hosts] = None,
+        hosts: Hosts | None = None,
         index: str = "default",
         max_chunk_bytes: int = DEFAULT_MAX_CHUNK_BYTES,
         embedding_dim: int = 768,
         return_embedding: bool = False,
-        method: Optional[dict[str, Any]] = None,
-        mappings: Optional[dict[str, Any]] = None,
-        settings: Optional[dict[str, Any]] = DEFAULT_SETTINGS,
+        method: dict[str, Any] | None = None,
+        mappings: dict[str, Any] | None = None,
+        settings: dict[str, Any] | None = DEFAULT_SETTINGS,
         create_index: bool = True,
         http_auth: Any = (
             Secret.from_env_var("OPENSEARCH_USERNAME", strict=False),  # noqa: B008
             Secret.from_env_var("OPENSEARCH_PASSWORD", strict=False),  # noqa: B008
         ),
-        use_ssl: Optional[bool] = None,
-        verify_certs: Optional[bool] = None,
-        timeout: Optional[int] = None,
+        use_ssl: bool | None = None,
+        verify_certs: bool | None = None,
+        timeout: int | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -155,8 +155,8 @@ class OpenSearchDocumentStore:
 
         # Client is initialized lazily to prevent side effects when
         # the document store is instantiated.
-        self._client: Optional[OpenSearch] = None
-        self._async_client: Optional[AsyncOpenSearch] = None
+        self._client: OpenSearch | None = None
+        self._async_client: AsyncOpenSearch | None = None
         self._initialized = False
 
     def _get_default_mappings(self) -> dict[str, Any]:
@@ -180,9 +180,9 @@ class OpenSearchDocumentStore:
 
     def create_index(
         self,
-        index: Optional[str] = None,
-        mappings: Optional[dict[str, Any]] = None,
-        settings: Optional[dict[str, Any]] = None,
+        index: str | None = None,
+        mappings: dict[str, Any] | None = None,
+        settings: dict[str, Any] | None = None,
     ) -> None:
         """
         Creates an index in OpenSearch.
@@ -216,7 +216,7 @@ class OpenSearchDocumentStore:
             Dictionary with serialized data.
         """
         # Handle http_auth serialization
-        http_auth: Union[list[dict[str, Any]], dict[str, Any], tuple[str, str], list[str], str] = ""
+        http_auth: list[dict[str, Any]] | dict[str, Any] | tuple[str, str] | list[str] | str = ""
         if isinstance(self._http_auth, list) and self._http_auth_are_secrets:
             # Recreate the Secret objects for serialization
             http_auth = [
@@ -355,7 +355,7 @@ class OpenSearchDocumentStore:
 
         return out
 
-    def _prepare_filter_search_request(self, filters: Optional[dict[str, Any]]) -> dict[str, Any]:
+    def _prepare_filter_search_request(self, filters: dict[str, Any] | None) -> dict[str, Any]:
         search_kwargs: dict[str, Any] = {"size": 10_000}
         if filters:
             search_kwargs["query"] = {"bool": {"filter": normalize_filters(filters)}}
@@ -376,7 +376,7 @@ class OpenSearchDocumentStore:
         search_results = await self._async_client.search(index=self._index, body=request_body)
         return OpenSearchDocumentStore._deserialize_search_hits(search_results["hits"]["hits"])
 
-    def filter_documents(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Returns the documents that match the filters provided.
 
@@ -389,7 +389,7 @@ class OpenSearchDocumentStore:
         self._ensure_initialized()
         return self._search_documents(self._prepare_filter_search_request(filters))
 
-    async def filter_documents_async(self, filters: Optional[dict[str, Any]] = None) -> list[Document]:
+    async def filter_documents_async(self, filters: dict[str, Any] | None = None) -> list[Document]:
         """
         Asynchronously returns the documents that match the filters provided.
 
@@ -564,7 +564,7 @@ class OpenSearchDocumentStore:
         document_ids: list[str],
         is_async: bool,
         refresh: Literal["wait_for", True, False],
-        routing: Optional[dict[str, str]] = None,
+        routing: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         def action_generator():
             for id_ in document_ids:
@@ -587,7 +587,7 @@ class OpenSearchDocumentStore:
         self,
         document_ids: list[str],
         refresh: Literal["wait_for", True, False] = "wait_for",
-        routing: Optional[dict[str, str]] = None,
+        routing: dict[str, str] | None = None,
     ) -> None:
         """
         Deletes documents that match the provided `document_ids` from the document store.
@@ -615,7 +615,7 @@ class OpenSearchDocumentStore:
         self,
         document_ids: list[str],
         refresh: Literal["wait_for", True, False] = "wait_for",
-        routing: Optional[dict[str, str]] = None,
+        routing: dict[str, str] | None = None,
     ) -> None:
         """
         Asynchronously deletes documents that match the provided `document_ids` from the document store.
@@ -869,11 +869,11 @@ class OpenSearchDocumentStore:
         self,
         *,
         query: str,
-        filters: Optional[dict[str, Any]],
-        fuzziness: Union[int, str],
+        filters: dict[str, Any] | None,
+        fuzziness: int | str,
         top_k: int,
         all_terms_must_match: bool,
-        custom_query: Optional[dict[str, Any]],
+        custom_query: dict[str, Any] | None,
     ) -> dict[str, Any]:
         if not query:
             body: dict[str, Any] = {"query": {"bool": {"must": {"match_all": {}}}}}
@@ -934,12 +934,12 @@ class OpenSearchDocumentStore:
         self,
         query: str,
         *,
-        filters: Optional[dict[str, Any]] = None,
-        fuzziness: Union[int, str] = "AUTO",
+        filters: dict[str, Any] | None = None,
+        fuzziness: int | str = "AUTO",
         top_k: int = 10,
         scale_score: bool = False,
         all_terms_must_match: bool = False,
-        custom_query: Optional[dict[str, Any]] = None,
+        custom_query: dict[str, Any] | None = None,
     ) -> list[Document]:
         """
         Retrieves documents that match the provided `query` using the BM25 search algorithm.
@@ -972,12 +972,12 @@ class OpenSearchDocumentStore:
         self,
         query: str,
         *,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         fuzziness: str = "AUTO",
         top_k: int = 10,
         scale_score: bool = False,
         all_terms_must_match: bool = False,
-        custom_query: Optional[dict[str, Any]] = None,
+        custom_query: dict[str, Any] | None = None,
     ) -> list[Document]:
         """
         Asynchronously retrieves documents that match the provided `query` using the BM25 search algorithm.
@@ -1012,9 +1012,9 @@ class OpenSearchDocumentStore:
         self,
         *,
         query_embedding: list[float],
-        filters: Optional[dict[str, Any]],
+        filters: dict[str, Any] | None,
         top_k: int,
-        custom_query: Optional[dict[str, Any]],
+        custom_query: dict[str, Any] | None,
         efficient_filtering: bool = False,
     ) -> dict[str, Any]:
         if not query_embedding:
@@ -1068,9 +1068,9 @@ class OpenSearchDocumentStore:
         self,
         query_embedding: list[float],
         *,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        custom_query: Optional[dict[str, Any]] = None,
+        custom_query: dict[str, Any] | None = None,
         efficient_filtering: bool = False,
     ) -> list[Document]:
         """
@@ -1098,9 +1098,9 @@ class OpenSearchDocumentStore:
         self,
         query_embedding: list[float],
         *,
-        filters: Optional[dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         top_k: int = 10,
-        custom_query: Optional[dict[str, Any]] = None,
+        custom_query: dict[str, Any] | None = None,
         efficient_filtering: bool = False,
     ) -> list[Document]:
         """


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack/issues/10268

### Proposed Changes
- drop Python 3.9 and use X|Y typing

### How did you test it?
CI

### Notes for the reviewer
Since this is breaking, I'll release a new major version when merged.
*This PR is partly generated using a script and reviewed/contributed to by me.*
