### PR TITLE
feat:  adding count, filtering and metadata related operations to `PGVectorDocumentStore`

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -1512,8 +1512,10 @@ class PgvectorDocumentStore:
         # Validate field name to prevent SQL injection
         # Only allow alphanumeric characters, underscores, and hyphens
         if not all(c.isalnum() or c in ("_", "-") for c in field_name):
-            msg = (f"Invalid metadata field name: '{field_name}'. Field names can only contain alphanumeric "
-                   f"characters, underscores, and hyphens.")
+            msg = (
+                f"Invalid metadata field name: '{field_name}'. Field names can only contain alphanumeric "
+                f"characters, underscores, and hyphens."
+            )
             raise ValueError(msg)
 
         return field_name
@@ -1552,8 +1554,7 @@ class PgvectorDocumentStore:
 
     @staticmethod
     def _process_count_unique_metadata_result(
-        result: dict[str, Any] | None,
-        normalized_fields: list[str]
+        result: dict[str, Any] | None, normalized_fields: list[str]
     ) -> dict[str, int]:
         """
         Processes the result from counting unique metadata values.
@@ -1568,9 +1569,7 @@ class PgvectorDocumentStore:
         # Return dictionary with normalized field names
         return {field: result.get(field, 0) for field in normalized_fields}
 
-    def count_unique_metadata_by_filter(
-        self, filters: dict[str, Any], metadata_fields: list[str]
-    ) -> dict[str, int]:
+    def count_unique_metadata_by_filter(self, filters: dict[str, Any], metadata_fields: list[str]) -> dict[str, int]:
         """
         Returns the count of unique values for each specified metadata field,
         considering only documents that match the provided filters.
@@ -1764,7 +1763,7 @@ class PgvectorDocumentStore:
                     MAX((meta->>{} )::integer) AS max_value
                 FROM {}.{}
                 WHERE meta->>{} IS NOT NULL
-                """ # noqa: W291
+                """  # noqa: W291
             ).format(
                 field_literal,
                 field_literal,
@@ -1781,7 +1780,7 @@ class PgvectorDocumentStore:
                     MAX((meta->>{} )::real) AS max_value
                 FROM {}.{}
                 WHERE meta->>{} IS NOT NULL
-                """ # noqa: W291
+                """  # noqa: W291
             ).format(
                 field_literal,
                 field_literal,
@@ -1800,7 +1799,7 @@ class PgvectorDocumentStore:
                     MAX(meta->>{} COLLATE "C") AS max_value
                 FROM {}.{}
                 WHERE meta->>{} IS NOT NULL
-                """ # noqa: W291
+                """  # noqa: W291
             ).format(
                 field_literal,
                 field_literal,
@@ -1942,8 +1941,7 @@ class PgvectorDocumentStore:
 
     @staticmethod
     def _process_unique_values_result(
-        count_result: dict[str, Any] | None,
-        records: list[dict[str, Any]]
+        count_result: dict[str, Any] | None, records: list[dict[str, Any]]
     ) -> tuple[list[str], int]:
         """
         Processes the results from unique values queries.
@@ -2021,7 +2019,7 @@ class PgvectorDocumentStore:
                 sql_query=sql_count,
                 params=params,
                 error_msg=f"Could not count unique values for metadata field '{metadata_field}' in "
-                          f"PgvectorDocumentStore",
+                f"PgvectorDocumentStore",
             )
         ).fetchone()
 

--- a/integrations/pgvector/tests/test_document_store_async.py
+++ b/integrations/pgvector/tests/test_document_store_async.py
@@ -716,6 +716,38 @@ async def test_get_metadata_field_unique_values_async(document_store: PgvectorDo
     assert unique_values_page2[0] in ["A", "B", "C"]
     assert total_count_page2 == 3
 
+    # Test pagination - verify pages don't overlap
+    assert not set(unique_values_page1).intersection(set(unique_values_page2))
+
+    # Test pagination - verify all values are covered
+    all_values = set(unique_values_page1) | set(unique_values_page2)
+    assert all_values == {"A", "B", "C"}
+
+    # Test pagination - size larger than total count
+    unique_values_large, total_large = await document_store.get_metadata_field_unique_values_async(
+        "meta.category", None, 0, 100
+    )
+    assert len(unique_values_large) == 3
+    assert set(unique_values_large) == {"A", "B", "C"}
+    assert total_large == 3
+
+    # Test pagination - from_ beyond total count (should return empty)
+    unique_values_beyond, total_beyond = await document_store.get_metadata_field_unique_values_async(
+        "meta.category", None, 10, 10
+    )
+    assert len(unique_values_beyond) == 0
+    assert total_beyond == 3
+
+    # Test pagination - single item per page
+    unique_values_single1, _ = await document_store.get_metadata_field_unique_values_async("meta.category", None, 0, 1)
+    unique_values_single2, _ = await document_store.get_metadata_field_unique_values_async("meta.category", None, 1, 1)
+    unique_values_single3, _ = await document_store.get_metadata_field_unique_values_async("meta.category", None, 2, 1)
+    assert len(unique_values_single1) == 1
+    assert len(unique_values_single2) == 1
+    assert len(unique_values_single3) == 1
+    # All three pages should be different
+    assert len(set(unique_values_single1 + unique_values_single2 + unique_values_single3)) == 3
+
     # Test with search term - filter by content matching "Python"
     unique_values_filtered, total_filtered = await document_store.get_metadata_field_unique_values_async(
         "meta.category", "Python", 0, 10
@@ -729,6 +761,21 @@ async def test_get_metadata_field_unique_values_async(document_store: PgvectorDo
     )
     assert set(unique_values_java) == {"B"}  # Only category B has documents with "Java" in content
     assert total_java == 1
+
+    # Test pagination with search term
+    unique_values_search_page1, total_search = await document_store.get_metadata_field_unique_values_async(
+        "meta.language", "Python", 0, 1
+    )
+    assert len(unique_values_search_page1) == 1
+    assert unique_values_search_page1[0] == "Python"
+    assert total_search == 1
+
+    # Test pagination with search term - beyond results
+    unique_values_search_empty, total_search_empty = await document_store.get_metadata_field_unique_values_async(
+        "meta.language", "Python", 10, 10
+    )
+    assert len(unique_values_search_empty) == 0
+    assert total_search_empty == 1
 
     # Test with integer values
     int_docs = [


### PR DESCRIPTION
### Related Issues

- fixes #2639 

### Proposed Changes:

```
def count_documents_by_filter(filter: dict) -> int

def count_unique_metadata_by_filter(filters: dict[str, Any], metadata_fields: list[str]) -> dict[str, int]`

def get_metadata_fields_info() -> dict[str, dict]

def get_metadata_field_min_max(metadata_field: str) -> dict[str, Any]

def get_metadata_field_unique_values(metadata_field: str, search_term: str | None, from_: int, size: int) -> tuple[list[str]
```

### How did you test it?

- new integrations tests for both the sync and async version

### NOTES

- SQLRetriever or similar will be handled in a different issue/PR

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
