### PR TITLE
chore: Add ruff's ANN ruleset for type annotations to the integration template

### DIFF
--- a/scripts/utils/templates/pyproject.toml
+++ b/scripts/utils/templates/pyproject.toml
@@ -78,6 +78,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
     "A",
+    "ANN",
     "ARG",
     "B",
     "C",
@@ -117,6 +118,8 @@ ignore = [
     "PLR0912",
     "PLR0913",
     "PLR0915",
+    # Allow `Any` type - used legitimately for dynamic types and SDK boundaries
+    "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -126,8 +129,8 @@ known-first-party = ["haystack_integrations"]
 ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Tests can use magic values, assertions, relative imports, and don't need type annotations
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]


### PR DESCRIPTION
### Related Issues

@sjrl suggested to update the template after reviewing one of the PRs where I added the ANN ruleset to an integration.

### Proposed Changes:

- Enable ANN ruleset
- Exclude tests from ANN ruleset
- Exclude ANN401, which means the `Any` type can be used and doesn't violate type annotation rules. I believe this makes sense in the template because the large majority of the integrations benefit. 

### How did you test it?

I used the same ruff ruleset for a couple of recently merged PRs 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
