### PR TITLE
chore: enforce ruff docstring rules in integrations 21-30 (langfuse, lara, llama_cpp, llama_stack, mcp, meta_llama, mistral, mongodb_atlas, nvidia, ollama)

### DIFF
--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -88,6 +88,13 @@ select = [
   "ARG",
   "B",
   "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
   "DTZ",
   "E",
   "EM",
@@ -136,10 +143,10 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 # Examples can print their output
-"examples/**" = ["T201", "ANN"]
-"example/**" = ["T201", "ANN"]
+"examples/**" = ["T201", "ANN", "D"]
+"example/**" = ["T201", "ANN", "D"]
 "tests/**" = ["T201"]
 
 [tool.coverage.run]

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 class LangfuseConnector:
     """
     LangfuseConnector connects Haystack LLM framework with [Langfuse](https://langfuse.com) in order to enable the
+
     tracing of operations and data flow within various components of a pipeline.
 
     To use LangfuseConnector, add it to your pipeline without connecting it to any other components.

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -125,6 +125,7 @@ class LangfuseSpan(Span):
         return self._data
 
     def get_correlation_data_for_logs(self) -> dict[str, Any]:
+        """Return correlation data for log enrichment."""
         return {}
 
 
@@ -234,9 +235,11 @@ class SpanHandler(ABC):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "SpanHandler":
+        """Deserialize a SpanHandler from a dictionary."""
         return default_from_dict(cls, data)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this SpanHandler to a dictionary."""
         return default_to_dict(self)
 
 
@@ -273,6 +276,7 @@ class DefaultSpanHandler(SpanHandler):
     """DefaultSpanHandler provides the default Langfuse tracing behavior for Haystack."""
 
     def create_span(self, context: SpanContext) -> LangfuseSpan:
+        """Create a Langfuse span based on the given context."""
         if self.tracer is None:
             message = (
                 "Tracer is not initialized. "
@@ -343,6 +347,7 @@ class DefaultSpanHandler(SpanHandler):
             return LangfuseSpan(self.tracer.start_as_current_span(name=context.name))
 
     def handle(self, span: LangfuseSpan, component_type: str | None) -> None:
+        """Process and enrich a span after component execution."""
         # If the span is at the pipeline level, we add input and output keys to the span
         at_pipeline_level = span.get_data().get(_PIPELINE_INPUT_KEY) is not None
         if at_pipeline_level:
@@ -456,6 +461,7 @@ class LangfuseTracer(Tracer):
     def trace(
         self, operation_name: str, tags: dict[str, Any] | None = None, parent_span: Span | None = None
     ) -> Iterator[Span]:
+        """Create and manage a tracing span as a context manager."""
         tags = tags or {}
         span_name = tags.get(_COMPONENT_NAME_KEY, operation_name)
         component_type = tags.get(_COMPONENT_TYPE_KEY)
@@ -543,6 +549,7 @@ class LangfuseTracer(Tracer):
                 self.flush()
 
     def flush(self) -> None:
+        """Flush all pending spans to Langfuse."""
         self._tracer.flush()
 
     def current_span(self) -> Span | None:
@@ -558,6 +565,7 @@ class LangfuseTracer(Tracer):
     def get_trace_url(self) -> str:
         """
         Return the URL to the tracing data.
+
         :return: The URL to the tracing data.
         """
         return self._tracer.get_trace_url() or ""
@@ -565,6 +573,7 @@ class LangfuseTracer(Tracer):
     def get_trace_id(self) -> str:
         """
         Return the trace ID.
+
         :return: The trace ID.
         """
         return self._tracer.get_current_trace_id() or ""

--- a/integrations/lara/pyproject.toml
+++ b/integrations/lara/pyproject.toml
@@ -95,6 +95,13 @@ select = [
     "ARG",
     "B",
     "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
     "DTZ",
     "E",
     "EM",
@@ -149,7 +156,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -99,6 +99,13 @@ select = [
     "ARG",
     "B",
     "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
     "DTZ",
     "E",
     "EM",
@@ -142,7 +149,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 # Examples can print their output
 "examples/**" = ["T201"]
 "tests/**" = ["T201"]

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -211,8 +211,11 @@ class LlamaCppChatGenerator:
         model_clip_path: str | None = None,
     ) -> None:
         """
+        Initialize LlamaCppChatGenerator.
+
         :param model: The path of a quantized model for text generation, for example, "zephyr-7b-beta.Q4_0.gguf".
             If the model path is also specified in the `model_kwargs`, this parameter will be ignored.
+
         :param n_ctx: The number of tokens in the context. When set to 0, the context will be taken from the model.
         :param n_batch: Prompt processing maximum batch size.
         :param model_kwargs: Dictionary containing keyword arguments used to initialize the LLM for text generation.
@@ -274,6 +277,7 @@ class LlamaCppChatGenerator:
         self._inference_lock = asyncio.Lock()
 
     def warm_up(self) -> None:
+        """Load and initialize the llama.cpp model."""
         if self._model is not None:
             return
 
@@ -462,6 +466,7 @@ class LlamaCppChatGenerator:
     ) -> dict[str, list[ChatMessage]]:
         """
         Take streaming responses from llama.cpp, convert to Haystack StreamingChunk objects, stream them,
+
         and finally convert them to a ChatMessage.
 
         :param response_stream: The streaming responses from llama.cpp.

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/generator.py
@@ -38,8 +38,11 @@ class LlamaCppGenerator:
         generation_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
+        Initialize LlamaCppGenerator.
+
         :param model: The path of a quantized model for text generation, for example, "zephyr-7b-beta.Q4_0.gguf".
             If the model path is also specified in the `model_kwargs`, this parameter will be ignored.
+
         :param n_ctx: The number of tokens in the context. When set to 0, the context will be taken from the model.
         :param n_batch: Prompt processing maximum batch size.
         :param model_kwargs: Dictionary containing keyword arguments used to initialize the LLM for text generation.
@@ -69,6 +72,7 @@ class LlamaCppGenerator:
         self.model: Llama | None = None
 
     def warm_up(self) -> None:
+        """Load and initialize the llama.cpp model."""
         if self.model is None:
             self.model = Llama(**self.model_kwargs)
 

--- a/integrations/llama_stack/pyproject.toml
+++ b/integrations/llama_stack/pyproject.toml
@@ -84,6 +84,13 @@ select = [
   "ARG",
   "B",
   "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
   "DTZ",
   "E",
   "EM",
@@ -137,7 +144,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN", "E501", "F841"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN", "E501", "F841"]
 # Examples can print their output and don't need type annotations
 "examples/**/*" = ["T201", "ANN"]
 

--- a/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
+++ b/integrations/llama_stack/src/haystack_integrations/components/generators/llama_stack/chat/chat_generator.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 class LlamaStackChatGenerator(OpenAIChatGenerator):
     """
     Enables text generation using Llama Stack framework.
+
     Llama Stack Server supports multiple inference providers, including Ollama, Together,
     and vLLM and other cloud providers.
     For a complete list of inference providers, see [Llama Stack docs](https://llama-stack.readthedocs.io/en/latest/providers/inference/index.html).
@@ -70,8 +71,10 @@ class LlamaStackChatGenerator(OpenAIChatGenerator):
         http_client_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
-        Creates an instance of LlamaStackChatGenerator. To use this chat generator,
-        you need to setup Llama Stack Server with an inference provider and have a model available.
+        Creates an instance of LlamaStackChatGenerator.
+
+        To use this chat generator, you need to setup Llama Stack Server with an inference provider and have a model
+        available.
 
         :param model:
             The name of the model to use for chat completion.

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -99,6 +99,13 @@ select = [
     "ARG",
     "B",
     "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
     "DTZ",
     "E",
     "EM",
@@ -153,8 +160,8 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
-"examples/**/*" = ["T201", "E501", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
+"examples/**/*" = ["T201", "E501", "ANN", "D"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -119,8 +119,7 @@ class AsyncExecutor:
         self, coro_factory: Callable[[asyncio.Event], Coroutine[Any, Any, Any]], timeout: float | None = None
     ) -> tuple[concurrent.futures.Future[Any], asyncio.Event]:
         """
-        Schedule `coro_factory` to run in the executor's event loop **without** blocking the
-        caller thread.
+        Schedule `coro_factory` to run in the executor's event loop **without** blocking the caller thread.
 
         The factory receives an :class:`asyncio.Event` that can be used to cooperatively shut
         the coroutine down. The method returns **both** the concurrent future (to observe
@@ -1292,7 +1291,8 @@ class MCPTool(Tool):
 
 
 class _MCPClientSessionManager:
-    """Runs an MCPClient connect/close inside the AsyncExecutor's event loop.
+    """
+    Runs an MCPClient connect/close inside the AsyncExecutor's event loop.
 
     Life-cycle:
       1.  Create the worker to schedule a long-running coroutine in the

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
@@ -113,8 +113,7 @@ def _deserialize_state_config(config: dict[str, dict[str, Any]] | None) -> dict[
 
 class MCPToolset(Toolset):
     """
-    A Toolset that connects to an MCP (Model Context Protocol) server and provides
-    access to its tools.
+    A Toolset that connects to an MCP (Model Context Protocol) server and provides access to its tools.
 
     MCPToolset dynamically discovers and loads all tools from any MCP-compliant server,
     supporting both network-based streaming connections (Streamable HTTP, SSE) and local
@@ -289,7 +288,8 @@ class MCPToolset(Toolset):
             self._warmup_called = True
 
     def warm_up(self) -> None:
-        """Connect and load tools when eager_connect is turned off.
+        """
+        Connect and load tools when eager_connect is turned off.
 
         This method is automatically called by ``ToolInvoker.warm_up()`` and ``Pipeline.warm_up()``.
         You can also call it directly before using the toolset to ensure all tool schemas

--- a/integrations/meta_llama/pyproject.toml
+++ b/integrations/meta_llama/pyproject.toml
@@ -84,6 +84,13 @@ select = [
   "ARG",
   "B",
   "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
   "DTZ",
   "E",
   "EM",
@@ -133,7 +140,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
+++ b/integrations/meta_llama/src/haystack_integrations/components/generators/meta_llama/chat/chat_generator.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 class MetaLlamaChatGenerator(OpenAIChatGenerator):
     """
     Enables text generation using Llama generative models.
+
     For supported models, see [Llama API Docs](https://llama.developer.meta.com/docs/).
 
     Users can pass any text generation parameters valid for the Llama Chat Completion API
@@ -76,8 +77,9 @@ class MetaLlamaChatGenerator(OpenAIChatGenerator):
         tools: ToolsType | None = None,
     ) -> None:
         """
-        Creates an instance of LlamaChatGenerator. Unless specified otherwise in the `model`, this is for Llama's
-        `Llama-4-Scout-17B-16E-Instruct-FP8` model.
+        Creates an instance of LlamaChatGenerator.
+
+        Unless specified otherwise in the `model`, this is for Llama's `Llama-4-Scout-17B-16E-Instruct-FP8` model.
 
         :param api_key:
             The Llama API key.

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -87,6 +87,13 @@ select = [
   "ARG",
   "B",
   "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
   "DTZ",
   "E",
   "EM",
@@ -136,7 +143,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
+++ b/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
@@ -26,8 +26,9 @@ logger = logging.getLogger(__name__)
 @component
 class MistralOCRDocumentConverter:
     """
-    This component extracts text from documents using Mistral's OCR API, with optional structured
-    annotations for both individual image regions (bounding boxes) and full documents.
+    Extract text from documents using Mistral's OCR API with optional structured annotations.
+
+    Supports optional structured annotations for individual image regions (bounding boxes) and full documents.
 
     Accepts document sources in various formats (str/Path for local files, ByteStream for in-memory data,
     DocumentURLChunk for document URLs, ImageURLChunk for image URLs, or FileChunk for Mistral file IDs)

--- a/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
+++ b/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
@@ -12,6 +12,7 @@ from haystack.utils.auth import Secret
 class MistralDocumentEmbedder(OpenAIDocumentEmbedder):
     """
     A component for computing Document embeddings using Mistral models.
+
     The embedding of each Document is stored in the `embedding` field of the Document.
 
     Usage example:

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 class MistralChatGenerator(OpenAIChatGenerator):
     """
     Enables text generation using Mistral AI generative models.
+
     For supported models, see [Mistral AI docs](https://docs.mistral.ai/getting-started/models).
 
     Users can pass any text generation parameters valid for the Mistral Chat Completion API
@@ -124,8 +125,9 @@ class MistralChatGenerator(OpenAIChatGenerator):
         http_client_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
-        Creates an instance of MistralChatGenerator. Unless specified otherwise in the `model`, this is for Mistral's
-        `mistral-small-latest` model.
+        Creates an instance of MistralChatGenerator.
+
+        Unless specified otherwise in the `model`, this is for Mistral's `mistral-small-latest` model.
 
         :param api_key:
             The Mistral API key.

--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -89,6 +89,13 @@ select = [
   "ARG",
   "B",
   "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
   "DTZ",
   "E",
   "EM",
@@ -140,7 +147,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 # examples can contain "print" commands
 "examples/**/*" = ["T201"]
 

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -142,8 +142,7 @@ class MongoDBAtlasEmbeddingRetriever:
         top_k: int | None = None,
     ) -> dict[str, list[Document]]:
         """
-        Asynchronously retrieve documents from the MongoDBAtlasDocumentStore, based on the provided embedding
-        similarity.
+        Asynchronously retrieve documents from MongoDBAtlasDocumentStore based on embedding similarity.
 
         :param query_embedding: Embedding of the query.
         :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
@@ -49,6 +49,7 @@ class MongoDBAtlasFullTextRetriever:
     ) -> None:
         """
         :param document_store: An instance of MongoDBAtlasDocumentStore.
+
         :param filters: Filters applied to the retrieved Documents. Make sure that the fields used in the filters are
             included in the configuration of the `full_text_search_index`. The configuration must be done manually
             in the Web UI of MongoDB Atlas.

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -23,8 +23,7 @@ logger = logging.getLogger(__name__)
 
 class MongoDBAtlasDocumentStore:
     """
-    A MongoDBAtlasDocumentStore implementation that uses the
-    [MongoDB Atlas](https://www.mongodb.com/atlas/database) service that is easy to deploy, operate, and scale.
+    A MongoDBAtlasDocumentStore backed by [MongoDB Atlas](https://www.mongodb.com/atlas/database).
 
     To connect to MongoDB Atlas, you need to provide a connection string in the format:
     `"mongodb+srv://{mongo_atlas_username}:{mongo_atlas_password}@{mongo_atlas_host}/?{mongo_atlas_params_string}"`.
@@ -120,6 +119,7 @@ class MongoDBAtlasDocumentStore:
 
     @property
     def connection(self) -> AsyncMongoClient | MongoClient:
+        """Return the active MongoDB client connection."""
         if self._connection:
             return self._connection
         if self._connection_async:
@@ -129,6 +129,7 @@ class MongoDBAtlasDocumentStore:
 
     @property
     def collection(self) -> AsyncCollection | Collection:
+        """Return the active MongoDB collection."""
         if self._collection:
             return self._collection
         if self._collection_async:
@@ -352,8 +353,7 @@ class MongoDBAtlasDocumentStore:
         self, filters: dict[str, Any], metadata_fields: list[str]
     ) -> dict[str, int]:
         """
-        Asynchronously applies a filter selecting documents and counts the unique values for each meta field of the
-        matched documents.
+        Asynchronously applies a filter selecting documents and counts unique metadata values for each meta field.
 
         :param filters: The filters to apply to the document list.
         :param metadata_fields: The metadata fields to count unique values for.
@@ -538,8 +538,7 @@ class MongoDBAtlasDocumentStore:
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
     ) -> tuple[list[str], int]:
         """
-        Asynchronously retrieves unique values for a field matching a search_term or all possible values if no search
-        term is given.
+        Asynchronously retrieves unique values for a metadata field, optionally filtered by a search term.
 
         :param metadata_field: The metadata field to retrieve unique values for.
         :param search_term: The search term to filter values. Matches as a case-insensitive substring.
@@ -972,8 +971,7 @@ class MongoDBAtlasDocumentStore:
         self, query_embedding: list[float], filters: dict[str, Any] | None = None, top_k: int = 10
     ) -> list[Document]:
         """
-        Asynchronously find the documents that are most similar to the provided `query_embedding` by using a vector
-        similarity metric.
+        Asynchronously find the documents most similar to the provided `query_embedding` using vector similarity.
 
         :param query_embedding: Embedding of the query
         :param filters: Optional filters.

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -91,6 +91,13 @@ select = [
   "ARG",
   "B",
   "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
   "DTZ",
   "E",
   "EM",
@@ -140,7 +147,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 
 [tool.coverage.run]
 source = ["haystack_integrations"]

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/document_embedder.py
@@ -20,8 +20,7 @@ logger = logging.getLogger(__name__)
 @component
 class NvidiaDocumentEmbedder:
     """
-    A component for embedding documents using embedding models provided by
-    [NVIDIA NIMs](https://ai.nvidia.com).
+    A component for embedding documents using embedding models provided by [NVIDIA NIMs](https://ai.nvidia.com).
 
     Usage example:
     ```python
@@ -107,6 +106,7 @@ class NvidiaDocumentEmbedder:
 
     @classmethod
     def class_name(cls) -> str:
+        """Return the class name identifier for serialization."""
         return "NvidiaDocumentEmbedder"
 
     def default_model(self) -> None:

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/text_embedder.py
@@ -18,8 +18,7 @@ logger = logging.getLogger(__name__)
 @component
 class NvidiaTextEmbedder:
     """
-    A component for embedding strings using embedding models provided by
-    [NVIDIA NIMs](https://ai.nvidia.com).
+    A component for embedding strings using embedding models provided by [NVIDIA NIMs](https://ai.nvidia.com).
 
     For models that differentiate between query and document inputs,
     this component embeds the input string as a query.
@@ -90,6 +89,7 @@ class NvidiaTextEmbedder:
 
     @classmethod
     def class_name(cls) -> str:
+        """Return the class name identifier for serialization."""
         return "NvidiaTextEmbedder"
 
     def default_model(self) -> None:

--- a/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/embedders/nvidia/truncate.py
@@ -8,6 +8,7 @@ from enum import Enum
 class EmbeddingTruncateMode(Enum):
     """
     Specifies how inputs to the NVIDIA embedding components are truncated.
+
     If START, the input will be truncated from the start.
     If END, the input will be truncated from the end.
     If NONE, an error will be returned (if the input is too long).

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/chat/chat_generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/chat/chat_generator.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 class NvidiaChatGenerator(OpenAIChatGenerator):
     """
     Enables text generation using NVIDIA generative models.
+
     For supported models, see [NVIDIA Docs](https://build.nvidia.com/models).
 
     Users can pass any text generation parameters valid for the NVIDIA Chat Completion API

--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
@@ -15,8 +15,9 @@ from haystack_integrations.utils.nvidia import DEFAULT_API_URL, Client, Model, N
 @component
 class NvidiaGenerator:
     """
-    Generates text using generative models hosted with
-    [NVIDIA NIM](https://ai.nvidia.com) on the [NVIDIA API Catalog](https://build.nvidia.com/explore/discover).
+    Generates text using generative models hosted with [NVIDIA NIM](https://ai.nvidia.com).
+
+    Available via the [NVIDIA API Catalog](https://build.nvidia.com/explore/discover).
 
     ### Usage example
 
@@ -88,6 +89,7 @@ class NvidiaGenerator:
 
     @classmethod
     def class_name(cls) -> str:
+        """Return the class name identifier for serialization."""
         return "NvidiaGenerator"
 
     def default_model(self) -> None:

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/ranker.py
@@ -18,8 +18,7 @@ logger = logging.getLogger(__name__)
 @component
 class NvidiaRanker:
     """
-    A component for ranking documents using ranking models provided by
-    [NVIDIA NIMs](https://ai.nvidia.com).
+    A component for ranking documents using ranking models provided by [NVIDIA NIMs](https://ai.nvidia.com).
 
     Usage example:
     ```python
@@ -120,6 +119,7 @@ class NvidiaRanker:
 
     @classmethod
     def class_name(cls) -> str:
+        """Return the class name identifier for serialization."""
         return "NvidiaRanker"
 
     def to_dict(self) -> dict[str, Any]:

--- a/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
+++ b/integrations/nvidia/src/haystack_integrations/components/rankers/nvidia/truncate.py
@@ -8,6 +8,7 @@ from enum import Enum
 class RankerTruncateMode(str, Enum):
     """
     Specifies how inputs to the NVIDIA ranker components are truncated.
+
     If NONE, the input will not be truncated and an error returned instead.
     If END, the input will be truncated from the end.
     """

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/models.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/models.py
@@ -36,6 +36,7 @@ class Model:
         return hash(self.id)
 
     def validate(self) -> int:
+        """Validate the model against the backend and return a sort key."""
         if self.client:
             client = self.client if isinstance(self.client, Client) else Client.from_str(self.client)
             supported = {

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
@@ -74,6 +74,7 @@ class NimBackend:
         self.timeout = timeout
 
     def embed(self, texts: list[str]) -> tuple[list[list[float]], dict[str, Any]]:
+        """Compute embeddings for a list of texts via the NIM API."""
         url = f"{self.api_url}/embeddings"
 
         try:
@@ -99,6 +100,7 @@ class NimBackend:
         return embeddings, {"usage": data["usage"]}
 
     def generate(self, prompt: str) -> tuple[list[str], list[dict[str, Any]]]:
+        """Generate text completions for a prompt via the NIM API."""
         # We're using the chat completion endpoint as the NIM API doesn't support
         # the /completions endpoint. So both the non-chat and chat generator will use this.
         # This is the same for local containers and the cloud API.
@@ -152,6 +154,7 @@ class NimBackend:
         return replies, meta
 
     def models(self) -> list[Model]:
+        """Retrieve available models from the NIM API."""
         url = f"{self.api_url}/models"
 
         res = self.session.get(
@@ -175,6 +178,7 @@ class NimBackend:
         return models
 
     def rank(self, query_text: str, document_texts: list[str]) -> list[dict[str, Any]]:
+        """Rank documents by relevance to a query via the NIM API."""
         url = self.api_url
 
         try:

--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/utils.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/utils.py
@@ -49,6 +49,7 @@ def is_hosted(api_url: str) -> bool:
 def lookup_model(name: str) -> Model | None:
     """
     Lookup a model by name, using only the table of known models.
+
     The name is either:
         - directly in the table
         - an alias in the table
@@ -66,8 +67,7 @@ def lookup_model(name: str) -> Model | None:
 
 def determine_model(name: str) -> Model | None:
     """
-    Determine the model to use based on a name, using
-    only the table of known models.
+    Determine the model to use based on a name, using only the table of known models.
 
     Raise a warning if the model is found to be
     an alias of a known model.

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -94,6 +94,13 @@ select = [
     "ARG",
     "B",
     "C",
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D205",   # 1 blank line required between summary line and description
+  "D209",   # Closing triple quotes go to new line
+  "D213",   # summary lines must be positioned on the second physical line of the docstring
+  "D417",   # Missing argument descriptions in the docstring
+  "D419",   # Docstring is empty
     "DTZ",
     "E",
     "EM",
@@ -137,7 +144,7 @@ ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252", "ANN"]
+"tests/**/*" = ["D", "PLR2004", "S101", "TID252", "ANN"]
 # Examples can print their output
 "examples/**" = ["T201"]
 

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
@@ -10,8 +10,9 @@ from ollama import AsyncClient, Client
 @component
 class OllamaDocumentEmbedder:
     """
-    Computes the embeddings of a list of Documents and stores the obtained vectors in the embedding field of each
-    Document. It uses embedding models compatible with the Ollama Library.
+    Computes the embeddings of a list of Documents and stores the obtained vectors in each Document's embedding field.
+
+    It uses embedding models compatible with the Ollama Library.
 
     Usage example:
     ```python
@@ -41,8 +42,11 @@ class OllamaDocumentEmbedder:
         batch_size: int = 32,
     ) -> None:
         """
+        Create a new OllamaDocumentEmbedder instance.
+
         :param model:
             The name of the model to use. The model should be available in the running Ollama instance.
+
         :param url:
             The URL of a running Ollama instance.
         :param generation_kwargs:

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
@@ -8,8 +8,9 @@ from ollama import AsyncClient, Client
 @component
 class OllamaTextEmbedder:
     """
-    Computes the embeddings of a list of Documents and stores the obtained vectors in the embedding field of
-    each Document. It uses embedding models compatible with the Ollama Library.
+    Computes the embeddings of a list of Documents and stores the obtained vectors in each Document's embedding field.
+
+    It uses embedding models compatible with the Ollama Library.
 
     Usage example:
     ```python
@@ -30,6 +31,8 @@ class OllamaTextEmbedder:
         keep_alive: float | str | None = None,
     ) -> None:
         """
+        Create a new OllamaTextEmbedder instance.
+
         :param model:
             The name of the model to use. The model should be available in the running Ollama instance.
         :param url:

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -104,6 +104,7 @@ def _convert_chatmessage_to_ollama_format(message: ChatMessage) -> dict[str, Any
 def _convert_ollama_meta_to_openai_format(input_response_dict: dict) -> dict[str, Any]:
     """
     Map Ollama metadata keys onto the OpenAI-compatible names Haystack expects.
+
     All fields that are not part of the OpenAI metadata are left unchanged in the returned dict.
 
     Example Ollama metadata:
@@ -253,6 +254,8 @@ class OllamaChatGenerator:
         think: bool | Literal["low", "medium", "high"] = False,
     ) -> None:
         """
+        Create a new OllamaChatGenerator instance.
+
         :param model:
             The name of the model to use. The model must already be present (pulled) in the running Ollama instance.
         :param url:
@@ -355,9 +358,9 @@ class OllamaChatGenerator:
         callback: SyncStreamingCallbackT | None,
     ) -> dict[str, list[ChatMessage]]:
         """
-        Merge an Ollama streaming response into a single ChatMessage, preserving
-        tool calls.  Works even when arguments arrive piecemeal as str fragments
-        or as full JSON dicts.
+        Merge an Ollama streaming response into a single ChatMessage, preserving tool calls.
+
+        Works even when arguments arrive piecemeal as str fragments or as full JSON dicts.
         """
 
         component_info = ComponentInfo.from_component(self)
@@ -439,9 +442,10 @@ class OllamaChatGenerator:
         callback: AsyncStreamingCallbackT | None,
     ) -> dict[str, list[ChatMessage]]:
         """
-        Merge an Ollama async streaming response into a single ChatMessage, preserving
-        tool calls.  Works even when arguments arrive piecemeal as str fragments
-        or as full JSON dicts."""
+        Merge an Ollama async streaming response into a single ChatMessage, preserving tool calls.
+
+        Works even when arguments arrive piecemeal as str fragments or as full JSON dicts.
+        """
         component_info = ComponentInfo.from_component(self)
         chunks: list[StreamingChunk] = []
 

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/generator.py
@@ -108,6 +108,8 @@ class OllamaGenerator:
         streaming_callback: Callable[[StreamingChunk], None] | None = None,
     ) -> None:
         """
+        Create a new OllamaGenerator instance.
+
         :param model:
             The name of the model to use. The model should be available in the running Ollama instance.
         :param url:


### PR DESCRIPTION
### Related Issues

Part 3/5 of https://github.com/deepset-ai/haystack-core-integrations/issues/2947

### Proposed Changes:

- Adds ruff pydocstyle rules D102, D103, D205, D209, D213, D417, D419 to `pyproject.toml` for 10 integrations: langfuse, lara, llama_cpp, llama_stack, mcp, meta_llama, mistral, mongodb_atlas, nvidia, ollama
- Fixes all resulting docstring violations (D205 — blank line between summary and description; D102 — missing docstrings on public methods)
- D213/D209 violations were auto-fixed by `ruff --fix`; D205/D102 violations fixed manually
- Added `"D"` to `examples/**` per-file-ignores for langfuse and mcp (example files don't need docstrings)

### How did you test it?

Ran tests locally

### Notes for the reviewer

This is batch 3 of the docstring rules enforcement. Batch 1 (aimlapi through cometapi) was #3008, batch 2 (deepeval through kreuzberg) was #3009.

I thought about adding [D107](https://docs.astral.sh/ruff/rules/undocumented-public-init/), which is not mentioned in the issue. D107 checks that `__init__` method definitions have docstrings. I could open one separate PR that adds D107 to all integrations and one PR to add it to Haystack if we agree its beneficial. For consistency it makes sense but there is not much value added but the `__init__` docstrings so it's not of importance. 

The failing Nvidia tests are unrelated and I wouldn't block this PR because of them.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.