### PR TITLE
ci: fix docusaurus-mdx-checker installation

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Set up Docker
         if: runner.os == 'Linux'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # we need to pull the mcp/brave-search image to run the test
       # on the actual mcp server as an example of real life usage


### PR DESCRIPTION
### Related Issues

- docusaurus-mdx-checker fails installation: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22723349403/job/65891392202?pr=2904
- the problem seems related to katex broken ESM build (explained better in the workflow comment)

### Proposed Changes:
- force CommonJS resolution in the npx command

### How did you test it?
Triggered a docstring change and got the workflow running correctly: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22724219852/job/65894574610

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
