### PR TITLE
fix: Ollama - better reasoning streaming support

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -376,8 +376,7 @@ class OllamaChatGenerator:
         id_order: list[str] = []
         tool_call_index: int = 0
 
-        # Track reasoning and content blocks to correctly set start=True on the first chunk of each block.
-        # This ensures print_streaming_chunk prints [REASONING] and [ASSISTANT] headers at the right time.
+        # track reasoning and content blocks to correctly set start=True on the first chunk of each block
         reasoning_started = False
         content_started = False
 
@@ -470,8 +469,7 @@ class OllamaChatGenerator:
         id_order: list[str] = []
         tool_call_index: int = 0
 
-        # Track reasoning and content blocks to correctly set start=True on the first chunk of each block.
-        # This ensures print_streaming_chunk prints [REASONING] and [ASSISTANT] headers at the right time.
+        # track reasoning and content blocks to correctly set start=True on the first chunk of each block
         reasoning_started = False
         content_started = False
 

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -376,6 +376,11 @@ class OllamaChatGenerator:
         id_order: list[str] = []
         tool_call_index: int = 0
 
+        # Track reasoning and content blocks to correctly set start=True on the first chunk of each block.
+        # This ensures print_streaming_chunk prints [REASONING] and [ASSISTANT] headers at the right time.
+        reasoning_started = False
+        content_started = False
+
         # Stream
         for index, raw in enumerate(response_iter):
             if raw.message.tool_calls:
@@ -383,7 +388,14 @@ class OllamaChatGenerator:
             chunk = _build_chunk(
                 chunk_response=raw, component_info=component_info, index=index, tool_call_index=tool_call_index
             )
-            start = index == 0 or bool(chunk.tool_calls)
+
+            if chunk.reasoning:
+                start = not reasoning_started or bool(chunk.tool_calls)
+                reasoning_started = True
+            else:
+                start = (not content_started) or bool(chunk.tool_calls)
+                content_started = True
+
             chunk = replace(chunk, start=start)
             chunks.append(chunk)
 
@@ -458,6 +470,11 @@ class OllamaChatGenerator:
         id_order: list[str] = []
         tool_call_index: int = 0
 
+        # Track reasoning and content blocks to correctly set start=True on the first chunk of each block.
+        # This ensures print_streaming_chunk prints [REASONING] and [ASSISTANT] headers at the right time.
+        reasoning_started = False
+        content_started = False
+
         # Stream
         index = 0
         async for raw in response_iter:
@@ -466,7 +483,14 @@ class OllamaChatGenerator:
             chunk = _build_chunk(
                 chunk_response=raw, component_info=component_info, index=index, tool_call_index=tool_call_index
             )
-            start = index == 0 or bool(chunk.tool_calls)
+
+            if chunk.reasoning:
+                start = not reasoning_started or bool(chunk.tool_calls)
+                reasoning_started = True
+            else:
+                start = (not content_started) or bool(chunk.tool_calls)
+                content_started = True
+
             chunk = replace(chunk, start=start)
             chunks.append(chunk)
 

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -267,6 +267,70 @@ class TestUtils:
         assert streaming_chunks[1].start is False
         assert streaming_chunks[2].start is False
 
+    def test_handle_streaming_response_with_thinking(self):
+        ollama_chunks = [
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T15:27:09.265818Z",
+                done=False,
+                message=Message(role="assistant", content="", thinking="Let me think"),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T15:27:09.265818Z",
+                done=False,
+                message=Message(role="assistant", content="", thinking=" about this."),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T15:27:09.265818Z",
+                done=False,
+                message=Message(role="assistant", content="The capital"),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T15:27:09.265818Z",
+                done=False,
+                message=Message(role="assistant", content=" is Amman."),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T15:27:09.355211Z",
+                done=True,
+                done_reason="stop",
+                total_duration=1303416458,
+                load_duration=953922333,
+                prompt_eval_count=22,
+                prompt_eval_duration=254166208,
+                eval_count=3,
+                eval_duration=92965792,
+                message=Message(role="assistant", content=""),
+            ),
+        ]
+
+        generator = OllamaChatGenerator()
+        streaming_chunks = []
+
+        def test_callback(chunk: StreamingChunk):
+            streaming_chunks.append(chunk)
+
+        response = generator._handle_streaming_response(ollama_chunks, test_callback)
+        assert response["replies"][0].text == "The capital is Amman."
+        assert response["replies"][0].reasoning.reasoning_text == "Let me think about this."
+
+        assert len(streaming_chunks) == 5
+        # First reasoning chunk: start=True
+        assert streaming_chunks[0].start is True
+        assert streaming_chunks[0].reasoning.reasoning_text == "Let me think"
+        # Second reasoning chunk: start=False
+        assert streaming_chunks[1].start is False
+        # First content chunk after reasoning: start=True
+        assert streaming_chunks[2].start is True
+        assert streaming_chunks[2].content == "The capital"
+        # Remaining content chunks: start=False
+        assert streaming_chunks[3].start is False
+        assert streaming_chunks[4].start is False
+
     def test_handle_streaming_response_tool_calls(self):
         ollama_chunks = [
             ChatResponse(


### PR DESCRIPTION
### Related Issues

When experimenting with Gemma 4, I realized that on Ollama we have the same issue @sjrl noticed on the draft implementation of vLLM: `chunk.start` not correctly set when we pass from `reasoning` from `content`.

When used with `print_streaming_chunk`, this does not print `[ASSISTANT]`.

### Proposed Changes:
- better set `chunk.start` 

### How did you test it?
New test, tested locally in several scenarios (no reasoning, reasoning, tools)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
