### PR TITLE
build: Add environment configuration for PyPI release

### DIFF
--- a/.github/workflows/CI_pypi_release.yml
+++ b/.github/workflows/CI_pypi_release.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   release-on-pypi:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write
 


### PR DESCRIPTION
### Related Issues

- fixes an issue with trusted publishing reported by @bogdankostic https://github.com/deepset-ai/haystack-core-integrations/actions/runs/23850168608/attempts/2

### Proposed Changes:

- Add missing environment called `pypi`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
