### PR TITLE
chore: disabling progress bar in `QdrantDocumentStore` tests

### DIFF
--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -147,9 +147,7 @@ class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocu
         assert sparse_config[SPARSE_VECTORS_NAME].modifier == rest.Modifier.IDF
 
     def test_query_hybrid(self, generate_sparse_embedding):
-        document_store = QdrantDocumentStore(
-            location=":memory:", use_sparse_embeddings=True, progress_bar=False
-        )
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True, progress_bar=False)
 
         docs = []
         for i in range(20):
@@ -174,9 +172,7 @@ class TestQdrantDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocu
             assert document.embedding
 
     def test_query_hybrid_with_group_by(self, generate_sparse_embedding):
-        document_store = QdrantDocumentStore(
-            location=":memory:", use_sparse_embeddings=True, progress_bar=False
-        )
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True, progress_bar=False)
 
         docs = []
         for i in range(20):

--- a/integrations/qdrant/tests/test_document_store_async.py
+++ b/integrations/qdrant/tests/test_document_store_async.py
@@ -60,9 +60,7 @@ class TestQdrantDocumentStore:
 
     @pytest.mark.asyncio
     async def test_query_hybrid_async(self, generate_sparse_embedding):
-        document_store = QdrantDocumentStore(
-            location=":memory:", use_sparse_embeddings=True, progress_bar=False
-        )
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True, progress_bar=False)
 
         docs = []
         for i in range(20):
@@ -87,9 +85,7 @@ class TestQdrantDocumentStore:
 
     @pytest.mark.asyncio
     async def test_query_hybrid_with_group_by_async(self, generate_sparse_embedding):
-        document_store = QdrantDocumentStore(
-            location=":memory:", use_sparse_embeddings=True, progress_bar=False
-        )
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=True, progress_bar=False)
 
         docs = []
         for i in range(20):


### PR DESCRIPTION
### Proposed Changes:

Disabling progress bar in Qdrant tests so that one can easily confirm which tests are running. Helps when just testing specially some tests and running locally.


```python
tests/test_converters.py::test_convert_id_is_deterministic PASSED
tests/test_converters.py::test_point_to_document_reverts_proper_structure_from_record_with_sparse PASSED
tests/test_converters.py::test_point_to_document_reverts_proper_structure_from_record_without_sparse PASSED
tests/test_dict_converters.py::test_to_dict PASSED
tests/test_dict_converters.py::test_from_dict PASSED
100it [00:00, 281685.96it/s]
PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_documents_empty_document_store <- ../../../haystack/haystack/testing/document_store.py PASSED
100it [00:00, 788403.01it/s]
PASSED
100it [00:00, 961996.33it/s]
100it [00:00, 1997287.62it/s]
PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_all_documents_empty_store <- ../../../haystack/haystack/testing/document_store.py PASSED
100it [00:00, 1097985.34it/s]
100it [00:00, 2219208.47it/s]
PASSED
100it [00:00, 1353001.29it/s]
100it [00:00, 2036069.90it/s]
PASSED
100it [00:00, 1889326.13it/s]
PASSED
100it [00:00, 1619422.39it/s]
0it [00:00, ?it/s]
PASSED
100it [00:00, 1855886.73it/s]
100it [00:00, 2184533.33it/s]
PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_write_documents_invalid_input <- ../../../haystack/haystack/testing/document_store.py PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_count_empty <- ../../../haystack/haystack/testing/document_store.py PASSED
100it [00:00, 1072712.02it/s]
```
To this:

```python
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_all_documents <- ../../../haystack/haystack/testing/document_store.py PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_all_documents_empty_store <- ../../../haystack/haystack/testing/document_store.py PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_all_documents_without_recreate_index <- ../../../haystack/haystack/testing/document_store.py PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_all_documents_with_recreate_index <- ../../../haystack/haystack/testing/document_store.py PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_all_documents_no_index_recreation PASSED
tests/test_document_store.py::TestQdrantDocumentStore::test_delete_all_documents_index_recreation PASSED
tests/test_document_store_async.py::TestQdrantDocumentStore::test_delete_all_documents_async_no_index_recreation PASSED
tests/test_document_store_async.py::TestQdrantDocumentStore::test_delete_all_documents_async_index_recreation PASSED
```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
