### PR TITLE
fix(anthropic): Add output_config in AnthropicChatGenerator 

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -107,6 +107,7 @@ class AnthropicChatGenerator:
         "top_k",
         "extra_headers",
         "thinking",
+        "output_config",
     ]
 
     def __init__(
@@ -144,6 +145,7 @@ class AnthropicChatGenerator:
             - `thinking`: A dictionary of thinking parameters to be passed to the model.
                 The `budget_tokens` passed for thinking should be less than `max_tokens`.
                 For more details and supported models, see: [Anthropic Extended Thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
+            - `output_config`: A dictionary of output configuration options to be passed to the model.
 
         :param ignore_tools_thinking_messages: Anthropic's approach to tools (function calling) resolution involves a
             "chain of thought" messages before returning the actual function names and parameters in a message. If

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -328,6 +328,20 @@ class TestAnthropicChatGenerator:
         assert response["replies"][0].meta["model"] == "claude-sonnet-4-5"
         assert response["replies"][0].meta["finish_reason"] == "stop"
 
+    def test_run_with_output_config(self, chat_messages, mock_anthropic_completion):
+        """
+        Test that output_config is passed to the Anthropic API.
+        """
+        output_config = {"effort": "medium"}
+        component = AnthropicChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            generation_kwargs={"max_tokens": 10, "output_config": output_config},
+        )
+        component.run(chat_messages)
+
+        _, kwargs = mock_anthropic_completion.call_args
+        assert kwargs["output_config"] == output_config
+
     @pytest.mark.parametrize(
         "generation_kwargs,expected_kwargs",
         [


### PR DESCRIPTION
### Related Issues

- fixes #2894

### Proposed Changes

Added support for `output_config` in `AnthropicChatGenerator` so it is no longer filtered out from `generation_kwargs`.

- Added `"output_config"` to `AnthropicChatGenerator.ALLOWED_PARAMS`
- Updated `AnthropicChatGenerator` docstring to list `output_config` among supported `generation_kwargs`
- Added unit test coverage to verify `output_config` is passed through to Anthropic `messages.create()`

### How did you test it?

- Ran targeted unit tests:
  - `hatch run test:unit tests/test_chat_generator.py -k "output_config or run_with_params or flattened_generation_kwargs"`
  - Result: `7 passed, 50 deselected`
- Ran type checks:
  - `hatch run test:types`
  - Result: success, no issues found
- Ran formatting:
  - `hatch run fmt`
  - Result: all checks passed, no formatting changes needed

### Notes for the Reviewer

- This change is intentionally scoped to parameter allowlisting and test coverage.
- Existing behavior is unchanged except that `output_config` is now forwarded instead of being dropped with a warning.


### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
