### PR TITLE
feat: Add Azure AI Search document store metadata operations

### DIFF
--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -91,6 +91,18 @@ logger = logging.getLogger(__name__)
 python_logging.getLogger("azure").setLevel(python_logging.ERROR)
 python_logging.getLogger("azure.identity").setLevel(python_logging.DEBUG)
 
+SPECIAL_FIELDS = {"id", "embedding"}
+FIELD_TYPE_MAPPING = {
+    "Edm.String": "keyword",
+    "Edm.Boolean": "boolean",
+    "Edm.Int16": "long",
+    "Edm.Int32": "long",
+    "Edm.Int64": "long",
+    "Edm.Single": "double",
+    "Edm.Double": "double",
+    "Edm.DateTimeOffset": "date",
+}
+
 
 class AzureAISearchDocumentStore:
     def __init__(
@@ -347,6 +359,197 @@ class AzureAISearchDocumentStore:
         :returns: list of retrieved documents.
         """
         return self.client.get_document_count()
+
+    @staticmethod
+    def _normalize_metadata_field_name(metadata_field: str) -> str:
+        """
+        Normalizes a metadata field name by removing the `meta.` prefix if present.
+        """
+        return metadata_field[5:] if metadata_field.startswith("meta.") else metadata_field
+
+    def _get_index_schema_fields(self) -> dict[str, Any]:
+        """
+        Returns the index schema fields keyed by field name.
+        """
+        _ = self.client
+        if self._index_client is None:
+            msg = "Search Index Client is not initialized."
+            raise AzureAISearchDocumentStoreConfigError(msg)
+
+        index_fields = self._index_client.get_index(self._index_name).fields
+        return {field.name: field for field in index_fields}
+
+    def _validate_index_fields(self, field_names: list[str]) -> None:
+        """
+        Validates that all provided field names exist in the index schema.
+        """
+        if not self._index_fields:
+            self._index_fields = list(self._get_index_schema_fields().keys())
+
+        missing_fields = [field for field in field_names if field not in self._index_fields]
+        if missing_fields:
+            msg = f"Fields {missing_fields} are not defined in index schema. Available fields: {self._index_fields}"
+            raise ValueError(msg)
+
+    def _fetch_raw_documents(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        select: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Fetches raw Azure documents, optionally filtered and projected to selected fields.
+        """
+        normalized_filters = _normalize_filters(filters) if filters else None
+        result = self.client.search(search_text="*", filter=normalized_filters, select=select, top=BIG_TOP_K)
+        return list(result)
+
+    @staticmethod
+    def _collect_unique_values(documents: list[dict[str, Any]], field_name: str) -> set[Any]:
+        """
+        Collects unique field values from Azure documents.
+        """
+        unique_values: set[Any] = set()
+        for document in documents:
+            value = document.get(field_name)
+            if isinstance(value, list):
+                unique_values.update(value)
+            elif value is not None:
+                unique_values.add(value)
+        return unique_values
+
+    @staticmethod
+    def _get_min_max_from_documents(documents: list[dict[str, Any]], field_name: str) -> dict[str, Any]:
+        """
+        Computes min and max values for a field from Azure documents.
+        """
+        values: list[bool | int | float | str | datetime] = []
+        for document in documents:
+            value = document.get(field_name)
+            if isinstance(value, (bool, int, float, str, datetime)):
+                values.append(value)
+
+        if not values:
+            return {"min": None, "max": None}
+
+        return {"min": min(values), "max": max(values)}
+
+    @staticmethod
+    def _map_azure_field_type(field: Any) -> str:
+        """
+        Maps Azure Search field definitions to Haystack metadata field types.
+        """
+        field_type = getattr(field, "type", None)
+        if field.name == "content":
+            return "text"
+        if field_type is None:
+            return "keyword"
+
+        field_type_name = str(field_type)
+        if field_type_name.startswith("Collection("):
+            inner_type = field_type_name[len("Collection(") : -1]
+            return FIELD_TYPE_MAPPING.get(inner_type, "keyword")
+
+        if field_type_name == "Edm.String" and getattr(field, "searchable", False):
+            return "text"
+
+        return FIELD_TYPE_MAPPING.get(field_type_name, "keyword")
+
+    def count_documents_by_filter(self, filters: dict[str, Any]) -> int:
+        """
+        Returns the count of documents that match the provided filters.
+
+        :param filters: The filters to apply to the document list.
+            For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
+        :returns: The number of documents that match the filters.
+        """
+        normalized_filters = _normalize_filters(filters)
+        result = self.client.search(
+            search_text="*",
+            filter=normalized_filters,
+            select=["id"],
+            top=1,
+            include_total_count=True,
+        )
+        count = result.get_count()
+        return count if count is not None else len(self._fetch_raw_documents(filters=filters, select=["id"]))
+
+    def count_unique_metadata_by_filter(self, filters: dict[str, Any], metadata_fields: list[str]) -> dict[str, int]:
+        """
+        Counts unique values for each specified metadata field in documents matching the filters.
+
+        :param filters: The filters to apply to select documents.
+        :param metadata_fields: List of field names to count unique values for.
+        :returns: Dictionary mapping field names to counts of unique values.
+        """
+        normalized_metadata_fields = [self._normalize_metadata_field_name(field) for field in metadata_fields]
+        self._validate_index_fields(normalized_metadata_fields)
+
+        documents = self._fetch_raw_documents(filters=filters, select=normalized_metadata_fields)
+        return {
+            field_name: len(self._collect_unique_values(documents, field_name))
+            for field_name in normalized_metadata_fields
+        }
+
+    def get_metadata_fields_info(self) -> dict[str, dict[str, str]]:
+        """
+        Returns the information about metadata fields in the index.
+
+        :returns: Dictionary mapping field names to type information.
+        """
+        schema_fields = self._get_index_schema_fields()
+        return {
+            name: {"type": self._map_azure_field_type(field)}
+            for name, field in schema_fields.items()
+            if name not in SPECIAL_FIELDS
+        }
+
+    def get_metadata_field_min_max(self, metadata_field: str) -> dict[str, Any]:
+        """
+        Returns the minimum and maximum values for the given metadata field.
+
+        :param metadata_field: The metadata field to get the minimum and maximum values for.
+        :returns: A dictionary with the keys "min" and "max".
+        """
+        field_name = self._normalize_metadata_field_name(metadata_field)
+        self._validate_index_fields([field_name])
+
+        documents = self._fetch_raw_documents(select=[field_name])
+        return self._get_min_max_from_documents(documents, field_name)
+
+    def get_metadata_field_unique_values(
+        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+    ) -> tuple[list[str], int]:
+        """
+        Retrieves unique values for a metadata field with optional search and pagination.
+
+        :param metadata_field: The metadata field to get unique values for.
+        :param search_term: Optional search term to filter unique values.
+        :param from_: Starting offset for pagination.
+        :param size: Number of values to return.
+        :returns: Tuple of (list of unique values, total count of matching values).
+        """
+        field_name = self._normalize_metadata_field_name(metadata_field)
+        self._validate_index_fields([field_name])
+
+        documents = self._fetch_raw_documents(select=[field_name])
+        unique_values = sorted(str(value) for value in self._collect_unique_values(documents, field_name))
+
+        if search_term:
+            normalized_search_term = search_term.lower()
+            unique_values = [value for value in unique_values if normalized_search_term in value.lower()]
+
+        total_count = len(unique_values)
+        return unique_values[from_ : from_ + size], total_count
+
+    def query_sql(self, query: str) -> Any:
+        """
+        Executes an SQL query if supported by the document store backend.
+
+        Azure AI Search does not support SQL queries.
+        """
+        msg = f"Azure AI Search does not support SQL queries: {query}"
+        raise NotImplementedError(msg)
 
     def write_documents(self, documents: list[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE) -> int:
         """

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -5,10 +5,17 @@
 import os
 import random
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
-from azure.search.documents.indexes.models import CustomAnalyzer, SearchField, SearchResourceEncryptionKey, SimpleField
+from azure.search.documents.indexes.models import (
+    CustomAnalyzer,
+    SearchableField,
+    SearchField,
+    SearchFieldDataType,
+    SearchResourceEncryptionKey,
+    SimpleField,
+)
 from haystack.dataclasses.document import Document
 from haystack.errors import FilterError
 from haystack.testing.document_store import (
@@ -234,6 +241,128 @@ def test_init():
     assert document_store._vector_search_configuration == DEFAULT_VECTOR_SEARCH
 
 
+def _build_mock_document_store_with_schema(index_fields):
+    store = AzureAISearchDocumentStore(
+        api_key=Secret.from_token("fake-api-key"),
+        azure_endpoint=Secret.from_token("fake-endpoint"),
+        index_name="test-index",
+    )
+    search_client = Mock()
+    index_client = Mock()
+    index_client.list_index_names.return_value = ["test-index"]
+    index_client.get_index.return_value = Mock(fields=index_fields)
+    index_client.get_search_client.return_value = search_client
+    store._index_client = index_client
+    return store, search_client, index_client
+
+
+def test_count_documents_by_filter():
+    index_fields = [
+        SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+        SimpleField(name="category", type=SearchFieldDataType.String, filterable=True),
+    ]
+    document_store, search_client, _ = _build_mock_document_store_with_schema(index_fields)
+    count_result = Mock()
+    count_result.get_count.return_value = 3
+    search_client.search.return_value = count_result
+
+    count = document_store.count_documents_by_filter({"field": "meta.category", "operator": "==", "value": "news"})
+
+    assert count == 3
+    search_client.search.assert_called_once()
+    assert search_client.search.call_args.kwargs["include_total_count"] is True
+
+
+def test_count_unique_metadata_by_filter():
+    index_fields = [
+        SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+        SimpleField(name="category", type=SearchFieldDataType.String, filterable=True),
+        SimpleField(name="status", type=SearchFieldDataType.String, filterable=True),
+    ]
+    document_store, search_client, _ = _build_mock_document_store_with_schema(index_fields)
+    search_client.search.return_value = [
+        {"category": "news", "status": "draft"},
+        {"category": "docs", "status": "draft"},
+        {"category": "news", "status": "published"},
+    ]
+
+    counts = document_store.count_unique_metadata_by_filter(
+        filters={"field": "meta.status", "operator": "!=", "value": "archived"},
+        metadata_fields=["meta.category", "status"],
+    )
+
+    assert counts == {"category": 2, "status": 2}
+
+
+def test_get_metadata_fields_info():
+    index_fields = [
+        SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+        SimpleField(name="category", type=SearchFieldDataType.String, filterable=True),
+        SimpleField(name="status", type=SearchFieldDataType.String, filterable=True),
+        SimpleField(name="priority", type=SearchFieldDataType.Int32, filterable=True),
+    ]
+    document_store, _, _ = _build_mock_document_store_with_schema(index_fields)
+
+    info = document_store.get_metadata_fields_info()
+
+    assert info == {
+        "content": {"type": "text"},
+        "category": {"type": "keyword"},
+        "status": {"type": "keyword"},
+        "priority": {"type": "long"},
+    }
+
+
+def test_get_metadata_field_min_max():
+    index_fields = [
+        SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+        SimpleField(name="priority", type=SearchFieldDataType.Int32, filterable=True),
+    ]
+    document_store, search_client, _ = _build_mock_document_store_with_schema(index_fields)
+    search_client.search.return_value = [{"priority": 10}, {"priority": 2}, {"priority": 7}]
+
+    result = document_store.get_metadata_field_min_max("meta.priority")
+
+    assert result == {"min": 2, "max": 10}
+
+
+def test_get_metadata_field_unique_values():
+    index_fields = [
+        SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+        SimpleField(name="category", type=SearchFieldDataType.String, filterable=True),
+    ]
+    document_store, search_client, _ = _build_mock_document_store_with_schema(index_fields)
+    search_client.search.return_value = [
+        {"category": "news"},
+        {"category": "docs"},
+        {"category": "api"},
+        {"category": "news"},
+    ]
+
+    values, total_count = document_store.get_metadata_field_unique_values(
+        metadata_field="meta.category", search_term="d", from_=0, size=10
+    )
+
+    assert values == ["docs"]
+    assert total_count == 1
+
+
+def test_query_sql_raises_not_implemented():
+    document_store = AzureAISearchDocumentStore(
+        api_key=Secret.from_token("fake-api-key"),
+        azure_endpoint=Secret.from_token("fake-endpoint"),
+        index_name="test-index",
+    )
+
+    with pytest.raises(NotImplementedError, match="does not support SQL queries"):
+        document_store.query_sql("SELECT * FROM test-index")
+
+
 def _assert_documents_are_equal(received: list[Document], expected: list[Document]):
     """
     Assert that two lists of Documents are equal.
@@ -396,6 +525,101 @@ class TestDocumentStore(
             )
         assert "nonexistent_field" in str(exc_info.value)
         assert "not defined in index schema" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str, "status": str, "priority": int}}],
+        indirect=True,
+    )
+    def test_count_documents_by_filter_integration(self, document_store: AzureAISearchDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "news", "status": "draft", "priority": 1}),
+            Document(content="Doc 2", meta={"category": "news", "status": "published", "priority": 2}),
+            Document(content="Doc 3", meta={"category": "docs", "status": "draft", "priority": 3}),
+        ]
+        document_store.write_documents(docs)
+
+        count = document_store.count_documents_by_filter({"field": "meta.category", "operator": "==", "value": "news"})
+
+        assert count == 2
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str, "status": str, "priority": int}}],
+        indirect=True,
+    )
+    def test_count_unique_metadata_by_filter_integration(self, document_store: AzureAISearchDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "news", "status": "draft", "priority": 1}),
+            Document(content="Doc 2", meta={"category": "news", "status": "published", "priority": 2}),
+            Document(content="Doc 3", meta={"category": "docs", "status": "draft", "priority": 3}),
+        ]
+        document_store.write_documents(docs)
+
+        counts = document_store.count_unique_metadata_by_filter(
+            filters={"field": "meta.priority", "operator": ">=", "value": 1},
+            metadata_fields=["meta.category", "status"],
+        )
+
+        assert counts == {"category": 2, "status": 2}
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str, "status": str, "priority": int}}],
+        indirect=True,
+    )
+    def test_get_metadata_fields_info_integration(self, document_store: AzureAISearchDocumentStore):
+        info = document_store.get_metadata_fields_info()
+
+        assert info["content"] == {"type": "text"}
+        assert info["category"] == {"type": "keyword"}
+        assert info["status"] == {"type": "keyword"}
+        assert info["priority"] == {"type": "long"}
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str, "status": str, "priority": int}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_min_max_integration(self, document_store: AzureAISearchDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "news", "status": "draft", "priority": 1}),
+            Document(content="Doc 2", meta={"category": "news", "status": "published", "priority": 8}),
+            Document(content="Doc 3", meta={"category": "docs", "status": "draft", "priority": 3}),
+        ]
+        document_store.write_documents(docs)
+
+        result = document_store.get_metadata_field_min_max("meta.priority")
+
+        assert result == {"min": 1, "max": 8}
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str, "status": str, "priority": int}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_integration(self, document_store: AzureAISearchDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "news", "status": "draft", "priority": 1}),
+            Document(content="Doc 2", meta={"category": "guides", "status": "published", "priority": 8}),
+            Document(content="Doc 3", meta={"category": "docs", "status": "draft", "priority": 3}),
+            Document(content="Doc 4", meta={"category": "news", "status": "archived", "priority": 10}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total_count = document_store.get_metadata_field_unique_values(
+            metadata_field="meta.category",
+            search_term="d",
+            from_=0,
+            size=10,
+        )
+
+        assert values == ["docs", "guides"]
+        assert total_count == 2
+
+    def test_query_sql_integration(self, document_store: AzureAISearchDocumentStore):
+        with pytest.raises(NotImplementedError, match="does not support SQL queries"):
+            document_store.query_sql("SELECT * FROM documents")
 
 
 def _random_embeddings(n):


### PR DESCRIPTION
### Related Issues

- fixes #2642

### Proposed Changes:

Added the missing document store capability methods to `AzureAISearchDocumentStore`:

- `count_documents_by_filter`
- `count_unique_metadata_by_filter`
- `get_metadata_fields_info`
- `get_metadata_field_min_max`
- `get_metadata_field_unique_values`
- `query_sql`

The new metadata-related methods accept field names with or without the `meta.` prefix and normalize them to the flat Azure AI Search field names used in the index schema.

Implementation details:
- added helpers to normalize metadata field names, fetch index schema fields, and validate requested fields
- added filtered document counting using Azure AI Search `include_total_count`
- added Python-side aggregation for unique metadata counts, min/max, and unique value extraction
- added Azure EDM to Haystack/OpenSearch-style type mapping for `get_metadata_fields_info`
- implemented `query_sql` as an explicit unsupported operation by raising `NotImplementedError`, since Azure AI Search does not support SQL queries

### How did you test it?

- added unit tests for all newly introduced methods in `tests/test_document_store.py`
- added integration tests for all newly introduced methods in `tests/test_document_store.py`
- ran unit tests with:
  - `hatch run test:unit`
  - hatch run test:integration -rs -vv
 ```
tests/test_bm25_retriever.py::TestRetriever::test_run PASSED                                                                               [  1%]
tests/test_bm25_retriever.py::TestRetriever::test_run_with_search_metadata[document_store0] PASSED                                         [  2%]
tests/test_bm25_retriever.py::TestRetriever::test_document_retrieval PASSED                                                                [  3%]
tests/test_document_store.py::TestDocumentStore::test_write_documents_duplicate_overwrite <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [  5%]
tests/test_document_store.py::TestDocumentStore::test_write_documents_invalid_input <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [  6%]
tests/test_document_store.py::TestDocumentStore::test_delete_all_documents <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [  7%]
tests/test_document_store.py::TestDocumentStore::test_delete_all_documents_empty_store <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [  8%]
tests/test_document_store.py::TestDocumentStore::test_delete_all_documents_without_recreate_index <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py SKIPPED [ 10%]
tests/test_document_store.py::TestDocumentStore::test_delete_all_documents_with_recreate_index <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py SKIPPED [ 11%]
tests/test_document_store.py::TestDocumentStore::test_delete_documents <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 12%]
tests/test_document_store.py::TestDocumentStore::test_delete_documents_empty_document_store <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 13%]
tests/test_document_store.py::TestDocumentStore::test_delete_documents_non_existing_document <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 15%]
tests/test_document_store.py::TestDocumentStore::test_count_empty <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 16%]
tests/test_document_store.py::TestDocumentStore::test_count_not_empty <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 17%]
tests/test_document_store.py::TestDocumentStore::test_write_documents PASSED                                                               [ 18%]
tests/test_document_store.py::TestDocumentStore::test_write_documents_with_meta[document_store0] PASSED                                    [ 20%]
tests/test_document_store.py::TestDocumentStore::test_write_documents_duplicate_fail SKIPPED (Azure AI search index overwrites duplicate
documents by default)                                                                                                                      [ 21%]
tests/test_document_store.py::TestDocumentStore::test_write_documents_duplicate_skip SKIPPED (Azure AI search index overwrites duplicate
documents by default)                                                                                                                      [ 22%]
tests/test_document_store.py::TestDocumentStore::test_delete_by_filter[document_store0] PASSED                                             [ 23%]
tests/test_document_store.py::TestDocumentStore::test_delete_by_filter_no_matches[document_store0] PASSED                                  [ 25%]
tests/test_document_store.py::TestDocumentStore::test_delete_by_filter_advanced_filters[document_store0] PASSED                            [ 26%]
tests/test_document_store.py::TestDocumentStore::test_update_by_filter[document_store0] PASSED                                             [ 27%]
tests/test_document_store.py::TestDocumentStore::test_update_by_filter_no_matches[document_store0] PASSED                                  [ 28%]
tests/test_document_store.py::TestDocumentStore::test_update_by_filter_multiple_fields[document_store0] PASSED                             [ 30%]
tests/test_document_store.py::TestDocumentStore::test_update_by_filter_advanced_filters[document_store0] PASSED                            [ 31%]
tests/test_document_store.py::TestDocumentStore::test_update_by_filter_invalid_field[document_store0] PASSED                               [ 32%]
tests/test_document_store.py::TestDocumentStore::test_count_documents_by_filter_integration[document_store0] PASSED                        [ 33%]
tests/test_document_store.py::TestDocumentStore::test_count_unique_metadata_by_filter_integration[document_store0] PASSED                  [ 35%]
tests/test_document_store.py::TestDocumentStore::test_get_metadata_fields_info_integration[document_store0] PASSED                         [ 36%]
tests/test_document_store.py::TestDocumentStore::test_get_metadata_field_min_max_integration[document_store0] PASSED                       [ 37%]
tests/test_document_store.py::TestDocumentStore::test_get_metadata_field_unique_values_integration[document_store0] PASSED                 [ 38%]
tests/test_document_store.py::TestDocumentStore::test_query_sql_integration PASSED                                                         [ 40%]
tests/test_document_store.py::TestFilters::test_no_filters[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 41%]
tests/test_document_store.py::TestFilters::test_comparison_equal[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 42%]
tests/test_document_store.py::TestFilters::test_comparison_equal_with_none[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 43%]
tests/test_document_store.py::TestFilters::test_comparison_not_equal[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 45%]
tests/test_document_store.py::TestFilters::test_comparison_not_equal_with_none[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 46%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 47%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_with_string[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 48%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_with_list[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 50%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_equal[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 51%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_equal_with_string[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 52%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_equal_with_list[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 53%]
tests/test_document_store.py::TestFilters::test_comparison_less_than[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 55%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_with_string[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 56%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_with_list[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 57%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_equal[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 58%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_equal_with_string[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 60%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_equal_with_list[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 61%]
tests/test_document_store.py::TestFilters::test_comparison_in_with_with_non_list[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 62%]
tests/test_document_store.py::TestFilters::test_comparison_in_with_with_non_list_iterable[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 63%]
tests/test_document_store.py::TestFilters::test_and_operator[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 65%]
tests/test_document_store.py::TestFilters::test_or_operator[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 66%]
tests/test_document_store.py::TestFilters::test_not_operator[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 67%]
tests/test_document_store.py::TestFilters::test_missing_top_level_operator_key[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 68%]
tests/test_document_store.py::TestFilters::test_missing_top_level_conditions_key[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 70%]
tests/test_document_store.py::TestFilters::test_missing_condition_field_key[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 71%]
tests/test_document_store.py::TestFilters::test_missing_condition_value_key[document_store0] <- ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py PASSED [ 72%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_with_iso_date[document_store0] PASSED                              [ 73%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_equal_with_iso_date[document_store0] PASSED                        [ 75%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_with_iso_date[document_store0] PASSED                                 [ 76%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_equal_with_iso_date[document_store0] PASSED                           [ 77%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_with_none[document_store0] PASSED                                  [ 78%]
tests/test_document_store.py::TestFilters::test_comparison_greater_than_equal_with_none[document_store0] PASSED                            [ 80%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_with_none[document_store0] PASSED                                     [ 81%]
tests/test_document_store.py::TestFilters::test_comparison_less_than_equal_with_none[document_store0] PASSED                               [ 82%]
tests/test_document_store.py::TestFilters::test_comparison_in[document_store0] PASSED                                                      [ 83%]
tests/test_document_store.py::TestFilters::test_comparison_not_in[document_store0] SKIPPED (Azure AI search index does not support not in
operator)                                                                                                                                  [ 85%]
tests/test_document_store.py::TestFilters::test_comparison_not_in_with_with_non_list[document_store0] SKIPPED (Azure AI search index does
not support not in operator)                                                                                                               [ 86%]
tests/test_document_store.py::TestFilters::test_comparison_not_in_with_with_non_list_iterable[document_store0] SKIPPED (Azure AI search
index does not support not in operator)                                                                                                    [ 87%]
tests/test_document_store.py::TestFilters::test_missing_condition_operator_key[document_store0] PASSED                                     [ 88%]
tests/test_document_store.py::TestFilters::test_nested_logical_filters[document_store0] PASSED                                             [ 90%]
tests/test_embedding_retriever.py::TestRetriever::test_run PASSED                                                                          [ 91%]
tests/test_embedding_retriever.py::TestRetriever::test_embedding_retrieval PASSED                                                          [ 92%]
tests/test_embedding_retriever.py::TestRetriever::test_empty_query_embedding PASSED                                                        [ 93%]
tests/test_embedding_retriever.py::TestRetriever::test_query_embedding_wrong_dimension PASSED                                              [ 95%]
tests/test_hybrid_retriever.py::TestRetriever::test_run PASSED                                                                             [ 96%]
tests/test_hybrid_retriever.py::TestRetriever::test_hybrid_retrieval PASSED                                                                [ 97%]
tests/test_hybrid_retriever.py::TestRetriever::test_empty_query_embedding PASSED                                                           [ 98%]
tests/test_hybrid_retriever.py::TestRetriever::test_query_embedding_wrong_dimension PASSED                                                 [100%]

============================================================ short test summary info =============================================================
SKIPPED [1] ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py:674: delete_all_documents has no recreate_index or recreate_collection parameter
SKIPPED [1] ../../../../../Library/Application Support/hatch/env/virtual/azure-ai-search-haystack/qinczEFb/test/lib/python3.14/site-packages/haystack/testing/document_store.py:696: delete_all_documents has no recreate_index or recreate_collection parameter
SKIPPED [1] tests/test_document_store.py:428: Azure AI search index overwrites duplicate documents by default
SKIPPED [1] tests/test_document_store.py:431: Azure AI search index overwrites duplicate documents by default
SKIPPED [1] tests/test_document_store.py:809: Azure AI search index does not support not in operator
SKIPPED [1] tests/test_document_store.py:812: Azure AI search index does not support not in operator
SKIPPED [1] tests/test_document_store.py:815: Azure AI search index does not support not in operator
=========================================== 73 passed, 7 skipped, 30 deselected in 1114.09s (0:18:34) ============================================

```
### Notes for the reviewer

- `get_metadata_fields_info()` intentionally includes `content` and excludes store-specific fields like `id` and `embedding`, to match the expected OpenSearch-style output shape from the issue
- `query_sql()` is intentionally unsupported for Azure AI Search because the backend exposes search and OData-based filtering APIs, not SQL

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
