### PR TITLE
test: try to avoid rate limits for Meta Llama

### DIFF
--- a/.github/workflows/meta_llama.yml
+++ b/.github/workflows/meta_llama.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.13"]
-      max-parallel: 2  # to avoid rate limiting        
+      max-parallel: 3  # to avoid rate limiting        
 
     steps:
       - name: Support longpaths


### PR DESCRIPTION
### Related Issues

Meta Llama tests are frequently failing due to rate limits: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/20939974186

### Proposed Changes:
- set `max_parallel` to 3 to reduce the number of API calls per minute.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
