### PR TITLE
ci: stop asking reviews for API reference updates

### DIFF
--- a/.github/workflows/CI_docusaurus_sync.yml
+++ b/.github/workflows/CI_docusaurus_sync.yml
@@ -118,4 +118,3 @@ jobs:
             docs-website
           body: |
             This PR syncs the Core Integrations API reference (${{ env.INTEGRATION_NAME }}) on Docusaurus. Just approve and merge it.
-          reviewers: "${{ github.actor }}"


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-private/issues/217
- simplified version of https://github.com/deepset-ai/haystack/pull/10867

### Proposed Changes:
- remove the assigned reviewer from the API reference update workflow

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
