### PR TITLE
test: Bedrock - use Sonnet 4.6 due to 3.5 EOL

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -39,8 +39,8 @@ class AmazonBedrockChatGenerator:
     """
     Completes chats using LLMs hosted on Amazon Bedrock available via the Bedrock Converse API.
 
-    For example, to use the Anthropic Claude 3 Sonnet model, initialize this component with the
-    'anthropic.claude-3-5-sonnet-20240620-v1:0' model name.
+    For example, to use the Anthropic Claude 4.6 Sonnet model, initialize this component with the
+    'global.anthropic.claude-sonnet-4-6' model name.
 
     **Usage example**
 
@@ -53,7 +53,7 @@ class AmazonBedrockChatGenerator:
                 ChatMessage.from_user("What's Natural Language Processing?")]
 
 
-    client = AmazonBedrockChatGenerator(model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+    client = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6",
                                         streaming_callback=print_streaming_chunk)
     client.run(messages, generation_kwargs={"max_tokens": 512})
     ```
@@ -64,7 +64,7 @@ class AmazonBedrockChatGenerator:
     from haystack.dataclasses import ChatMessage, ImageContent
     from haystack_integrations.components.generators.amazon_bedrock import AmazonBedrockChatGenerator
 
-    generator = AmazonBedrockChatGenerator(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+    generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
 
     image_content = ImageContent.from_file_path(file_path="apple.jpg")
 
@@ -107,7 +107,7 @@ class AmazonBedrockChatGenerator:
 
     # Initialize generator with tool
     client = AmazonBedrockChatGenerator(
-        model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        model="global.anthropic.claude-sonnet-4-6",
         tools=[weather_tool]
     )
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -211,7 +211,7 @@ class TestAmazonBedrockChatGenerator:
                     "aws_session_token": {"type": "env_var", "env_vars": ["AWS_SESSION_TOKEN"], "strict": False},
                     "aws_region_name": {"type": "env_var", "env_vars": ["AWS_DEFAULT_REGION"], "strict": False},
                     "aws_profile_name": {"type": "env_var", "env_vars": ["AWS_PROFILE"], "strict": False},
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "generation_kwargs": {"temperature": 0.7},
                     "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                     "boto3_config": boto3_config,
@@ -221,7 +221,7 @@ class TestAmazonBedrockChatGenerator:
                 },
             }
         )
-        assert generator.model == "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        assert generator.model == "global.anthropic.claude-sonnet-4-6"
         assert generator.streaming_callback == print_streaming_chunk
         assert generator.boto3_config == boto3_config
 
@@ -229,8 +229,8 @@ class TestAmazonBedrockChatGenerator:
         """
         Test that the default constructor sets the correct values
         """
-        layer = AmazonBedrockChatGenerator(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
-        assert layer.model == "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        layer = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
+        assert layer.model == "global.anthropic.claude-sonnet-4-6"
 
         # assert mocked boto3 client called exactly once
         mock_boto3_session.assert_called_once()
@@ -250,7 +250,7 @@ class TestAmazonBedrockChatGenerator:
         """
         generation_kwargs = {"temperature": 0.7}
         layer = AmazonBedrockChatGenerator(
-            model="anthropic.claude-3-5-sonnet-20240620-v1:0", generation_kwargs=generation_kwargs
+            model="global.anthropic.claude-sonnet-4-6", generation_kwargs=generation_kwargs
         )
         assert layer.generation_kwargs == generation_kwargs
 
@@ -276,7 +276,7 @@ class TestAmazonBedrockChatGenerator:
         )
 
         generator = AmazonBedrockChatGenerator(
-            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            model="global.anthropic.claude-sonnet-4-6",
             generation_kwargs={"temperature": 0.7, "stopSequences": ["eviscerate"]},
             streaming_callback=print_streaming_chunk,
             tools=[tool],
@@ -303,7 +303,7 @@ class TestAmazonBedrockChatGenerator:
                         "aws_session_token": {"type": "env_var", "env_vars": ["AWS_SESSION_TOKEN"], "strict": False},
                         "aws_region_name": {"type": "env_var", "env_vars": ["AWS_DEFAULT_REGION"], "strict": False},
                         "aws_profile_name": {"type": "env_var", "env_vars": ["AWS_PROFILE"], "strict": False},
-                        "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                        "model": "global.anthropic.claude-sonnet-4-6",
                         "generation_kwargs": {"temperature": 0.7, "stopSequences": ["eviscerate"]},
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "boto3_config": None,
@@ -335,7 +335,7 @@ class TestAmazonBedrockChatGenerator:
         assert pipeline_dict == expected_dict
 
     def test_prepare_request_params_tool_config(self, top_song_tool_config, mock_boto3_session, set_env_variables):
-        generator = AmazonBedrockChatGenerator(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+        generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
         request_params, _ = generator._prepare_request_params(
             messages=[ChatMessage.from_user("What's the capital of France?")],
             generation_kwargs={"toolConfig": top_song_tool_config},
@@ -346,7 +346,7 @@ class TestAmazonBedrockChatGenerator:
 
     def test_prepare_request_params_guardrail_config(self, mock_boto3_session, set_env_variables):
         generator = AmazonBedrockChatGenerator(
-            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            model="global.anthropic.claude-sonnet-4-6",
             guardrail_config={"guardrailIdentifier": "test", "guardrailVersion": "test"},
         )
         request_params, _ = generator._prepare_request_params(
@@ -374,7 +374,7 @@ class TestAmazonBedrockChatGenerator:
         toolset = Toolset([population_tool])
 
         generator = AmazonBedrockChatGenerator(
-            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            model="global.anthropic.claude-sonnet-4-6",
             tools=[weather_tool, toolset],
         )
 
@@ -398,7 +398,7 @@ class TestAmazonBedrockChatGenerator:
         )
         toolset = Toolset([population_tool])
 
-        generator = AmazonBedrockChatGenerator(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+        generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
         request_params, _ = generator._prepare_request_params(
             messages=[ChatMessage.from_user("What's the capital of France?")],
             tools=[weather_tool, toolset],
@@ -487,7 +487,7 @@ class TestAmazonBedrockChatGenerator:
     def test_prepare_request_params_with_flattened_generation_kwargs(
         self, mock_boto3_session, set_env_variables, generation_kwargs, additional_model_request_fields
     ):
-        generator = AmazonBedrockChatGenerator(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+        generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
         request_params, _ = generator._prepare_request_params(
             messages=[ChatMessage.from_user("What's the capital of France?")],
             generation_kwargs=generation_kwargs,
@@ -969,7 +969,7 @@ class TestAmazonBedrockChatGeneratorInference:
     def test_live_run_with_guardrail(self, streaming_callback):
         messages = [ChatMessage.from_user("Should I invest in Tesla or Apple?")]
         component = AmazonBedrockChatGenerator(
-            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            model="global.anthropic.claude-sonnet-4-6",
             guardrail_config={
                 "guardrailIdentifier": os.getenv("AWS_BEDROCK_GUARDRAIL_ID"),
                 "guardrailVersion": os.getenv("AWS_BEDROCK_GUARDRAIL_VERSION"),

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -426,7 +426,7 @@ class TestAmazonBedrockChatGeneratorUtils:
                 ],
                 name=None,
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "index": 0,
                     "finish_reason": "tool_use",
                     "usage": {"prompt_tokens": 366, "completion_tokens": 134, "total_tokens": 500},
@@ -493,7 +493,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         ]
 
     def test_extract_replies_from_text_response(self, mock_boto3_session):
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
         text_response = {
             "output": {"message": {"role": "assistant", "content": [{"text": "This is a test response"}]}},
             "stopReason": "end_turn",
@@ -526,7 +526,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         }
 
     def test_extract_replies_from_tool_response(self, mock_boto3_session):
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
         tool_response = {
             "output": {
                 "message": {
@@ -560,7 +560,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         }
 
     def test_extract_replies_from_text_mixed_response(self, mock_boto3_session):
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
         mixed_response = {
             "output": {
                 "message": {
@@ -598,7 +598,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         }
 
     def test_extract_replies_from_multi_tool_response(self, mock_boto3_session):
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
         response_body = {
             "ResponseMetadata": {
                 "RequestId": "0ba58797-2194-4779-9a53-597c24ce337a",
@@ -658,7 +658,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             ],
             name=None,
             meta={
-                "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                "model": "global.anthropic.claude-sonnet-4-6",
                 "index": 0,
                 "finish_reason": "tool_calls",
                 "usage": {
@@ -759,7 +759,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         assert replies[0] == expected_message
 
     def test_extract_replies_with_guardrail(self, mock_boto3_session):
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
 
         trace = {
             "guardrail": {
@@ -919,7 +919,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         """
         Test that process_streaming_response correctly handles streaming events and accumulates responses
         """
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
         type_ = (
             "haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator.AmazonBedrockChatGenerator"
         )
@@ -1199,7 +1199,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             assert "reasoning_contents" not in chunk.meta
 
     def test_parse_streaming_response_with_two_tool_calls(self, mock_boto3_session):
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
         type_ = (
             "haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator.AmazonBedrockChatGenerator"
         )
@@ -1266,7 +1266,7 @@ class TestAmazonBedrockChatGeneratorUtils:
                     ),
                 ],
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "index": 0,
                     "finish_reason": "tool_calls",
                     "usage": {
@@ -1284,7 +1284,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         assert replies == expected_messages
 
     def test_parse_streaming_response_with_guardrail(self, mock_boto3_session):
-        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        model = "global.anthropic.claude-sonnet-4-6"
         type_ = (
             "haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator.AmazonBedrockChatGenerator"
         )
@@ -1371,7 +1371,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="Certainly! I",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.072764+00:00",
                 },
                 index=0,
@@ -1380,7 +1380,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=" can help",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.111264+00:00",
                 },
                 index=0,
@@ -1388,7 +1388,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=" you print",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.162575+00:00",
                 },
                 index=0,
@@ -1396,7 +1396,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=' "Hello World"',
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.215535+00:00",
                 },
                 index=0,
@@ -1404,7 +1404,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=" using the available",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.270642+00:00",
                 },
                 index=0,
@@ -1412,7 +1412,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=' "',
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.349415+00:00",
                 },
                 index=0,
@@ -1420,7 +1420,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content='hello_world" tool',
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.426891+00:00",
                 },
                 index=0,
@@ -1428,7 +1428,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=". This tool is",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.495910+00:00",
                 },
                 index=0,
@@ -1436,7 +1436,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=' designed to print "',
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.527426+00:00",
                 },
                 index=0,
@@ -1444,7 +1444,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content='Hello World" an',
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.590629+00:00",
                 },
                 index=0,
@@ -1452,7 +1452,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="d doesn't require any parameters",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.682261+00:00",
                 },
                 index=0,
@@ -1460,7 +1460,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=". Let",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.790526+00:00",
                 },
                 index=0,
@@ -1468,7 +1468,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="'s go ahead an",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.845332+00:00",
                 },
                 index=0,
@@ -1476,7 +1476,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="d use",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.990588+00:00",
                 },
                 index=0,
@@ -1484,7 +1484,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content=" it.",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:07.994309+00:00",
                 },
                 index=0,
@@ -1492,14 +1492,14 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:08.359127+00:00",
                 },
             ),
             StreamingChunk(
                 content="",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:08.359912+00:00",
                 },
                 index=1,
@@ -1510,7 +1510,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:08.361612+00:00",
                 },
                 index=1,
@@ -1519,14 +1519,14 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:08.592175+00:00",
                 },
             ),
             StreamingChunk(
                 content="",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:08.592175+00:00",
                 },
                 finish_reason="tool_calls",
@@ -1534,7 +1534,7 @@ class TestAmazonBedrockChatGeneratorUtils:
             StreamingChunk(
                 content="",
                 meta={
-                    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "model": "global.anthropic.claude-sonnet-4-6",
                     "received_at": "2025-07-31T08:46:08.596700+00:00",
                     "usage": {"prompt_tokens": 349, "completion_tokens": 84, "total_tokens": 433},
                 },
@@ -1557,7 +1557,7 @@ class TestAmazonBedrockChatGeneratorUtils:
         assert tool_call.arguments == {}
 
         # Verify meta information
-        assert message._meta["model"] == "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        assert message._meta["model"] == "global.anthropic.claude-sonnet-4-6"
         assert message._meta["index"] == 0
         assert message._meta["finish_reason"] == "tool_calls"
         assert message._meta["usage"] == {"completion_tokens": 84, "prompt_tokens": 349, "total_tokens": 433}


### PR DESCRIPTION
### Related Issues

- tests failing due to Claude Sonnet 3.5 EOL: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/23826258147/job/69449840484

### Proposed Changes:
- replace it with 4.6 (not all replacements in our tests were needed to make tests pass, but I did them for consistency)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
