### PR TITLE
feat: (docling) Drop temp files for ByteStream sources

### DIFF
--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+from docling_core.types.io import DocumentStream
 from haystack import Document, component
 from haystack.components.converters.utils import normalize_metadata
 from haystack.dataclasses import ByteStream
@@ -16,11 +17,11 @@ from haystack.dataclasses import ByteStream
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
 from docling.document_converter import DocumentConverter
-from docling_core.types.io import DocumentStream
 
 
 def _bytestream_to_document_stream(source: ByteStream) -> DocumentStream:
-    """Build a `DocumentStream` from a Haystack `ByteStream`.
+    """
+    Build a `DocumentStream` from a Haystack `ByteStream`.
 
     Resolves the stream name by checking common metadata keys (`file_path`, `file_name`, `name`) and falling back to
     MIME-type extension guessing so that docling can reliably detect the input format.

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -1,6 +1,7 @@
 """Docling Haystack converter module."""
 
 import json
+import mimetypes
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -16,6 +17,27 @@ from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
 from docling.document_converter import DocumentConverter
 from docling_core.types.io import DocumentStream
+
+
+def _bytestream_to_document_stream(source: ByteStream) -> DocumentStream:
+    """Build a `DocumentStream` from a Haystack `ByteStream`.
+
+    Resolves the stream name by checking common metadata keys (`file_path`,
+    `filename`, `name`) and falling back to MIME-type extension guessing so
+    that docling can reliably detect the input format.
+    """
+    meta = source.meta or {}
+    raw_name = meta.get("file_path") or meta.get("filename") or meta.get("name")
+    if raw_name:
+        name = Path(raw_name).name
+        if not Path(name).suffix and source.mime_type:
+            ext = mimetypes.guess_extension(source.mime_type)
+            if ext:
+                name = f"{name}{ext}"
+    else:
+        ext = mimetypes.guess_extension(source.mime_type) if source.mime_type else ""
+        name = f"document{ext or ''}"
+    return DocumentStream(name=name, stream=BytesIO(source.data))
 
 
 class ExportType(str, Enum):
@@ -141,8 +163,7 @@ class DoclingConverter:
         documents: list[Document] = []
         for source, source_meta in zip(sources, meta_list, strict=True):
             if isinstance(source, ByteStream):
-                name = Path(source.meta.get("file_path", "document")).name if source.meta else "document"
-                doc_stream = DocumentStream(name=name, stream=BytesIO(source.data))
+                doc_stream = _bytestream_to_document_stream(source)
                 dl_doc = self._converter_instance.convert(source=doc_stream, **self.convert_kwargs).document
                 # merge ByteStream meta (e.g. file_path, mime_type) with user-supplied meta
                 merged_meta = {**(source.meta or {}), **source_meta}

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -1,11 +1,10 @@
 """Docling Haystack converter module."""
 
 import json
-import os
-import tempfile
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +15,7 @@ from haystack.dataclasses import ByteStream
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
 from docling.document_converter import DocumentConverter
+from docling_core.types.io import DocumentStream
 
 
 class ExportType(str, Enum):
@@ -141,14 +141,9 @@ class DoclingConverter:
         documents: list[Document] = []
         for source, source_meta in zip(sources, meta_list, strict=True):
             if isinstance(source, ByteStream):
-                # docling requires a file path; write ByteStream data to a temp file
-                with tempfile.NamedTemporaryFile(delete=False) as tmp:
-                    tmp.write(source.data)
-                    tmp_path = Path(tmp.name)
-                try:
-                    dl_doc = self._converter_instance.convert(source=tmp_path, **self.convert_kwargs).document
-                finally:
-                    os.unlink(tmp_path)
+                name = Path(source.meta.get("file_path", "document")).name if source.meta else "document"
+                doc_stream = DocumentStream(name=name, stream=BytesIO(source.data))
+                dl_doc = self._converter_instance.convert(source=doc_stream, **self.convert_kwargs).document
                 # merge ByteStream meta (e.g. file_path, mime_type) with user-supplied meta
                 merged_meta = {**(source.meta or {}), **source_meta}
             else:

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -22,12 +22,11 @@ from docling_core.types.io import DocumentStream
 def _bytestream_to_document_stream(source: ByteStream) -> DocumentStream:
     """Build a `DocumentStream` from a Haystack `ByteStream`.
 
-    Resolves the stream name by checking common metadata keys (`file_path`,
-    `filename`, `name`) and falling back to MIME-type extension guessing so
-    that docling can reliably detect the input format.
+    Resolves the stream name by checking common metadata keys (`file_path`, `file_name`, `name`) and falling back to
+    MIME-type extension guessing so that docling can reliably detect the input format.
     """
     meta = source.meta or {}
-    raw_name = meta.get("file_path") or meta.get("filename") or meta.get("name")
+    raw_name = meta.get("file_path") or meta.get("file_name") or meta.get("name")
     if raw_name:
         name = Path(raw_name).name
         if not Path(name).suffix and source.mime_type:

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -28,15 +28,17 @@ def _bytestream_to_document_stream(source: ByteStream) -> DocumentStream:
     """
     meta = source.meta or {}
     raw_name = meta.get("file_path") or meta.get("file_name") or meta.get("name")
+
     if raw_name:
         name = Path(raw_name).name
-        if not Path(name).suffix and source.mime_type:
-            ext = mimetypes.guess_extension(source.mime_type)
-            if ext:
-                name = f"{name}{ext}"
     else:
-        ext = mimetypes.guess_extension(source.mime_type) if source.mime_type else ""
-        name = f"document{ext or ''}"
+        name = "document"
+
+    if not Path(name).suffix and source.mime_type:
+        ext = mimetypes.guess_extension(source.mime_type)
+        if ext:
+            name = f"{name}{ext}"
+
     return DocumentStream(name=name, stream=BytesIO(source.data))
 
 

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -386,8 +386,8 @@ class TestBytestreamToDocumentStream:
         ds = _bytestream_to_document_stream(bs)
         assert ds.name == "report.pdf"
 
-    def test_uses_filename_key(self) -> None:
-        bs = ByteStream(data=b"data", meta={"filename": "slide-deck.pptx"})
+    def test_uses_file_name_key(self) -> None:
+        bs = ByteStream(data=b"data", meta={"file_name": "slide-deck.pptx"})
         ds = _bytestream_to_document_stream(bs)
         assert ds.name == "slide-deck.pptx"
 
@@ -396,13 +396,13 @@ class TestBytestreamToDocumentStream:
         ds = _bytestream_to_document_stream(bs)
         assert ds.name == "notes.docx"
 
-    def test_file_path_takes_priority_over_filename(self) -> None:
-        bs = ByteStream(data=b"data", meta={"file_path": "real.pdf", "filename": "other.pdf"})
+    def test_file_path_takes_priority_over_file_name(self) -> None:
+        bs = ByteStream(data=b"data", meta={"file_path": "real.pdf", "file_name": "other.pdf"})
         ds = _bytestream_to_document_stream(bs)
         assert ds.name == "real.pdf"
 
-    def test_filename_takes_priority_over_name(self) -> None:
-        bs = ByteStream(data=b"data", meta={"filename": "chosen.pdf", "name": "ignored.pdf"})
+    def test_file_name_takes_priority_over_name(self) -> None:
+        bs = ByteStream(data=b"data", meta={"file_name": "chosen.pdf", "name": "ignored.pdf"})
         ds = _bytestream_to_document_stream(bs)
         assert ds.name == "chosen.pdf"
 

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -1,10 +1,12 @@
 import json
 import warnings
+from io import BytesIO
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
+from docling_core.types.io import DocumentStream
 from haystack.core.serialization import component_from_dict, component_to_dict
 from haystack.dataclasses import ByteStream
 
@@ -356,13 +358,15 @@ def test_run_with_bytestream_source() -> None:
 
     bytestream = ByteStream(data=b"%PDF-1.4 fake pdf content", meta={"file_path": "uploaded.pdf"})
 
-    with patch("os.unlink"):
-        result = converter.run(sources=[bytestream])
+    result = converter.run(sources=[bytestream])
 
     documents = result["documents"]
     assert len(documents) == 1
     # ByteStream meta is merged into the output document
     assert documents[0].meta["file_path"] == "uploaded.pdf"
-    # docling was called with a temp file path, not the ByteStream directly
+    # docling was called with a DocumentStream, not a temp file path
     call_args = converter_mock.convert.call_args
-    assert call_args.kwargs["source"] != bytestream
+    passed_source = call_args.kwargs["source"]
+    assert isinstance(passed_source, DocumentStream)
+    assert passed_source.name == "uploaded.pdf"
+    assert isinstance(passed_source.stream, BytesIO)

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 import warnings
 from io import BytesIO
 from types import SimpleNamespace
@@ -11,6 +12,7 @@ from haystack.core.serialization import component_from_dict, component_to_dict
 from haystack.dataclasses import ByteStream
 
 from haystack_integrations.components.converters.docling import DoclingConverter, ExportType
+from haystack_integrations.components.converters.docling.converter import _bytestream_to_document_stream
 
 
 def test_run_doc_chunks_minimal() -> None:
@@ -370,3 +372,72 @@ def test_run_with_bytestream_source() -> None:
     assert isinstance(passed_source, DocumentStream)
     assert passed_source.name == "uploaded.pdf"
     assert isinstance(passed_source.stream, BytesIO)
+
+
+class TestBytestreamToDocumentStream:
+    def test_uses_file_path(self) -> None:
+        bs = ByteStream(data=b"data", meta={"file_path": "report.pdf"})
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "report.pdf"
+        assert ds.stream.read() == b"data"
+
+    def test_strips_directory_from_file_path(self) -> None:
+        bs = ByteStream(data=b"data", meta={"file_path": "/some/deep/path/report.pdf"})
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "report.pdf"
+
+    def test_uses_filename_key(self) -> None:
+        bs = ByteStream(data=b"data", meta={"filename": "slide-deck.pptx"})
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "slide-deck.pptx"
+
+    def test_uses_name_key(self) -> None:
+        bs = ByteStream(data=b"data", meta={"name": "notes.docx"})
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "notes.docx"
+
+    def test_file_path_takes_priority_over_filename(self) -> None:
+        bs = ByteStream(data=b"data", meta={"file_path": "real.pdf", "filename": "other.pdf"})
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "real.pdf"
+
+    def test_filename_takes_priority_over_name(self) -> None:
+        bs = ByteStream(data=b"data", meta={"filename": "chosen.pdf", "name": "ignored.pdf"})
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "chosen.pdf"
+
+    def test_guesses_extension_from_mime_type(self) -> None:
+        mime = "application/pdf"
+        expected_ext = mimetypes.guess_extension(mime)
+        bs = ByteStream(data=b"data", meta={"file_path": "report"}, mime_type=mime)
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == f"report{expected_ext}"
+
+    def test_keeps_extension_when_present(self) -> None:
+        # mime_type should not override an already-present extension
+        bs = ByteStream(data=b"data", meta={"file_path": "report.pdf"}, mime_type="text/plain")
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "report.pdf"
+
+    def test_no_meta_no_mime_type(self) -> None:
+        bs = ByteStream(data=b"data")
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "document"
+
+    def test_no_meta_with_mime_type(self) -> None:
+        mime = "application/pdf"
+        expected_ext = mimetypes.guess_extension(mime)
+        bs = ByteStream(data=b"data", mime_type=mime)
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == f"document{expected_ext}"
+
+    def test_empty_meta_no_mime_type(self) -> None:
+        bs = ByteStream(data=b"data", meta={})
+        ds = _bytestream_to_document_stream(bs)
+        assert ds.name == "document"
+
+    def test_returns_document_stream_with_bytesio(self) -> None:
+        bs = ByteStream(data=b"hello", meta={"file_path": "f.pdf"})
+        ds = _bytestream_to_document_stream(bs)
+        assert isinstance(ds, DocumentStream)
+        assert isinstance(ds.stream, BytesIO)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

In our docling converter `ByteStream` sources previously required writing to a temporary file. During a large indexing job this could create I/O issues which could cause a performance bottleneck. Docling also has a `DocumentStream` API which accepts a `BytesIO` directly, so the temp file write and `os.unlink` are no longer needed.

Also we try to do our best effort in guessing the filename passed to `DocumentStream` by checking `file_path`, `filename`, and `name` meta keys in that order, and falls back to guessing an extension from `mime_type` when no extension is present. This is to help docling reliably detect the file format even for `ByteStream` objects.

The conversion logic is extracted into a `_bytestream_to_document_stream` helper.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
