### PR TITLE
chore: enable ANN ruff ruleset for cohere integration

### DIFF
--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -84,6 +84,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -124,6 +125,8 @@ ignore = [
   # Misc
   "B008",
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -133,8 +136,8 @@ known-first-party = ["haystack_integrations"]
 ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Tests can use magic values, assertions, relative imports, and don't need type annotations
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
@@ -49,7 +49,7 @@ class CohereDocumentEmbedder:
         meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
         embedding_type: EmbeddingTypes | None = None,
-    ):
+    ) -> None:
         """
         :param api_key: the Cohere API key.
         :param model: the name of the model to use. Supported Models are:

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/embedding_types.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/embedding_types.py
@@ -21,7 +21,7 @@ class EmbeddingTypes(Enum):
     BINARY = "binary"
     UBINARY = "ubinary"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
     @staticmethod

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
@@ -41,7 +41,7 @@ class CohereTextEmbedder:
         truncate: str = "END",
         timeout: float = 120.0,
         embedding_type: EmbeddingTypes | None = None,
-    ):
+    ) -> None:
         """
         :param api_key: the Cohere API key.
         :param model: the name of the model to use. Supported Models are:

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -491,7 +491,7 @@ class CohereChatGenerator:
         *,
         timeout: float | None = None,
         max_retries: int | None = None,
-    ):
+    ) -> None:
         """
         Initialize the CohereChatGenerator instance.
 

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -37,7 +37,7 @@ class CohereGenerator(CohereChatGenerator):
         streaming_callback: Callable | None = None,
         api_base_url: str | None = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         """
         Instantiates a `CohereGenerator` component.
 

--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -41,7 +41,7 @@ class CohereRanker:
         meta_fields_to_embed: list[str] | None = None,
         meta_data_separator: str = "\n",
         max_tokens_per_doc: int = 4096,
-    ):
+    ) -> None:
         """
         Creates an instance of the 'CohereRanker'.
 


### PR DESCRIPTION
### Related Issues
None

### Proposed Changes:
- Add `ANN` (flake8-annotations) to ruff `select` in `pyproject.toml`
- Add `ANN401` to ruff `ignore` (allow `Any` for SDK boundaries)
- Exclude `tests/**/*` from ANN checks via `per-file-ignores`
- Add `-> None` return type annotations to `__init__` in `text_embedder.py`, `document_embedder.py`, `generator.py`, `chat_generator.py`, and `ranker.py`
- Add `-> str` return type annotation to `EmbeddingTypes.__str__`

### How did you test it?
Ran tests locally

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.