### PR TITLE
chore: add ANN ruff ruleset to optimum, paddleocr, pgvector, pinecone, pyversity, qdrant, ragas, snowflake

### DIFF
--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -102,6 +102,7 @@ exclude = ["example", "tests"]
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -129,6 +130,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Ignore checks for possible passwords
   "S105",
   "S106",
@@ -148,7 +151,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # Examples can print their output
 "examples/**" = ["T201"]
 "tests/**" = ["T201"]

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
@@ -83,7 +83,7 @@ class _EmbedderParams:
 
 
 class _EmbedderBackend:
-    def __init__(self, params: _EmbedderParams):
+    def __init__(self, params: _EmbedderParams) -> None:
         check_valid_model(params.model, HFModelType.EMBEDDING, params.token)
         resolved_token = params.token.resolve_value() if params.token else None
 
@@ -117,7 +117,7 @@ class _EmbedderBackend:
         self.tokenizer = None
         self.pooling_layer: SentenceTransformerPoolingLayer | None = None
 
-    def warm_up(self):
+    def warm_up(self) -> None:
         assert self.params.model_kwargs
         model_kwargs = copy.deepcopy(self.params.model_kwargs)
         model = ORTModelForFeatureExtraction.from_pretrained(**model_kwargs, export=True)

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimization.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimization.py
@@ -27,7 +27,7 @@ class OptimumEmbedderOptimizationMode(Enum):
     #: Same as O3 with mixed precision.
     O4 = "o4"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
     @classmethod

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimum_text_embedder.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimum_text_embedder.py
@@ -48,7 +48,7 @@ class OptimumTextEmbedder:
         working_dir: str | None = None,
         optimizer_settings: OptimumEmbedderOptimizationConfig | None = None,
         quantizer_settings: OptimumEmbedderQuantizationConfig | None = None,
-    ):
+    ) -> None:
         """
         Create a OptimumTextEmbedder component.
 
@@ -121,7 +121,7 @@ class OptimumTextEmbedder:
         self._backend = _EmbedderBackend(params)
         self._initialized = False
 
-    def warm_up(self):
+    def warm_up(self) -> None:
         """
         Initializes the component.
         """

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/pooling.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/pooling.py
@@ -32,7 +32,7 @@ class OptimumEmbedderPooling(Enum):
     #: Perform Last Token Pooling on the output of the embedding model.
     LAST_TOKEN = "last_token"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
     @classmethod

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/quantization.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/quantization.py
@@ -27,7 +27,7 @@ class OptimumEmbedderQuantizationMode(Enum):
     #: Quantization with AVX-512 and VNNI instructions.
     AVX512_VNNI = "avx512_vnni"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
     @classmethod

--- a/integrations/paddleocr/pyproject.toml
+++ b/integrations/paddleocr/pyproject.toml
@@ -84,6 +84,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -111,6 +112,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Ignore checks for possible passwords
   "S105",
   "S106",
@@ -134,7 +137,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -175,7 +175,7 @@ class PaddleOCRVLDocumentConverter:
         relevel_titles: bool | None = None,
         visualize: bool | None = None,
         additional_params: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Create a `PaddleOCRVLDocumentConverter` component.
 

--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -91,6 +91,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -119,6 +120,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Allow boolean positional values in function calls, like `dict.get(... True)`
   "FBT003",
   # Ignore checks for possible passwords
@@ -145,7 +148,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # examples can contain "print" commands
 "examples/**/*" = ["T201"]
 

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
@@ -66,7 +66,7 @@ class PgvectorEmbeddingRetriever:
         top_k: int = 10,
         vector_function: Literal["cosine_similarity", "inner_product", "l2_distance"] | None = None,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         :param document_store: An instance of `PgvectorDocumentStore`.
         :param filters: Filters applied to the retrieved Documents.

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
@@ -55,7 +55,7 @@ class PgvectorKeywordRetriever:
         filters: dict[str, Any] | None = None,
         top_k: int = 10,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         :param document_store: An instance of `PgvectorDocumentStore`.
         :param filters: Filters applied to the retrieved Documents.

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -96,7 +96,7 @@ class PgvectorDocumentStore:
         hnsw_index_name: str = "haystack_hnsw_index",
         hnsw_ef_search: int | None = None,
         keyword_index_name: str = "haystack_keyword_index",
-    ):
+    ) -> None:
         """
         Creates a new PgvectorDocumentStore instance.
         It is meant to be connected to a PostgreSQL database with the pgvector extension installed.
@@ -223,7 +223,7 @@ class PgvectorDocumentStore:
         return default_from_dict(cls, data)
 
     @staticmethod
-    def _connection_is_valid(connection):
+    def _connection_is_valid(connection: Connection) -> bool:
         """
         Internal method to check if the connection is still valid.
         """
@@ -238,7 +238,7 @@ class PgvectorDocumentStore:
         return True
 
     @staticmethod
-    async def _connection_is_valid_async(connection):
+    async def _connection_is_valid_async(connection: AsyncConnection) -> bool:
         """
         Internal method to check if the async connection is still valid.
         """
@@ -250,18 +250,18 @@ class PgvectorDocumentStore:
 
     @overload
     def _execute_sql(
-        self, cursor: Cursor, sql_query: Composed, params: tuple | None = None, error_msg: str = ""
+        self, cursor: Cursor, sql_query: SQL | Composed, params: tuple | None = None, error_msg: str = ""
     ) -> Cursor: ...
 
     @overload
     def _execute_sql(
-        self, cursor: Cursor[DictRow], sql_query: Composed, params: tuple | None = None, error_msg: str = ""
+        self, cursor: Cursor[DictRow], sql_query: SQL | Composed, params: tuple | None = None, error_msg: str = ""
     ) -> Cursor[DictRow]: ...
 
     def _execute_sql(
         self,
         cursor: Cursor | Cursor[DictRow],
-        sql_query: Composed,
+        sql_query: SQL | Composed,
         params: tuple | None = None,
         error_msg: str = "",
     ) -> Cursor | Cursor[DictRow]:
@@ -299,18 +299,18 @@ class PgvectorDocumentStore:
 
     @overload
     async def _execute_sql_async(
-        self, cursor: AsyncCursor, sql_query: Composed, params: tuple | None = None, error_msg: str = ""
+        self, cursor: AsyncCursor, sql_query: SQL | Composed, params: tuple | None = None, error_msg: str = ""
     ) -> AsyncCursor: ...
 
     @overload
     async def _execute_sql_async(
-        self, cursor: AsyncCursor[DictRow], sql_query: Composed, params: tuple | None = None, error_msg: str = ""
+        self, cursor: AsyncCursor[DictRow], sql_query: SQL | Composed, params: tuple | None = None, error_msg: str = ""
     ) -> AsyncCursor[DictRow]: ...
 
     async def _execute_sql_async(
         self,
         cursor: AsyncCursor | AsyncCursor[DictRow],
-        sql_query: Composed,
+        sql_query: SQL | Composed,
         params: tuple | None = None,
         error_msg: str = "",
     ) -> AsyncCursor | AsyncCursor[DictRow]:
@@ -346,7 +346,7 @@ class PgvectorDocumentStore:
 
         return result
 
-    def _ensure_db_setup(self):
+    def _ensure_db_setup(self) -> None:
         """
         Ensures that the connection to the PostgreSQL database exists and is valid.
         If not, connection and cursors are created.
@@ -384,7 +384,7 @@ class PgvectorDocumentStore:
         if not self._table_initialized:
             self._initialize_table()
 
-    async def _ensure_db_setup_async(self):
+    async def _ensure_db_setup_async(self) -> None:
         """
         Async internal method.
         Ensures that the connection to the PostgreSQL database exists and is valid.
@@ -426,7 +426,7 @@ class PgvectorDocumentStore:
         if not self._table_initialized:
             await self._initialize_table_async()
 
-    def _build_table_creation_queries(self):
+    def _build_table_creation_queries(self) -> tuple[SQL, Composed, SQL, Composed]:
         """
         Internal method to build the SQL queries for table creation.
         """
@@ -453,7 +453,7 @@ class PgvectorDocumentStore:
 
         return sql_table_exists, sql_create_table, sql_keyword_index_exists, sql_create_keyword_index
 
-    def _initialize_table(self):
+    def _initialize_table(self) -> None:
         """
         Internal method to initialize the table.
         """
@@ -497,7 +497,7 @@ class PgvectorDocumentStore:
 
         self._table_initialized = True
 
-    async def _initialize_table_async(self):
+    async def _initialize_table_async(self) -> None:
         """
         Internal async method to initialize the table.
         """
@@ -547,7 +547,7 @@ class PgvectorDocumentStore:
 
         self._table_initialized = True
 
-    def delete_table(self):
+    def delete_table(self) -> None:
         """
         Deletes the table used to store Haystack documents.
         The name of the schema (`schema_name`) and the name of the table (`table_name`)
@@ -567,7 +567,7 @@ class PgvectorDocumentStore:
             error_msg=f"Could not delete table {self.schema_name}.{self.table_name} in PgvectorDocumentStore",
         )
 
-    async def delete_table_async(self):
+    async def delete_table_async(self) -> None:
         """
         Async method to delete the table used to store Haystack documents.
         """
@@ -585,7 +585,7 @@ class PgvectorDocumentStore:
             error_msg=f"Could not delete table {self.schema_name}.{self.table_name} in PgvectorDocumentStore",
         )
 
-    def _build_hnsw_queries(self):
+    def _build_hnsw_queries(self) -> tuple[Composed | None, SQL, Composed, Composed]:
         """Common method to build all HNSW-related SQL queries"""
 
         sql_set_hnsw_ef_search = (
@@ -633,7 +633,7 @@ class PgvectorDocumentStore:
 
         return sql_set_hnsw_ef_search, sql_hnsw_index_exists, sql_drop_hnsw_index, sql_create_hnsw_index
 
-    def _handle_hnsw(self):
+    def _handle_hnsw(self) -> None:
         """
         Internal method to handle the HNSW index creation.
         It also sets the `hnsw.ef_search` parameter for queries if it is specified.
@@ -645,7 +645,7 @@ class PgvectorDocumentStore:
 
         assert self._cursor is not None
 
-        if self.hnsw_ef_search:
+        if sql_set_hnsw_ef_search is not None:
             self._execute_sql(
                 cursor=self._cursor, sql_query=sql_set_hnsw_ef_search, error_msg="Could not set hnsw.ef_search"
             )
@@ -671,7 +671,7 @@ class PgvectorDocumentStore:
 
         self._execute_sql(cursor=self._cursor, sql_query=sql_create_hnsw_index, error_msg="Could not create HNSW index")
 
-    async def _handle_hnsw_async(self):
+    async def _handle_hnsw_async(self) -> None:
         """
         Internal async method to handle the HNSW index creation.
         """
@@ -682,7 +682,7 @@ class PgvectorDocumentStore:
 
         assert self._async_cursor is not None
 
-        if self.hnsw_ef_search:
+        if sql_set_hnsw_ef_search is not None:
             await self._execute_sql_async(
                 cursor=self._async_cursor, sql_query=sql_set_hnsw_ef_search, error_msg="Could not set hnsw.ef_search"
             )
@@ -1439,7 +1439,7 @@ class PgvectorDocumentStore:
         docs = _from_pg_to_haystack_documents(records)
         return docs
 
-    def _prepare_filters_count_documents(self, filters):
+    def _prepare_filters_count_documents(self, filters: dict[str, Any] | None) -> tuple[tuple[Any, ...], Composed]:
         _validate_filters(filters)
         sql_count = SQL("SELECT COUNT(*) FROM {schema_name}.{table_name}").format(
             schema_name=Identifier(self.schema_name), table_name=Identifier(self.table_name)
@@ -1681,7 +1681,7 @@ class PgvectorDocumentStore:
 
         return fields_info
 
-    def _analyze_metadata_from_docs_query(self):
+    def _analyze_metadata_from_docs_query(self) -> Composed:
         # query all documents to analyze metadata structure
         sql_query = SQL("SELECT meta FROM {schema_name}.{table_name} WHERE meta IS NOT NULL").format(
             schema_name=Identifier(self.schema_name), table_name=Identifier(self.table_name)

--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -90,6 +90,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -118,6 +119,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Allow boolean positional values in function calls, like `dict.get(... True)`
   "FBT003",
   # Ignore checks for possible passwords
@@ -142,7 +145,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # examples can contain "print" commands
 "examples/**/*" = ["T201"]
 

--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -58,7 +58,7 @@ class PineconeEmbeddingRetriever:
         filters: dict[str, Any] | None = None,
         top_k: int = 10,
         filter_policy: str | FilterPolicy = FilterPolicy.REPLACE,
-    ):
+    ) -> None:
         """
         :param document_store: The Pinecone Document Store.
         :param filters: Filters applied to the retrieved Documents.

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -44,7 +44,7 @@ class PineconeDocumentStore:
         spec: dict[str, Any] | None = None,
         metric: Literal["cosine", "euclidean", "dotproduct"] = "cosine",
         show_progress: bool = True,
-    ):
+    ) -> None:
         """
         Creates a new PineconeDocumentStore instance.
         It is meant to be connected to a Pinecone index and namespace.
@@ -81,9 +81,9 @@ class PineconeDocumentStore:
         self._async_index: _IndexAsyncio | None = None
         self._dummy_vector = [-10.0] * self.dimension
 
-    def _initialize_index(self):
+    def _initialize_index(self) -> None:
         if self._index is not None:
-            return self._index
+            return
 
         client = Pinecone(api_key=self.api_key.resolve_value(), source_tag="haystack")
 
@@ -108,9 +108,9 @@ class PineconeDocumentStore:
         self.dimension = actual_dimension or self.dimension
         self._dummy_vector = [-10.0] * self.dimension
 
-    async def _initialize_async_index(self):
+    async def _initialize_async_index(self) -> None:
         if self._async_index is not None:
-            return self._async_index
+            return
 
         async_client = PineconeAsyncio(api_key=self.api_key.resolve_value(), source_tag="haystack")
 
@@ -143,7 +143,7 @@ class PineconeDocumentStore:
 
         await async_client.close()
 
-    def close(self):
+    def close(self) -> None:
         """
         Close the associated synchronous resources.
         """
@@ -151,7 +151,7 @@ class PineconeDocumentStore:
             self._index.close()
             self._index = None
 
-    async def close_async(self):
+    async def close_async(self) -> None:
         """
         Close the associated asynchronous resources. To be invoked manually when the Document Store is no longer needed.
         """

--- a/integrations/pyversity/pyproject.toml
+++ b/integrations/pyversity/pyproject.toml
@@ -84,6 +84,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -111,6 +112,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Ignore checks for possible passwords
   "S105",
   "S106",
@@ -134,7 +137,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # Examples can use print statements
 "examples/**/*" = ["T201"]
 

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -88,6 +88,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -116,6 +117,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Allow boolean positional values in function calls, like `dict.get(... True)`
   "FBT003",
   # Allow boolean arguments in function definition
@@ -140,7 +143,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 # examples can contain "print" commands
 "examples/**/*" = ["T201"]
 

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -85,6 +85,7 @@ exclude = ["example", "tests"]
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -113,6 +114,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Allow boolean positional values in function calls, like `dict.get(... True)`
   "FBT003",
   # Ignore checks for possible passwords
@@ -139,7 +142,7 @@ ban-relative-imports = "all"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -57,7 +57,7 @@ class RagasEvaluator:
         ragas_metrics: list[Metric],
         evaluator_llm: BaseRagasLLM | None = None,
         evaluator_embedding: BaseRagasEmbeddings | None = None,
-    ):
+    ) -> None:
         """
         Constructs a new Ragas evaluator.
 

--- a/integrations/snowflake/pyproject.toml
+++ b/integrations/snowflake/pyproject.toml
@@ -86,6 +86,7 @@ line-length = 120
 [tool.ruff.lint]
 select = [
   "A",
+  "ANN",
   "ARG",
   "B",
   "C",
@@ -113,6 +114,8 @@ select = [
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
+  # Allow Any in type annotations at dynamic boundaries
+  "ANN401",
   # Ignore checks for possible passwords
   "S105",
   "S106",
@@ -137,7 +140,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]


### PR DESCRIPTION
### Related Issues

None

### Proposed Changes:

- Add `ANN` (flake8-annotations) to the ruff `select` ruleset for 8 integrations: `optimum`, `paddleocr`, `pgvector`, `pinecone`, `pyversity`, `qdrant`, `ragas`, `snowflake`
- Add `ANN401` to `ignore` (allow `Any` at dynamic/SDK boundaries)
- Add `ANN` to `tests/**/*` per-file-ignores (tests don't need type annotations)
- Fix all ANN violations in source files: add missing return types (`-> None`, `-> str`, etc.) and parameter type annotations
- In `pgvector`: broaden `_execute_sql` / `_execute_sql_async` overload signatures from `Composed` to `SQL | Composed` to correctly reflect accepted types; fix `_handle_hnsw` type narrowing
- In PineconeDocumentStore's `_initialize_index` and `_initialize_async_index`: return `None` instead of the index

### How did you test it?

Ran tests locally

### Notes for the reviewer

The only changes that are out of the ordinary ANN ruleset changes are in PineconeDocumentStore's `_initialize_index` and `_initialize_async_index`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.