### PR TITLE
feat: use StreamingChunk.reasoning field in Ollama chat generator

### DIFF
--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -477,18 +477,19 @@ class TestUtils:
         assert result["replies"][0].meta["model"] == "qwen3:0.6b"
 
         assert len(streaming_chunks) == 14
-        assert streaming_chunks[0].meta["reasoning"] == "Okay"
-        assert streaming_chunks[1].meta["reasoning"] == ","
-        assert streaming_chunks[2].meta["reasoning"] == " the"
-        assert streaming_chunks[3].meta["reasoning"] == " user"
-        assert streaming_chunks[4].meta["reasoning"] == " is"
-        assert streaming_chunks[5].meta["reasoning"] == " asking"
-        assert streaming_chunks[6].meta["reasoning"] == " "
-        assert streaming_chunks[7].meta["reasoning"] == "2"
-        assert streaming_chunks[8].meta["reasoning"] == " plus"
-        assert streaming_chunks[9].meta["reasoning"] == " "
-        assert streaming_chunks[10].meta["reasoning"] == "2"
-        assert streaming_chunks[11].meta["reasoning"] == "."
+        assert streaming_chunks[0].reasoning is not None
+        assert streaming_chunks[0].reasoning.reasoning_text == "Okay"
+        assert streaming_chunks[1].reasoning.reasoning_text == ","
+        assert streaming_chunks[2].reasoning.reasoning_text == " the"
+        assert streaming_chunks[3].reasoning.reasoning_text == " user"
+        assert streaming_chunks[4].reasoning.reasoning_text == " is"
+        assert streaming_chunks[5].reasoning.reasoning_text == " asking"
+        assert streaming_chunks[6].reasoning.reasoning_text == " "
+        assert streaming_chunks[7].reasoning.reasoning_text == "2"
+        assert streaming_chunks[8].reasoning.reasoning_text == " plus"
+        assert streaming_chunks[9].reasoning.reasoning_text == " "
+        assert streaming_chunks[10].reasoning.reasoning_text == "2"
+        assert streaming_chunks[11].reasoning.reasoning_text == "."
 
         for i, chunk in enumerate(streaming_chunks):
             if i in [0, 12]:


### PR DESCRIPTION
## Summary

This mirrors the approach from #2849 (Anthropic) for the Ollama integration:

- Populate `StreamingChunk.reasoning` with `ReasoningContent` instead of stuffing thinking data into `meta["reasoning"]`
- Update the accumulation logic in both sync and async streaming handlers to read from `chunk.reasoning`
- Update test assertions accordingly

The Ollama case is simpler than Anthropic since there are no signatures or redacted thinking blocks — just a plain `message.thinking` string per chunk.

## Changes

- `_build_chunk()`: create `ReasoningContent` from the `thinking` field and pass it as the `reasoning` kwarg
- `_handle_streaming_response()` / `_handle_streaming_response_async()`: read `c.reasoning.reasoning_text` instead of `c.meta.get("reasoning")`
- Tests: assert on `chunk.reasoning.reasoning_text` instead of `chunk.meta["reasoning"]`

fixes deepset-ai/haystack#10481
Related: deepset-ai/haystack#9785 (parent tracking issue)