### PR TITLE
docs(fastembed): remove explicit warm_up from examples

### DIFF
--- a/integrations/fastembed/examples/example.py
+++ b/integrations/fastembed/examples/example.py
@@ -14,7 +14,6 @@ documents = [
 ]
 
 document_embedder = FastembedDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_embeddings)
 

--- a/integrations/fastembed/examples/sparse_example.py
+++ b/integrations/fastembed/examples/sparse_example.py
@@ -25,7 +25,6 @@ document_list = [
 ]
 
 document_embedder = FastembedSparseDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(document_list)["documents"]
 
 for doc in documents_with_embeddings:


### PR DESCRIPTION
## Context

- Partially address #2751. 

Fastembed embedders auto-warm-up on first run, so explicit `warm_up()` calls in examples are no longer needed.

## Changes

- Remove explicit `warm_up()` in fastembed embedder example
- Remove explicit `warm_up()` in fastembed sparse embedder example
- Leave ranker example unchanged (ranker still requires manual warm-up)

## Testing

- Not run (docs/examples change only)
