### PR TITLE
feat: use reasoning field in StreamingChunk for Bedrock

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -480,13 +480,15 @@ def _convert_event_to_streaming_chunk(
             reasoning_content = delta["reasoningContent"]
             if "redactedContent" in reasoning_content:
                 reasoning_content["redacted_content"] = reasoning_content.pop("redactedContent")
+            reasoning_text = reasoning_content.get("text", "")
             streaming_chunk = StreamingChunk(
                 content="",
                 index=block_idx,
-                meta={
-                    **base_meta,
-                    "reasoning_contents": [{"index": block_idx, "reasoning_content": reasoning_content}],
-                },
+                reasoning=ReasoningContent(
+                    reasoning_text=reasoning_text,
+                    extra={"reasoning_contents": [{"index": block_idx, "reasoning_content": reasoning_content}]},
+                ),
+                meta=base_meta,
             )
 
     elif "messageStop" in event:
@@ -537,7 +539,10 @@ def _process_reasoning_contents(chunks: list[StreamingChunk]) -> ReasoningConten
     reasoning_signature = None
     redacted_content = None
     for chunk in chunks:
-        reasoning_contents = chunk.meta.get("reasoning_contents", [])
+        if chunk.reasoning and chunk.reasoning.extra:
+            reasoning_contents = chunk.reasoning.extra.get("reasoning_contents", [])
+        else:
+            reasoning_contents = []
 
         for reasoning_content in reasoning_contents:
             content_block_index = reasoning_content["index"]

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -1102,6 +1102,12 @@ class TestAmazonBedrockChatGeneratorUtils:
         ]
         assert replies == expected_messages
 
+        # Verify streaming chunks carry reasoning in the reasoning field, not in meta
+        reasoning_chunks = [c for c in streaming_chunks if c.reasoning is not None]
+        assert len(reasoning_chunks) > 0
+        for chunk in reasoning_chunks:
+            assert "reasoning_contents" not in chunk.meta
+
     def test_process_streaming_response_with_one_tool_call_with_redacted_thinking(self, mock_boto3_session):
         model = "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-sonnet-3-7-20250219-v1:0"
         type_ = (


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack#10480

### Proposed Changes:

Populate `StreamingChunk.reasoning` with `ReasoningContent` instead of storing reasoning content deltas in `meta["reasoning_contents"]`. This aligns the Bedrock integration with the standard `StreamingChunk.reasoning` field, consistent with other integrations (Ollama in #2850, Google GenAI in #2900).

Changes:
- `_process_streaming_event()`: Create `ReasoningContent` with reasoning text and Bedrock-specific block data in `extra`, pass via `reasoning` kwarg instead of `meta["reasoning_contents"]`
- `_process_reasoning_contents()`: Read from `chunk.reasoning.extra["reasoning_contents"]` instead of `chunk.meta["reasoning_contents"]`

### How did you test it?

- All 23 existing unit tests pass
- Added assertion in `test_process_streaming_response_one_tool_call_with_thinking` verifying streaming chunks carry reasoning in `chunk.reasoning` and not in `chunk.meta`

### Notes for the reviewer

The `extra` field on `ReasoningContent` preserves the Bedrock-specific structure (block indices, signatures, redacted content) needed for round-tripping with the Bedrock API.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.