### PR TITLE
chore: add ANN type annotations to google_genai, hanlp, jina, langfuse, lara

### DIFF
--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -91,6 +91,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -137,6 +138,8 @@ ignore = [
   "ARG005",
   # Allow function call argument defaults e.g. `Secret.from_env_var`
   "B008",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -147,7 +150,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # Examples can use print statements
 "examples/**/*" = ["T201"]
 

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -203,7 +203,7 @@ class GoogleGenAIChatGenerator:
         tools: ToolsType | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
-    ):
+    ) -> None:
         """
         Initialize a GoogleGenAIChatGenerator instance.
 

--- a/integrations/hanlp/pyproject.toml
+++ b/integrations/hanlp/pyproject.toml
@@ -96,6 +96,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -139,6 +140,8 @@ ignore = [
   "ARG005",
   "RUF001",
   "RUF002",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -149,7 +152,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -84,6 +84,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -121,6 +122,8 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -131,7 +134,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # examples can contain "print" commands
 "examples/**/*" = ["T201"]
 

--- a/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
+++ b/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
@@ -45,7 +45,7 @@ class JinaReaderConnector:
         mode: JinaReaderMode | str,
         api_key: Secret = Secret.from_env_var("JINA_API_KEY"),  # noqa: B008
         json_response: bool = True,
-    ):
+    ) -> None:
         """
         Initialize a JinaReader instance.
 

--- a/integrations/jina/src/haystack_integrations/components/connectors/jina/reader_mode.py
+++ b/integrations/jina/src/haystack_integrations/components/connectors/jina/reader_mode.py
@@ -19,7 +19,7 @@ class JinaReaderMode(Enum):
     SEARCH = "search"
     GROUND = "ground"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
     @classmethod

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
@@ -49,7 +49,7 @@ class JinaDocumentEmbedder:
         task: str | None = None,
         dimensions: int | None = None,
         late_chunking: bool | None = None,
-    ):
+    ) -> None:
         """
         Create a JinaDocumentEmbedder component.
 

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/document_image_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/document_image_embedder.py
@@ -62,7 +62,7 @@ class JinaDocumentImageEmbedder:
         embedding_dimension: int | None = None,
         image_size: tuple[int, int] | None = None,
         batch_size: int = 5,
-    ):
+    ) -> None:
         """
         Create a JinaDocumentImageEmbedder component.
 

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/text_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/text_embedder.py
@@ -42,7 +42,7 @@ class JinaTextEmbedder:
         task: str | None = None,
         dimensions: int | None = None,
         late_chunking: bool | None = None,
-    ):
+    ) -> None:
         """
         Create a JinaTextEmbedder component.
 

--- a/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
+++ b/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
@@ -36,7 +36,7 @@ class JinaRanker:
         api_key: Secret = Secret.from_env_var("JINA_API_KEY"),  # noqa: B008,
         top_k: int | None = None,
         score_threshold: float | None = None,
-    ):
+    ) -> None:
         """
         Creates an instance of JinaRanker.
 
@@ -110,7 +110,7 @@ class JinaRanker:
         documents: list[Document],
         top_k: int | None = None,
         score_threshold: float | None = None,
-    ):
+    ) -> dict[str, list[Document]]:
         """
         Returns a list of Documents ranked by their similarity to the given query.
 

--- a/integrations/langfuse/example/basic_rag.py
+++ b/integrations/langfuse/example/basic_rag.py
@@ -62,5 +62,5 @@ if __name__ == "__main__":
     question = "What does Rhodes Statue look like?"
     response = pipeline.run({"text_embedder": {"text": question}, "prompt_builder": {"question": question}})
 
-    print(response["llm"]["replies"][0])  # noqa: T201
-    print(response["tracer"]["trace_url"])  # noqa: T201
+    print(response["llm"]["replies"][0])
+    print(response["tracer"]["trace_url"])

--- a/integrations/langfuse/example/chat.py
+++ b/integrations/langfuse/example/chat.py
@@ -59,5 +59,5 @@ if __name__ == "__main__":
             },
         }
     )
-    print(response["llm"]["replies"][0])  # noqa: T201
-    print(response["tracer"]["trace_url"])  # noqa: T201
+    print(response["llm"]["replies"][0])
+    print(response["tracer"]["trace_url"])

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -84,6 +84,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -123,6 +124,8 @@ ignore = [
   "PLR0915",
   # Asserts
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -133,9 +136,10 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # Examples can print their output
-"examples/**" = ["T201"]
+"examples/**" = ["T201", "ANN"]
+"example/**" = ["T201", "ANN"]
 "tests/**" = ["T201"]
 
 [tool.coverage.run]

--- a/integrations/lara/pyproject.toml
+++ b/integrations/lara/pyproject.toml
@@ -90,6 +90,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
     "A",
+    "ANN",
     "ARG",
     "B",
     "C",
@@ -131,6 +132,8 @@ ignore = [
     "PLR0912",
     "PLR0913",
     "PLR0915",
+    # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+    "ANN401",
 ]
 unfixable = [
     # Don't touch unused imports
@@ -145,7 +148,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/lara/src/haystack_integrations/components/translators/lara/document_translator.py
+++ b/integrations/lara/src/haystack_integrations/components/translators/lara/document_translator.py
@@ -53,7 +53,7 @@ class LaraDocumentTranslator:
         adapt_to: list[str] | None = None,
         glossaries: list[str] | None = None,
         reasoning: bool = False,
-    ):
+    ) -> None:
         """
         Creats an instance of the LaraDocumentTranslator component.
 


### PR DESCRIPTION
### Related Issues

<!-- If applicable, reference any related issues or tickets -->

### Proposed Changes

Enable ruff's ANN ruleset (flake8-annotations) for five integrations and fix resulting violations. 

- `google_genai`: Enable ANN in ruff config; add `-> None` to `__init__` in `GoogleGenAIChatGenerator`
- `hanlp`: Enable ANN in ruff config only (all annotations were already present)
- `jina`: Enable ANN in ruff config; add `-> None` to `__init__` in `JinaReaderConnector`, `JinaTextEmbedder`, `JinaDocumentEmbedder`, `JinaDocumentImageEmbedder`, `JinaRanker`; add `-> str` to `JinaReaderMode.__str__`; add `-> dict[str, list[Document]]` to `JinaRanker.run`
- `langfuse`: Enable ANN in ruff config; add `ANN` to `example/**` per-file-ignores (langfuse uses `example/` singular); remove now-redundant `# noqa: T201` from example files
- `lara`: Enable ANN in ruff config; add `-> None` to `__init__` in `LaraDocumentTranslator`

For all integrations:
- Added `"ANN"` to ruff `select`
- Added `"ANN401"` to ruff `ignore` (allow `Any` at SDK/dynamic boundaries)
- Added `"ANN"` to `tests/**/*` per-file-ignores (tests don't need type annotations)

### How did you test it

- Ran `hatch run fmt-check` and `hatch run test:types` locally

### Notes for reviewer
~~ Failing Jina tests are because the API key needs to be rotated and I am waiting for approval. I wouldn't block this PR because of that.~~ I updated the Jina API key now.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used a [conventional commit type](https://www.conventionalcommits.org/en/v1.0.0/) in the PR title

🤖 Generated with [Claude Code](https://claude.com/claude-code)