### PR TITLE
chore: add ANN type annotations to faiss, fastembed, firecrawl, github, google_ai

### DIFF
--- a/integrations/faiss/pyproject.toml
+++ b/integrations/faiss/pyproject.toml
@@ -89,6 +89,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -133,6 +134,8 @@ ignore = [
   "ARG002",
   # Allow assertions
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 exclude = ["example"]
 
@@ -144,7 +147,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 "example/**/*" = ["T201"]
 
 [tool.coverage.run]

--- a/integrations/faiss/src/haystack_integrations/components/retrievers/faiss/embedding_retriever.py
+++ b/integrations/faiss/src/haystack_integrations/components/retrievers/faiss/embedding_retriever.py
@@ -59,7 +59,7 @@ class FAISSEmbeddingRetriever:
         filters: dict[str, Any] | None = None,
         top_k: int = 10,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         :param document_store: An instance of `FAISSDocumentStore`.
         :param filters: Filters applied to the retrieved Documents at initialisation time. At runtime, these are merged

--- a/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
+++ b/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
@@ -34,7 +34,7 @@ class FAISSDocumentStore:
         index_path: str | None = None,
         index_string: str = "Flat",
         embedding_dim: int = 768,
-    ):
+    ) -> None:
         """
         Initializes the FAISSDocumentStore.
 
@@ -61,7 +61,7 @@ class FAISSDocumentStore:
         else:
             self._create_new_index()
 
-    def _create_new_index(self):
+    def _create_new_index(self) -> None:
         """Creates a new FAISS index."""
         try:
             # We use IndexIDMap to support add_with_ids

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -79,6 +79,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -115,6 +116,8 @@ ignore = [
   "S105",
   "S106",
   "S107",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
   # Ignore complexity
   "C901",
   "PLR0911",
@@ -131,7 +134,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # examples can contain "print" commands
 "examples/**/*" = ["T201", "E501"]
 

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/embedding_backend/fastembed_backend.py
@@ -44,7 +44,7 @@ class _FastembedEmbeddingBackend:
         cache_dir: str | None = None,
         threads: int | None = None,
         local_files_only: bool = False,
-    ):
+    ) -> None:
         self.model = TextEmbedding(
             model_name=model_name, cache_dir=cache_dir, threads=threads, local_files_only=local_files_only
         )
@@ -103,7 +103,7 @@ class _FastembedSparseEmbeddingBackend:
         threads: int | None = None,
         local_files_only: bool = False,
         model_kwargs: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         model_kwargs = model_kwargs or {}
 
         self.model = SparseTextEmbedding(

--- a/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
+++ b/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
@@ -46,7 +46,7 @@ class FastembedRanker:
         local_files_only: bool = False,
         meta_fields_to_embed: list[str] | None = None,
         meta_data_separator: str = "\n",
-    ):
+    ) -> None:
         """
         Creates an instance of the 'FastembedRanker'.
 
@@ -114,7 +114,7 @@ class FastembedRanker:
         """
         return default_from_dict(cls, data)
 
-    def warm_up(self):
+    def warm_up(self) -> None:
         """
         Initializes the component.
         """

--- a/integrations/firecrawl/pyproject.toml
+++ b/integrations/firecrawl/pyproject.toml
@@ -88,6 +88,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
     "A",
+    "ANN",
     "ARG",
     "B",
     "C",
@@ -123,6 +124,8 @@ ignore = [
     "S105",
     "S106",
     "S107",
+    # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+    "ANN401",
     # Ignore complexity
     "C901",
     "PLR0911",
@@ -143,7 +146,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -81,6 +81,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -121,6 +122,8 @@ ignore = [
   # Misc
   "B008",
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -131,7 +134,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # Ignore RUF001 for all files in the prompts directory
 "src/haystack_integrations/components/prompts/**/*" = ["RUF001"]
 

--- a/integrations/github/src/haystack_integrations/components/connectors/github/file_editor.py
+++ b/integrations/github/src/haystack_integrations/components/connectors/github/file_editor.py
@@ -82,7 +82,7 @@ class GitHubFileEditor:
         repo: str | None = None,
         branch: str = "main",
         raise_on_failure: bool = True,
-    ):
+    ) -> None:
         """
         Initialize the component.
 

--- a/integrations/github/src/haystack_integrations/components/connectors/github/issue_commenter.py
+++ b/integrations/github/src/haystack_integrations/components/connectors/github/issue_commenter.py
@@ -41,7 +41,7 @@ class GitHubIssueCommenter:
         github_token: Secret = Secret.from_env_var("GITHUB_TOKEN"),
         raise_on_failure: bool = True,
         retry_attempts: int = 2,
-    ):
+    ) -> None:
         """
         Initialize the component.
 

--- a/integrations/github/src/haystack_integrations/components/connectors/github/issue_viewer.py
+++ b/integrations/github/src/haystack_integrations/components/connectors/github/issue_viewer.py
@@ -40,7 +40,7 @@ class GitHubIssueViewer:
         github_token: Secret | None = None,
         raise_on_failure: bool = True,
         retry_attempts: int = 2,
-    ):
+    ) -> None:
         """
         Initialize the component.
 

--- a/integrations/github/src/haystack_integrations/components/connectors/github/pr_creator.py
+++ b/integrations/github/src/haystack_integrations/components/connectors/github/pr_creator.py
@@ -38,7 +38,12 @@ class GitHubPRCreator:
     ```
     """
 
-    def __init__(self, *, github_token: Secret = Secret.from_env_var("GITHUB_TOKEN"), raise_on_failure: bool = True):
+    def __init__(
+        self,
+        *,
+        github_token: Secret = Secret.from_env_var("GITHUB_TOKEN"),
+        raise_on_failure: bool = True,
+    ) -> None:
         """
         Initialize the component.
 

--- a/integrations/github/src/haystack_integrations/components/connectors/github/repo_forker.py
+++ b/integrations/github/src/haystack_integrations/components/connectors/github/repo_forker.py
@@ -48,7 +48,7 @@ class GitHubRepoForker:
         poll_interval: int = 2,
         auto_sync: bool = True,
         create_branch: bool = True,
-    ):
+    ) -> None:
         """
         Initialize the component.
 

--- a/integrations/github/src/haystack_integrations/components/connectors/github/repo_viewer.py
+++ b/integrations/github/src/haystack_integrations/components/connectors/github/repo_viewer.py
@@ -76,7 +76,7 @@ class GitHubRepoViewer:
         max_file_size: int = 1_000_000,  # 1MB default limit
         repo: str | None = None,
         branch: str = "main",
-    ):
+    ) -> None:
         """
         Initialize the component.
 

--- a/integrations/github/src/haystack_integrations/tools/github/file_editor_tool.py
+++ b/integrations/github/src/haystack_integrations/tools/github/file_editor_tool.py
@@ -31,7 +31,7 @@ class GitHubFileEditorTool(ComponentTool):
         outputs_to_string: dict[str, str | Callable[[Any], str]] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, str | Callable]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the GitHub file editor tool.
 

--- a/integrations/github/src/haystack_integrations/tools/github/issue_commenter_tool.py
+++ b/integrations/github/src/haystack_integrations/tools/github/issue_commenter_tool.py
@@ -30,7 +30,7 @@ class GitHubIssueCommenterTool(ComponentTool):
         outputs_to_string: dict[str, str | Callable[[Any], str]] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, str | Callable]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the GitHub issue commenter tool.
 

--- a/integrations/github/src/haystack_integrations/tools/github/issue_viewer_tool.py
+++ b/integrations/github/src/haystack_integrations/tools/github/issue_viewer_tool.py
@@ -30,7 +30,7 @@ class GitHubIssueViewerTool(ComponentTool):
         outputs_to_string: dict[str, str | Callable[[Any], str]] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, str | Callable]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the GitHub issue viewer tool.
 

--- a/integrations/github/src/haystack_integrations/tools/github/pr_creator_tool.py
+++ b/integrations/github/src/haystack_integrations/tools/github/pr_creator_tool.py
@@ -29,7 +29,7 @@ class GitHubPRCreatorTool(ComponentTool):
         outputs_to_string: dict[str, str | Callable[[Any], str]] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, str | Callable]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the GitHub PR creator tool.
 

--- a/integrations/github/src/haystack_integrations/tools/github/repo_forker_tool.py
+++ b/integrations/github/src/haystack_integrations/tools/github/repo_forker_tool.py
@@ -29,7 +29,7 @@ class GitHubRepoForkerTool(ComponentTool):
         outputs_to_string: dict[str, str | Callable[[Any], str]] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, str | Callable]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the GitHub Repo Forker tool.
 

--- a/integrations/github/src/haystack_integrations/tools/github/repo_viewer_tool.py
+++ b/integrations/github/src/haystack_integrations/tools/github/repo_viewer_tool.py
@@ -32,7 +32,7 @@ class GitHubRepoViewerTool(ComponentTool):
         outputs_to_string: dict[str, str | Callable[[Any], str]] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, str | Callable]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the GitHub repository viewer tool.
 

--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -87,6 +87,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -121,6 +122,8 @@ ignore = [
   "S105",
   "S106",
   "S107",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
   # Ignore complexity
   "C901",
   "PLR0911",
@@ -141,7 +144,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/chat/gemini.py
@@ -151,7 +151,7 @@ class GoogleAIGeminiChatGenerator:
         tools: Optional[list[Tool]] = None,
         tool_config: Optional[content_types.ToolConfigDict] = None,
         streaming_callback: Optional[StreamingCallbackT] = None,
-    ):
+    ) -> None:
         """
         Initializes a `GoogleAIGeminiChatGenerator` instance.
 
@@ -262,7 +262,7 @@ class GoogleAIGeminiChatGenerator:
         streaming_callback: Optional[StreamingCallbackT] = None,
         *,
         tools: Optional[list[Tool]] = None,
-    ):
+    ) -> dict[str, list[ChatMessage]]:
         """
         Generates text based on the provided messages.
 
@@ -315,7 +315,7 @@ class GoogleAIGeminiChatGenerator:
         streaming_callback: Optional[StreamingCallbackT] = None,
         *,
         tools: Optional[list[Tool]] = None,
-    ):
+    ) -> dict[str, list[ChatMessage]]:
         """
         Async version of the run method. Generates text based on the provided messages.
 

--- a/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
+++ b/integrations/google_ai/src/haystack_integrations/components/generators/google_ai/gemini.py
@@ -62,7 +62,7 @@ class GoogleAIGeminiGenerator:
     ```
     """
 
-    def __new__(cls, *_, **kwargs):
+    def __new__(cls, *_: Any, **kwargs: Any) -> "GoogleAIGeminiGenerator":
         if "tools" in kwargs:
             msg = (
                 "GoogleAIGeminiGenerator does not support the `tools` parameter. "
@@ -80,7 +80,7 @@ class GoogleAIGeminiGenerator:
         generation_config: Optional[Union[GenerationConfig, dict[str, Any]]] = None,
         safety_settings: Optional[dict[HarmCategory, HarmBlockThreshold]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-    ):
+    ) -> None:
         """
         Initializes a `GoogleAIGeminiGenerator` instance.
 
@@ -185,7 +185,7 @@ class GoogleAIGeminiGenerator:
         self,
         parts: Variadic[Union[str, ByteStream, Part]],
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-    ):
+    ) -> dict[str, list[str]]:
         """
         Generates text based on the given input parts.
 


### PR DESCRIPTION
## Related Issues

<!-- If applicable, reference any related issues or tickets -->

## Proposed Changes

Enable ruff's ANN ruleset (flake8-annotations) for five integrations and fix all resulting violations. Changes are consistent across all integrations:

- `faiss`: Enable ANN in ruff config; add `-> None` to `__init__` in `FAISSDocumentStore` and `FAISSEmbeddingRetriever`; add `-> None` to `_create_new_index`
- `fastembed`: Enable ANN in ruff config; add `-> None` to `__init__` in `_FastembedEmbeddingBackend`, `_FastembedSparseEmbeddingBackend`, and `FastembedRanker`; add `-> None` to `warm_up` in `FastembedRanker`
- `firecrawl`: Enable ANN in ruff config only (all annotations were already present)
- `github`: Enable ANN in ruff config; add `-> None` to `__init__` in all 6 connector classes and 6 tool classes
- `google_ai`: Enable ANN in ruff config; add `-> None` to `__init__` in both generators; add `-> "GoogleAIGeminiGenerator"` to `__new__` with proper `*_: Any` and `**kwargs: Any` annotations; add `-> dict[str, list[str]]` / `-> dict[str, list[ChatMessage]]` to `run` and `run_async` methods

For all integrations:
- Added `"ANN"` to ruff `select`
- Added `"ANN401"` to ruff `ignore` (allow `Any` at SDK/dynamic boundaries)
- Added `"ANN"` to `tests/**/*` per-file-ignores (tests don't need type annotations)

## How did you test it

- Ran `hatch run fmt-check` for all 5 integrations — all pass
- Ran `hatch run test:types` for all 5 integrations — all pass (google_ai pre-existing errors are unchanged)
- Verified `ruff check --select ANN --ignore ANN401` reports zero violations across all 5 integrations

## Notes for reviewer

`google_ai` has pre-existing mypy errors unrelated to this PR. It's archived anyway.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have updated the related documentation if needed
- [x] I have added tests for the changes I made (N/A - annotation-only changes)
- [x] I have run `hatch run test:types` and all checks pass
- [x] I have run `hatch run fmt-check` and all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)