### PR TITLE
test: fix Weaviate tests to include grpc_config

### DIFF
--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -212,6 +212,7 @@ class TestWeaviateDocumentStore(DocumentStoreBaseExtendedTests):
                         "session_pool_max_retries": 3,
                         "session_pool_timeout": 5,
                     },
+                    "grpc_config": None,
                     "proxies": {"http": "http://proxy:1234", "https": None, "grpc": None},
                     "timeout": [30, 90],
                     "trust_env": False,


### PR DESCRIPTION
### Related Issues

- failing nightly tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22375950763
- weaviate-python-client==4.20.0 was [released yesterday](https://github.com/weaviate/weaviate-python-client/blob/main/docs/changelog.rst#version-4200); it includes a new parameter: `grpc_config`

### Proposed Changes:
- fix Weaviate tests to include `grpc_config`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
