### PR TITLE
chore: enable ANN ruff ruleset for azure_doc_intelligence integration

### DIFF
--- a/integrations/azure_doc_intelligence/pyproject.toml
+++ b/integrations/azure_doc_intelligence/pyproject.toml
@@ -90,6 +90,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
     "A",
+    "ANN",
     "ARG",
     "B",
     "C",
@@ -115,6 +116,7 @@ select = [
     "YTT",
 ]
 ignore = [
+    "ANN401",  # Allow Any - used legitimately for dynamic types and SDK boundaries
     # Allow non-abstract empty methods in abstract base classes
     "B027",
     # Allow function calls in argument defaults (common Haystack pattern for Secret.from_env_var)
@@ -145,7 +147,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/azure_doc_intelligence/src/haystack_integrations/components/converters/azure_doc_intelligence/converter.py
+++ b/integrations/azure_doc_intelligence/src/haystack_integrations/components/converters/azure_doc_intelligence/converter.py
@@ -67,7 +67,7 @@ class AzureDocumentIntelligenceConverter:
         api_key: Secret = Secret.from_env_var("AZURE_DI_API_KEY"),
         model_id: str = "prebuilt-document",
         store_full_path: bool = False,
-    ):
+    ) -> None:
         """
         Creates an AzureDocumentIntelligenceConverter component.
 
@@ -93,7 +93,7 @@ class AzureDocumentIntelligenceConverter:
         self.store_full_path = store_full_path
         self.client: DocumentIntelligenceClient | None = None
 
-    def warm_up(self):
+    def warm_up(self) -> None:
         """
         Initializes the Azure Document Intelligence client.
         """


### PR DESCRIPTION
### Related Issues
None

### Proposed Changes:
- Add `ANN` (flake8-annotations) to ruff `select` in `pyproject.toml`
- Add `ANN401` to ruff `ignore` (allow `Any` for SDK boundaries)
- Exclude `tests/**/*` from ANN checks via `per-file-ignores`
- Add `-> None` return type annotations to `__init__` and `warm_up`

### How did you test it?
Ran tests locally

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.