### PR TITLE
chore: enable ANN ruff ruleset for elasticsearch integration

### DIFF
--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -85,6 +85,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -125,6 +126,8 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -134,8 +137,8 @@ known-first-party = ["haystack_integrations"]
 ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Tests can use magic values, assertions, relative imports, and don't need type annotations
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/bm25_retriever.py
@@ -52,7 +52,7 @@ class ElasticsearchBM25Retriever:
         top_k: int = 10,
         scale_score: bool = False,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         Initialize ElasticsearchBM25Retriever with an instance ElasticsearchDocumentStore.
 

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
@@ -53,7 +53,7 @@ class ElasticsearchEmbeddingRetriever:
         top_k: int = 10,
         num_candidates: int | None = None,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         Create the ElasticsearchEmbeddingRetriever component.
 

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/sql_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/sql_retriever.py
@@ -42,7 +42,7 @@ class ElasticsearchSQLRetriever:
         document_store: ElasticsearchDocumentStore,
         raise_on_failure: bool = True,
         fetch_size: int | None = None,
-    ):
+    ) -> None:
         """
         Creates the ElasticsearchSQLRetriever component.
 

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -86,7 +86,7 @@ class ElasticsearchDocumentStore:
         api_key_id: Secret | str | None = Secret.from_env_var("ELASTIC_API_KEY_ID", strict=False),
         embedding_similarity_function: Literal["cosine", "dot_product", "l2_norm", "max_inner_product"] = "cosine",
         **kwargs: Any,
-    ):
+    ) -> None:
         """
         Creates a new ElasticsearchDocumentStore instance.
 
@@ -156,7 +156,7 @@ class ElasticsearchDocumentStore:
                 ],
             }
 
-    def _ensure_initialized(self):
+    def _ensure_initialized(self) -> None:
         """
         Ensures both sync and async clients are initialized and the index exists.
         """


### PR DESCRIPTION
### Related Issues
None

### Proposed Changes:
- Add `ANN` (flake8-annotations) to ruff `select` in `pyproject.toml`
- Add `ANN401` to ruff `ignore` (allow `Any` for `**kwargs` and Elasticsearch SDK boundaries)
- Exclude `tests/**/*` from ANN checks via `per-file-ignores`
- Add `-> None` return type annotations to `__init__` in `ElasticsearchBM25Retriever`, `ElasticsearchEmbeddingRetriever`, `ElasticsearchSQLRetriever`, and `ElasticsearchDocumentStore`
- Add `-> None` return type annotation to `_ensure_initialized` in `ElasticsearchDocumentStore`

### How did you test it?
Ran tests locally

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.