### PR TITLE
feat: add run_async to AstraEmbeddingRetriever

### DIFF
--- a/integrations/astra/src/haystack_integrations/components/retrievers/astra/retriever.py
+++ b/integrations/astra/src/haystack_integrations/components/retrievers/astra/retriever.py
@@ -79,6 +79,28 @@ class AstraEmbeddingRetriever:
 
         return {"documents": self.document_store.search(query_embedding, top_k, filters=filters)}
 
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query_embedding: list[float],
+        filters: dict[str, Any] | None = None,
+        top_k: int | None = None,
+    ) -> dict[str, list[Document]]:
+        """Asynchronously retrieve documents from the AstraDocumentStore.
+
+        :param query_embedding: floats representing the query embedding
+        :param filters: Filters applied to the retrieved Documents. The way runtime filters are applied depends on
+                        the `filter_policy` chosen at retriever initialization. See init method docstring for more
+                        details.
+        :param top_k: the maximum number of documents to retrieve.
+        :returns: a dictionary with the following keys:
+            - `documents`: A list of documents retrieved from the AstraDocumentStore.
+        """
+        filters = apply_filter_policy(self.filter_policy, self.filters, filters)
+        top_k = top_k or self.top_k
+
+        return {"documents": await self.document_store.search_async(query_embedding, top_k, filters=filters)}
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.

--- a/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from collections.abc import Generator
 from typing import Any
 
@@ -447,6 +448,19 @@ class AstraDocumentStore:
         logger.debug(f"Raw responses: {result}")  # leaving for debugging
 
         return result
+
+    async def search_async(
+        self, query_embedding: list[float], top_k: int, filters: dict[str, Any] | None = None
+    ) -> list[Document]:
+        """
+        Async version of search(). Wraps the sync call via asyncio.to_thread.
+
+        :param query_embedding: a list of query embeddings.
+        :param top_k: the number of results to return.
+        :param filters: filters to apply during search.
+        :returns: matching documents.
+        """
+        return await asyncio.to_thread(self.search, query_embedding, top_k, filters=filters)
 
     def delete_documents(self, document_ids: list[str]) -> None:
         """

--- a/integrations/astra/tests/test_retriever_async.py
+++ b/integrations/astra/tests/test_retriever_async.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2023-present Anant Corporation <support@anant.us>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from haystack.document_stores.types import FilterPolicy
+
+from haystack_integrations.components.retrievers.astra import AstraEmbeddingRetriever
+from haystack_integrations.document_stores.astra import AstraDocumentStore
+
+
+@pytest.mark.asyncio
+@patch.dict(
+    "os.environ",
+    {"ASTRA_DB_APPLICATION_TOKEN": "fake-token", "ASTRA_DB_API_ENDPOINT": "http://fake-url.apps.astra.datastax.com"},
+)
+@patch("haystack_integrations.document_stores.astra.document_store.AstraClient")
+async def test_run_async_calls_search_async(*_):
+    ds = AstraDocumentStore()
+    ds.search_async = AsyncMock(return_value=[])
+    retriever = AstraEmbeddingRetriever(ds, filters={"foo": "bar"}, top_k=5)
+
+    result = await retriever.run_async(query_embedding=[0.1, 0.2, 0.3])
+
+    ds.search_async.assert_called_once_with([0.1, 0.2, 0.3], 5, filters={"foo": "bar"})
+    assert result == {"documents": []}
+
+
+@pytest.mark.asyncio
+@patch.dict(
+    "os.environ",
+    {"ASTRA_DB_APPLICATION_TOKEN": "fake-token", "ASTRA_DB_API_ENDPOINT": "http://fake-url.apps.astra.datastax.com"},
+)
+@patch("haystack_integrations.document_stores.astra.document_store.AstraClient")
+async def test_run_async_filter_policy_merge(*_):
+    ds = AstraDocumentStore()
+    ds.search_async = AsyncMock(return_value=[])
+    retriever = AstraEmbeddingRetriever(ds, filters={"foo": "bar"}, top_k=5, filter_policy=FilterPolicy.MERGE)
+
+    await retriever.run_async(query_embedding=[0.1, 0.2, 0.3], filters={"baz": "qux"})
+
+    # apply_filter_policy(MERGE, {"foo": "bar"}, {"baz": "qux"}) returns {"baz": "qux"}
+    # because the runtime filters override the init filters for overlapping / non-nested keys
+    ds.search_async.assert_called_once_with([0.1, 0.2, 0.3], 5, filters={"baz": "qux"})


### PR DESCRIPTION
### Related Issues

- fixes #1387 

### Proposed Changes:

Add run_async() to AstraEmbeddingRetriever and search_async() to AstraDocumentStore to support AsyncPipeline introduced in Haystack 2.10.
   
- AstraDocumentStore.search_async() wraps the existing blocking search() via asyncio.to_thread, offloading the blocking astrapy HTTP calls to a thread pool without requiring a full async client rewrite.
- AstraEmbeddingRetriever.run_async() mirrors the existing run() method, respecting filter_policy and top_k, and awaits search_async().   
                                                                                                                                            
### How did you test it?
                                                                                                                                            
Unit tests added in tests/test_retriever_async.py:                                                                                        
- test_run_async_calls_search_async — verifies search_async is called with correct args under the default REPLACE filter policy
- test_run_async_filter_policy_merge — verifies MERGE filter policy is applied correctly at runtime                                       

```                                                            
cd integrations/astra                                                                                                                     
hatch run test:unit

All 13 unit tests pass.
```
                                                            
### Notes for the reviewer       
                                                            
The astrapy client does not expose a native async API, so asyncio.to_thread is the same approach used by other integrations in this repo (e.g. Pinecone). Integration tests with a live Astra DB were not run locally but the logic is identical to the sync run() path.

_This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests._

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
