### PR TITLE
docs: Update Firecrawl module path in Docusaurus configuration

### DIFF
--- a/integrations/firecrawl/pydoc/config_docusaurus.yml
+++ b/integrations/firecrawl/pydoc/config_docusaurus.yml
@@ -1,6 +1,6 @@
 loaders:
   - modules:
-      - haystack_integrations.components.fetchers.firecrawl
+      - haystack_integrations.components.fetchers.firecrawl.firecrawl_crawler
     search_path: [../src]
 processors:
   - type: filter


### PR DESCRIPTION
### Related Issues

### Proposed Changes:

This PR fixes the path for the Firecrawl integration in the docusaurus configuration.
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
