### PR TITLE
chore: AnthropicVertexChatGenerator - add SUPPORTED_MODELS docstring

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
@@ -77,6 +77,8 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
         "claude-opus-4@20250514",
         "claude-haiku-4-5@20251001",
     ]
+    """A non-exhaustive list of chat models supported by this component. See
+     https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai#model-availability for the full list."""
 
     def __init__(
         self,


### PR DESCRIPTION
### Related Issues

- follow up of https://github.com/deepset-ai/haystack-core-integrations/pull/2932: I found out that if we don't add a docstring to the `SUPPORTED_MODELS` class var, it is not shown on the API reference: https://docs.haystack.deepset.ai/reference/integrations-anthropic#haystack_integrationscomponentsgeneratorsanthropicchatvertex_chat_generator

### Proposed Changes:
- add missing docstring

### How did you test it?
Run `hatch run docs` locally. It works

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
