### PR TITLE
test: MistalChatGenerator - relax test_live_run_with_tools test

### DIFF
--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -576,7 +576,6 @@ class TestMistralChatGenerator:
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
         message = results["replies"][0]
-        assert message.text == ""
 
         assert message.tool_calls
         tool_call = message.tool_call


### PR DESCRIPTION
### Related Issues

- failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/23172660070/job/67327875656

Now it seems that a text is returned, in addition to the tool call

### Proposed Changes:
- relax the test: remove `assert message.text == ""`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
