### PR TITLE
ci: refactor some workflows to make tests properly run on main

### DIFF
--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -81,8 +81,6 @@ jobs:
       - name: Install Hatch
         run: pip install hatch
 
-    # TODO: Once this integration is properly typed, use hatch run test:types
-    # https://github.com/deepset-ai/haystack-core-integrations/issues/1771
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -30,8 +30,6 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-  TEST_MATRIX_OS: '["ubuntu-latest"]'
-  TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 
 jobs:
   compute-test-matrix:
@@ -40,13 +38,20 @@ jobs:
       run:
         working-directory: .
     outputs:
-      os: ${{ steps.set.outputs.os }}
-      python-version: ${{ steps.set.outputs.python-version }}
+      matrix: ${{ steps.set.outputs.matrix }}
     steps:
       - id: set
         run: |
-          echo 'os=${{ github.event_name == 'push' && '["ubuntu-latest"]' || env.TEST_MATRIX_OS }}' >> "$GITHUB_OUTPUT"
-          echo 'python-version=${{ github.event_name == 'push' && '["3.10"]' || env.TEST_MATRIX_PYTHON }}' >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo 'matrix=[{"os":"ubuntu-latest","python-version":"3.10","INDEX_NAME":"index-310"}]' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX='['
+            # Pinecone tests are time expensive, so only test on Ubuntu
+            MATRIX+='{"os":"ubuntu-latest","python-version":"3.10","INDEX_NAME":"index-310"},'
+            MATRIX+='{"os":"ubuntu-latest","python-version":"3.14","INDEX_NAME":"index-313"}'
+            MATRIX+=']'
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          fi
 
   run:
     name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
@@ -58,14 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Pinecone tests are time expensive, so only test on Ubuntu
-        os: ${{ fromJSON(needs.compute-test-matrix.outputs.os) }}
-        python-version: ${{ fromJSON(needs.compute-test-matrix.outputs.python-version) }}
-        include:
-          - python-version: "3.10"
-            INDEX_NAME: "index-310"
-          - python-version: "3.14"
-            INDEX_NAME: "index-313"
+        include: ${{ fromJSON(needs.compute-test-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,8 +76,6 @@ jobs:
       - name: Install Hatch
         run: pip install hatch
 
-      # TODO: Once this integration is properly typed, use hatch run test:types
-      # https://github.com/deepset-ai/haystack-core-integrations/issues/1771
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types

--- a/integrations/llama_cpp/tests/models/.gitignore
+++ b/integrations/llama_cpp/tests/models/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -34,7 +34,9 @@ from haystack_integrations.components.generators.llama_cpp.chat.chat_generator i
 
 @pytest.fixture
 def model_path():
-    return Path(__file__).parent / "models"
+    path = Path.home() / ".cache" / "haystack_llama_cpp_tests"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def get_current_temperature(location: Annotated[str, "The city and state, e.g. San Francisco, CA"]):

--- a/integrations/llama_cpp/tests/test_generator.py
+++ b/integrations/llama_cpp/tests/test_generator.py
@@ -19,7 +19,9 @@ from haystack_integrations.components.generators.llama_cpp import LlamaCppGenera
 
 @pytest.fixture
 def model_path():
-    return Path(__file__).parent / "models"
+    path = Path.home() / ".cache" / "haystack_llama_cpp_tests"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def download_file(file_link, filename, capsys):


### PR DESCRIPTION
### Related Issues

We now need tests running on main to compute combined tests coverage.
Some workflows are not running correctly.

### Proposed Changes:
- Pinecone: manually build the test matrix which is complex
- llama.cpp: [here](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/23835951353/job/69479765482) we got permission denied when downloading models. This likely happens because the coverage action writes some files with root permissions. I'm now trying to fix this by downloading models to the cache dir, that should not be touched by the coverage action.

### How did you test it?
CI but since failures happened on main, we should merge to actually test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
