### PR TITLE
feat: Add ModelsLab integration (ModelsLabChatGenerator)

### DIFF
--- a/integrations/modelslab/README.md
+++ b/integrations/modelslab/README.md
@@ -1,0 +1,77 @@
+# modelslab-haystack
+
+[![PyPI](https://img.shields.io/pypi/v/modelslab-haystack)](https://pypi.org/project/modelslab-haystack/)
+
+[ModelsLab](https://modelslab.com) integration for [Haystack](https://haystack.deepset.ai/) — providing uncensored Llama 3.1 chat models with 128K context windows for RAG pipelines, agents, and LLM applications.
+
+## Installation
+
+```bash
+pip install modelslab-haystack
+```
+
+## Setup
+
+```bash
+export MODELSLAB_API_KEY="your-api-key"
+```
+
+Get your key at [modelslab.com](https://modelslab.com).
+
+## Usage
+
+### Basic chat
+
+```python
+from modelslab_haystack import ModelsLabChatGenerator
+from haystack.dataclasses import ChatMessage
+
+generator = ModelsLabChatGenerator(model="llama-3.1-8b-uncensored")
+
+messages = [ChatMessage.from_user("Explain retrieval-augmented generation.")]
+result = generator.run(messages=messages)
+print(result["replies"][0].text)
+```
+
+### In a RAG pipeline
+
+```python
+from haystack import Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from modelslab_haystack import ModelsLabChatGenerator
+
+pipeline = Pipeline()
+pipeline.add_component("retriever", InMemoryBM25Retriever(document_store=store))
+pipeline.add_component("prompt_builder", ChatPromptBuilder(template=template))
+pipeline.add_component("llm", ModelsLabChatGenerator(model="llama-3.1-70b-uncensored"))
+
+pipeline.connect("retriever.documents", "prompt_builder.documents")
+pipeline.connect("prompt_builder.prompt", "llm.messages")
+
+result = pipeline.run({"retriever": {"query": "What is RAG?"}})
+```
+
+### Streaming
+
+```python
+from haystack.dataclasses import ChatMessage
+
+def print_chunk(chunk):
+    print(chunk.content, end="", flush=True)
+
+generator = ModelsLabChatGenerator(streaming_callback=print_chunk)
+generator.run(messages=[ChatMessage.from_user("Write a haiku about AI.")])
+```
+
+## Models
+
+| Model | Context | Notes |
+|---|---|---|
+| `llama-3.1-8b-uncensored` | 128K | Default — fast, no content restrictions |
+| `llama-3.1-70b-uncensored` | 128K | Higher quality, deeper reasoning |
+
+## API Reference
+
+- ModelsLab docs: https://docs.modelslab.com/uncensored-chat
+- Haystack docs: https://docs.haystack.deepset.ai

--- a/integrations/modelslab/pyproject.toml
+++ b/integrations/modelslab/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "modelslab-haystack"
+version = "0.1.0"
+description = "ModelsLab integration for Haystack — uncensored Llama 3.1 models"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.9"
+keywords = ["modelslab", "haystack", "llm", "generative-ai", "uncensored", "llama"]
+authors = [
+    {name = "Your Name", email = "you@example.com"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "haystack-ai>=2.9.0",
+]
+
+[project.urls]
+Source = "https://github.com/deepset-ai/haystack-core-integrations"
+Documentation = "https://docs.modelslab.com"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/modelslab_haystack"]
+
+[tool.hatch.envs.default]
+dependencies = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests/}"
+cov = "pytest --cov=modelslab_haystack --cov-report=term-missing {args:tests/}"
+
+[tool.pytest.ini_options]
+addopts = "-v"
+
+[tool.ruff]
+line-length = 120

--- a/integrations/modelslab/src/modelslab_haystack/__init__.py
+++ b/integrations/modelslab/src/modelslab_haystack/__init__.py
@@ -1,0 +1,3 @@
+from modelslab_haystack.chat_generator import ModelsLabChatGenerator
+
+__all__ = ["ModelsLabChatGenerator"]

--- a/integrations/modelslab/src/modelslab_haystack/chat_generator.py
+++ b/integrations/modelslab/src/modelslab_haystack/chat_generator.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2024-present ModelsLab
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import StreamingCallbackT
+from haystack.tools import ToolsType
+from haystack.utils import Secret
+
+MODELSLAB_API_BASE = "https://modelslab.com/uncensored-chat/v1"
+MODELSLAB_DEFAULT_MODEL = "llama-3.1-8b-uncensored"
+
+
+@component
+class ModelsLabChatGenerator(OpenAIChatGenerator):
+    """
+    Completes chats using ModelsLab's uncensored Llama 3.1 models.
+
+    `ModelsLabChatGenerator` connects to ModelsLab's OpenAI-compatible API
+    to provide uncensored Llama 3.1 8B and 70B models with 128K context windows.
+    It extends `OpenAIChatGenerator` with ModelsLab-specific defaults, including
+    the correct ``api_base_url`` and ``MODELSLAB_API_KEY`` environment variable.
+
+    Models:
+        - ``llama-3.1-8b-uncensored`` — fast, efficient (default)
+        - ``llama-3.1-70b-uncensored`` — higher quality, deeper reasoning
+
+    Usage example:
+
+    ```python
+    from modelslab_haystack import ModelsLabChatGenerator
+    from haystack.dataclasses import ChatMessage
+
+    generator = ModelsLabChatGenerator()   # reads MODELSLAB_API_KEY from env
+
+    messages = [ChatMessage.from_user("Write a Python function to merge two sorted lists.")]
+    response = generator.run(messages=messages)
+    print(response["replies"][0].text)
+    ```
+
+    With streaming:
+
+    ```python
+    generator = ModelsLabChatGenerator(
+        model="llama-3.1-70b-uncensored",
+        streaming_callback=lambda chunk: print(chunk.content, end="", flush=True),
+    )
+    generator.run(messages=[ChatMessage.from_user("Explain transformers.")])
+    ```
+
+    Get your API key at: https://modelslab.com
+    API docs: https://docs.modelslab.com/uncensored-chat
+    """
+
+    def __init__(
+        self,
+        api_key: Secret = Secret.from_env_var("MODELSLAB_API_KEY"),
+        model: str = MODELSLAB_DEFAULT_MODEL,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        tools: ToolsType | None = None,
+        tools_strict: bool = False,
+        http_client_kwargs: dict[str, Any] | None = None,
+    ):
+        """
+        Initialize ``ModelsLabChatGenerator``.
+
+        :param api_key: ModelsLab API key.
+            Reads ``MODELSLAB_API_KEY`` from the environment by default.
+            Get your key at https://modelslab.com.
+        :param model: ModelsLab model to use.
+            Defaults to ``llama-3.1-8b-uncensored`` (128K context).
+            Also available: ``llama-3.1-70b-uncensored``.
+        :param streaming_callback: Optional callback for streaming responses.
+        :param generation_kwargs: Additional parameters for the API call
+            (e.g., ``temperature``, ``max_tokens``, ``top_p``).
+        :param timeout: Timeout in seconds for API requests.
+        :param max_retries: Number of retries on transient failures.
+        :param tools: Tools (functions) the model can call.
+        :param tools_strict: Whether to enforce strict tool schemas.
+        :param http_client_kwargs: Extra kwargs for the underlying httpx client.
+        """
+        super().__init__(
+            api_key=api_key,
+            model=model,
+            streaming_callback=streaming_callback,
+            api_base_url=MODELSLAB_API_BASE,
+            generation_kwargs=generation_kwargs,
+            timeout=timeout,
+            max_retries=max_retries,
+            tools=tools,
+            tools_strict=tools_strict,
+            http_client_kwargs=http_client_kwargs,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return default_to_dict(
+            self,
+            model=self.model,
+            streaming_callback=self.streaming_callback,
+            api_base_url=MODELSLAB_API_BASE,
+            generation_kwargs=self.generation_kwargs,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ModelsLabChatGenerator":
+        return default_from_dict(cls, data)

--- a/integrations/modelslab/tests/test_modelslab_chat_generator.py
+++ b/integrations/modelslab/tests/test_modelslab_chat_generator.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2024-present ModelsLab
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modelslab_haystack import ModelsLabChatGenerator
+from modelslab_haystack.chat_generator import MODELSLAB_API_BASE
+
+
+class TestModelsLabChatGeneratorInit:
+    """Test constructor and defaults."""
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_default_model(self):
+        gen = ModelsLabChatGenerator()
+        assert gen.model == "llama-3.1-8b-uncensored"
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_default_api_base(self):
+        gen = ModelsLabChatGenerator()
+        assert gen.api_base_url == MODELSLAB_API_BASE
+
+    def test_api_base_value(self):
+        assert MODELSLAB_API_BASE == "https://modelslab.com/uncensored-chat/v1"
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_custom_model(self):
+        gen = ModelsLabChatGenerator(model="llama-3.1-70b-uncensored")
+        assert gen.model == "llama-3.1-70b-uncensored"
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_inherits_openai_chat_generator(self):
+        from haystack.components.generators.chat import OpenAIChatGenerator
+        gen = ModelsLabChatGenerator()
+        assert isinstance(gen, OpenAIChatGenerator)
+
+    def test_explicit_api_key(self):
+        from haystack.utils import Secret
+        gen = ModelsLabChatGenerator(
+            api_key=Secret.from_token("explicit-key"),
+            model="llama-3.1-8b-uncensored",
+        )
+        assert gen.model == "llama-3.1-8b-uncensored"
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_generation_kwargs_passed_through(self):
+        gen = ModelsLabChatGenerator(
+            generation_kwargs={"temperature": 0.5, "max_tokens": 1024}
+        )
+        assert gen.generation_kwargs["temperature"] == 0.5
+        assert gen.generation_kwargs["max_tokens"] == 1024
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_streaming_callback_accepted(self):
+        callback = MagicMock()
+        gen = ModelsLabChatGenerator(streaming_callback=callback)
+        assert gen.model == "llama-3.1-8b-uncensored"
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_import_from_package(self):
+        from modelslab_haystack import ModelsLabChatGenerator as Gen
+        from modelslab_haystack.chat_generator import ModelsLabChatGenerator as GenBase
+        assert Gen is GenBase
+
+
+class TestModelsLabChatGeneratorSerialization:
+    """Test to_dict / from_dict round-trip."""
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_to_dict_contains_model(self):
+        gen = ModelsLabChatGenerator(model="llama-3.1-70b-uncensored")
+        d = gen.to_dict()
+        assert d["init_parameters"]["model"] == "llama-3.1-70b-uncensored"
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_to_dict_contains_api_base(self):
+        gen = ModelsLabChatGenerator()
+        d = gen.to_dict()
+        assert d["init_parameters"]["api_base_url"] == MODELSLAB_API_BASE
+
+    @patch.dict(os.environ, {"MODELSLAB_API_KEY": "test-key"})
+    def test_from_dict_round_trip(self):
+        gen = ModelsLabChatGenerator(model="llama-3.1-8b-uncensored")
+        d = gen.to_dict()
+        restored = ModelsLabChatGenerator.from_dict(d)
+        assert restored.model == "llama-3.1-8b-uncensored"
+        assert restored.api_base_url == MODELSLAB_API_BASE


### PR DESCRIPTION
# feat: Add ModelsLab integration (ModelsLabChatGenerator)

## Summary

Adds a new `modelslab-haystack` integration providing `ModelsLabChatGenerator` — a Haystack chat component backed by [ModelsLab's](https://modelslab.com) uncensored Llama 3.1 models with 128K context windows.

## What is ModelsLab?

ModelsLab is an AI API platform providing uncensored language models via an OpenAI-compatible endpoint — ideal for creative writing, research, and use cases where standard content restrictions are too limiting.

- Docs: https://docs.modelslab.com/uncensored-chat
- API key: https://modelslab.com/dashboard

## New Integration: `modelslab-haystack`

**Path:** `integrations/modelslab/`

| File | Description |
|---|---|
| `src/modelslab_haystack/chat_generator.py` | `ModelsLabChatGenerator` component |
| `src/modelslab_haystack/__init__.py` | Package exports |
| `pyproject.toml` | Package metadata (hatchling) |
| `README.md` | Basic + RAG + streaming examples |
| `tests/test_modelslab_chat_generator.py` | 12 test cases |

## Implementation

Subclasses `OpenAIChatGenerator` (same pattern as other OpenAI-compatible core integrations) with ModelsLab-specific defaults:

```python
@component
class ModelsLabChatGenerator(OpenAIChatGenerator):
    def __init__(
        self,
        api_key: Secret = Secret.from_env_var("MODELSLAB_API_KEY"),
        model: str = "llama-3.1-8b-uncensored",
        ...
    ):
        super().__init__(
            api_key=api_key,
            model=model,
            api_base_url="https://modelslab.com/uncensored-chat/v1",
            ...
        )
```

## Usage

```python
from modelslab_haystack import ModelsLabChatGenerator
from haystack.dataclasses import ChatMessage

generator = ModelsLabChatGenerator()
result = generator.run(messages=[ChatMessage.from_user("Hello!")])
```

## Models

| Model | Context |
|---|---|
| `llama-3.1-8b-uncensored` | 128K |
| `llama-3.1-70b-uncensored` | 128K |

## Tests

```bash
cd integrations/modelslab
hatch run test:all
```

12 test cases: defaults, custom model, API base, inheritance, explicit key, generation kwargs, streaming callback, import, `to_dict`/`from_dict` round-trip.

## Checklist

- [x] Subclasses `OpenAIChatGenerator` — inherits streaming, tools, async support automatically
- [x] `@component` decorator applied
- [x] `Secret.from_env_var("MODELSLAB_API_KEY")` for secure key handling
- [x] `to_dict` / `from_dict` serialization inherited and tested
- [x] Apache-2.0 license headers
- [x] `pyproject.toml` with hatchling build backend
- [x] README with basic, RAG pipeline, and streaming examples
- [x] No new dependencies beyond `haystack-ai`
