### PR TITLE
chore: Update mistral integration to work with mistralai>=2.0.0

### DIFF
--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "mistralai>=1.9.11,<2.0.0"]
+dependencies = ["haystack-ai>=2.22.0", "mistralai>=2.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mistral#readme"

--- a/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
+++ b/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
@@ -10,14 +10,14 @@ from haystack.components.converters.utils import (
 )
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret, deserialize_secrets_inplace
-from mistralai import Mistral
-from mistralai.extra import response_format_from_pydantic_model
-from mistralai.models import (
+from mistralai.client import Mistral
+from mistralai.client.models import (
     DocumentURLChunk,
     FileChunk,
     ImageURLChunk,
     OCRResponse,
 )
+from mistralai.extra import response_format_from_pydantic_model  # type: ignore[import-untyped]
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)

--- a/integrations/mistral/tests/test_ocr_document_converter.py
+++ b/integrations/mistral/tests/test_ocr_document_converter.py
@@ -8,7 +8,7 @@ import pytest
 from haystack import Document
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret
-from mistralai.models import DocumentURLChunk, FileChunk, ImageURLChunk
+from mistralai.client.models import DocumentURLChunk, FileChunk, ImageURLChunk
 from pydantic import BaseModel, Field
 
 from haystack_integrations.components.converters.mistral import (


### PR DESCRIPTION
### Related Issues

- fixes #2950 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Followed MistralAI's [migration guide](https://github.com/mistralai/client-python/blob/main/MIGRATION.md) to update the Mistral integration to work with `mistralai>=2.0.0`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
All existing tests now pass.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
