### PR TITLE
docs(nvidia): remove explicit warm_up from examples

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -30,7 +30,7 @@ class NvidiaDocumentEmbedder:
     doc = Document(content="I love pizza!")
 
     text_embedder = NvidiaDocumentEmbedder(model="nvidia/nv-embedqa-e5-v5", api_url="https://integrate.api.nvidia.com/v1")
-    text_embedder.warm_up()
+    # Components warm up automatically on first run.
 
     result = document_embedder.run([doc])
     print(result["documents"][0].embedding)

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -31,7 +31,7 @@ class NvidiaTextEmbedder:
     text_to_embed = "I love pizza!"
 
     text_embedder = NvidiaTextEmbedder(model="nvidia/nv-embedqa-e5-v5", api_url="https://integrate.api.nvidia.com/v1")
-    text_embedder.warm_up()
+    # Components warm up automatically on first run.
 
     print(text_embedder.run(text_to_embed))
     ```

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
@@ -31,7 +31,7 @@ class NvidiaGenerator:
             "max_tokens": 1024,
         },
     )
-    generator.warm_up()
+    # Components warm up automatically on first run.
 
     result = generator.run(prompt="What is the answer?")
     print(result["replies"])

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -31,7 +31,7 @@ class NvidiaRanker:
         model="nvidia/nv-rerankqa-mistral-4b-v3",
         api_key=Secret.from_env_var("NVIDIA_API_KEY"),
     )
-    ranker.warm_up()
+    # Components warm up automatically on first run.
 
     query = "What is the capital of Germany?"
     documents = [


### PR DESCRIPTION
## Context

- Partially addresses #2751

Nvidia components now auto-warm-up on first run, so explicit `warm_up()` calls in examples are redundant.

## Changes

* Removed explicit `warm_up()` calls from docstring examples in:

  * `NvidiaDocumentEmbedder`
  * `NvidiaTextEmbedder`
  * `NvidiaRanker`
  * `NvidiaGenerator`

## Testing

* Ran `hatch run test` — no regressions.