### PR TITLE
test: Extract method to extract text from mcp result

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -63,15 +63,15 @@ def _resolve_headers(headers: dict[str, str | Secret] | None) -> dict[str, str] 
     return resolved_headers
 
 
-def extract_first_text_element(result: str) -> str | dict[str, Any]:
+def _extract_first_text_element(tool_call_result: str) -> str | dict[str, Any]:
     """
-    Return the first text content block from an MCP tool response.
+    Return the first text content block from an MCP tool call result.
 
-    MCP tool responses may include mixed content types such as text, image, or
+    MCP tool call results may include mixed content types such as text, image, or
     audio blocks. This helper extracts the first text block because the tool
     invoker expects a single parsed payload rather than the full content list.
     """
-    parsed: dict = json.loads(result)
+    parsed: dict = json.loads(tool_call_result)
     content: list = parsed.get("content", [])
     for block in content:
         if isinstance(block, dict) and block.get("type") == "text":
@@ -1109,7 +1109,7 @@ class MCPTool(Tool):
             # Parse JSON to dict only when outputs_to_state is configured.
             # ToolInvoker requires dict for _merge_tool_outputs(); ToolCallResult.result expects str otherwise.
             if self.outputs_to_state:
-                return extract_first_text_element(result)
+                return _extract_first_text_element(result)
 
             return result
         except (MCPError, TimeoutError) as e:
@@ -1140,7 +1140,7 @@ class MCPTool(Tool):
             # Parse JSON to dict only when outputs_to_state is configured.
             # ToolInvoker requires dict for _merge_tool_outputs(); ToolCallResult.result expects str otherwise.
             if self.outputs_to_state:
-                return extract_first_text_element(result)
+                return _extract_first_text_element(result)
 
             return result
         except asyncio.TimeoutError as e:

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -63,9 +63,14 @@ def _resolve_headers(headers: dict[str, str | Secret] | None) -> dict[str, str] 
     return resolved_headers
 
 
-def extract_first_text_element(result: str) -> str:
-    # Per MCP spec, content[] may contain TextContent, ImageContent, AudioContent, etc.
-    # Parse only first TextContent block (ToolInvoker requires dict, not list).
+def extract_first_text_element(result: str) -> str | dict[str, Any]:
+    """
+    Return the first text content block from an MCP tool response.
+
+    MCP tool responses may include mixed content types such as text, image, or
+    audio blocks. This helper extracts the first text block because the tool
+    invoker expects a single parsed payload rather than the full content list.
+    """
     parsed: dict = json.loads(result)
     content: list = parsed.get("content", [])
     for block in content:
@@ -74,8 +79,9 @@ def extract_first_text_element(result: str) -> str:
             try:
                 return json.loads(text)
             except (json.JSONDecodeError, TypeError):
-                # No TextContent found, return full parsed response as fallback
                 return text
+    # No TextContent found, return full parsed response as fallback
+    return parsed
 
 
 class AsyncExecutor:

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -63,6 +63,21 @@ def _resolve_headers(headers: dict[str, str | Secret] | None) -> dict[str, str] 
     return resolved_headers
 
 
+def extract_first_text(result: str) -> str:
+    # Per MCP spec, content[] may contain TextContent, ImageContent, AudioContent, etc.
+    # Parse only first TextContent block (ToolInvoker requires dict, not list).
+    parsed: dict = json.loads(result)
+    content: list = parsed.get("content", [])
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text", "")
+            try:
+                return json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                # No TextContent found, return full parsed response as fallback
+                return text
+
+
 class AsyncExecutor:
     """Thread-safe event loop executor for running async code from sync contexts."""
 
@@ -1088,21 +1103,7 @@ class MCPTool(Tool):
             # Parse JSON to dict only when outputs_to_state is configured.
             # ToolInvoker requires dict for _merge_tool_outputs(); ToolCallResult.result expects str otherwise.
             if self.outputs_to_state:
-                parsed = json.loads(result)
-
-                # Per MCP spec, content[] may contain TextContent, ImageContent, AudioContent, etc.
-                # Parse only first TextContent block (ToolInvoker requires dict, not list).
-                content = parsed.get("content", [])
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text = block.get("text", "")
-                        try:
-                            return json.loads(text)
-                        except (json.JSONDecodeError, TypeError):
-                            return text
-
-                # No TextContent found, return full parsed response as fallback
-                return parsed
+                return self.extract_first_text(result)
 
             return result
         except (MCPError, TimeoutError) as e:
@@ -1133,21 +1134,7 @@ class MCPTool(Tool):
             # Parse JSON to dict only when outputs_to_state is configured.
             # ToolInvoker requires dict for _merge_tool_outputs(); ToolCallResult.result expects str otherwise.
             if self.outputs_to_state:
-                parsed = json.loads(result)
-
-                # Per MCP spec, content[] may contain TextContent, ImageContent, AudioContent, etc.
-                # Parse only first TextContent block (ToolInvoker requires dict, not list).
-                content = parsed.get("content", [])
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text = block.get("text", "")
-                        try:
-                            return json.loads(text)
-                        except (json.JSONDecodeError, TypeError):
-                            return text
-
-                # No TextContent found, return full parsed response as fallback
-                return parsed
+                return extract_first_text(result)
 
             return result
         except asyncio.TimeoutError as e:

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -63,7 +63,7 @@ def _resolve_headers(headers: dict[str, str | Secret] | None) -> dict[str, str] 
     return resolved_headers
 
 
-def extract_first_text(result: str) -> str:
+def extract_first_text_element(result: str) -> str:
     # Per MCP spec, content[] may contain TextContent, ImageContent, AudioContent, etc.
     # Parse only first TextContent block (ToolInvoker requires dict, not list).
     parsed: dict = json.loads(result)
@@ -1103,7 +1103,7 @@ class MCPTool(Tool):
             # Parse JSON to dict only when outputs_to_state is configured.
             # ToolInvoker requires dict for _merge_tool_outputs(); ToolCallResult.result expects str otherwise.
             if self.outputs_to_state:
-                return self.extract_first_text(result)
+                return extract_first_text_element(result)
 
             return result
         except (MCPError, TimeoutError) as e:
@@ -1134,7 +1134,7 @@ class MCPTool(Tool):
             # Parse JSON to dict only when outputs_to_state is configured.
             # ToolInvoker requires dict for _merge_tool_outputs(); ToolCallResult.result expects str otherwise.
             if self.outputs_to_state:
-                return extract_first_text(result)
+                return extract_first_text_element(result)
 
             return result
         except asyncio.TimeoutError as e:

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -255,7 +255,7 @@ class TestMCPTool:
             else:
                 assert errlog is mock_stderr
 
-    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
     def test_pipeline_warmup_with_mcp_tool(self):
         """Test lazy connection with Pipeline.warm_up() - replicates time_pipeline.py."""
@@ -278,7 +278,7 @@ class TestMCPTool:
             if tool:
                 tool.close()
 
-    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
     def test_agent_with_state_mapping(self):
         """Test Agent with MCPTool using state-mapping to inject location from state."""

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -15,7 +15,7 @@ from haystack_integrations.tools.mcp import (
     MCPTool,
     StdioServerInfo,
 )
-from haystack_integrations.tools.mcp.mcp_tool import StdioClient, extract_first_text_element
+from haystack_integrations.tools.mcp.mcp_tool import StdioClient, _extract_first_text_element
 
 from .mcp_memory_transport import InMemoryServerInfo
 from .mcp_servers_fixtures import calculator_mcp, echo_mcp
@@ -27,19 +27,21 @@ def simple_haystack_tool(name: str) -> str:
     return f"Hello, {name}!"
 
 
+# from https://modelcontextprotocol.io/specification/draft/server/tools#output-schema
+EXAMPLE_MCP_TOOL_CALL_RESULT = {
+    "content": [{"type": "text", "text": '{"temperature": 22.5, "conditions": "Partly cloudy", "humidity": 65}'}],
+    "structuredContent": {"temperature": 22.5, "conditions": "Partly cloudy", "humidity": 65},
+}
+
+
 def test_extract_first_text_element():
     """Test that extract_first_text skips non-text blocks and parses the first text block."""
-    result = json.dumps(
-        {
-            "content": [
-                {"type": "image", "data": "ignored"},
-                {"type": "text", "text": '{"answer": 42}'},
-                {"type": "text", "text": '{"answer": 7}'},
-            ]
-        }
-    )
+    tool_call_result = EXAMPLE_MCP_TOOL_CALL_RESULT
+    tool_call_result["content"].insert(0, {"type": "image", "data": "ignored"})
+    tool_call_result["content"].insert(1, {"type": "text", "text": '{"answer": 42}'})  # target
+    tool_call_result = json.dumps(tool_call_result)
 
-    extracted = extract_first_text_element(result)
+    extracted = _extract_first_text_element(tool_call_result)
 
     assert extracted == {"answer": 42}
 

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -15,7 +15,7 @@ from haystack_integrations.tools.mcp import (
     MCPTool,
     StdioServerInfo,
 )
-from haystack_integrations.tools.mcp.mcp_tool import StdioClient
+from haystack_integrations.tools.mcp.mcp_tool import StdioClient, extract_first_text_element
 
 from .mcp_memory_transport import InMemoryServerInfo
 from .mcp_servers_fixtures import calculator_mcp, echo_mcp
@@ -25,6 +25,23 @@ from .mcp_servers_fixtures import calculator_mcp, echo_mcp
 def simple_haystack_tool(name: str) -> str:
     """A simple Haystack tool for comparison."""
     return f"Hello, {name}!"
+
+
+def test_extract_first_text_element():
+    """Test that extract_first_text skips non-text blocks and parses the first text block."""
+    result = json.dumps(
+        {
+            "content": [
+                {"type": "image", "data": "ignored"},
+                {"type": "text", "text": '{"answer": 42}'},
+                {"type": "text", "text": '{"answer": 7}'},
+            ]
+        }
+    )
+
+    extracted = extract_first_text_element(result)
+
+    assert extracted == {"answer": 42}
 
 
 class TestMCPTool:

--- a/integrations/mcp/tests/test_mcp_toolset.py
+++ b/integrations/mcp/tests/test_mcp_toolset.py
@@ -382,7 +382,7 @@ class TestMCPToolset:
             assert tool.outputs_to_state is None
             assert tool.outputs_to_string is None
 
-    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
     async def test_pipeline_warmup_with_mcp_toolset(self):
         """Test lazy connection with Pipeline.warm_up() - replicates time_pipeline.py."""


### PR DESCRIPTION
### Proposed Changes:

While looking through the coverage report vor mcp_tool.py I found a section of untested duplicate code between the tool invokation and its async counter part. I extracted that part and added a test for it. 

### How did you test it?

Ran tests and linting accoding to contribution guidelines. Added a new test (AI generated) for the extracted method

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
