### PR TITLE
build: Update PyPI release action runner to ubuntu-latest

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   release-on-pypi:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
 


### PR DESCRIPTION
### Related Issues

Michele found that hayhooks release required ubuntu-latest instead of ubuntu-slim for trusted publishing because ubuntu-slim doesn't include docker command. https://github.com/deepset-ai/hayhooks/pull/234

### Proposed Changes:

- Change GitHub Actions runner from ubuntu-slim to ubuntu-latest

### How did you test it?

Action in the Haystack repo actually uses ubuntu-latest, which I overlooked. The action worked there for the nightly pre-release.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
