### PR TITLE
test: fix JinaDocumentImageEmbedder test

### DIFF
--- a/integrations/jina/tests/test_document_image_embedder.py
+++ b/integrations/jina/tests/test_document_image_embedder.py
@@ -263,6 +263,3 @@ class TestJinaDocumentImageEmbedder:
             assert len(doc.embedding) > 0  # Should have embedding dimensions
             assert all(isinstance(x, (int, float)) for x in doc.embedding)
             assert doc.meta["embedding_source"]["type"] == "image"
-
-            # Clean up
-            os.unlink(tmp_file.name)


### PR DESCRIPTION
### Related Issues

Failing nightly test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22081202480/job/63806571508

### Proposed Changes:
- do not explicitly remove the temporary file. This caused permission errors

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
