### PR TITLE
chore: pin transformers<5 for HanLP integration

### DIFF
--- a/integrations/hanlp/pyproject.toml
+++ b/integrations/hanlp/pyproject.toml
@@ -25,8 +25,10 @@ classifiers = [
 dependencies = [
   "haystack-ai>=2.22.0",
   "hanlp>=2.1.1",
-  # the following pin can be removed once HanLP supports transformers 5
+  # the following pins can be removed once HanLP supports transformers 5
   "transformers>=4.1.1,<5",
+  # tokenizers is a dependency of transformers. The following version is the first one which supports Python 3.13.
+  "tokenizers>=0.20.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

Failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/21379076464/job/61541847715

HanLP is not currently compatible with Transformers v5 and they don't pin it for the moment. See https://github.com/hankcs/HanLP/blob/master/setup.py

### Proposed Changes:
- pin transformers<5

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
