### PR TITLE
fix: fix GoogleGenAIMultimodalDocumentEmbedder input format

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
@@ -8,7 +8,6 @@ from typing import Any, Literal
 from google.genai import types
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.utils import Secret, deserialize_secrets_inplace
-from more_itertools import batched
 from tqdm import tqdm
 
 from haystack_integrations.components.common.google_genai.utils import _get_client
@@ -204,10 +203,11 @@ class GoogleGenAIDocumentEmbedder:
 
         all_embeddings = []
         meta: dict[str, Any] = {}
-        for batch in tqdm(
-            batched(texts_to_embed, batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
+        for i in tqdm(
+            range(0, len(texts_to_embed), batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
         ):
-            args: dict[str, Any] = {"model": self._model, "contents": list(batch)}
+            batch = texts_to_embed[i : i + batch_size]
+            args: dict[str, Any] = {"model": self._model, "contents": batch}
             if resolved_config:
                 args["config"] = resolved_config
 
@@ -235,10 +235,11 @@ class GoogleGenAIDocumentEmbedder:
 
         all_embeddings = []
         meta: dict[str, Any] = {}
-        for batch in tqdm(
-            batched(texts_to_embed, batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
+        for i in tqdm(
+            range(0, len(texts_to_embed), batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
         ):
-            args: dict[str, Any] = {"model": self._model, "contents": list(batch)}
+            batch = texts_to_embed[i : i + batch_size]
+            args: dict[str, Any] = {"model": self._model, "contents": batch}
             if self._config:
                 args["config"] = types.EmbedContentConfig(**self._config) if self._config else None
 

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -8,7 +8,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, Literal
 
-from google.genai.types import EmbedContentConfig, Part
+from google.genai.types import Content, EmbedContentConfig, Part
 from haystack import Document, component, logging
 from haystack.components.converters.image.image_utils import (
     _batch_convert_pdf_pages_to_images,
@@ -17,7 +17,6 @@ from haystack.components.converters.image.image_utils import (
 )
 from haystack.dataclasses import ByteStream
 from haystack.utils.auth import Secret
-from more_itertools import batched
 from tqdm import tqdm
 from tqdm.asyncio import tqdm as async_tqdm
 from typing_extensions import NotRequired, TypedDict
@@ -323,10 +322,11 @@ class GoogleGenAIMultimodalDocumentEmbedder:
 
         all_embeddings: list[list[float] | None] = []
         meta: dict[str, Any] = {}
-        for batch in tqdm(
-            batched(parts_to_embed, batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
+        for i in tqdm(
+            range(0, len(parts_to_embed), batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
         ):
-            args: dict[str, Any] = {"model": self._model, "contents": batch}
+            batch = parts_to_embed[i : i + batch_size]
+            args: dict[str, Any] = {"model": self._model, "contents": [Content(parts=[p]) for p in batch]}
             if resolved_config:
                 args["config"] = resolved_config
 
@@ -365,10 +365,11 @@ class GoogleGenAIMultimodalDocumentEmbedder:
 
         all_embeddings: list[list[float] | None] = []
         meta: dict[str, Any] = {}
-        async for batch in async_tqdm(
-            batched(parts_to_embed, batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
+        async for i in async_tqdm(
+            range(0, len(parts_to_embed), batch_size), disable=not self._progress_bar, desc="Calculating embeddings"
         ):
-            args: dict[str, Any] = {"model": self._model, "contents": batch}
+            batch = parts_to_embed[i : i + batch_size]
+            args: dict[str, Any] = {"model": self._model, "contents": [Content(parts=[p]) for p in batch]}
             if resolved_config:
                 args["config"] = resolved_config
 


### PR DESCRIPTION
### Related Issues

- failing nightly tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/24320187893/job/71004818216. Google GenAI SDK has recently been released (but does not announce breaking changes)

### Proposed Changes:
- in GoogleGenAIMultimodalDocumentEmbedder, adopt stricter input to GenAI SDK  (now mandatory)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
