### PR TITLE
docs: fixing docstring parsing error on `PineConeDocumentStore`

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -976,7 +976,6 @@ class PineconeDocumentStore:
             {
                 'content': {'type': 'text'},
                 'category': {'type': 'keyword'},
-                'status': {'type': 'keyword'},
                 'priority': {'type': 'long'},
             }
             ```


### PR DESCRIPTION
### Proposed Changes:

- fixing docstring parsing error

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
