### PR TITLE
docs: add out of scope section to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,17 @@ In your message, please include:
 1. Reproducible steps to trigger the vulnerability.
 2. An explanation of what makes you think there is a vulnerability.
 3. Any information you may have on active exploitations of the vulnerability (zero-day).
+4. An explanation of why you believe the vulnerability is not out of scope. See the Out of Scope section below.
+
+We encourage reports that are meaningful, high-impact, and reviewed by a human before submission. Fully automated or AI-generated reports submitted without human review and validation are unlikely to meet this bar and risk being declined.
+
+## Out of Scope
+
+Haystack is a framework intended to run inside a trusted execution environment. It assumes that the application built with it has already validated and sanitized user-supplied input before passing it to the framework. Validation and sanitization of input, for example URLs, file paths, filter expressions, and queries, are the responsibility of the application, not Haystack.
+
+Any vulnerability that can only be triggered by passing unsanitized, attacker-controlled input to Haystack is considered out of scope. This reflects a conscious design decision after evaluating the trade-offs and risks: as a framework, Haystack cannot and should not enforce input validation on behalf of every application that uses it.
+
+If you are uncertain whether a finding falls within scope, feel free to reach out before submitting a full report.
 
 ## Vulnerability Response
 


### PR DESCRIPTION
### Related Issues

We updated the SECURITY.md in the haystack GitHub repo in https://github.com/deepset-ai/haystack/pull/10666 and should keep it in sync with the SECURITY.md in haystack-core-integrations

### Proposed Changes:

- Added a note about the scope of vulnerabilities and the importance of human-reviewed reports. In sync with changes in the haystack GitHub repository

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

Rudy reviewed and approved the changes offline.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
