### PR TITLE
chore: Google GenAI - switch default embedding model to gemini-embedding-001

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
@@ -28,7 +28,7 @@ class GoogleGenAIDocumentEmbedder:
     from haystack_integrations.components.embedders.google_genai import GoogleGenAIDocumentEmbedder
 
     # export the environment variable (GOOGLE_API_KEY or GEMINI_API_KEY)
-    document_embedder = GoogleGenAIDocumentEmbedder(model="text-embedding-004")
+    document_embedder = GoogleGenAIDocumentEmbedder(model="gemini-embedding-001")
 
     **2. Vertex AI (Application Default Credentials)**
     ```python
@@ -39,7 +39,7 @@ class GoogleGenAIDocumentEmbedder:
         api="vertex",
         vertex_ai_project="my-project",
         vertex_ai_location="us-central1",
-        model="text-embedding-004"
+        model="gemini-embedding-001"
     )
     ```
 
@@ -50,7 +50,7 @@ class GoogleGenAIDocumentEmbedder:
     # export the environment variable (GOOGLE_API_KEY or GEMINI_API_KEY)
     document_embedder = GoogleGenAIDocumentEmbedder(
         api="vertex",
-        model="text-embedding-004"
+        model="gemini-embedding-001"
     )
     ```
 
@@ -78,7 +78,7 @@ class GoogleGenAIDocumentEmbedder:
         api: Literal["gemini", "vertex"] = "gemini",
         vertex_ai_project: str | None = None,
         vertex_ai_location: str | None = None,
-        model: str = "text-embedding-004",
+        model: str = "gemini-embedding-001",
         prefix: str = "",
         suffix: str = "",
         batch_size: int = 32,

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
@@ -27,7 +27,7 @@ class GoogleGenAITextEmbedder:
     from haystack_integrations.components.embedders.google_genai import GoogleGenAITextEmbedder
 
     # export the environment variable (GOOGLE_API_KEY or GEMINI_API_KEY)
-    text_embedder = GoogleGenAITextEmbedder(model="text-embedding-004")
+    text_embedder = GoogleGenAITextEmbedder(model="gemini-embedding-001")
 
     **2. Vertex AI (Application Default Credentials)**
     ```python
@@ -38,7 +38,7 @@ class GoogleGenAITextEmbedder:
         api="vertex",
         vertex_ai_project="my-project",
         vertex_ai_location="us-central1",
-        model="text-embedding-004"
+        model="gemini-embedding-001"
     )
     ```
 
@@ -49,7 +49,7 @@ class GoogleGenAITextEmbedder:
     # export the environment variable (GOOGLE_API_KEY or GEMINI_API_KEY)
     text_embedder = GoogleGenAITextEmbedder(
         api="vertex",
-        model="text-embedding-004"
+        model="gemini-embedding-001"
     )
     ```
 
@@ -66,7 +66,7 @@ class GoogleGenAITextEmbedder:
     print(text_embedder.run(text_to_embed))
 
     # {'embedding': [0.017020374536514282, -0.023255806416273117, ...],
-    # 'meta': {'model': 'text-embedding-004-v2',
+    # 'meta': {'model': 'gemini-embedding-001-v2',
     #          'usage': {'prompt_tokens': 4, 'total_tokens': 4}}}
     ```
     """
@@ -78,7 +78,7 @@ class GoogleGenAITextEmbedder:
         api: Literal["gemini", "vertex"] = "gemini",
         vertex_ai_project: str | None = None,
         vertex_ai_location: str | None = None,
-        model: str = "text-embedding-004",
+        model: str = "gemini-embedding-001",
         prefix: str = "",
         suffix: str = "",
         config: dict[str, Any] | None = None,
@@ -97,7 +97,7 @@ class GoogleGenAITextEmbedder:
             Required when using Vertex AI with Application Default Credentials.
         :param model:
             The name of the model to use for calculating embeddings.
-            The default model is `text-embedding-004`.
+            The default model is `gemini-embedding-001`.
         :param prefix:
             A string to add at the beginning of each text to embed.
         :param suffix:

--- a/integrations/google_genai/tests/test_document_embedder.py
+++ b/integrations/google_genai/tests/test_document_embedder.py
@@ -12,10 +12,10 @@ from haystack.utils.auth import Secret
 from haystack_integrations.components.embedders.google_genai import GoogleGenAIDocumentEmbedder
 
 
-def mock_google_response(contents: list[str], model: str = "text-embedding-004", **kwargs) -> dict:
+def mock_google_response(contents: list[str], model: str = "gemini-embedding-001", **kwargs) -> dict:
     secure_random = random.SystemRandom()
     dict_response = {
-        "embedding": [[secure_random.random() for _ in range(768)] for _ in contents],
+        "embedding": [[secure_random.random() for _ in range(3072)] for _ in contents],
         "meta": {"model": model},
     }
 
@@ -30,7 +30,7 @@ class TestGoogleGenAIDocumentEmbedder:
         assert embedder._api == "gemini"
         assert embedder._vertex_ai_project is None
         assert embedder._vertex_ai_location is None
-        assert embedder._model == "text-embedding-004"
+        assert embedder._model == "gemini-embedding-001"
         assert embedder._prefix == ""
         assert embedder._suffix == ""
         assert embedder._batch_size == 32
@@ -76,7 +76,7 @@ class TestGoogleGenAIDocumentEmbedder:
                 "haystack_integrations.components.embedders.google_genai.document_embedder.GoogleGenAIDocumentEmbedder"
             ),
             "init_parameters": {
-                "model": "text-embedding-004",
+                "model": "gemini-embedding-001",
                 "prefix": "",
                 "suffix": "",
                 "batch_size": 32,
@@ -131,7 +131,7 @@ class TestGoogleGenAIDocumentEmbedder:
                 "haystack_integrations.components.embedders.google_genai.document_embedder.GoogleGenAIDocumentEmbedder"
             ),
             "init_parameters": {
-                "model": "text-embedding-004",
+                "model": "gemini-embedding-001",
                 "prefix": "",
                 "suffix": "",
                 "batch_size": 32,
@@ -148,7 +148,7 @@ class TestGoogleGenAIDocumentEmbedder:
         monkeypatch.setenv("GOOGLE_API_KEY", "fake-api-key")
         embedder = GoogleGenAIDocumentEmbedder.from_dict(data)
         assert embedder._api_key.resolve_value() == "fake-api-key"
-        assert embedder._model == "text-embedding-004"
+        assert embedder._model == "gemini-embedding-001"
         assert embedder._prefix == ""
         assert embedder._suffix == ""
         assert embedder._batch_size == 32
@@ -213,7 +213,7 @@ class TestGoogleGenAIDocumentEmbedder:
         # Mock the _embed_batch method to return fake embeddings
         def mock_embed_batch(texts_to_embed, batch_size):
             embeddings = [[0.1, 0.2, 0.3] for _ in texts_to_embed]
-            meta = {"model": "text-embedding-004"}
+            meta = {"model": "gemini-embedding-001"}
             return embeddings, meta
 
         embedder._embed_batch = mock_embed_batch
@@ -241,7 +241,7 @@ class TestGoogleGenAIDocumentEmbedder:
         # Mock the _embed_batch_async method to return fake embeddings
         async def mock_embed_batch_async(texts_to_embed, batch_size):
             embeddings = [[0.1, 0.2, 0.3] for _ in texts_to_embed]
-            meta = {"model": "text-embedding-004"}
+            meta = {"model": "gemini-embedding-001"}
             return embeddings, meta
 
         embedder._embed_batch_async = mock_embed_batch_async
@@ -267,7 +267,7 @@ class TestGoogleGenAIDocumentEmbedder:
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
 
-        model = "text-embedding-004"
+        model = "gemini-embedding-001"
 
         embedder = GoogleGenAIDocumentEmbedder(model=model, meta_fields_to_embed=["topic"], embedding_separator=" | ")
 
@@ -278,12 +278,10 @@ class TestGoogleGenAIDocumentEmbedder:
         for doc in documents_with_embeddings:
             assert isinstance(doc, Document)
             assert isinstance(doc.embedding, list)
-            assert len(doc.embedding) == 768
+            assert len(doc.embedding) == 3072
             assert all(isinstance(x, float) for x in doc.embedding)
 
-        assert "text" in result["meta"]["model"] and "004" in result["meta"]["model"], (
-            "The model name does not contain 'text' and '004'"
-        )
+        assert result["meta"]["model"] == model
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -297,7 +295,7 @@ class TestGoogleGenAIDocumentEmbedder:
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
 
-        model = "text-embedding-004"
+        model = "gemini-embedding-001"
 
         embedder = GoogleGenAIDocumentEmbedder(model=model, meta_fields_to_embed=["topic"], embedding_separator=" | ")
 
@@ -308,12 +306,9 @@ class TestGoogleGenAIDocumentEmbedder:
         for doc in documents_with_embeddings:
             assert isinstance(doc, Document)
             assert isinstance(doc.embedding, list)
-            assert len(doc.embedding) == 768
+            assert len(doc.embedding) == 3072
             assert all(isinstance(x, float) for x in doc.embedding)
 
-        assert "text" in result["meta"]["model"] and "004" in result["meta"]["model"], (
-            "The model name does not contain 'text' and '004'"
-        )
+        assert result["meta"]["model"] == model
         assert result["documents"][0].meta == {"topic": "Cuisine"}
         assert result["documents"][1].meta == {"topic": "ML"}
-        assert result["meta"] == {"model": model}

--- a/integrations/google_genai/tests/test_text_embedder.py
+++ b/integrations/google_genai/tests/test_text_embedder.py
@@ -17,7 +17,7 @@ class TestGoogleGenAITextEmbedder:
         embedder = GoogleGenAITextEmbedder()
 
         assert embedder._api_key.resolve_value() == "fake-api-key"
-        assert embedder._model_name == "text-embedding-004"
+        assert embedder._model_name == "gemini-embedding-001"
         assert embedder._prefix == ""
         assert embedder._suffix == ""
         assert embedder._config == {"task_type": "SEMANTIC_SIMILARITY"}
@@ -47,7 +47,7 @@ class TestGoogleGenAITextEmbedder:
             "type": "haystack_integrations.components.embedders.google_genai.text_embedder.GoogleGenAITextEmbedder",
             "init_parameters": {
                 "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"], "strict": False},
-                "model": "text-embedding-004",
+                "model": "gemini-embedding-001",
                 "prefix": "",
                 "suffix": "",
                 "config": {"task_type": "SEMANTIC_SIMILARITY"},
@@ -87,7 +87,7 @@ class TestGoogleGenAITextEmbedder:
             "type": "haystack_integrations.components.embedders.google_genai.text_embedder.GoogleGenAITextEmbedder",
             "init_parameters": {
                 "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"], "strict": False},
-                "model": "text-embedding-004",
+                "model": "gemini-embedding-001",
                 "prefix": "",
                 "suffix": "",
                 "config": {"task_type": "CLASSIFICATION"},
@@ -98,7 +98,7 @@ class TestGoogleGenAITextEmbedder:
         }
         component = GoogleGenAITextEmbedder.from_dict(data)
         assert component._api_key.resolve_value() == "fake-api-key"
-        assert component._model_name == "text-embedding-004"
+        assert component._model_name == "gemini-embedding-001"
         assert component._prefix == ""
         assert component._suffix == ""
         assert component._config == {"task_type": "CLASSIFICATION"}
@@ -110,7 +110,7 @@ class TestGoogleGenAITextEmbedder:
         contents = "The food was delicious"
         prepared_input = embedder._prepare_input(contents)
         assert prepared_input == {
-            "model": "text-embedding-004",
+            "model": "gemini-embedding-001",
             "contents": "The food was delicious",
             "config": EmbedContentConfig(
                 http_options=None,
@@ -133,7 +133,7 @@ class TestGoogleGenAITextEmbedder:
         result = embedder._prepare_output(result=response)
         assert result == {
             "embedding": [0.1, 0.2, 0.3],
-            "meta": {"model": "text-embedding-004"},
+            "meta": {"model": "gemini-embedding-001"},
         }
 
     def test_run_wrong_input_format(self):
@@ -150,17 +150,15 @@ class TestGoogleGenAITextEmbedder:
     )
     @pytest.mark.integration
     def test_run(self):
-        model = "text-embedding-004"
+        model = "gemini-embedding-001"
 
         embedder = GoogleGenAITextEmbedder(model=model)
         result = embedder.run(text="The food was delicious")
 
-        assert len(result["embedding"]) == 768
+        assert len(result["embedding"]) == 3072
         assert all(isinstance(x, float) for x in result["embedding"])
 
-        assert "text" in result["meta"]["model"] and "004" in result["meta"]["model"], (
-            "The model name does not contain 'text' and '004'"
-        )
+        assert result["meta"]["model"] == model
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -169,15 +167,12 @@ class TestGoogleGenAITextEmbedder:
     )
     @pytest.mark.integration
     async def test_run_async(self):
-        model = "text-embedding-004"
+        model = "gemini-embedding-001"
 
         embedder = GoogleGenAITextEmbedder(model=model)
         result = await embedder.run_async(text="The food was delicious")
 
-        assert len(result["embedding"]) == 768
+        assert len(result["embedding"]) == 3072
         assert all(isinstance(x, float) for x in result["embedding"])
 
-        assert "text" in result["meta"]["model"] and "004" in result["meta"]["model"], (
-            "The model name does not contain 'text' and '004'"
-        )
-        assert result["meta"] == {"model": model}
+        assert result["meta"]["model"] == model


### PR DESCRIPTION
### Related Issues
Failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/21808171728/job/62915074488

In our tests, we use Gemini API.

We were using `text-embedding-004` as a default
- removed from Gemini API ([source](https://ai.google.dev/gemini-api/docs/deprecations#embedding-models)); also `text-embedding-005` is not available on Gemini API, based on my tests (can't find official docs)
- still available on Vertex AI ([source](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#embeddings-models))

### Proposed Changes:
- switch default embedding model to `gemini-embedding-001` (available both in Gemini and Vertex APIs)

### How did you test it?
CI

### Notes for the reviewer
The most straightforward way to use this integration is via Gemini API and should work out of the box.

For Vertex AI, there is a risk of breaking some use cases if users don't explicitly set the model. **Let me know if you prefer me to release this with a major version bump.**

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
