### PR TITLE
test(weaviate): replace in-place Document mutations with dataclasses.replace()

### DIFF
--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
-from dataclasses import replace
 import logging
 import os
 from collections.abc import Generator
+from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
+from dataclasses import replace
 import logging
 import os
 from collections.abc import Generator
@@ -373,7 +374,7 @@ class TestWeaviateDocumentStore(
         assert document_store.write_documents([doc]) == 1
         assert document_store.count_documents() == 1
 
-        doc.content = "test doc 2"
+        doc = replace(doc, content="test doc 2")
         assert document_store.write_documents([doc]) == 1
         assert document_store.count_documents() == 1
 

--- a/integrations/weaviate/tests/test_document_store_async.py
+++ b/integrations/weaviate/tests/test_document_store_async.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import replace
 import logging
 from collections.abc import AsyncGenerator
+from dataclasses import replace
 from pathlib import Path
 
 import pytest

--- a/integrations/weaviate/tests/test_document_store_async.py
+++ b/integrations/weaviate/tests/test_document_store_async.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import replace
 import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -100,7 +101,7 @@ class TestWeaviateDocumentStoreAsync:
         assert await document_store.write_documents_async([doc]) == 1
         assert await document_store.count_documents_async() == 1
 
-        doc.content = "test doc 2"
+        doc = replace(doc, content="test doc 2")
         assert await document_store.write_documents_async([doc]) == 1
         assert await document_store.count_documents_async() == 1
 


### PR DESCRIPTION
## Summary

fixes deepset-ai/haystack#11088.

Two tests in the Weaviate integration mutated a `Document`'s `content` field directly after construction:

```python
doc.content = "test doc 2"
```

This triggers the `DeprecationWarning` introduced in deepset-ai/haystack#10650 (`_warn_on_inplace_mutation`). Both the synchronous and asynchronous test suites are affected.

**Affected files:**

| File | Line | Mutated field |
|---|---|---|
| `integrations/weaviate/tests/test_document_store.py` | 376 | `doc.content` |
| `integrations/weaviate/tests/test_document_store_async.py` | 103 | `doc.content` |

**Fix:** replace direct assignment with `dataclasses.replace()`:

```python
doc = replace(doc, content="test doc 2")
```

## Test plan

- [ ] Weaviate unit tests pass with zero dataclass mutation warnings (`pytest -m "not integration"`)