### PR TITLE
fix(watsonx): use dataclass replace to avoid modifying input documents

### DIFF
--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -204,11 +205,12 @@ class WatsonxDocumentEmbedder:
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
         embeddings = self.embedder.embed_documents(texts_to_embed)
 
+        new_documents = []
         for doc, emb in zip(documents, embeddings, strict=True):
-            doc.embedding = emb
+            new_documents.append(replace(doc, embedding=emb))
 
         return {
-            "documents": documents,
+            "documents": new_documents,
             "meta": {
                 "model": self.model,
                 "truncate_input_tokens": self.truncate_input_tokens,

--- a/integrations/watsonx/tests/test_document_embedder.py
+++ b/integrations/watsonx/tests/test_document_embedder.py
@@ -175,6 +175,30 @@ class TestWatsonXDocumentEmbedder:
             "meta": {"model": "ibm/slate-30m-english-rtrvr-v2", "truncate_input_tokens": None, "batch_size": 1000},
         }
 
+    def test_run_does_not_modify_original_documents(self, mock_watsonx):
+        """Test that original documents are not modified during embedding"""
+        embedder = WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
+        original_docs = [
+            Document(content="I love cheese"),
+            Document(content="A transformer is a deep learning architecture"),
+        ]
+
+        # Mock the embedder to return embeddings
+        mock_watsonx["embeddings_instance"].embed_documents.return_value = [
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+        ]
+
+        result = embedder.run(documents=original_docs)
+
+        # Check that original documents are not modified
+        for doc in original_docs:
+            assert doc.embedding is None
+
+        # Check that returned documents have embeddings
+        for doc_with_embedding in result["documents"]:
+            assert doc_with_embedding.embedding is not None
+
 
 @pytest.mark.integration
 class TestWatsonxDocumentEmbedderIntegration:


### PR DESCRIPTION
## Related Issues

- partially addresses #2174
- & also closes #2174 

## Proposed Changes

This PR fixes the Watson X Document Embedder to avoid mutating input Documents when setting embeddings.

### Changes Made

**`WatsonxDocumentEmbedder`:**
- `run()` method: Use `replace(doc, embedding=emb)` instead of `doc.embedding = emb`

### Tests Added
- `test_run_does_not_modify_original_documents` for document embedder

## How did you test it?

```bash
cd integrations/watsonx
hatch run test:unit  # All 58 tests pass
hatch run fmt-check  # All checks pass
```

## Notes for the reviewer

This follows the established pattern from:
- haystack-ai/haystack#9693 (core Haystack fix)
- #2678 (FastEmbed)
- #2675 (Optimum)
- #2680 (Nvidia)
- #2702 (Bedrock)
- #2755 (Cohere)
- #2762 (Google GenAI)
- #2765 (jina)