### PR TITLE
test: Chroma - remove tests for invalid Settings (now ignored)

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -114,7 +114,11 @@ class ChromaDocumentStore:
             # Use dict to conditionally pass settings because Chroma doesn't accept settings=None
             client_kwargs: dict[str, Any] = {}
             if self._client_settings:
-                client_kwargs["settings"] = Settings(**self._client_settings)
+                try:
+                    client_kwargs["settings"] = Settings(**self._client_settings)
+                except ValueError as e:
+                    msg = f"Invalid client_settings ({self._client_settings}): {e}"
+                    raise ValueError(msg) from e
 
             if self._host and self._port is not None:
                 # Remote connection via HTTP client
@@ -166,7 +170,11 @@ class ChromaDocumentStore:
             # Use dict to conditionally pass settings because Chroma doesn't accept settings=None
             client_kwargs: dict[str, Any] = {}
             if self._client_settings:
-                client_kwargs["settings"] = Settings(**self._client_settings)
+                try:
+                    client_kwargs["settings"] = Settings(**self._client_settings)
+                except ValueError as e:
+                    msg = f"Invalid client_settings ({self._client_settings}): {e}"
+                    raise ValueError(msg) from e
 
             client = await chromadb.AsyncHttpClient(
                 host=self._host,

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -124,18 +124,6 @@ class TestDocumentStore(
         store._ensure_initialized()
         assert store._client.get_settings().anonymized_telemetry is False
 
-    def test_invalid_client_settings_are_ignored(self, clear_chroma_system_cache):
-        store = ChromaDocumentStore(
-            client_settings={
-                "invalid_setting_name": "some_value",
-                "another_fake_setting": 123,
-            }
-        )
-        store._ensure_initialized()
-        settings = store._client.get_settings()
-        assert not hasattr(settings, "invalid_setting_name")
-        assert not hasattr(settings, "another_fake_setting")
-
     def test_to_dict(self, request):
         ds = ChromaDocumentStore(
             collection_name=request.node.name,

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -107,21 +107,6 @@ class TestDocumentStoreAsync:
         await store._ensure_initialized_async()
         assert store._async_client.get_settings().anonymized_telemetry is False
 
-    async def test_invalid_client_settings_are_ignored_async(self):
-        store = ChromaDocumentStore(
-            host="localhost",
-            port=8000,
-            client_settings={
-                "invalid_setting_name": "some_value",
-                "another_fake_setting": 123,
-            },
-            collection_name=f"{uuid.uuid1()}-async-invalid",
-        )
-        await store._ensure_initialized_async()
-        settings = store._async_client.get_settings()
-        assert not hasattr(settings, "invalid_setting_name")
-        assert not hasattr(settings, "another_fake_setting")
-
     async def test_search_async(self):
         document_store = ChromaDocumentStore(host="localhost", port=8000, collection_name="my_custom_collection")
 


### PR DESCRIPTION
### Related Issues

- failing nightly test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22880550806
- [Chroma 1.5.3](https://github.com/chroma-core/chroma/releases/tag/1.5.3) has been recently released and it no longer fails when invalid `Settings` fields are passed but ignore them

### Proposed Changes:
- remove tests for invalid Settings

I initially thought about of changing tests to verify that invalid Settings are ignored.
The problem is: they are ignored starting from Chroma 1.5.3, so these tests would fail when running with lowest direct dependencies (Chroma 1.0.2).
Another option would be to bump the library to 1.5.3, but this does not seem like a valid reason to do so. Happy to discuss, though.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
