### PR TITLE
docs(llama_cpp): remove explicit warm_up calls

### DIFF
--- a/integrations/llama_cpp/examples/llama_cpp_generator_example.py
+++ b/integrations/llama_cpp/examples/llama_cpp_generator_example.py
@@ -1,7 +1,7 @@
 from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
 
 generator = LlamaCppGenerator(model="openchat-3.5-1210.Q3_K_S.gguf", n_ctx=512, n_batch=128)
-generator.warm_up()
+# Components warm up automatically on first run.
 
 question = "Who is the best American actor?"
 prompt = f"GPT4 Correct User: {question} <|end_of_turn|> GPT4 Correct Assistant:"

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -191,7 +191,6 @@ class LlamaCppChatGenerator:
         model_clip_path="mmproj-model-f16.gguf",  # CLIP model
         n_ctx=4096  # Larger context for image processing
     )
-    generator.warm_up()
 
     result = generator.run(messages)
     print(result)


### PR DESCRIPTION
## Context

- Partially addresses #2751

Llama.cpp components now auto-warm-up on first run, so explicit `warm_up()` calls in examples are redundant.

## Changes

* Removed explicit `warm_up()` call from docstring examples in:

  * `LlamaCppChatGenerator`

* Removed explicit `warm_up()` call from:

  * `examples/llama_cpp_generator_example.py`

## Testing

* Ran `hatch run test` (skipped locally due to missing build environment; relying on CI validation).