### PR TITLE
test: relax AIMLAPI tests

### DIFF
--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
@@ -264,7 +264,7 @@ class TestAIMLAPIChatGenerator:
         message: ChatMessage = results["replies"][0]
         assert message.text
         assert "Paris" in message.text
-        assert "gpt-5-nano-2025-08-07" in message.meta["model"]
+        assert "gpt-5-nano" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
     @pytest.mark.skipif(
@@ -301,7 +301,7 @@ class TestAIMLAPIChatGenerator:
         assert message.text
         assert "Paris" in message.text
 
-        assert "gpt-5-nano-2025-08-07" in message.meta["model"]
+        assert "gpt-5-nano" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
         assert callback.counter > 1

--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator_async.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator_async.py
@@ -138,7 +138,7 @@ class TestAIMLAPIChatGeneratorAsync:
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
-        assert "gpt-5-nano-2025-08-07" in message.meta["model"]
+        assert "gpt-5-nano" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
     @pytest.mark.skipif(
@@ -164,7 +164,7 @@ class TestAIMLAPIChatGeneratorAsync:
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
 
-        assert "gpt-5-nano-2025-08-07" in message.meta["model"]
+        assert "gpt-5-nano" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
         assert counter > 1


### PR DESCRIPTION
### Related Issues

Faling nightly tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/21733556116/job/62693456060

### Proposed Changes:
- relax the check for model name, as it seems that sometimes the model name in `ChatMessage.meta` is just `gpt-5-nano` instead of `gpt-5-nano-2025-08-07`
### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
