### PR TITLE
docs: generate missing API reference for Chat Generator

### DIFF
--- a/integrations/llama_cpp/pydoc/config_docusaurus.yml
+++ b/integrations/llama_cpp/pydoc/config_docusaurus.yml
@@ -3,6 +3,7 @@ loaders:
   - __init__
   modules:
   - haystack_integrations.components.generators.llama_cpp.generator
+  - haystack_integrations.components.generators.llama_cpp.chat.chat_generator
   search_path:
   - ../src
   type: haystack_pydoc_tools.loaders.CustomPythonLoader


### PR DESCRIPTION
### Related Issues

Missing API reference for llama.cpp Chat Generator: https://docs.haystack.deepset.ai/reference/next/integrations-llama-cpp

### Proposed Changes:
- modify pydoc config to include it

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
