### PR TITLE
fix: None value handling of flattened generation kwargs for AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -425,16 +425,18 @@ class AmazonBedrockChatGenerator:
         generation_kwargs = generation_kwargs.copy()
 
         disable_parallel_tool_use = generation_kwargs.pop("disable_parallel_tool_use", None)
+        parallel_tool_use = generation_kwargs.pop("parallel_tool_use", None)
+
+        if disable_parallel_tool_use is not None and parallel_tool_use is not None:
+            msg = "Cannot set both disable_parallel_tool_use and parallel_tool_use"
+            raise ValueError(msg)
+        elif parallel_tool_use is not None:
+            disable_parallel_tool_use = not parallel_tool_use
+
         if disable_parallel_tool_use is not None:
             tool_choice = generation_kwargs.setdefault("tool_choice", {})
             tool_choice["disable_parallel_tool_use"] = disable_parallel_tool_use
-
-        parallel_tool_use = generation_kwargs.pop("parallel_tool_use", None)
-        if parallel_tool_use is not None:
-            disable_parallel_tool_use = not parallel_tool_use
-            tool_choice = generation_kwargs.setdefault("tool_choice", {})
-            tool_choice["disable_parallel_tool_use"] = disable_parallel_tool_use
-            tool_choice["type"] = "auto"  # default value
+            tool_choice.setdefault("type", "auto")  # default value
 
         tool_choice_type = generation_kwargs.pop("tool_choice_type", None)
         if tool_choice_type is not None:
@@ -445,7 +447,7 @@ class AmazonBedrockChatGenerator:
         if thinking_budget_tokens is not None:
             thinking = generation_kwargs.setdefault("thinking", {})
             thinking["budget_tokens"] = thinking_budget_tokens
-            thinking["type"] = "enabled"
+            thinking.setdefault("type", "enabled")
 
         return generation_kwargs
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -442,6 +442,14 @@ class TestAmazonBedrockChatGenerator:
             ),
             (
                 {
+                    "disable_parallel_tool_use": True,
+                },
+                {
+                    "tool_choice": {"disable_parallel_tool_use": True, "type": "auto"},
+                },
+            ),
+            (
+                {
                     "thinking_budget_tokens": None,
                     "parallel_tool_use": None,
                     "tool_choice_type": None,


### PR DESCRIPTION
### Related Issues

- fixes broken config when `setting parallel_tool_use`: `tool_choice.type` was not set which is required however
- fixes broken config when `thinking_budget_tokens: None`: `thinking.budget_tokens` is not nullable

### Proposed Changes:
- don't unflatten arg when value is `None`
- set `tool.choice.typ = "auto"` when setting `parallel_tool_use`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
- Anthropic API specs: https://platform.claude.com/docs/en/api/messages/create

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
