### PR TITLE
chore: improve test coverage colors; better handle coverage in the scaffolding script

### DIFF
--- a/.github/workflows/CI_coverage_comment.yml
+++ b/.github/workflows/CI_coverage_comment.yml
@@ -75,3 +75,5 @@ jobs:
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
           SUBPROJECT_ID: ${{ steps.integration.outputs.name }}
           COMMENT_ARTIFACT_NAME: coverage-comment-${{ steps.integration.outputs.name }}
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60

--- a/.github/workflows/aimlapi.yml
+++ b/.github/workflows/aimlapi.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/aimlapi
           SUBPROJECT_ID: aimlapi
           COMMENT_ARTIFACT_NAME: coverage-comment-aimlapi
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/aimlapi
           SUBPROJECT_ID: aimlapi-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-aimlapi-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/amazon_bedrock.yml
+++ b/.github/workflows/amazon_bedrock.yml
@@ -103,6 +103,8 @@ jobs:
           COVERAGE_PATH: integrations/amazon_bedrock
           SUBPROJECT_ID: amazon_bedrock
           COMMENT_ARTIFACT_NAME: coverage-comment-amazon_bedrock
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       # Do not authenticate on PRs from forks and on PRs created by dependabot
       - name: AWS authentication
@@ -125,6 +127,8 @@ jobs:
           COVERAGE_PATH: integrations/amazon_bedrock
           SUBPROJECT_ID: amazon_bedrock-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-amazon_bedrock-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/amazon_sagemaker.yml
+++ b/.github/workflows/amazon_sagemaker.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/amazon_sagemaker
           SUBPROJECT_ID: amazon_sagemaker
           COMMENT_ARTIFACT_NAME: coverage-comment-amazon_sagemaker
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/amazon_sagemaker
           SUBPROJECT_ID: amazon_sagemaker-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-amazon_sagemaker-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/anthropic
           SUBPROJECT_ID: anthropic
           COMMENT_ARTIFACT_NAME: coverage-comment-anthropic
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/anthropic
           SUBPROJECT_ID: anthropic-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-anthropic-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/arcadedb.yml
+++ b/.github/workflows/arcadedb.yml
@@ -98,6 +98,8 @@ jobs:
           COVERAGE_PATH: integrations/arcadedb
           SUBPROJECT_ID: arcadedb
           COMMENT_ARTIFACT_NAME: coverage-comment-arcadedb
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -110,6 +112,8 @@ jobs:
           COVERAGE_PATH: integrations/arcadedb
           SUBPROJECT_ID: arcadedb-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-arcadedb-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/astra
           SUBPROJECT_ID: astra
           COMMENT_ARTIFACT_NAME: coverage-comment-astra
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         env:
@@ -108,6 +110,8 @@ jobs:
           COVERAGE_PATH: integrations/astra
           SUBPROJECT_ID: astra-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-astra-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -90,6 +90,8 @@ jobs:
           COVERAGE_PATH: integrations/azure_ai_search
           SUBPROJECT_ID: azure_ai_search
           COMMENT_ARTIFACT_NAME: coverage-comment-azure_ai_search
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -102,6 +104,8 @@ jobs:
           COVERAGE_PATH: integrations/azure_ai_search
           SUBPROJECT_ID: azure_ai_search-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-azure_ai_search-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/azure_doc_intelligence.yml
+++ b/.github/workflows/azure_doc_intelligence.yml
@@ -90,6 +90,8 @@ jobs:
           COVERAGE_PATH: integrations/azure_doc_intelligence
           SUBPROJECT_ID: azure_doc_intelligence
           COMMENT_ARTIFACT_NAME: coverage-comment-azure_doc_intelligence
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -102,6 +104,8 @@ jobs:
           COVERAGE_PATH: integrations/azure_doc_intelligence
           SUBPROJECT_ID: azure_doc_intelligence-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-azure_doc_intelligence-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/chroma.yml
+++ b/.github/workflows/chroma.yml
@@ -96,6 +96,8 @@ jobs:
           COVERAGE_PATH: integrations/chroma
           SUBPROJECT_ID: chroma
           COMMENT_ARTIFACT_NAME: coverage-comment-chroma
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -108,6 +110,8 @@ jobs:
           COVERAGE_PATH: integrations/chroma
           SUBPROJECT_ID: chroma-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-chroma-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/cohere
           SUBPROJECT_ID: cohere
           COMMENT_ARTIFACT_NAME: coverage-comment-cohere
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/cohere
           SUBPROJECT_ID: cohere-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-cohere-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/cometapi.yml
+++ b/.github/workflows/cometapi.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/cometapi
           SUBPROJECT_ID: cometapi
           COMMENT_ARTIFACT_NAME: coverage-comment-cometapi
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/cometapi
           SUBPROJECT_ID: cometapi-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-cometapi-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/deepeval
           SUBPROJECT_ID: deepeval
           COMMENT_ARTIFACT_NAME: coverage-comment-deepeval
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/deepeval
           SUBPROJECT_ID: deepeval-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-deepeval-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -90,6 +90,8 @@ jobs:
           COVERAGE_PATH: integrations/elasticsearch
           SUBPROJECT_ID: elasticsearch
           COMMENT_ARTIFACT_NAME: coverage-comment-elasticsearch
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -102,6 +104,8 @@ jobs:
           COVERAGE_PATH: integrations/elasticsearch
           SUBPROJECT_ID: elasticsearch-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-elasticsearch-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/faiss.yml
+++ b/.github/workflows/faiss.yml
@@ -88,6 +88,8 @@ jobs:
           COVERAGE_PATH: integrations/faiss
           SUBPROJECT_ID: faiss
           COMMENT_ARTIFACT_NAME: coverage-comment-faiss
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -100,6 +102,8 @@ jobs:
           COVERAGE_PATH: integrations/faiss
           SUBPROJECT_ID: faiss-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-faiss-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
       - name: Run unit tests with lowest direct dependencies
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: |

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -80,6 +80,8 @@ jobs:
           COVERAGE_PATH: integrations/fastembed
           SUBPROJECT_ID: fastembed
           COMMENT_ARTIFACT_NAME: coverage-comment-fastembed
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -92,6 +94,8 @@ jobs:
           COVERAGE_PATH: integrations/fastembed
           SUBPROJECT_ID: fastembed-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-fastembed-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/firecrawl.yml
+++ b/.github/workflows/firecrawl.yml
@@ -88,6 +88,8 @@ jobs:
           COVERAGE_PATH: integrations/firecrawl
           SUBPROJECT_ID: firecrawl
           COMMENT_ARTIFACT_NAME: coverage-comment-firecrawl
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -100,6 +102,8 @@ jobs:
           COVERAGE_PATH: integrations/firecrawl
           SUBPROJECT_ID: firecrawl-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-firecrawl-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -91,6 +91,8 @@ jobs:
           COVERAGE_PATH: integrations/github
           SUBPROJECT_ID: github
           COMMENT_ARTIFACT_NAME: coverage-comment-github
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       # No integration tests yet — add integration-cov-append-retry + combined coverage step when needed
 

--- a/.github/workflows/google_genai.yml
+++ b/.github/workflows/google_genai.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/google_genai
           SUBPROJECT_ID: google_genai
           COMMENT_ARTIFACT_NAME: coverage-comment-google_genai
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/google_genai
           SUBPROJECT_ID: google_genai-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-google_genai-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/hanlp.yml
+++ b/.github/workflows/hanlp.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/hanlp
           SUBPROJECT_ID: hanlp
           COMMENT_ARTIFACT_NAME: coverage-comment-hanlp
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/hanlp
           SUBPROJECT_ID: hanlp-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-hanlp-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/jina
           SUBPROJECT_ID: jina
           COMMENT_ARTIFACT_NAME: coverage-comment-jina
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/jina
           SUBPROJECT_ID: jina-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-jina-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/kreuzberg.yml
+++ b/.github/workflows/kreuzberg.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/kreuzberg
           SUBPROJECT_ID: kreuzberg
           COMMENT_ARTIFACT_NAME: coverage-comment-kreuzberg
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/kreuzberg
           SUBPROJECT_ID: kreuzberg-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-kreuzberg-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -97,6 +97,8 @@ jobs:
           COVERAGE_PATH: integrations/langfuse
           SUBPROJECT_ID: langfuse
           COMMENT_ARTIFACT_NAME: coverage-comment-langfuse
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -109,6 +111,8 @@ jobs:
           COVERAGE_PATH: integrations/langfuse
           SUBPROJECT_ID: langfuse-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-langfuse-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/lara.yml
+++ b/.github/workflows/lara.yml
@@ -90,6 +90,8 @@ jobs:
           COVERAGE_PATH: integrations/lara
           SUBPROJECT_ID: lara
           COMMENT_ARTIFACT_NAME: coverage-comment-lara
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -102,6 +104,8 @@ jobs:
           COVERAGE_PATH: integrations/lara
           SUBPROJECT_ID: lara-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-lara-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/libreoffice.yml
+++ b/.github/workflows/libreoffice.yml
@@ -106,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/libreoffice
           SUBPROJECT_ID: libreoffice
           COMMENT_ARTIFACT_NAME: coverage-comment-libreoffice
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -118,6 +120,8 @@ jobs:
           COVERAGE_PATH: integrations/libreoffice
           SUBPROJECT_ID: libreoffice-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-libreoffice-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -102,6 +102,8 @@ jobs:
           COVERAGE_PATH: integrations/llama_cpp
           SUBPROJECT_ID: llama_cpp
           COMMENT_ARTIFACT_NAME: coverage-comment-llama_cpp
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -114,6 +116,8 @@ jobs:
           COVERAGE_PATH: integrations/llama_cpp
           SUBPROJECT_ID: llama_cpp-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-llama_cpp-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/llama_stack.yml
+++ b/.github/workflows/llama_stack.yml
@@ -155,6 +155,8 @@ jobs:
           COVERAGE_PATH: integrations/llama_stack
           SUBPROJECT_ID: llama_stack
           COMMENT_ARTIFACT_NAME: coverage-comment-llama_stack
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -167,6 +169,8 @@ jobs:
           COVERAGE_PATH: integrations/llama_stack
           SUBPROJECT_ID: llama_stack-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-llama_stack-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/markitdown.yml
+++ b/.github/workflows/markitdown.yml
@@ -91,6 +91,8 @@ jobs:
           COVERAGE_PATH: integrations/markitdown
           SUBPROJECT_ID: markitdown
           COMMENT_ARTIFACT_NAME: coverage-comment-markitdown
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -103,6 +105,8 @@ jobs:
           COVERAGE_PATH: integrations/markitdown
           SUBPROJECT_ID: markitdown-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-markitdown-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -106,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/mcp
           SUBPROJECT_ID: mcp
           COMMENT_ARTIFACT_NAME: coverage-comment-mcp
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -118,6 +120,8 @@ jobs:
           COVERAGE_PATH: integrations/mcp
           SUBPROJECT_ID: mcp-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-mcp-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/meta_llama.yml
+++ b/.github/workflows/meta_llama.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/meta_llama
           SUBPROJECT_ID: meta_llama
           COMMENT_ARTIFACT_NAME: coverage-comment-meta_llama
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/meta_llama
           SUBPROJECT_ID: meta_llama-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-meta_llama-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/mistral
           SUBPROJECT_ID: mistral
           COMMENT_ARTIFACT_NAME: coverage-comment-mistral
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/mistral
           SUBPROJECT_ID: mistral-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-mistral-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -89,6 +89,8 @@ jobs:
           COVERAGE_PATH: integrations/mongodb_atlas
           SUBPROJECT_ID: mongodb_atlas
           COMMENT_ARTIFACT_NAME: coverage-comment-mongodb_atlas
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -101,6 +103,8 @@ jobs:
           COVERAGE_PATH: integrations/mongodb_atlas
           SUBPROJECT_ID: mongodb_atlas-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-mongodb_atlas-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -94,6 +94,8 @@ jobs:
           COVERAGE_PATH: integrations/nvidia
           SUBPROJECT_ID: nvidia
           COMMENT_ARTIFACT_NAME: coverage-comment-nvidia
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -106,6 +108,8 @@ jobs:
           COVERAGE_PATH: integrations/nvidia
           SUBPROJECT_ID: nvidia-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-nvidia-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -131,6 +131,8 @@ jobs:
           COVERAGE_PATH: integrations/ollama
           SUBPROJECT_ID: ollama
           COMMENT_ARTIFACT_NAME: coverage-comment-ollama
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -143,6 +145,8 @@ jobs:
           COVERAGE_PATH: integrations/ollama
           SUBPROJECT_ID: ollama-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-ollama-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/openrouter
           SUBPROJECT_ID: openrouter
           COMMENT_ARTIFACT_NAME: coverage-comment-openrouter
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/openrouter
           SUBPROJECT_ID: openrouter-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-openrouter-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -90,6 +90,8 @@ jobs:
           COVERAGE_PATH: integrations/opensearch
           SUBPROJECT_ID: opensearch
           COMMENT_ARTIFACT_NAME: coverage-comment-opensearch
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests (in parallel, using 4 cores)
         run: hatch run test:integration-cov-append-retry -n 4  # GA runner has 4 cores
@@ -102,6 +104,8 @@ jobs:
           COVERAGE_PATH: integrations/opensearch
           SUBPROJECT_ID: opensearch-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-opensearch-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/optimum
           SUBPROJECT_ID: optimum
           COMMENT_ARTIFACT_NAME: coverage-comment-optimum
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/optimum
           SUBPROJECT_ID: optimum-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-optimum-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/paddleocr.yml
+++ b/.github/workflows/paddleocr.yml
@@ -94,6 +94,8 @@ jobs:
           COVERAGE_PATH: integrations/paddleocr
           SUBPROJECT_ID: paddleocr
           COMMENT_ARTIFACT_NAME: coverage-comment-paddleocr
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -106,6 +108,8 @@ jobs:
           COVERAGE_PATH: integrations/paddleocr
           SUBPROJECT_ID: paddleocr-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-paddleocr-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/pgvector.yml
+++ b/.github/workflows/pgvector.yml
@@ -96,6 +96,8 @@ jobs:
           COVERAGE_PATH: integrations/pgvector
           SUBPROJECT_ID: pgvector
           COMMENT_ARTIFACT_NAME: coverage-comment-pgvector
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -108,6 +110,8 @@ jobs:
           COVERAGE_PATH: integrations/pgvector
           SUBPROJECT_ID: pgvector-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-pgvector-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/pinecone
           SUBPROJECT_ID: pinecone
           COMMENT_ARTIFACT_NAME: coverage-comment-pinecone
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         env:
@@ -106,6 +108,8 @@ jobs:
           COVERAGE_PATH: integrations/pinecone
           SUBPROJECT_ID: pinecone-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-pinecone-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/pyversity.yml
+++ b/.github/workflows/pyversity.yml
@@ -81,6 +81,8 @@ jobs:
           COVERAGE_PATH: integrations/pyversity
           SUBPROJECT_ID: pyversity
           COMMENT_ARTIFACT_NAME: coverage-comment-pyversity
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       # No integration tests yet — add integration-cov-append-retry + combined coverage step when needed
 

--- a/.github/workflows/qdrant.yml
+++ b/.github/workflows/qdrant.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/qdrant
           SUBPROJECT_ID: qdrant
           COMMENT_ARTIFACT_NAME: coverage-comment-qdrant
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/qdrant
           SUBPROJECT_ID: qdrant-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-qdrant-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
           
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/ragas
           SUBPROJECT_ID: ragas
           COMMENT_ARTIFACT_NAME: coverage-comment-ragas
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       # No integration tests yet — add integration-cov-append-retry + combined coverage step when needed
 

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/snowflake
           SUBPROJECT_ID: snowflake
           COMMENT_ARTIFACT_NAME: coverage-comment-snowflake
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       # No integration tests yet — add integration-cov-append-retry + combined coverage step when needed
 

--- a/.github/workflows/stackit.yml
+++ b/.github/workflows/stackit.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/stackit
           SUBPROJECT_ID: stackit
           COMMENT_ARTIFACT_NAME: coverage-comment-stackit
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/stackit
           SUBPROJECT_ID: stackit-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-stackit-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/tavily.yml
+++ b/.github/workflows/tavily.yml
@@ -91,6 +91,8 @@ jobs:
           COVERAGE_PATH: integrations/tavily
           SUBPROJECT_ID: tavily
           COMMENT_ARTIFACT_NAME: coverage-comment-tavily
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -103,6 +105,8 @@ jobs:
           COVERAGE_PATH: integrations/tavily
           SUBPROJECT_ID: tavily-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-tavily-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/togetherai.yml
+++ b/.github/workflows/togetherai.yml
@@ -92,6 +92,8 @@ jobs:
           COVERAGE_PATH: integrations/togetherai
           SUBPROJECT_ID: togetherai
           COMMENT_ARTIFACT_NAME: coverage-comment-togetherai
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -104,6 +106,8 @@ jobs:
           COVERAGE_PATH: integrations/togetherai
           SUBPROJECT_ID: togetherai-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-togetherai-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/unstructured.yml
+++ b/.github/workflows/unstructured.yml
@@ -104,6 +104,8 @@ jobs:
           COVERAGE_PATH: integrations/unstructured
           SUBPROJECT_ID: unstructured
           COMMENT_ARTIFACT_NAME: coverage-comment-unstructured
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -116,6 +118,8 @@ jobs:
           COVERAGE_PATH: integrations/unstructured
           SUBPROJECT_ID: unstructured-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-unstructured-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/valkey.yml
+++ b/.github/workflows/valkey.yml
@@ -98,6 +98,8 @@ jobs:
           COVERAGE_PATH: integrations/valkey
           SUBPROJECT_ID: valkey
           COMMENT_ARTIFACT_NAME: coverage-comment-valkey
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -110,6 +112,8 @@ jobs:
           COVERAGE_PATH: integrations/valkey
           SUBPROJECT_ID: valkey-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-valkey-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/watsonx.yml
+++ b/.github/workflows/watsonx.yml
@@ -94,6 +94,8 @@ jobs:
           COVERAGE_PATH: integrations/watsonx
           SUBPROJECT_ID: watsonx
           COMMENT_ARTIFACT_NAME: coverage-comment-watsonx
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -106,6 +108,8 @@ jobs:
           COVERAGE_PATH: integrations/watsonx
           SUBPROJECT_ID: watsonx-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-watsonx-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/weave.yml
+++ b/.github/workflows/weave.yml
@@ -89,6 +89,8 @@ jobs:
           COVERAGE_PATH: integrations/weave
           SUBPROJECT_ID: weave
           COMMENT_ARTIFACT_NAME: coverage-comment-weave
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -101,6 +103,8 @@ jobs:
           COVERAGE_PATH: integrations/weave
           SUBPROJECT_ID: weave-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-weave-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/.github/workflows/weaviate.yml
+++ b/.github/workflows/weaviate.yml
@@ -90,6 +90,8 @@ jobs:
           COVERAGE_PATH: integrations/weaviate
           SUBPROJECT_ID: weaviate
           COMMENT_ARTIFACT_NAME: coverage-comment-weaviate
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -102,6 +104,8 @@ jobs:
           COVERAGE_PATH: integrations/weaviate
           SUBPROJECT_ID: weaviate-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-weaviate-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,7 @@ The script takes care of the full setup in one step:
   source package, tests, pydoc config, example components, and a README).
 - Creates a GitHub Actions CI workflow at `.github/workflows/<name>.yml`.
 - Adds label rules to `.github/labeler.yml`.
+- Registers the new workflow in `.github/workflows/CI_coverage_comment.yml` so PR coverage comments work automatically.
 - Adds the new integration to the table in the root `README.md`.
 
 Once the script finishes, follow the printed next-steps to fill in your component code, add dependencies, and

--- a/scripts/create_new_integration.py
+++ b/scripts/create_new_integration.py
@@ -11,6 +11,7 @@ from utils.naming import folder_to_package, get_module_path, validate_name
 from utils.scaffold import (
     create_integration_files,
     create_workflow,
+    update_coverage_comment_workflow,
     update_labeler,
     update_root_readme,
 )
@@ -135,6 +136,9 @@ def main():
 
     labeler_path = update_labeler(name, repo_root=REPO_ROOT)
     print(f"  Updated: {labeler_path}")
+
+    coverage_path = update_coverage_comment_workflow(name, repo_root=REPO_ROOT)
+    print(f"  Updated: {coverage_path}")
 
     readme_path = update_root_readme(name, component_type, TYPE_LABELS, repo_root=REPO_ROOT)
     print(f"  Updated: {readme_path}")

--- a/scripts/utils/scaffold.py
+++ b/scripts/utils/scaffold.py
@@ -102,6 +102,35 @@ def update_labeler(name: str, *, repo_root: Path) -> str:
     return str(labeler_path.relative_to(repo_root))
 
 
+def update_coverage_comment_workflow(name: str, *, repo_root: Path) -> str:
+    """Insert a workflow trigger entry in CI_coverage_comment.yml in alphabetical order. Returns the relative path."""
+    workflow_path = repo_root / ".github" / "workflows" / "CI_coverage_comment.yml"
+    content = workflow_path.read_text()
+
+    new_entry = f'      - "Test / {name}"'
+
+    # Find all existing workflow trigger entries and insert in sorted order
+    entry_pattern = re.compile(r'^      - "Test / ([^"]+)"', re.MULTILINE)
+    matches = list(entry_pattern.finditer(content))
+
+    insert_pos = None
+    for match in matches:
+        if match.group(1) > name:
+            insert_pos = match.start()
+            break
+
+    if insert_pos is not None:
+        content = content[:insert_pos] + new_entry + "\n" + content[insert_pos:]
+    else:
+        # Insert after the last entry (before the `types:` line)
+        last_match = matches[-1]
+        insert_pos = last_match.end()
+        content = content[:insert_pos] + "\n" + new_entry + content[insert_pos:]
+
+    workflow_path.write_text(content)
+    return str(workflow_path.relative_to(repo_root))
+
+
 def update_root_readme(
     name: str,
     component_type: str,

--- a/scripts/utils/templates/workflow.yml
+++ b/scripts/utils/templates/workflow.yml
@@ -91,6 +91,8 @@ jobs:
           COVERAGE_PATH: integrations/$name
           SUBPROJECT_ID: $name
           COMMENT_ARTIFACT_NAME: coverage-comment-$name
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -103,6 +105,8 @@ jobs:
           COVERAGE_PATH: integrations/$name
           SUBPROJECT_ID: $name-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-$name-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'


### PR DESCRIPTION
Related to https://github.com/deepset-ai/haystack-private/issues/275

### Proposed Changes:
- set less alarming colors: red under 60%, then orange; green for over 90% (there's no way to centralize this setting)
- modify the scaffolding script with colors and also automatically update CI_coverage_comment workflow

### How did you test it?
New colors will appear once tests run on main, after 5-10 minutes

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
