### PR TITLE
fix: Fix docstrings in valkey integration

### DIFF
--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -181,7 +181,7 @@ class ValkeyDocumentStore(DocumentStore):
         :param embedding_dim: Dimension of document embeddings. Defaults to 768.
         :param metadata_fields: Dictionary mapping metadata field names to Python types for filtering.
             Supported types: str (for exact matching), int (for numeric comparisons).
-            Example: {"category": str, "priority": int}.
+            Example: `{"category": str, "priority": int}`.
             If not provided, no metadata fields will be indexed for filtering.
         """
         self._index_name = index_name
@@ -1037,7 +1037,7 @@ class ValkeyDocumentStore(DocumentStore):
 
         :param raw: Raw search results from Valkey FT.SEARCH command. Expected format is a list where
             raw[0] is the total count (int) and raw[1] is a dict mapping document keys to field dictionaries
-            containing b"payload", b"vector", and b"__vector_score" as byte keys.
+            containing `b"payload"`, `b"vector"`, and `b"__vector_score"` as byte keys.
         :param with_embedding: Whether to include embeddings in parsed documents.
         :return: List of Document objects with scores and optional embeddings.
         """


### PR DESCRIPTION
### Related Issues

- hopefully fixes failing deployment here https://github.com/deepset-ai/haystack/pull/10470

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
