### PR TITLE
test: Openrouter - make test_live_run_with_tools more robust

### DIFF
--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -333,7 +333,7 @@ class TestOpenRouterChatGenerator:
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
         message = results["replies"][0]
-        assert message.text == ""
+        assert not message.text
 
         assert message.tool_calls
         tool_call = message.tool_call


### PR DESCRIPTION
### Related Issues

Failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22602498249/job/65487331067

### Proposed Changes:
- make the test more robust by checking that when there are tool calls, `message.text` is `None` or an empty string

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
