### PR TITLE
chore: Optimum - use new import path for SentenceTransformerPoolingLayer

### DIFF
--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
@@ -13,7 +13,6 @@ import torch
 from haystack.utils import Secret, deserialize_secrets_inplace
 from haystack.utils.hf import HFModelType, check_valid_model, deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 from huggingface_hub import hf_hub_download
-from sentence_transformers.sentence_transformer.modules import Pooling as SentenceTransformerPoolingLayer
 from tqdm import tqdm
 from transformers import AutoTokenizer
 from transformers.modeling_outputs import BaseModelOutput
@@ -27,6 +26,15 @@ from optimum.onnxruntime import (
 from .optimization import OptimumEmbedderOptimizationConfig
 from .pooling import OptimumEmbedderPooling
 from .quantization import OptimumEmbedderQuantizationConfig
+
+# for sentence-transformers Pooling, we use the new module path if available. It also ships correct types
+# we also keep compatibility with older versions of sentence-transformers
+try:
+    from sentence_transformers.sentence_transformer.modules import Pooling as SentenceTransformerPoolingLayer
+except ImportError:
+    from sentence_transformers.models import (  # type: ignore[import-not-found, no-redef]
+        Pooling as SentenceTransformerPoolingLayer,
+    )
 
 
 @dataclass

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
@@ -13,7 +13,7 @@ import torch
 from haystack.utils import Secret, deserialize_secrets_inplace
 from haystack.utils.hf import HFModelType, check_valid_model, deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 from huggingface_hub import hf_hub_download
-from sentence_transformers.models import Pooling as SentenceTransformerPoolingLayer
+from sentence_transformers.sentence_transformer.modules import Pooling as SentenceTransformerPoolingLayer
 from tqdm import tqdm
 from transformers import AutoTokenizer
 from transformers.modeling_outputs import BaseModelOutput


### PR DESCRIPTION
### Related Issues

- failing mypy checks: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/24320307912/job/71034106888

The problem is that Sentence Transformers now has `Pooling` in a different path. They keep backward compatibility but this does not play well with mypy.

### Proposed Changes:
- use the new import path if available
- fall back to the old import path to keep compatibility with older Sentence Transformers version

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
