### PR TITLE
ci: remove API reference generation from test workflows

### DIFF
--- a/.github/workflows/aimlapi.yml
+++ b/.github/workflows/aimlapi.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -63,10 +63,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run unit tests
         run: hatch run test:unit
 

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         env:
           ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -51,10 +51,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/azure_doc_intelligence.yml
+++ b/.github/workflows/azure_doc_intelligence.yml
@@ -51,10 +51,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run Chroma server on Linux/macOS
         if: matrix.os != 'windows-latest'
         run: hatch run chroma run &

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/cometapi.yml
+++ b/.github/workflows/cometapi.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -51,10 +51,6 @@ jobs:
       - name: Run ElasticSearch container
         run: docker compose up -d
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -37,10 +37,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -52,10 +52,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/google_genai.yml
+++ b/.github/workflows/google_genai.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/hanlp.yml
+++ b/.github/workflows/hanlp.yml
@@ -59,10 +59,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -60,10 +60,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -67,10 +67,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/llama_stack.yml
+++ b/.github/workflows/llama_stack.yml
@@ -116,10 +116,6 @@ jobs:
         if: matrix.python-version == '3.12' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.12' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -67,10 +67,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/meta_llama.yml
+++ b/.github/workflows/meta_llama.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -50,10 +50,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -55,10 +55,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -92,10 +92,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -51,10 +51,6 @@ jobs:
       - name: Run opensearch container
         run: docker compose up -d
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests (in parallel, using 4 cores)
         run: hatch run test:cov-retry -n 4  # GA runner has 4 cores
 

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -55,10 +55,6 @@ jobs:
         if: matrix.python-version == '3.13' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -57,10 +57,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -58,10 +58,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         env:
           INDEX_NAME: ${{ matrix.INDEX_NAME }}

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -54,10 +54,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/stackit.yml
+++ b/.github/workflows/stackit.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/togetherai.yml
+++ b/.github/workflows/togetherai.yml
@@ -53,10 +53,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -65,10 +65,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/valkey.yml
+++ b/.github/workflows/valkey.yml
@@ -59,10 +59,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/watsonx.yml
+++ b/.github/workflows/watsonx.yml
@@ -55,10 +55,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/weave.yml
+++ b/.github/workflows/weave.yml
@@ -50,10 +50,6 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -51,10 +51,6 @@ jobs:
       - name: Run Weaviate container
         run: docker compose up -d
 
-      - name: Generate docs
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
-        run: hatch run docs
-
       - name: Run tests
         run: hatch run test:cov-retry
 


### PR DESCRIPTION
### Related Issues

- follow up of #2829
- we no longer need to generate API reference in standard test workflows because we now do this in "Core / Check API reference changes" workflow

### Proposed Changes:
- remove API reference generation step from all test workflows

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
