### PR TITLE
feat: `QdrantDocumentStore` return number deleted docs on `delete_by_filter`

### DIFF
--- a/integrations/qdrant/tests/test_document_store_async.py
+++ b/integrations/qdrant/tests/test_document_store_async.py
@@ -275,7 +275,10 @@ class TestQdrantDocumentStore:
         assert await document_store.count_documents_async() == 3
 
         # Delete documents with category="A"
-        await document_store.delete_by_filter_async(filters={"field": "meta.category", "operator": "==", "value": "A"})
+        deleted_count = await document_store.delete_by_filter_async(
+            filters={"field": "meta.category", "operator": "==", "value": "A"}
+        )
+        assert deleted_count == 2
         assert await document_store.count_documents_async() == 1
 
         # Verify only category B remains
@@ -286,7 +289,10 @@ class TestQdrantDocumentStore:
         assert remaining_docs[0].meta["category"] == "B"
 
         # Delete remaining document by year
-        await document_store.delete_by_filter_async(filters={"field": "meta.year", "operator": "==", "value": 2023})
+        deleted_count = await document_store.delete_by_filter_async(
+            filters={"field": "meta.year", "operator": "==", "value": 2023}
+        )
+        assert deleted_count == 1
         assert await document_store.count_documents_async() == 0
 
     @pytest.mark.asyncio
@@ -299,7 +305,10 @@ class TestQdrantDocumentStore:
         assert await document_store.count_documents_async() == 2
 
         # Try to delete documents with category="C" (no matches)
-        await document_store.delete_by_filter_async(filters={"field": "meta.category", "operator": "==", "value": "C"})
+        deleted_count = await document_store.delete_by_filter_async(
+            filters={"field": "meta.category", "operator": "==", "value": "C"}
+        )
+        assert deleted_count == 0
         assert await document_store.count_documents_async() == 2
 
     @pytest.mark.asyncio
@@ -312,8 +321,8 @@ class TestQdrantDocumentStore:
         await document_store.write_documents_async(docs)
         assert await document_store.count_documents_async() == 3
 
-        # AND condition
-        await document_store.delete_by_filter_async(
+        # AND condition (matches only Doc 1)
+        deleted_count = await document_store.delete_by_filter_async(
             filters={
                 "operator": "AND",
                 "conditions": [
@@ -322,10 +331,11 @@ class TestQdrantDocumentStore:
                 ],
             }
         )
+        assert deleted_count == 1
         assert await document_store.count_documents_async() == 2
 
-        # OR condition
-        await document_store.delete_by_filter_async(
+        # OR condition (matches Doc 2 and Doc 3)
+        deleted_count = await document_store.delete_by_filter_async(
             filters={
                 "operator": "OR",
                 "conditions": [
@@ -334,6 +344,7 @@ class TestQdrantDocumentStore:
                 ],
             }
         )
+        assert deleted_count == 2
         assert await document_store.count_documents_async() == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues

- fixes #2800 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
