### PR TITLE
fix: replace in place dataclass mutations for pgvector #11087

### DIFF
--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -17,6 +17,7 @@ from haystack_integrations.document_stores.pgvector.filters import (
     _treat_meta_field,
     _validate_filters,
 )
+from dataclasses import replace
 
 
 def _render(composed: Composed) -> str:
@@ -42,7 +43,8 @@ class TestFilters(FilterDocumentsTest):
             else:
                 assert received_doc.embedding == pytest.approx(expected_doc.embedding)
 
-            received_doc.embedding, expected_doc.embedding = None, None
+            received_doc = replace(received_doc, embedding=None)
+            expected_doc = replace(expected_doc, embedding=None)
             assert received_doc == expected_doc
 
     @pytest.mark.skip(reason="NOT operator is not supported in PgvectorDocumentStore")

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import replace
+
 import pytest
 from haystack.dataclasses.document import Document
 from haystack.testing.document_store import FilterDocumentsTest
@@ -17,7 +19,6 @@ from haystack_integrations.document_stores.pgvector.filters import (
     _treat_meta_field,
     _validate_filters,
 )
-from dataclasses import replace
 
 
 def _render(composed: Composed) -> str:
@@ -43,9 +44,9 @@ class TestFilters(FilterDocumentsTest):
             else:
                 assert received_doc.embedding == pytest.approx(expected_doc.embedding)
 
-            received_doc = replace(received_doc, embedding=None)
-            expected_doc = replace(expected_doc, embedding=None)
-            assert received_doc == expected_doc
+            received_doc_no_embedding = replace(received_doc, embedding=None)
+            expected_doc_no_embedding = replace(expected_doc, embedding=None)
+            assert received_doc_no_embedding == expected_doc_no_embedding
 
     @pytest.mark.skip(reason="NOT operator is not supported in PgvectorDocumentStore")
     def test_not_operator(self, document_store, filterable_docs): ...


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/11087

### Proposed Changes:

 Replace dataclass objects when modifying instead of mutating in place.

### How did you test it?
Ran all unit tests and integration tests and check if in place replacement warning still occurs.
hatch run fmt and hatch run test:all pass

### Notes for the reviewer

New variables are created, because linter does not like manipulating the loop variables.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
