### PR TITLE
test: Together AI - change tool calling model in tests

### DIFF
--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -685,7 +685,7 @@ class TestTogetherAIChatGenerator:
         initial_messages = [
             ChatMessage.from_user("What's the weather like in Paris and what is the population of Berlin?")
         ]
-        component = TogetherAIChatGenerator(model="moonshotai/kimi-k2-thinking", tools=mixed_tools)
+        component = TogetherAIChatGenerator(model="moonshotai/Kimi-K2.5", tools=mixed_tools)
         results = component.run(messages=initial_messages)
 
         assert len(results["replies"]) > 0, "No replies received"


### PR DESCRIPTION
### Related Issues

- failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/22881564322/job/66385289892

### Proposed Changes:
- replace Kimi K2 thinking (unavailable) with a newer model: Kimi-K2.5

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
