### PR TITLE
ci: use hatch action

### DIFF
--- a/.github/workflows/CI_check_api_ref.yml
+++ b/.github/workflows/CI_check_api_ref.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Install Hatch
         if: steps.changed.outputs.integrations != '[]'
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Generate API references
         if: steps.changed.outputs.integrations != '[]'

--- a/.github/workflows/CI_docusaurus_sync.yml
+++ b/.github/workflows/CI_docusaurus_sync.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Get project folder
         id: pathfinder

--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -34,8 +34,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Hatch
+        uses: pypa/hatch@install          
+
       - name: Install dependencies
-        run: pip install hatch requests
+        run: pip install requests
 
       - name: Validate version number
         run: python .github/utils/validate_version.py --tag ${{ github.ref_name }}

--- a/.github/workflows/aimlapi.yml
+++ b/.github/workflows/aimlapi.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/azure_doc_intelligence.yml
+++ b/.github/workflows/azure_doc_intelligence.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/cometapi.yml
+++ b/.github/workflows/cometapi.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/firecrawl.yml
+++ b/.github/workflows/firecrawl.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/google_genai.yml
+++ b/.github/workflows/google_genai.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/hanlp.yml
+++ b/.github/workflows/hanlp.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
     # TODO: Once this integration is properly typed, use hatch run test:types
     # https://github.com/deepset-ai/haystack-core-integrations/issues/1771

--- a/.github/workflows/lara.yml
+++ b/.github/workflows/lara.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/llama_stack.yml
+++ b/.github/workflows/llama_stack.yml
@@ -110,7 +110,7 @@ jobs:
           curl -fsS http://localhost:8321/v1/models || { echo "Health check failed. Logs:"; cat server.log; exit 1; }
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.12' && runner.os == 'Linux'

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Set up Docker
         if: runner.os == 'Linux'

--- a/.github/workflows/meta_llama.yml
+++ b/.github/workflows/meta_llama.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -86,7 +86,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         # we check types with python 3.13 because with 3.9, the installation of some type stubs fails

--- a/.github/workflows/paddleocr.yml
+++ b/.github/workflows/paddleocr.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       # TODO: Once this integration is properly typed, use hatch run test:types
       # https://github.com/deepset-ai/haystack-core-integrations/issues/1771

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/stackit.yml
+++ b/.github/workflows/stackit.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/togetherai.yml
+++ b/.github/workflows/togetherai.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/valkey.yml
+++ b/.github/workflows/valkey.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/watsonx.yml
+++ b/.github/workflows/watsonx.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/weave.yml
+++ b/.github/workflows/weave.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        uses: pypa/hatch@install
 
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'


### PR DESCRIPTION
### Related Issues

- https://github.com/pypa/hatch/issues/2193
- similar to https://github.com/deepset-ai/haystack/pull/10679

### Proposed Changes:
- use the official Hatch Github action instead of `pip install hatch`
  - packaged by Hatch maintainers, reliable (not affected by incompatibility with virtualenv)
  - faster than pip install: speed up on all our workflows (on Ubuntu, 2s vs 10s; on Windows, 14s vs 30s)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
