### PR TITLE
chore: add ANN ruff ruleset to llama_cpp, llama_stack, mcp, meta_llama, mistral, mongodb_atlas, nvidia, ollama, openrouter, opensearch

### DIFF
--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -94,6 +94,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
     "A",
+    "ANN",
     "ARG",
     "B",
     "C",
@@ -131,6 +132,8 @@ ignore = [
     "PLR0912",
     "PLR0913",
     "PLR0915",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]
@@ -138,7 +141,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # Examples can print their output
 "examples/**" = ["T201"]
 "tests/**" = ["T201"]

--- a/integrations/llama_stack/examples/llama-stack-with-tools.py
+++ b/integrations/llama_stack/examples/llama-stack-with-tools.py
@@ -41,9 +41,9 @@ messages = [ChatMessage.from_user("What's the weather in Tokyo?")]
 
 response = client.run(messages=messages, tools=[weather_tool])["replies"]
 
-print(f"assistant messages: {response[0]}\n")  # noqa: T201
+print(f"assistant messages: {response[0]}\n")
 
 # If the assistant message contains a tool call, run the tool invoker
 if response[0].tool_calls:
     tool_messages = tool_invoker.run(messages=response)["tool_messages"]
-    print(f"tool messages: {tool_messages}")  # noqa: T201
+    print(f"tool messages: {tool_messages}")

--- a/integrations/llama_stack/pyproject.toml
+++ b/integrations/llama_stack/pyproject.toml
@@ -79,6 +79,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -119,6 +120,8 @@ ignore = [
   # Misc
   "B008",
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 unfixable = [
   # Don't touch unused imports
@@ -133,7 +136,9 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "E501", "F841"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN", "E501", "F841"]
+# Examples can print their output and don't need type annotations
+"examples/**/*" = ["T201", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
+++ b/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
@@ -68,7 +68,7 @@ class LlamaStackChatGenerator(OpenAIChatGenerator):
         tools_strict: bool = False,
         max_retries: int | None = None,
         http_client_kwargs: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Creates an instance of LlamaStackChatGenerator. To use this chat generator,
         you need to setup Llama Stack Server with an inference provider and have a model available.

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -94,6 +94,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
     "A",
+    "ANN",
     "ARG",
     "B",
     "C",
@@ -135,6 +136,8 @@ ignore = [
     "RUF005",
     "S603",
     "S607",
+    # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+    "ANN401",
 ]
 unfixable = [
     # Don't touch unused imports
@@ -149,8 +152,8 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
-"examples/**/*" = ["T201", "E501"] 
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"examples/**/*" = ["T201", "E501", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -74,7 +74,7 @@ class AsyncExecutor:
                 cls._singleton_instance = cls()
             return cls._singleton_instance
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a dedicated event loop"""
         self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._thread: threading.Thread = threading.Thread(target=self._run_loop, daemon=True)
@@ -84,7 +84,7 @@ class AsyncExecutor:
             message = "AsyncExecutor failed to start background event loop"
             raise RuntimeError(message)
 
-    def _run_loop(self):
+    def _run_loop(self) -> None:
         """Run the event loop"""
         asyncio.set_event_loop(self._loop)
         self._started.set()
@@ -107,7 +107,7 @@ class AsyncExecutor:
             message = f"Operation timed out after {timeout} seconds"
             raise TimeoutError(message) from e
 
-    def get_loop(self):
+    def get_loop(self) -> asyncio.AbstractEventLoop:
         """
         Get the event loop.
 
@@ -135,7 +135,7 @@ class AsyncExecutor:
         # correct loop and can safely be set from other threads via *call_soon_threadsafe*.
         stop_event_promise: Future[asyncio.Event] = Future()
 
-        async def _coroutine_with_stop_event():
+        async def _coroutine_with_stop_event() -> None:
             stop_event = asyncio.Event()
             stop_event_promise.set_result(stop_event)
             await coro_factory(stop_event)
@@ -155,7 +155,7 @@ class AsyncExecutor:
         :param timeout: Timeout in seconds for shutting down the event loop
         """
 
-        def _stop_loop():
+        def _stop_loop() -> None:
             self._loop.stop()
 
         asyncio.run_coroutine_threadsafe(asyncio.sleep(0), self._loop).result(timeout=timeout)
@@ -680,7 +680,7 @@ class SSEServerInfo(MCPServerInfo):
     base_delay: float = 1.0
     max_delay: float = 30.0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate that either url or base_url is provided."""
         if not self.url and not self.base_url:
             message = "Either url or base_url must be provided"
@@ -766,7 +766,7 @@ class StreamableHttpServerInfo(MCPServerInfo):
     base_delay: float = 1.0
     max_delay: float = 30.0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate the URL."""
         if not is_valid_http_url(self.url):
             message = f"Invalid url: {self.url}"
@@ -911,7 +911,7 @@ class MCPTool(Tool):
         outputs_to_string: dict[str, Any] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, Any]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the MCP tool.
 
@@ -1062,7 +1062,7 @@ class MCPTool(Tool):
             # Connect on first use if eager_connect is turned off
             self.warm_up()
 
-            async def invoke():
+            async def invoke() -> Any:
                 logger.debug(f"TOOL: Inside invoke coroutine for '{self.name}'")
                 client = cast(MCPClient, self._client)
                 result = await asyncio.wait_for(client.call_tool(self.name, kwargs), timeout=self._invocation_timeout)
@@ -1274,7 +1274,7 @@ class MCPTool(Tool):
             outputs_to_state=outputs_to_state,
         )
 
-    def close(self):
+    def close(self) -> None:
         """Close the tool synchronously."""
         if hasattr(self, "_client") and self._client:
             try:
@@ -1284,7 +1284,7 @@ class MCPTool(Tool):
             except Exception as e:
                 logger.debug(f"TOOL: Error during synchronous worker stop: {e!s}")
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Cleanup resources when the tool is garbage collected."""
         logger.debug(f"TOOL: __del__ called for MCPTool '{self.name if hasattr(self, 'name') else 'unknown'}'")
 
@@ -1309,7 +1309,7 @@ class _MCPClientSessionManager:
     # Maximum time to wait for worker shutdown in seconds
     WORKER_SHUTDOWN_TIMEOUT = 2.0
 
-    def __init__(self, client: "MCPClient", *, timeout: float | None = None):
+    def __init__(self, client: "MCPClient", *, timeout: float | None = None) -> None:
         self._client = client
         self.executor = AsyncExecutor.get_instance()
 

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
@@ -232,7 +232,7 @@ class MCPToolset(Toolset):
         inputs_from_state: dict[str, dict[str, str]] | None = None,
         outputs_to_state: dict[str, dict[str, dict[str, Any]]] | None = None,
         outputs_to_string: dict[str, dict[str, Any]] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the MCP toolset.
 
@@ -531,7 +531,7 @@ class MCPToolset(Toolset):
             outputs_to_string=outputs_to_string if outputs_to_string else None,
         )
 
-    def close(self):
+    def close(self) -> None:
         """Close the underlying MCP client safely."""
         if hasattr(self, "_worker") and self._worker:
             try:
@@ -539,5 +539,5 @@ class MCPToolset(Toolset):
             except Exception as e:
                 logger.debug(f"TOOLSET: error during worker stop: {e!s}")
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()

--- a/integrations/meta_llama/pyproject.toml
+++ b/integrations/meta_llama/pyproject.toml
@@ -79,6 +79,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -119,6 +120,8 @@ ignore = [
   # Misc
   "B008",
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -129,7 +132,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
+++ b/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
@@ -74,7 +74,7 @@ class MetaLlamaChatGenerator(OpenAIChatGenerator):
         timeout: float | None = None,
         max_retries: int | None = None,
         tools: ToolsType | None = None,
-    ):
+    ) -> None:
         """
         Creates an instance of LlamaChatGenerator. Unless specified otherwise in the `model`, this is for Llama's
         `Llama-4-Scout-17B-16E-Instruct-FP8` model.

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -82,6 +82,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -122,6 +123,8 @@ ignore = [
   # Misc
   "B008",
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -132,7 +135,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
+++ b/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
@@ -117,7 +117,7 @@ class MistralOCRDocumentConverter:
         image_limit: int | None = None,
         image_min_size: int | None = None,
         cleanup_uploaded_files: bool = True,
-    ):
+    ) -> None:
         """
         Creates a MistralOCRDocumentConverter component.
 

--- a/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
+++ b/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
@@ -55,7 +55,7 @@ class MistralDocumentEmbedder(OpenAIDocumentEmbedder):
         timeout: float | None = None,
         max_retries: int | None = None,
         http_client_kwargs: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Creates a MistralDocumentEmbedder component.
 

--- a/integrations/mistral/src/haystack_integrations/components/embedders/mistral/text_embedder.py
+++ b/integrations/mistral/src/haystack_integrations/components/embedders/mistral/text_embedder.py
@@ -49,7 +49,7 @@ class MistralTextEmbedder(OpenAITextEmbedder):
         timeout: float | None = None,
         max_retries: int | None = None,
         http_client_kwargs: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Creates an MistralTextEmbedder component.
 

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -122,7 +122,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
         timeout: float | None = None,
         max_retries: int | None = None,
         http_client_kwargs: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Creates an instance of MistralChatGenerator. Unless specified otherwise in the `model`, this is for Mistral's
         `mistral-small-latest` model.

--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -84,6 +84,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -126,6 +127,8 @@ ignore = [
   "PLR0915",
   # Allow assert statements
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -136,7 +139,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # examples can contain "print" commands
 "examples/**/*" = ["T201"]
 

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -48,7 +48,7 @@ class MongoDBAtlasEmbeddingRetriever:
         filters: dict[str, Any] | None = None,
         top_k: int = 10,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         Create the MongoDBAtlasDocumentStore component.
 

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
@@ -46,7 +46,7 @@ class MongoDBAtlasFullTextRetriever:
         filters: dict[str, Any] | None = None,
         top_k: int = 10,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         :param document_store: An instance of MongoDBAtlasDocumentStore.
         :param filters: Filters applied to the retrieved Documents. Make sure that the fields used in the filters are

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -68,7 +68,7 @@ class MongoDBAtlasDocumentStore:
         full_text_search_index: str,
         embedding_field: str = "embedding",
         content_field: str = "content",
-    ):
+    ) -> None:
         """
         Creates a new MongoDBAtlasDocumentStore instance.
 

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -86,6 +86,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -126,6 +127,8 @@ ignore = [
   # Misc
   "B008",
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -136,7 +139,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -46,7 +46,7 @@ class NvidiaTextEmbedder:
         suffix: str = "",
         truncate: EmbeddingTruncateMode | str | None = None,
         timeout: float | None = None,
-    ):
+    ) -> None:
         """
         Create a NvidiaTextEmbedder component.
 
@@ -92,7 +92,7 @@ class NvidiaTextEmbedder:
     def class_name(cls) -> str:
         return "NvidiaTextEmbedder"
 
-    def default_model(self):
+    def default_model(self) -> None:
         """Set default model in local NIM mode."""
         valid_models = [
             model.id for model in self.available_models if not model.base_model or model.base_model == model.id
@@ -119,7 +119,7 @@ class NvidiaTextEmbedder:
             error_message = "No locally hosted model was found."
             raise ValueError(error_message)
 
-    def warm_up(self):
+    def warm_up(self) -> None:
         """
         Initializes the component.
         """

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -17,7 +17,7 @@ class EmbeddingTruncateMode(Enum):
     END = "END"
     NONE = "NONE"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
     @classmethod

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
@@ -15,7 +15,7 @@ class RankerTruncateMode(str, Enum):
     NONE = "NONE"
     END = "END"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
     @classmethod

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/models.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/models.py
@@ -35,7 +35,7 @@ class Model:
     def __hash__(self) -> int:
         return hash(self.id)
 
-    def validate(self):
+    def validate(self) -> int:
         if self.client:
             client = self.client if isinstance(self.client, Client) else Client.from_str(self.client)
             supported = {

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
@@ -29,7 +29,7 @@ class NimBackend:
         model_kwargs: dict[str, Any] | None = None,
         client: str | Client | None = None,
         timeout: float | None = None,
-    ):
+    ) -> None:
         headers = {
             "Content-Type": "application/json",
             "accept": "application/json",

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -90,6 +90,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
     "A",
+    "ANN",
     "ARG",
     "B",
     "C",
@@ -127,6 +128,8 @@ ignore = [
     "PLR0912",
     "PLR0913",
     "PLR0915",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]
@@ -134,7 +137,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # Examples can print their output
 "examples/**" = ["T201"]
 

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
@@ -39,7 +39,7 @@ class OllamaDocumentEmbedder:
         meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
         batch_size: int = 32,
-    ):
+    ) -> None:
         """
         :param model:
             The name of the model to use. The model should be available in the running Ollama instance.

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
@@ -28,7 +28,7 @@ class OllamaTextEmbedder:
         generation_kwargs: dict[str, Any] | None = None,
         timeout: int = 120,
         keep_alive: float | str | None = None,
-    ):
+    ) -> None:
         """
         :param model:
             The name of the model to use. The model should be available in the running Ollama instance.

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -251,7 +251,7 @@ class OllamaChatGenerator:
         tools: ToolsType | None = None,
         response_format: None | Literal["json"] | JsonSchemaValue | None = None,
         think: bool | Literal["low", "medium", "high"] = False,
-    ):
+    ) -> None:
         """
         :param model:
             The name of the model to use. The model must already be present (pulled) in the running Ollama instance.

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -106,7 +106,7 @@ class OllamaGenerator:
         timeout: int = 120,
         keep_alive: float | str | None = None,
         streaming_callback: Callable[[StreamingChunk], None] | None = None,
-    ):
+    ) -> None:
         """
         :param model:
             The name of the model to use. The model should be available in the running Ollama instance.

--- a/integrations/openrouter/examples/openrouter_with_tools_example.py
+++ b/integrations/openrouter/examples/openrouter_with_tools_example.py
@@ -44,9 +44,9 @@ messages = [ChatMessage.from_user("What's the weather in Tokyo?")]
 
 response = client.run(messages=messages, tools=[weather_tool])["replies"]
 
-print(f"assistant messages: {response[0]}\n")  # noqa: T201
+print(f"assistant messages: {response[0]}\n")
 
 # If the assistant message contains a tool call, run the tool invoker
 if response[0].tool_calls:
     tool_messages = tool_invoker.run(messages=response)["tool_messages"]
-    print(f"tool messages: {tool_messages}")  # noqa: T201
+    print(f"tool messages: {tool_messages}")

--- a/integrations/openrouter/pyproject.toml
+++ b/integrations/openrouter/pyproject.toml
@@ -80,6 +80,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -120,6 +121,8 @@ ignore = [
   # Misc
   "B008",
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -130,7 +133,9 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+# Examples can print their output and don't need type annotations
+"examples/**/*" = ["T201", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
+++ b/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
@@ -69,7 +69,7 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
         extra_headers: dict[str, Any] | None = None,
         max_retries: int | None = None,
         http_client_kwargs: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Creates an instance of OpenRouterChatGenerator. Unless specified otherwise,
         the default model is `openai/gpt-5-mini`.

--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -89,6 +89,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -131,6 +132,8 @@ ignore = [
   "PLR0915",
   # Ignore asserts
   "S101",
+  # Allow `Any` - used legitimately for dynamic types and SDK boundaries
+  "ANN401",
 ]
 
 [tool.ruff.lint.isort]
@@ -141,7 +144,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -36,7 +36,7 @@ class OpenSearchBM25Retriever:
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
         custom_query: dict[str, Any] | None = None,
         raise_on_failure: bool = True,
-    ):
+    ) -> None:
         """
         Creates the OpenSearchBM25Retriever component.
 

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -35,7 +35,7 @@ class OpenSearchEmbeddingRetriever:
         raise_on_failure: bool = True,
         efficient_filtering: bool = False,
         search_kwargs: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Create the OpenSearchEmbeddingRetriever component.
 

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/metadata_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/metadata_retriever.py
@@ -92,7 +92,7 @@ class OpenSearchMetadataRetriever:
         tie_breaker: float = 0.7,
         jaccard_n: int = 3,
         raise_on_failure: bool = True,
-    ):
+    ) -> None:
         """
         Create the OpenSearchMetadataRetriever component.
 

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
@@ -284,7 +284,7 @@ class OpenSearchHybridRetriever:
 
         return hybrid_retrieval
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize OpenSearchHybridRetriever to a dictionary.
 
@@ -327,7 +327,7 @@ class OpenSearchHybridRetriever:
         )
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: dict[str, Any]) -> "OpenSearchHybridRetriever":
         # deserialize the document store
         doc_store = OpenSearchDocumentStore.from_dict(data["init_parameters"]["document_store"])
         data["init_parameters"]["document_store"] = doc_store

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/sql_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/sql_retriever.py
@@ -28,7 +28,7 @@ class OpenSearchSQLRetriever:
         document_store: OpenSearchDocumentStore,
         raise_on_failure: bool = True,
         fetch_size: int | None = None,
-    ):
+    ) -> None:
         """
         Creates the OpenSearchSQLRetriever component.
 

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -4,7 +4,7 @@
 
 # ruff: noqa: FBT001, FBT002   boolean-type-hint-positional-argument and boolean-default-value-positional-argument
 
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from math import exp
 from typing import Any, Literal
 
@@ -275,7 +275,7 @@ class OpenSearchDocumentStore:
             return self._http_auth
         return None
 
-    def _ensure_initialized(self):
+    def _ensure_initialized(self) -> None:
         # Ideally, we have a warm-up stage for document stores as well as components.
         if not self._client:
             self._client = OpenSearch(
@@ -290,7 +290,7 @@ class OpenSearchDocumentStore:
 
             self._ensure_index_exists()
 
-    async def _ensure_initialized_async(self):
+    async def _ensure_initialized_async(self) -> None:
         if not self._async_client:
             resolved_auth = self._resolve_http_auth()
             async_http_auth = AsyncAWSAuth(resolved_auth) if isinstance(resolved_auth, AWSAuth) else resolved_auth
@@ -308,7 +308,7 @@ class OpenSearchDocumentStore:
             self._initialized = True
             await self._ensure_index_exists_async()
 
-    async def _ensure_index_exists_async(self):
+    async def _ensure_index_exists_async(self) -> None:
         assert self._async_client is not None
 
         if await self._async_client.indices.exists(index=self._index):
@@ -322,7 +322,7 @@ class OpenSearchDocumentStore:
             body = {"mappings": self._mappings, "settings": self._settings}
             await self._async_client.indices.create(index=self._index, body=body)
 
-    def _ensure_index_exists(self):
+    def _ensure_index_exists(self) -> None:
         assert self._client is not None
 
         if self._client.indices.exists(index=self._index):
@@ -577,7 +577,7 @@ class OpenSearchDocumentStore:
         refresh: Literal["wait_for", True, False],
         routing: dict[str, str] | None = None,
     ) -> dict[str, Any]:
-        def action_generator():
+        def action_generator() -> Generator[dict[str, Any], None, None]:
             for id_ in document_ids:
                 action = {"_op_type": "delete", "_id": id_}
                 # Add routing if provided for this document ID


### PR DESCRIPTION
### Related Issues

None

### Proposed Changes:

Straight forward additions that enforce ruff's ANN ruleset in 10 more integrations.

- Added `"ANN"` (flake8-annotations) to the ruff `select` ruleset for 10 integrations: `llama_cpp`, `llama_stack`, `mcp`, `meta_llama`, `mistral`, `mongodb_atlas`, `nvidia`, `ollama`, `openrouter`, `opensearch`
- Added `"ANN401"` to the `ignore` list in each integration (allows `Any` at dynamic/SDK boundaries)
- Added `"ANN"` to `tests/**/*` per-file-ignores so test files are exempt from type annotation requirements
- Added `"ANN"` to `examples/**/*` per-file-ignores where example directories exist
- Fixed all ANN violations in source files by adding missing return type annotations (`-> None` for `__init__`, `warm_up`, `close`, `__del__`, `__post_init__`, etc.; specific return types for other methods)
- Fixed stale `# noqa: T201` directives in example files for `llama_stack` and `openrouter` (became redundant after adding `"ANN"` to examples per-file-ignores)
- Added `Generator` import from `collections.abc` in `opensearch/document_store.py` for the `action_generator` nested function return type

### How did you test it?

- Ran tests locally

### Notes for the reviewer

meta_llama and mistral have one pre-existing error each (Cannot override instance variable with class variable for SUPPORTED_MODELS: ClassVar[list[str]]). That's unrelated to ANN annotations and the patch release in Haystack is in progress.
The error in tests/test_nvidia_chat_generator.py::TestNvidiaChatGenerator::test_live_run_with_guided_json_schema - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0) is also pre-existing. For example, see https://github.com/deepset-ai/haystack-core-integrations/actions/runs/23099361470/job/67097212344#step:7:233

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.