### PR TITLE
test: GitHub - make tests compatible with new Agent parameters

### DIFF
--- a/integrations/github/tests/test_file_editor_tool.py
+++ b/integrations/github/tests/test_file_editor_tool.py
@@ -204,10 +204,13 @@ class TestGitHubFileEditorTool:
             "connections": [],
             "connection_type_validation": True,
         }
-        if "confirmation_strategies" in pipeline_dict["components"]["agent"]["init_parameters"]:
-            expected_dict["components"]["agent"]["init_parameters"]["confirmation_strategies"] = pipeline_dict[
-                "components"
-            ]["agent"]["init_parameters"]["confirmation_strategies"]
+
+        # Compatibility with newer versions of Haystack that include these parameters
+        for key in ["confirmation_strategies", "required_variables", "user_prompt"]:
+            if key in pipeline_dict["components"]["agent"]["init_parameters"]:
+                expected_dict["components"]["agent"]["init_parameters"][key] = pipeline_dict["components"]["agent"][
+                    "init_parameters"
+                ][key]
 
         assert pipeline_dict == expected_dict
 


### PR DESCRIPTION
### Related Issues

- Nightly test with Haystack main are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22288517127/job/64471432908

### Proposed Changes:
- make tests compatible with new Agent parameters

### How did you test it?
Ran tests locally with Haystack main branch

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
