### PR TITLE
test: Unstructured - free up more disk space

### DIFF
--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -38,6 +38,7 @@ jobs:
         working-directory: .
         run: |
           sudo docker image prune --all --force
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/local/lib/android /opt/hostedtoolcache/CodeQL
 
       - name: Run Unstructured API (docker)
         working-directory: .


### PR DESCRIPTION
### Related Issues

A new unstructured Docker image was recently released and it's larger than before, causing the CI to fail with no space left on device: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/21953077908/job/63409085291

### Proposed Changes:
- aggressively free up disk space on the GitHub runner

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
