### PR TITLE
fix(langfuse): apply invocation_context to trace metadata

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .tracer import DefaultSpanHandler, LangfuseSpan, LangfuseTracer, SpanContext, SpanHandler
+from .tracer import DefaultSpanHandler, LangfuseSpan, LangfuseTracer, SpanContext, SpanHandler, tracing_context_var
 
-__all__ = ["DefaultSpanHandler", "LangfuseSpan", "LangfuseTracer", "SpanContext", "SpanHandler"]
+__all__ = ["DefaultSpanHandler", "LangfuseSpan", "LangfuseTracer", "SpanContext", "SpanHandler", "tracing_context_var"]


### PR DESCRIPTION
- Fixes #2484

## Problem
`LangfuseConnector.run()` accepts `invocation_context` but only logs it—never applies it to Langfuse trace metadata.

## Solution
Set `tracing_context_var` from `invocation_context` with supported keys (`user_id`, `session_id`, `trace_id`, `tags`, `version`).

## Changes
- `langfuse_connector.py`: Apply context to `tracing_context_var` in `run()`
- `__init__.py`: Export `tracing_context_var` for direct access
- Added unit test for new behavior

## Testing
- All unit tests pass (7/7)
- Lint/format checks pass