### PR TITLE
docs: fix docstring for AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -134,7 +134,7 @@ class AmazonBedrockChatGenerator:
     > Based on the information I've received, I can tell you that the weather in Paris is
     > currently sunny with a temperature of 32°C (which is about 90°F).
     ```
-    
+
     **Prompt caching**
 
     This component supports prompt caching. You can use the `tools_cachepoint_config` parameter to configure the cache


### PR DESCRIPTION
### Related Issues

- Broken Docusaurus build: https://github.com/deepset-ai/haystack/pull/10511
- Also existing API reference doesn't render correctly: https://docs.haystack.deepset.ai/reference/integrations-amazon-bedrock#amazonbedrockchatgenerator

### Proposed Changes:
- find a way to make the docstring render properly in Markdown and Docusaurus (I iterated a lot)

### How did you test it?
Tested the generated Markdown file on Haystack docs website (local build)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
