### PR TITLE
docs(snowflake): remove explicit warm_up from examples

### DIFF
--- a/integrations/snowflake/src/haystack_integrations/components/retrievers/snowflake/snowflake_table_retriever.py
+++ b/integrations/snowflake/src/haystack_integrations/components/retrievers/snowflake/snowflake_table_retriever.py
@@ -39,7 +39,7 @@ class SnowflakeTableRetriever:
         db_schema="<SCHEMA-NAME>",
         warehouse="<WAREHOUSE-NAME>",
     )
-    executor.warm_up()
+    # Components warm up automatically on first run.
     ```
 
     #### Key-pair Authentication (MFA):
@@ -54,7 +54,7 @@ class SnowflakeTableRetriever:
         db_schema="<SCHEMA-NAME>",
         warehouse="<WAREHOUSE-NAME>",
     )
-    executor.warm_up()
+    # Components warm up automatically on first run.
     ```
 
     #### OAuth Authentication (MFA):
@@ -70,7 +70,7 @@ class SnowflakeTableRetriever:
         db_schema="<SCHEMA-NAME>",
         warehouse="<WAREHOUSE-NAME>",
     )
-    executor.warm_up()
+    # Components warm up automatically on first run.
     ```
 
     #### Running queries:


### PR DESCRIPTION
## Context

- Partially address #2751.

Snowflake components auto-warm-up on first run, so explicit `warm_up()` calls in examples are no longer needed.

## Changes

- Remove explicit `warm_up()` in `SnowflakeTableRetriever` docstring examples (Password, Key-pair, and OAuth authentication)

## Testing

- Ran `hatch run test:unit` to ensure no regressions.