### PR TITLE
chore: set consistent test coverage colors for dspy integration

### DIFF
--- a/.github/workflows/dspy.yml
+++ b/.github/workflows/dspy.yml
@@ -93,6 +93,8 @@ jobs:
           COVERAGE_PATH: integrations/dspy
           SUBPROJECT_ID: dspy
           COMMENT_ARTIFACT_NAME: coverage-comment-dspy
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run integration tests
         run: hatch run test:integration-cov-append-retry
@@ -105,6 +107,8 @@ jobs:
           COVERAGE_PATH: integrations/dspy
           SUBPROJECT_ID: dspy-combined
           COMMENT_ARTIFACT_NAME: coverage-comment-dspy-combined
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
 
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'


### PR DESCRIPTION
### Proposed Changes:
- set consistent test coverage colors for dspy integration (forgotten in https://github.com/deepset-ai/haystack-core-integrations/pull/2831)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
