### PR TITLE
doc: fixing `QdrantDocumentStore` docstring parsing error

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -974,7 +974,7 @@ class QdrantDocumentStore:
             A dictionary mapping field names to their types e.g.:
             ```python
             {"field_name": "integer"}
-            ```python
+            ```
         """
         self._initialize_client()
         assert self._client is not None
@@ -995,7 +995,7 @@ class QdrantDocumentStore:
             A dictionary mapping field names to their types e.g.:
             ```python
             {"field_name": "integer"}
-            ```python
+            ```
         """
         await self._initialize_async_client()
         assert self._async_client is not None


### PR DESCRIPTION
### Proposed Changes:

- fixing docstrings

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
