### PR TITLE
ci: fix pull before changelog push

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -78,6 +78,6 @@ jobs:
           message: "Update the changelog"
           add: ${{ steps.pathfinder.outputs.project_path }}
           # to avoid that the pushed branch tip is behind its remote counterpart, we need to pull first
-          pull: "--rebase --autostash"
+          pull: "origin main --rebase --autostash"
           push: origin HEAD:main
 


### PR DESCRIPTION
### Related Issues

Failing workflow: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/21062640964/job/60572330620

### Proposed Changes:
- pass appropriate `pull` configuration

### How did you test it?
Tested on my fork: pull seems to work
https://github.com/anakin87/haystack-core-integrations/actions/runs/21063465232/job/60575077553

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
