### PR TITLE
feat(jina): add async support and migrate from requests to httpx

### DIFF
--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["httpx>=0.24.0", "httpcore>=1.0.8", "haystack-ai>=2.22.0"]
+dependencies = ["httpx>=0.28.0", "haystack-ai>=2.22.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina#readme"

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["httpx", "haystack-ai>=2.22.0"]
+dependencies = ["httpx>=0.24.0", "haystack-ai>=2.22.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina#readme"

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["httpx>=0.24.0", "haystack-ai>=2.22.0"]
+dependencies = ["httpx>=0.24.0", "httpcore>=1.0.8", "haystack-ai>=2.22.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina#readme"

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["requests>=2.25.0", "haystack-ai>=2.22.0"]
+dependencies = ["httpx", "haystack-ai>=2.22.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina#readme"

--- a/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
+++ b/integrations/jina/src/haystack_integrations/components/connectors/jina/reader.py
@@ -2,11 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 from typing import Any
 from urllib.parse import quote
 
-import requests
+import httpx
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
 
@@ -105,6 +104,31 @@ class JinaReaderConnector:
         document = Document(content=content, meta=data)
         return document
 
+    def _prepare_request(self, query: str, headers: dict[str, str] | None = None) -> tuple[str, dict[str, str]]:
+        headers = headers or {}
+        headers["Authorization"] = f"Bearer {self.api_key.resolve_value()}"
+
+        if self.json_response:
+            headers["Accept"] = "application/json"
+
+        endpoint_url = READER_ENDPOINT_URL_BY_MODE[self.mode]
+        encoded_target = quote(query, safe="")
+        url = f"{endpoint_url}{encoded_target}"
+        return url, headers
+
+    def _parse_response(self, response: httpx.Response, query: str) -> dict[str, list[Document]]:
+        # raw response: we just return a single Document with text
+        if not self.json_response:
+            meta = {"content_type": response.headers["Content-Type"], "query": query}
+            return {"documents": [Document(content=response.text, meta=meta)]}
+
+        response_json = response.json().get("data", {})
+        if self.mode == JinaReaderMode.SEARCH:
+            documents = [self._json_to_document(record) for record in response_json]
+            return {"documents": documents}
+
+        return {"documents": [self._json_to_document(response_json)]}
+
     @component.output_types(documents=list[Document])
     def run(self, query: str, headers: dict[str, str] | None = None) -> dict[str, list[Document]]:
         """
@@ -118,26 +142,32 @@ class JinaReaderConnector:
             A dictionary with the following keys:
                 - `documents`: A list of `Document` objects.
         """
-        headers = headers or {}
-        headers["Authorization"] = f"Bearer {self.api_key.resolve_value()}"
+        url, request_headers = self._prepare_request(query, headers)
 
-        if self.json_response:
-            headers["Accept"] = "application/json"
+        with httpx.Client() as client:
+            response = client.get(url, headers=request_headers, timeout=60)
 
-        endpoint_url = READER_ENDPOINT_URL_BY_MODE[self.mode]
-        encoded_target = quote(query, safe="")
-        url = f"{endpoint_url}{encoded_target}"
+        return self._parse_response(response, query)
 
-        response = requests.get(url, headers=headers, timeout=60)
+    @component.output_types(documents=list[Document])
+    async def run_async(self, query: str, headers: dict[str, str] | None = None) -> dict[str, list[Document]]:
+        """
+        Asynchronously process the query/URL using the Jina AI reader service.
 
-        # raw response: we just return a single Document with text
-        if not self.json_response:
-            meta = {"content_type": response.headers["Content-Type"], "query": query}
-            return {"documents": [Document(content=response.text, meta=meta)]}
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in async code.
 
-        response_json = json.loads(response.content).get("data", {})
-        if self.mode == JinaReaderMode.SEARCH:
-            documents = [self._json_to_document(record) for record in response_json]
-            return {"documents": documents}
+        :param query: The query string or URL to process.
+        :param headers: Optional headers to include in the request for customization. Refer to the
+            [Jina Reader documentation](https://jina.ai/reader/) for more information.
 
-        return {"documents": [self._json_to_document(response_json)]}
+        :returns:
+            A dictionary with the following keys:
+                - `documents`: A list of `Document` objects.
+        """
+        url, request_headers = self._prepare_request(query, headers)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=request_headers, timeout=60)
+
+        return self._parse_response(response, query)

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
@@ -4,7 +4,7 @@
 from dataclasses import replace
 from typing import Any
 
-import requests
+import httpx
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
 from tqdm import tqdm
@@ -89,14 +89,11 @@ class JinaDocumentEmbedder:
         self.progress_bar = progress_bar
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
-        self._session = requests.Session()
-        self._session.headers.update(
-            {
-                "Authorization": f"Bearer {resolved_api_key}",
-                "Accept-Encoding": "identity",
-                "Content-type": "application/json",
-            }
-        )
+        self._headers = {
+            "Authorization": f"Bearer {resolved_api_key}",
+            "Accept-Encoding": "identity",
+            "Content-type": "application/json",
+        }
         self.task = task
         self.dimensions = dimensions
         self.late_chunking = late_chunking
@@ -164,39 +161,95 @@ class JinaDocumentEmbedder:
             texts_to_embed.append(text_to_embed)
         return texts_to_embed
 
+    def _validate_input(self, documents: list[Document]) -> None:
+        if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
+            msg = (
+                "JinaDocumentEmbedder expects a list of Documents as input."
+                "In case you want to embed a string, please use the JinaTextEmbedder."
+            )
+            raise TypeError(msg)
+
+    def _prepare_parameters(self) -> dict[str, Any]:
+        parameters: dict[str, Any] = {}
+        if self.task is not None:
+            parameters["task"] = self.task
+        if self.dimensions is not None:
+            parameters["dimensions"] = self.dimensions
+        if self.late_chunking is not None:
+            parameters["late_chunking"] = self.late_chunking
+        return parameters
+
+    @staticmethod
+    def _process_batch_response(
+        response: dict[str, Any], all_embeddings: list[list[float]], metadata: dict[str, Any]
+    ) -> None:
+        if "data" not in response:
+            raise RuntimeError(response["detail"])
+
+        # Sort resulting embeddings by index
+        sorted_embeddings = sorted(response["data"], key=lambda e: e["index"])
+        embeddings = [result["embedding"] for result in sorted_embeddings]
+        all_embeddings.extend(embeddings)
+        if "model" not in metadata:
+            metadata["model"] = response["model"]
+        if "usage" not in metadata:
+            metadata["usage"] = dict(response["usage"].items())
+        else:
+            metadata["usage"]["prompt_tokens"] += response["usage"]["prompt_tokens"]
+            metadata["usage"]["total_tokens"] += response["usage"]["total_tokens"]
+
     def _embed_batch(
         self, texts_to_embed: list[str], batch_size: int, parameters: dict | None = None
     ) -> tuple[list[list[float]], dict[str, Any]]:
-        """
-        Embed a list of texts in batches.
-        """
-
-        all_embeddings = []
-        metadata = {}
-        for i in tqdm(
-            range(0, len(texts_to_embed), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
-        ):
-            batch = texts_to_embed[i : i + batch_size]
-            response = self._session.post(
-                self.base_url,
-                json={"input": batch, "model": self.model_name, **(parameters or {})},
-            ).json()
-            if "data" not in response:
-                raise RuntimeError(response["detail"])
-
-            # Sort resulting embeddings by index
-            sorted_embeddings = sorted(response["data"], key=lambda e: e["index"])
-            embeddings = [result["embedding"] for result in sorted_embeddings]
-            all_embeddings.extend(embeddings)
-            if "model" not in metadata:
-                metadata["model"] = response["model"]
-            if "usage" not in metadata:
-                metadata["usage"] = dict(response["usage"].items())
-            else:
-                metadata["usage"]["prompt_tokens"] += response["usage"]["prompt_tokens"]
-                metadata["usage"]["total_tokens"] += response["usage"]["total_tokens"]
+        """Embed a list of texts in batches."""
+        all_embeddings: list[list[float]] = []
+        metadata: dict[str, Any] = {}
+        with httpx.Client() as client:
+            for i in tqdm(
+                range(0, len(texts_to_embed), batch_size),
+                disable=not self.progress_bar,
+                desc="Calculating embeddings",
+            ):
+                batch = texts_to_embed[i : i + batch_size]
+                response = client.post(
+                    self.base_url,
+                    json={"input": batch, "model": self.model_name, **(parameters or {})},
+                    headers=self._headers,
+                ).json()
+                self._process_batch_response(response, all_embeddings, metadata)
 
         return all_embeddings, metadata
+
+    async def _embed_batch_async(
+        self, texts_to_embed: list[str], batch_size: int, parameters: dict | None = None
+    ) -> tuple[list[list[float]], dict[str, Any]]:
+        """Asynchronously embed a list of texts in batches."""
+        all_embeddings: list[list[float]] = []
+        metadata: dict[str, Any] = {}
+        async with httpx.AsyncClient() as client:
+            for i in tqdm(
+                range(0, len(texts_to_embed), batch_size),
+                disable=not self.progress_bar,
+                desc="Calculating embeddings",
+            ):
+                batch = texts_to_embed[i : i + batch_size]
+                resp = await client.post(
+                    self.base_url,
+                    json={"input": batch, "model": self.model_name, **(parameters or {})},
+                    headers=self._headers,
+                )
+                self._process_batch_response(resp.json(), all_embeddings, metadata)
+
+        return all_embeddings, metadata
+
+    @staticmethod
+    def _build_result(
+        documents: list[Document], embeddings: list[list[float]], metadata: dict[str, Any]
+    ) -> dict[str, Any]:
+        new_documents: list[Document] = []
+        for doc, emb in zip(documents, embeddings, strict=True):
+            new_documents.append(replace(doc, embedding=emb))
+        return {"documents": new_documents, "meta": metadata}
 
     @component.output_types(documents=list[Document], meta=dict[str, Any])
     def run(self, documents: list[Document]) -> dict[str, Any]:
@@ -209,27 +262,36 @@ class JinaDocumentEmbedder:
             - `meta`: A dictionary with metadata including the model name and usage statistics.
         :raises TypeError: If the input is not a list of Documents.
         """
-        if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
-            msg = (
-                "JinaDocumentEmbedder expects a list of Documents as input."
-                "In case you want to embed a string, please use the JinaTextEmbedder."
-            )
-            raise TypeError(msg)
+        self._validate_input(documents)
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
-        parameters: dict[str, Any] = {}
-        if self.task is not None:
-            parameters["task"] = self.task
-        if self.dimensions is not None:
-            parameters["dimensions"] = self.dimensions
-        if self.late_chunking is not None:
-            parameters["late_chunking"] = self.late_chunking
+        parameters = self._prepare_parameters()
         embeddings, metadata = self._embed_batch(
             texts_to_embed=texts_to_embed, batch_size=self.batch_size, parameters=parameters
         )
 
-        new_documents: list[Document] = []
-        for doc, emb in zip(documents, embeddings, strict=True):
-            new_documents.append(replace(doc, embedding=emb))
+        return self._build_result(documents, embeddings, metadata)
 
-        return {"documents": new_documents, "meta": metadata}
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    async def run_async(self, documents: list[Document]) -> dict[str, Any]:
+        """
+        Asynchronously compute the embeddings for a list of Documents.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in async code.
+
+        :param documents: A list of Documents to embed.
+        :returns: A dictionary with following keys:
+            - `documents`: List of Documents, each with an `embedding` field containing the computed embedding.
+            - `meta`: A dictionary with metadata including the model name and usage statistics.
+        :raises TypeError: If the input is not a list of Documents.
+        """
+        self._validate_input(documents)
+
+        texts_to_embed = self._prepare_texts_to_embed(documents=documents)
+        parameters = self._prepare_parameters()
+        embeddings, metadata = await self._embed_batch_async(
+            texts_to_embed=texts_to_embed, batch_size=self.batch_size, parameters=parameters
+        )
+
+        return self._build_result(documents, embeddings, metadata)

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/document_embedder.py
@@ -233,12 +233,12 @@ class JinaDocumentEmbedder:
                 desc="Calculating embeddings",
             ):
                 batch = texts_to_embed[i : i + batch_size]
-                resp = await client.post(
+                response = await client.post(
                     self.base_url,
                     json={"input": batch, "model": self.model_name, **(parameters or {})},
                     headers=self._headers,
                 )
-                self._process_batch_response(resp.json(), all_embeddings, metadata)
+                self._process_batch_response(response.json(), all_embeddings, metadata)
 
         return all_embeddings, metadata
 

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/document_image_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/document_image_embedder.py
@@ -4,7 +4,7 @@
 from dataclasses import replace
 from typing import Any
 
-import requests
+import httpx
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.components.converters.image.image_utils import (
     _batch_convert_pdf_pages_to_images,
@@ -97,14 +97,11 @@ class JinaDocumentImageEmbedder:
         self.embedding_dimension = embedding_dimension
         self.image_size = image_size
         self.batch_size = batch_size
-        self._session = requests.Session()
-        self._session.headers.update(
-            {
-                "Authorization": f"Bearer {resolved_api_key}",
-                "Accept-Encoding": "identity",
-                "Content-type": "application/json",
-            }
-        )
+        self._headers = {
+            "Authorization": f"Bearer {resolved_api_key}",
+            "Accept-Encoding": "identity",
+            "Content-type": "application/json",
+        }
 
     def _get_telemetry_data(self) -> dict[str, Any]:
         """
@@ -208,6 +205,36 @@ class JinaDocumentImageEmbedder:
         # tested above that image is not None, but mypy doesn't know that
         return images_to_embed  # type: ignore[return-value]
 
+    def _prepare_parameters(self) -> dict[str, Any]:
+        parameters: dict[str, Any] = {}
+        if self.embedding_dimension is not None:
+            parameters["dimensions"] = self.embedding_dimension
+        return parameters
+
+    @staticmethod
+    def _process_batch_response(resp: dict[str, Any], embeddings: list[list[float]]) -> None:
+        if "data" not in resp:
+            error_msg = resp.get("detail", "Unknown error occurred")
+            msg = f"Jina API error: {error_msg}"
+            raise RuntimeError(msg)
+
+        batch_embeddings = [item["embedding"] for item in resp["data"]]
+        embeddings.extend(batch_embeddings)
+
+    @staticmethod
+    def _build_result(
+        documents: list[Document], embeddings: list[list[float]], file_path_meta_field: str
+    ) -> dict[str, list[Document]]:
+        docs_with_embeddings = []
+        for doc, emb in zip(documents, embeddings, strict=True):
+            new_meta = {
+                **doc.meta,
+                "embedding_source": {"type": "image", "file_path_meta_field": file_path_meta_field},
+            }
+            new_doc = replace(doc, meta=new_meta, embedding=emb)
+            docs_with_embeddings.append(new_doc)
+        return {"documents": docs_with_embeddings}
+
     @component.output_types(documents=list[Document])
     def run(self, documents: list[Document]) -> dict[str, list[Document]]:
         """
@@ -220,53 +247,67 @@ class JinaDocumentImageEmbedder:
             A dictionary with the following keys:
             - `documents`: Documents with embeddings.
         """
-
         if not documents:
             return {"documents": []}
 
         images_to_embed = self._extract_images_to_embed(documents)
+        parameters = self._prepare_parameters()
+        embeddings: list[list[float]] = []
 
-        embeddings = []
+        with httpx.Client() as client:
+            for i in range(0, len(images_to_embed), self.batch_size):
+                batch_images = images_to_embed[i : i + self.batch_size]
+                try:
+                    response = client.post(
+                        self.base_url,
+                        json={"input": batch_images, "model": self.model_name, **parameters},
+                        headers=self._headers,
+                    )
+                    resp = response.json()
+                except Exception as e:
+                    msg = f"Error calling Jina API: {e}"
+                    raise RuntimeError(msg) from e
 
-        # Process images in batches
-        for i in range(0, len(images_to_embed), self.batch_size):
-            batch_images = images_to_embed[i : i + self.batch_size]
+                self._process_batch_response(resp, embeddings)
 
-            # Prepare request parameters
-            parameters: dict[str, Any] = {}
-            if self.embedding_dimension is not None:
-                parameters["dimensions"] = self.embedding_dimension
+        return self._build_result(documents, embeddings, self.file_path_meta_field)
 
-            try:
-                response = self._session.post(
-                    self.base_url,
-                    json={
-                        "input": batch_images,
-                        "model": self.model_name,
-                        **parameters,
-                    },
-                )
-                resp = response.json()
-            except Exception as e:
-                msg = f"Error calling Jina API: {e}"
-                raise RuntimeError(msg) from e
+    @component.output_types(documents=list[Document])
+    async def run_async(self, documents: list[Document]) -> dict[str, list[Document]]:
+        """
+        Asynchronously embed a list of image documents.
 
-            if "data" not in resp:
-                error_msg = resp.get("detail", "Unknown error occurred")
-                msg = f"Jina API error: {error_msg}"
-                raise RuntimeError(msg)
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in async code.
 
-            batch_embeddings = [item["embedding"] for item in resp["data"]]
-            embeddings.extend(batch_embeddings)
+        :param documents:
+            Documents to embed.
 
-        docs_with_embeddings = []
-        for doc, emb in zip(documents, embeddings, strict=True):
-            # we store this information for later inspection
-            new_meta = {
-                **doc.meta,
-                "embedding_source": {"type": "image", "file_path_meta_field": self.file_path_meta_field},
-            }
-            new_doc = replace(doc, meta=new_meta, embedding=emb)
-            docs_with_embeddings.append(new_doc)
+        :returns:
+            A dictionary with the following keys:
+            - `documents`: Documents with embeddings.
+        """
+        if not documents:
+            return {"documents": []}
 
-        return {"documents": docs_with_embeddings}
+        images_to_embed = self._extract_images_to_embed(documents)
+        parameters = self._prepare_parameters()
+        embeddings: list[list[float]] = []
+
+        async with httpx.AsyncClient() as client:
+            for i in range(0, len(images_to_embed), self.batch_size):
+                batch_images = images_to_embed[i : i + self.batch_size]
+                try:
+                    response = await client.post(
+                        self.base_url,
+                        json={"input": batch_images, "model": self.model_name, **parameters},
+                        headers=self._headers,
+                    )
+                    resp = response.json()
+                except Exception as e:
+                    msg = f"Error calling Jina API: {e}"
+                    raise RuntimeError(msg) from e
+
+                self._process_batch_response(resp, embeddings)
+
+        return self._build_result(documents, embeddings, self.file_path_meta_field)

--- a/integrations/jina/src/haystack_integrations/components/embedders/jina/text_embedder.py
+++ b/integrations/jina/src/haystack_integrations/components/embedders/jina/text_embedder.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any
 
-import requests
+import httpx
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
 
@@ -74,14 +74,11 @@ class JinaTextEmbedder:
         self.base_url = base_url
         self.prefix = prefix
         self.suffix = suffix
-        self._session = requests.Session()
-        self._session.headers.update(
-            {
-                "Authorization": f"Bearer {resolved_api_key}",
-                "Accept-Encoding": "identity",
-                "Content-type": "application/json",
-            }
-        )
+        self._headers = {
+            "Authorization": f"Bearer {resolved_api_key}",
+            "Accept-Encoding": "identity",
+            "Content-type": "application/json",
+        }
         self.task = task
         self.dimensions = dimensions
         self.late_chunking = late_chunking
@@ -128,6 +125,37 @@ class JinaTextEmbedder:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
+    def _validate_input(self, text: str) -> None:
+        if not isinstance(text, str):
+            msg = (
+                "JinaTextEmbedder expects a string as an input."
+                "In case you want to embed a list of Documents, please use the JinaDocumentEmbedder."
+            )
+            raise TypeError(msg)
+
+    def _prepare_request_payload(self, text: str) -> dict[str, Any]:
+        text_to_embed = self.prefix + text + self.suffix
+
+        payload: dict[str, Any] = {"input": [text_to_embed], "model": self.model_name}
+        if self.task is not None:
+            payload["task"] = self.task
+        if self.dimensions is not None:
+            payload["dimensions"] = self.dimensions
+        if self.late_chunking is not None:
+            payload["late_chunking"] = self.late_chunking
+
+        return payload
+
+    @staticmethod
+    def _parse_response(resp: dict[str, Any]) -> dict[str, Any]:
+        if "data" not in resp:
+            raise RuntimeError(resp["detail"])
+
+        metadata = {"model": resp["model"], "usage": dict(resp["usage"].items())}
+        embedding = resp["data"][0]["embedding"]
+
+        return {"embedding": embedding, "meta": metadata}
+
     @component.output_types(embedding=list[float], meta=dict[str, Any])
     def run(self, text: str) -> dict[str, Any]:
         """
@@ -139,32 +167,34 @@ class JinaTextEmbedder:
             - `meta`: A dictionary with metadata including the model name and usage statistics.
         :raises TypeError: If the input is not a string.
         """
-        if not isinstance(text, str):
-            msg = (
-                "JinaTextEmbedder expects a string as an input."
-                "In case you want to embed a list of Documents, please use the JinaDocumentEmbedder."
-            )
-            raise TypeError(msg)
+        self._validate_input(text)
+        payload = self._prepare_request_payload(text)
 
-        text_to_embed = self.prefix + text + self.suffix
+        with httpx.Client() as client:
+            response = client.post(self.base_url, json=payload, headers=self._headers)
+        resp = response.json()
 
-        parameters: dict[str, Any] = {}
-        if self.task is not None:
-            parameters["task"] = self.task
-        if self.dimensions is not None:
-            parameters["dimensions"] = self.dimensions
-        if self.late_chunking is not None:
-            parameters["late_chunking"] = self.late_chunking
+        return self._parse_response(resp)
 
-        resp = self._session.post(
-            self.base_url,
-            json={"input": [text_to_embed], "model": self.model_name, **parameters},
-        ).json()
+    @component.output_types(embedding=list[float], meta=dict[str, Any])
+    async def run_async(self, text: str) -> dict[str, Any]:
+        """
+        Asynchronously embed a string.
 
-        if "data" not in resp:
-            raise RuntimeError(resp["detail"])
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in async code.
 
-        metadata = {"model": resp["model"], "usage": dict(resp["usage"].items())}
-        embedding = resp["data"][0]["embedding"]
+        :param text: The string to embed.
+        :returns: A dictionary with following keys:
+            - `embedding`: The embedding of the input string.
+            - `meta`: A dictionary with metadata including the model name and usage statistics.
+        :raises TypeError: If the input is not a string.
+        """
+        self._validate_input(text)
+        payload = self._prepare_request_payload(text)
 
-        return {"embedding": embedding, "meta": metadata}
+        async with httpx.AsyncClient() as client:
+            response = await client.post(self.base_url, json=payload, headers=self._headers)
+        resp = response.json()
+
+        return self._parse_response(resp)

--- a/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
+++ b/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
@@ -4,7 +4,7 @@
 from dataclasses import replace
 from typing import Any
 
-import requests
+import httpx
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
 
@@ -66,14 +66,11 @@ class JinaRanker:
             msg = f"top_k must be > 0, but got {top_k}"
             raise ValueError(msg)
 
-        self._session = requests.Session()
-        self._session.headers.update(
-            {
-                "Authorization": f"Bearer {resolved_api_key}",
-                "Accept-Encoding": "identity",
-                "Content-type": "application/json",
-            }
-        )
+        self._headers = {
+            "Authorization": f"Bearer {resolved_api_key}",
+            "Accept-Encoding": "identity",
+            "Content-type": "application/json",
+        }
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -110,6 +107,57 @@ class JinaRanker:
         """
         return {"model": self.model}
 
+    def _prepare_request_data(
+        self,
+        query: str,
+        documents: list[Document],
+        top_k: int | None = None,
+        score_threshold: float | None = None,
+    ) -> tuple[dict[str, Any], int | None, float | None]:
+        if top_k is not None and top_k <= 0:
+            msg = f"top_k must be > 0, but got {top_k}"
+            raise ValueError(msg)
+
+        top_k = top_k or self.top_k
+        score_threshold = score_threshold or self.score_threshold
+
+        data = {
+            "query": query,
+            "documents": [doc.content or "" for doc in documents],
+            "model": self.model,
+            "top_n": top_k,
+        }
+        return data, top_k, score_threshold
+
+    @staticmethod
+    def _parse_response(
+        resp: dict[str, Any],
+        documents: list[Document],
+        top_k: int | None,
+        score_threshold: float | None,
+    ) -> dict[str, Any]:
+        if "results" not in resp:
+            raise RuntimeError(resp["detail"])
+
+        results = resp["results"]
+
+        ranked_docs: list[Document] = []
+        for result in results:
+            index = result["index"]
+            relevance_score = result["relevance_score"]
+            doc = documents[index]
+            if top_k is None or len(ranked_docs) < top_k:
+                scored_doc = replace(doc, score=relevance_score)
+                if score_threshold is not None:
+                    if relevance_score >= score_threshold:
+                        ranked_docs.append(scored_doc)
+                else:
+                    ranked_docs.append(scored_doc)
+            else:
+                break
+
+        return {"documents": ranked_docs, "meta": {"model": resp["model"], "usage": resp["usage"]}}
+
     @component.output_types(documents=list[Document])
     def run(
         self,
@@ -139,43 +187,50 @@ class JinaRanker:
         if not documents:
             return {"documents": []}
 
-        if top_k is not None and top_k <= 0:
-            msg = f"top_k must be > 0, but got {top_k}"
-            raise ValueError(msg)
+        data, top_k, score_threshold = self._prepare_request_data(query, documents, top_k, score_threshold)
 
-        top_k = top_k or self.top_k
-        score_threshold = score_threshold or self.score_threshold
+        with httpx.Client() as client:
+            response = client.post(self.base_url, json=data, headers=self._headers)
+        resp = response.json()
 
-        data = {
-            "query": query,
-            "documents": [doc.content or "" for doc in documents],
-            "model": self.model,
-            "top_n": top_k,
-        }
+        return self._parse_response(resp, documents, top_k, score_threshold)
 
-        resp = self._session.post(
-            self.base_url,
-            json=data,
-        ).json()
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query: str,
+        documents: list[Document],
+        top_k: int | None = None,
+        score_threshold: float | None = None,
+    ) -> dict[str, list[Document]]:
+        """
+        Asynchronously returns a list of Documents ranked by their similarity to the given query.
 
-        if "results" not in resp:
-            raise RuntimeError(resp["detail"])
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in async code.
 
-        results = resp["results"]
+        :param query:
+            Query string.
+        :param documents:
+            List of Documents.
+        :param top_k:
+            The maximum number of Documents you want the Ranker to return.
+        :param score_threshold:
+            If provided only returns documents with a score above this threshold.
+        :returns:
+            A dictionary with the following keys:
+            - `documents`: List of Documents most similar to the given query in descending order of similarity.
 
-        ranked_docs: list[Document] = []
-        for result in results:
-            index = result["index"]
-            relevance_score = result["relevance_score"]
-            doc = documents[index]
-            if top_k is None or len(ranked_docs) < top_k:
-                scored_doc = replace(doc, score=relevance_score)
-                if score_threshold is not None:
-                    if relevance_score >= score_threshold:
-                        ranked_docs.append(scored_doc)
-                else:
-                    ranked_docs.append(scored_doc)
-            else:
-                break
+        :raises ValueError:
+            If `top_k` is not > 0.
+        """
+        if not documents:
+            return {"documents": []}
 
-        return {"documents": ranked_docs, "meta": {"model": resp["model"], "usage": resp["usage"]}}
+        data, top_k, score_threshold = self._prepare_request_data(query, documents, top_k, score_threshold)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(self.base_url, json=data, headers=self._headers)
+        resp = response.json()
+
+        return self._parse_response(resp, documents, top_k, score_threshold)

--- a/integrations/jina/tests/test_document_embedder.py
+++ b/integrations/jina/tests/test_document_embedder.py
@@ -1,29 +1,25 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import json
 import os
 from unittest.mock import patch
 
+import httpx
 import pytest
-import requests
 from haystack import Document
 from haystack.utils import Secret
 
 from haystack_integrations.components.embedders.jina import JinaDocumentEmbedder
 
 
-def mock_session_post_response(*args, **kwargs):  # noqa: ARG001
+def mock_httpx_post_response(*args, **kwargs):  # noqa: ARG001
     inputs = kwargs["json"]["input"]
     model = kwargs["json"]["model"]
-    mock_response = requests.Response()
-    mock_response.status_code = 200
     data = [{"object": "embedding", "index": i, "embedding": [0.1, 0.2, 0.3]} for i in range(len(inputs))]
-    mock_response._content = json.dumps(
-        {"model": model, "object": "list", "usage": {"total_tokens": 4, "prompt_tokens": 4}, "data": data}
-    ).encode()
-
-    return mock_response
+    return httpx.Response(
+        200,
+        json={"model": model, "object": "list", "usage": {"total_tokens": 4, "prompt_tokens": 4}, "data": data},
+    )
 
 
 class TestJinaDocumentEmbedder:
@@ -166,7 +162,7 @@ class TestJinaDocumentEmbedder:
     def test_embed_batch(self):
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
 
-        with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
             embedder = JinaDocumentEmbedder(api_key=Secret.from_token("fake-api-key"), model="model")
 
             embeddings, metadata = embedder._embed_batch(texts_to_embed=texts, batch_size=2)
@@ -187,7 +183,7 @@ class TestJinaDocumentEmbedder:
         ]
 
         model = "jina-embeddings-v2-base-en"
-        with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
             embedder = JinaDocumentEmbedder(
                 api_key=Secret.from_token("fake-api-key"),
                 model=model,
@@ -218,7 +214,7 @@ class TestJinaDocumentEmbedder:
         ]
 
         model = "jina-embeddings-v2-base-en"
-        with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
             embedder = JinaDocumentEmbedder(
                 api_key=Secret.from_token("fake-api-key"),
                 model=model,
@@ -240,7 +236,7 @@ class TestJinaDocumentEmbedder:
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
         model = "jina-embeddings-v2-base-en"
-        with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
             embedder = JinaDocumentEmbedder(
                 api_key=Secret.from_token("fake-api-key"),
                 model=model,
@@ -287,6 +283,51 @@ class TestJinaDocumentEmbedder:
         assert result["documents"] is not None
         assert not result["documents"]  # empty list
 
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        docs = [
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
+        ]
+
+        model = "jina-embeddings-v2-base-en"
+        with patch("httpx.AsyncClient.post", side_effect=mock_httpx_post_response):
+            embedder = JinaDocumentEmbedder(
+                api_key=Secret.from_token("fake-api-key"),
+                model=model,
+                prefix="prefix ",
+                suffix=" suffix",
+                meta_fields_to_embed=["topic"],
+                embedding_separator=" | ",
+            )
+
+            result = await embedder.run_async(documents=docs)
+
+        documents_with_embeddings = result["documents"]
+        metadata = result["meta"]
+
+        assert isinstance(documents_with_embeddings, list)
+        assert len(documents_with_embeddings) == len(docs)
+        for doc in documents_with_embeddings:
+            assert isinstance(doc, Document)
+            assert isinstance(doc.embedding, list)
+            assert len(doc.embedding) == 3
+            assert all(isinstance(x, float) for x in doc.embedding)
+        assert metadata == {"model": model, "usage": {"prompt_tokens": 4, "total_tokens": 4}}
+
+    @pytest.mark.asyncio
+    async def test_run_async_wrong_input_format(self):
+        embedder = JinaDocumentEmbedder(api_key=Secret.from_token("fake-api-key"))
+
+        string_input = "text"
+        list_integers_input = [1, 2, 3]
+
+        with pytest.raises(TypeError, match="JinaDocumentEmbedder expects a list of Documents as input"):
+            await embedder.run_async(documents=string_input)
+
+        with pytest.raises(TypeError, match="JinaDocumentEmbedder expects a list of Documents as input"):
+            await embedder.run_async(documents=list_integers_input)
+
     def test_run_with_v3(self):
         docs = [
             Document(content="I love cheese", meta={"topic": "Cuisine"}),
@@ -294,7 +335,7 @@ class TestJinaDocumentEmbedder:
         ]
 
         model = "jina-embeddings-v3"
-        with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
             embedder = JinaDocumentEmbedder(
                 api_key=Secret.from_token("fake-api-key"),
                 model=model,
@@ -329,6 +370,31 @@ class TestJinaDocumentEmbedder:
         ]
 
         result = embedder.run(documents=docs)
+
+        assert "documents" in result
+        assert len(result["documents"]) == 2
+        for doc in result["documents"]:
+            assert isinstance(doc, Document)
+            assert isinstance(doc.embedding, list)
+            assert len(doc.embedding) > 0
+            assert all(isinstance(x, (int, float)) for x in doc.embedding)
+
+        assert "meta" in result
+        assert isinstance(result["meta"], dict)
+        assert "model" in result["meta"]
+        assert "usage" in result["meta"]
+
+    @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY env var not set")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_run_async_integration(self):
+        embedder = JinaDocumentEmbedder(model="jina-embeddings-v3", task="retrieval.passage")
+        docs = [
+            Document(content="Paris is the capital of France."),
+            Document(content="Berlin is the capital of Germany."),
+        ]
+
+        result = await embedder.run_async(documents=docs)
 
         assert "documents" in result
         assert len(result["documents"]) == 2

--- a/integrations/jina/tests/test_document_image_embedder.py
+++ b/integrations/jina/tests/test_document_image_embedder.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 from haystack import Document
 from haystack.utils.auth import Secret
@@ -122,16 +123,18 @@ class TestJinaDocumentImageEmbedder:
 
         embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
 
+        mock_response = httpx.Response(
+            200,
+            json={
+                "data": [{"embedding": [1.0] * MOCK_EMBEDDING_DIM}],
+                "model": "jina-clip-v2",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
+        )
+
         # Mock the _extract_images_to_embed method to return base64 image data
         with patch.object(embedder, "_extract_images_to_embed", return_value=["data:image/jpeg;base64,fake_base64"]):
-            with patch.object(embedder._session, "post") as mock_post:
-                mock_response = Mock()
-                mock_response.json.return_value = {
-                    "data": [{"embedding": [1.0] * MOCK_EMBEDDING_DIM}],
-                    "model": "jina-clip-v2",
-                    "usage": {"prompt_tokens": 1, "total_tokens": 1},
-                }
-                mock_post.return_value = mock_response
+            with patch("httpx.Client.post", return_value=mock_response):
                 result = embedder.run(documents=documents)
 
                 assert "documents" in result
@@ -144,12 +147,11 @@ class TestJinaDocumentImageEmbedder:
 
         embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
 
+        mock_response = httpx.Response(400, json={"detail": "API Error occurred"})
+
         # Mock the _extract_images_to_embed method to return base64 image data
         with patch.object(embedder, "_extract_images_to_embed", return_value=["data:image/jpeg;base64,fake_base64"]):
-            with patch.object(embedder._session, "post") as mock_post:
-                mock_response = Mock()
-                mock_response.json.return_value = {"detail": "API Error occurred"}
-                mock_post.return_value = mock_response
+            with patch("httpx.Client.post", return_value=mock_response):
                 with pytest.raises(RuntimeError, match="Jina API error: API Error occurred"):
                     embedder.run(documents=documents)
 
@@ -206,7 +208,7 @@ class TestJinaDocumentImageEmbedder:
         embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
 
         with patch.object(embedder, "_extract_images_to_embed", return_value=["data:image/jpeg;base64,fake_base64"]):
-            with patch.object(embedder._session, "post", side_effect=Exception("Connection failed")):
+            with patch("httpx.Client.post", side_effect=Exception("Connection failed")):
                 with pytest.raises(RuntimeError, match="Error calling Jina API: Connection failed"):
                     embedder.run(documents=documents)
 
@@ -217,19 +219,15 @@ class TestJinaDocumentImageEmbedder:
 
         fake_images = [f"data:image/jpeg;base64,fake_base64_{i}" for i in range(12)]
 
+        def mock_response_func(*_args, **kwargs):
+            batch_size = len(kwargs["json"]["input"])
+            return httpx.Response(
+                200,
+                json={"data": [{"embedding": [1.0] * MOCK_EMBEDDING_DIM} for _ in range(batch_size)]},
+            )
+
         with patch.object(embedder, "_extract_images_to_embed", return_value=fake_images):
-            with patch.object(embedder._session, "post") as mock_post:
-                # Mock response that adapts to batch size
-                def mock_response_func(*_args, **kwargs):
-                    batch_size = len(kwargs["json"]["input"])
-                    mock_response = Mock()
-                    mock_response.json.return_value = {
-                        "data": [{"embedding": [1.0] * MOCK_EMBEDDING_DIM} for _ in range(batch_size)]
-                    }
-                    return mock_response
-
-                mock_post.side_effect = mock_response_func
-
+            with patch("httpx.Client.post", side_effect=mock_response_func) as mock_post:
                 result = embedder.run(documents=documents)
 
                 # Should have made 3 API calls (12 images / 5 batch_size = 3 batches: 5, 5, 2)
@@ -241,6 +239,36 @@ class TestJinaDocumentImageEmbedder:
                 assert len(call_args_list[0][1]["json"]["input"]) == 5  # First batch: 5 images
                 assert len(call_args_list[1][1]["json"]["input"]) == 5  # Second batch: 5 images
                 assert len(call_args_list[2][1]["json"]["input"]) == 2  # Third batch: 2 images
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_successful_request(self):
+        documents = [Document(content="Test image", meta={"file_path": "test.jpg"})]
+
+        embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
+
+        mock_response = httpx.Response(
+            200,
+            json={
+                "data": [{"embedding": [1.0] * MOCK_EMBEDDING_DIM}],
+                "model": "jina-clip-v2",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
+        )
+
+        with patch.object(embedder, "_extract_images_to_embed", return_value=["data:image/jpeg;base64,fake_base64"]):
+            with patch("httpx.AsyncClient.post", return_value=mock_response):
+                result = await embedder.run_async(documents=documents)
+
+                assert "documents" in result
+                assert len(result["documents"]) == 1
+                assert result["documents"][0].embedding == [1.0] * MOCK_EMBEDDING_DIM
+                assert result["documents"][0].meta["embedding_source"]["type"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_run_async_on_empty_list(self):
+        embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
+        result = await embedder.run_async(documents=[])
+        assert result == {"documents": []}
 
     @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY not set")
     @pytest.mark.integration

--- a/integrations/jina/tests/test_ranker.py
+++ b/integrations/jina/tests/test_ranker.py
@@ -1,32 +1,28 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import json
 import os
 from unittest.mock import patch
 
+import httpx
 import pytest
-import requests
 from haystack import Document
 from haystack.utils import Secret
 
 from haystack_integrations.components.rankers.jina import JinaRanker
 
 
-def mock_session_post_response(*args, **kwargs):  # noqa: ARG001
+def mock_httpx_post_response(*args, **kwargs):  # noqa: ARG001
     model = kwargs["json"]["model"]
     documents = kwargs["json"]["documents"]
-    mock_response = requests.Response()
-    mock_response.status_code = 200
     results = [
         {"index": i, "relevance_score": len(documents) - i, "document": {"text": doc}}
         for i, doc in enumerate(documents)
     ]
-    mock_response._content = json.dumps(
-        {"model": model, "usage": {"total_tokens": 4, "prompt_tokens": 4}, "results": results}
-    ).encode()
-
-    return mock_response
+    return httpx.Response(
+        200,
+        json={"model": model, "usage": {"total_tokens": 4, "prompt_tokens": 4}, "results": results},
+    )
 
 
 class TestJinaRanker:
@@ -97,7 +93,7 @@ class TestJinaRanker:
         query = "What is a transformer?"
 
         model = "jina-ranker"
-        with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
             ranker = JinaRanker(
                 api_key=Secret.from_token("fake-api-key"),
                 model=model,
@@ -125,7 +121,7 @@ class TestJinaRanker:
         query = "What is a transformer?"
 
         model = "jina-ranker"
-        with patch("requests.sessions.Session.post", side_effect=mock_session_post_response):
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
             ranker = JinaRanker(
                 api_key=Secret.from_token("fake-api-key"),
                 model=model,
@@ -140,6 +136,44 @@ class TestJinaRanker:
         # returned docs carry scores
         for doc in result["documents"]:
             assert doc.score is not None
+
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        docs = [
+            Document(content="I love cheese"),
+            Document(content="A transformer is a deep learning architecture"),
+            Document(content="A transformer is something"),
+            Document(content="A transformer is not good"),
+        ]
+        query = "What is a transformer?"
+
+        model = "jina-ranker"
+        with patch("httpx.AsyncClient.post", side_effect=mock_httpx_post_response):
+            ranker = JinaRanker(
+                api_key=Secret.from_token("fake-api-key"),
+                model=model,
+            )
+
+            result = await ranker.run_async(query=query, documents=docs)
+
+        ranked_documents = result["documents"]
+        metadata = result["meta"]
+
+        assert isinstance(ranked_documents, list)
+        assert len(ranked_documents) == len(docs)
+        for i, doc in enumerate(ranked_documents):
+            assert isinstance(doc, Document)
+            assert doc.score == len(ranked_documents) - i
+        assert metadata == {"model": model, "usage": {"prompt_tokens": 4, "total_tokens": 4}}
+
+    @pytest.mark.asyncio
+    async def test_run_async_on_empty_docs(self):
+        ranker = JinaRanker(api_key=Secret.from_token("fake-api-key"))
+
+        result = await ranker.run_async(query="a", documents=[])
+
+        assert result["documents"] is not None
+        assert not result["documents"]
 
     def test_run_wrong_input_format(self):
         ranker = JinaRanker(api_key=Secret.from_token("fake-api-key"))
@@ -167,6 +201,32 @@ class TestJinaRanker:
         ]
 
         result = ranker.run(query="What is the capital of France?", documents=docs, top_k=2)
+
+        assert "documents" in result
+        ranked_docs = result["documents"]
+        assert len(ranked_docs) == 2
+        assert all(isinstance(doc, Document) for doc in ranked_docs)
+        assert all(doc.score is not None for doc in ranked_docs)
+        assert ranked_docs[0].score >= ranked_docs[1].score
+        assert "Paris" in ranked_docs[0].content
+
+        assert "meta" in result
+        assert isinstance(result["meta"], dict)
+        assert "model" in result["meta"]
+        assert "usage" in result["meta"]
+
+    @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY env var not set")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_run_async_integration(self):
+        ranker = JinaRanker(model="jina-reranker-v1-base-en")
+        docs = [
+            Document(content="Paris is the capital of France."),
+            Document(content="Bananas are yellow fruits."),
+            Document(content="Berlin is the capital of Germany."),
+        ]
+
+        result = await ranker.run_async(query="What is the capital of France?", documents=docs, top_k=2)
 
         assert "documents" in result
         ranked_docs = result["documents"]

--- a/integrations/jina/tests/test_reader_connector.py
+++ b/integrations/jina/tests/test_reader_connector.py
@@ -1,7 +1,7 @@
-import json
 import os
 from unittest.mock import patch
 
+import httpx
 import pytest
 from haystack import Document
 from haystack.utils import Secret
@@ -87,17 +87,20 @@ class TestJinaReaderConnector:
             {"url": "https://example.com", "keyQuote": "Mocked key quote", "isSupportive": False}
         ]
 
-    @patch("requests.get")
-    def test_run_with_mocked_response(self, mock_get, monkeypatch):
+    def test_run_with_mocked_response(self, monkeypatch):
         monkeypatch.setenv("JINA_API_KEY", "test-api-key")
         mock_json_response = {
             "data": {"content": "Mocked content", "title": "Mocked Title", "url": "https://example.com"}
         }
-        mock_get.return_value.content = json.dumps(mock_json_response).encode("utf-8")
-        mock_get.return_value.headers = {"Content-Type": "application/json"}
+        mock_response = httpx.Response(
+            200,
+            json=mock_json_response,
+            headers={"Content-Type": "application/json"},
+        )
 
-        reader = JinaReaderConnector(mode="read")
-        result = reader.run(query="https://example.com")
+        with patch("httpx.Client.get", return_value=mock_response) as mock_get:
+            reader = JinaReaderConnector(mode="read")
+            result = reader.run(query="https://example.com")
 
         assert mock_get.call_count == 1
         assert mock_get.call_args[0][0] == "https://r.jina.ai/https%3A%2F%2Fexample.com"
@@ -106,6 +109,30 @@ class TestJinaReaderConnector:
             "Accept": "application/json",
         }
 
+        assert len(result) == 1
+        document = result["documents"][0]
+        assert isinstance(document, Document)
+        assert document.content == "Mocked content"
+        assert document.meta["title"] == "Mocked Title"
+        assert document.meta["url"] == "https://example.com"
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_mocked_response(self, monkeypatch):
+        monkeypatch.setenv("JINA_API_KEY", "test-api-key")
+        mock_json_response = {
+            "data": {"content": "Mocked content", "title": "Mocked Title", "url": "https://example.com"}
+        }
+        mock_response = httpx.Response(
+            200,
+            json=mock_json_response,
+            headers={"Content-Type": "application/json"},
+        )
+
+        with patch("httpx.AsyncClient.get", return_value=mock_response) as mock_get:
+            reader = JinaReaderConnector(mode="read")
+            result = await reader.run_async(query="https://example.com")
+
+        assert mock_get.call_count == 1
         assert len(result) == 1
         document = result["documents"][0]
         assert isinstance(document, Document)
@@ -139,3 +166,17 @@ class TestJinaReaderConnector:
             assert "title" in doc.meta
             assert "url" in doc.meta
             assert "description" in doc.meta
+
+    @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY env var not set")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_run_async_reader_mode(self):
+        reader = JinaReaderConnector(mode="read")
+        result = await reader.run_async(query="https://example.com")
+
+        assert len(result) == 1
+        document = result["documents"][0]
+        assert isinstance(document, Document)
+        assert "This domain is for use in documentation examples" in document.content
+        assert document.meta["title"] == "Example Domain"
+        assert document.meta["url"] == "https://example.com/"

--- a/integrations/jina/tests/test_text_embedder.py
+++ b/integrations/jina/tests/test_text_embedder.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import json
 import os
 from unittest.mock import patch
 
+import httpx
 import pytest
-import requests
 from haystack.utils import Secret
 
 from haystack_integrations.components.embedders.jina import JinaTextEmbedder
@@ -85,26 +84,23 @@ class TestJinaTextEmbedder:
 
     def test_run(self):
         model = "jina-embeddings-v2-base-en"
-        with patch("requests.sessions.Session.post") as mock_post:
-            # Configure the mock to return a specific response
-            mock_response = requests.Response()
-            mock_response.status_code = 200
-            mock_response._content = json.dumps(
-                {
-                    "model": "jina-embeddings-v2-base-en",
-                    "object": "list",
-                    "usage": {"total_tokens": 6, "prompt_tokens": 6},
-                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}],
-                }
-            ).encode()
+        mock_response = httpx.Response(
+            200,
+            json={
+                "model": "jina-embeddings-v2-base-en",
+                "object": "list",
+                "usage": {"total_tokens": 6, "prompt_tokens": 6},
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}],
+            },
+        )
 
-            mock_post.return_value = mock_response
-
+        with patch("httpx.Client.post", return_value=mock_response) as mock_post:
             embedder = JinaTextEmbedder(
                 api_key=Secret.from_token("fake-api-key"), model=model, prefix="prefix ", suffix=" suffix"
             )
             result = embedder.run(text="The food was delicious")
 
+        mock_post.assert_called_once()
         assert len(result["embedding"]) == 3
         assert all(isinstance(x, float) for x in result["embedding"])
         assert result["meta"] == {
@@ -122,21 +118,17 @@ class TestJinaTextEmbedder:
 
     def test_with_v3(self):
         model = "jina-embeddings-v3"
-        with patch("requests.sessions.Session.post") as mock_post:
-            # Configure the mock to return a specific response
-            mock_response = requests.Response()
-            mock_response.status_code = 200
-            mock_response._content = json.dumps(
-                {
-                    "model": "jina-embeddings-v3",
-                    "object": "list",
-                    "usage": {"total_tokens": 6, "prompt_tokens": 6},
-                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}],
-                }
-            ).encode()
+        mock_response = httpx.Response(
+            200,
+            json={
+                "model": "jina-embeddings-v3",
+                "object": "list",
+                "usage": {"total_tokens": 6, "prompt_tokens": 6},
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}],
+            },
+        )
 
-            mock_post.return_value = mock_response
-
+        with patch("httpx.Client.post", return_value=mock_response) as mock_post:
             embedder = JinaTextEmbedder(
                 api_key=Secret.from_token("fake-api-key"),
                 model=model,
@@ -146,6 +138,7 @@ class TestJinaTextEmbedder:
             )
             result = embedder.run(text="The food was delicious")
 
+        mock_post.assert_called_once()
         assert len(result["embedding"]) == 3
         assert all(isinstance(x, float) for x in result["embedding"])
         assert result["meta"] == {
@@ -153,11 +146,63 @@ class TestJinaTextEmbedder:
             "usage": {"prompt_tokens": 6, "total_tokens": 6},
         }
 
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        model = "jina-embeddings-v2-base-en"
+        mock_response = httpx.Response(
+            200,
+            json={
+                "model": "jina-embeddings-v2-base-en",
+                "object": "list",
+                "usage": {"total_tokens": 6, "prompt_tokens": 6},
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}],
+            },
+        )
+
+        with patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+            embedder = JinaTextEmbedder(
+                api_key=Secret.from_token("fake-api-key"), model=model, prefix="prefix ", suffix=" suffix"
+            )
+            result = await embedder.run_async(text="The food was delicious")
+
+        mock_post.assert_called_once()
+        assert len(result["embedding"]) == 3
+        assert all(isinstance(x, float) for x in result["embedding"])
+        assert result["meta"] == {
+            "model": "jina-embeddings-v2-base-en",
+            "usage": {"prompt_tokens": 6, "total_tokens": 6},
+        }
+
+    def test_run_async_wrong_input_format(self):
+        embedder = JinaTextEmbedder(api_key=Secret.from_token("fake-api-key"))
+
+        list_integers_input = [1, 2, 3]
+
+        with pytest.raises(TypeError, match="JinaTextEmbedder expects a string as an input"):
+            embedder.run(text=list_integers_input)
+
     @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY env var not set")
     @pytest.mark.integration
     def test_run_integration(self):
         embedder = JinaTextEmbedder(task="retrieval.query")
         result = embedder.run(text="What is the capital of France?")
+
+        assert "embedding" in result
+        assert isinstance(result["embedding"], list)
+        assert len(result["embedding"]) > 0
+        assert all(isinstance(x, (int, float)) for x in result["embedding"])
+
+        assert "meta" in result
+        assert isinstance(result["meta"], dict)
+        assert "model" in result["meta"]
+        assert "usage" in result["meta"]
+
+    @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY env var not set")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_run_async_integration(self):
+        embedder = JinaTextEmbedder(task="retrieval.query")
+        result = await embedder.run_async(text="What is the capital of France?")
 
         assert "embedding" in result
         assert isinstance(result["embedding"], list)

--- a/integrations/jina/tests/test_text_embedder.py
+++ b/integrations/jina/tests/test_text_embedder.py
@@ -173,13 +173,14 @@ class TestJinaTextEmbedder:
             "usage": {"prompt_tokens": 6, "total_tokens": 6},
         }
 
-    def test_run_async_wrong_input_format(self):
+    @pytest.mark.asyncio
+    async def test_run_async_wrong_input_format(self):
         embedder = JinaTextEmbedder(api_key=Secret.from_token("fake-api-key"))
 
         list_integers_input = [1, 2, 3]
 
         with pytest.raises(TypeError, match="JinaTextEmbedder expects a string as an input"):
-            embedder.run(text=list_integers_input)
+            await embedder.run_async(text=list_integers_input)
 
     @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY env var not set")
     @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes #3134

### Proposed Changes:

Add `run_async` methods to all Jina integration components (`JinaTextEmbedder`, `JinaDocumentEmbedder`, `JinaDocumentImageEmbedder`, `JinaRanker`, `JinaReaderConnector`) and migrate HTTP calls from `requests` to `httpx`, enabling use with Haystack's `AsyncPipeline`.

The async pattern follows haystack core's `SerperDevWebSearch` — using `httpx.Client` / `httpx.AsyncClient` as context managers per call.

### How did you test it?

- 60 unit tests pass (up from 51), with 9 new async unit tests and 4 new async integration tests for every component
- `hatch run fmt` and `hatch run test:types` pass
- Async integration tests added and verified with a live `JINA_API_KEY`

### Notes for the reviewer

- The per-call client pattern trades connection pooling across `run()` calls for simplicity and consistency with the framework. Batching components (`JinaDocumentEmbedder`, `JinaDocumentImageEmbedder`) still pool within a single `run()` call.
- This PR was primarily generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.