### PR TITLE
added PromptTemplateAdapter

### DIFF
--- a/integrations/dspy/src/haystack_integrations/components/generators/dspy/prompt_template_adapter.py
+++ b/integrations/dspy/src/haystack_integrations/components/generators/dspy/prompt_template_adapter.py
@@ -1,31 +1,26 @@
-class PromptTemplateAdapter:
-    """ Makes DSPy base prompts better with custom model templates, for an enhanced text output. """
+import typing
 
-    templates = {
+
+class PromptTemplateAdapter:
+    """Makes DSPy base prompts better with custom model templates, for an enhanced text output."""
+
+    templates: typing.ClassVar = {
         "mistral": "[INST] {prompt} [/INST]",
-        "llama":   "<s>[INST] {prompt} [/INST]",
-        "chatml":  "<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
+        "llama": "<s>[INST] {prompt} [/INST]",
+        "chatml": "<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
         "default": "{prompt}",
     }
     # Templates currently made for only 3 models as samples. This can be extended.
     # (function written below
-
 
     def __init__(self, model_family: str = "default"):
         if model_family not in self.templates:
             self.template = self.templates["default"]
         else:
             self.template = self.templates[model_family]
-        
+
         self.model_family = model_family
 
-
     def wrap(self, prompt: str) -> str:
+        """Wqrap the prompt according to the model family template."""
         return self.template.format(prompt=prompt)
-
-
-    # Makes addition of models and the templates possible.
-    @classmethod
-    def register_template(cls, name: str, template: str) -> None:
-        """Allow users to add custom model families."""
-        cls.templates[name] = template

--- a/integrations/dspy/src/haystack_integrations/components/generators/dspy/prompt_template_adapter.py
+++ b/integrations/dspy/src/haystack_integrations/components/generators/dspy/prompt_template_adapter.py
@@ -1,0 +1,31 @@
+class PromptTemplateAdapter:
+    """ Makes DSPy base prompts better with custom model templates, for an enhanced text output. """
+
+    templates = {
+        "mistral": "[INST] {prompt} [/INST]",
+        "llama":   "<s>[INST] {prompt} [/INST]",
+        "chatml":  "<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
+        "default": "{prompt}",
+    }
+    # Templates currently made for only 3 models as samples. This can be extended.
+    # (function written below
+
+
+    def __init__(self, model_family: str = "default"):
+        if model_family not in self.templates:
+            self.template = self.templates["default"]
+        else:
+            self.template = self.templates[model_family]
+        
+        self.model_family = model_family
+
+
+    def wrap(self, prompt: str) -> str:
+        return self.template.format(prompt=prompt)
+
+
+    # Makes addition of models and the templates possible.
+    @classmethod
+    def register_template(cls, name: str, template: str) -> None:
+        """Allow users to add custom model families."""
+        cls.templates[name] = template

--- a/integrations/dspy/tests/test_prompt_template_adapter.py
+++ b/integrations/dspy/tests/test_prompt_template_adapter.py
@@ -1,0 +1,24 @@
+import sys
+
+sys.path.insert(0, "src/haystack_integrations/components/generators/dspy")
+from prompt_template_adapter import PromptTemplateAdapter
+
+
+def test_mistral_wraps_correctly():
+    adapter = PromptTemplateAdapter(model_family="mistral")
+    assert adapter.wrap("Hello") == "[INST] Hello [/INST]"
+
+
+def test_llama_wraps_correctly():
+    adapter = PromptTemplateAdapter(model_family="llama")
+    assert adapter.wrap("Hello") == "<s>[INST] Hello [/INST]"
+
+
+def test_default_is_passthrough():
+    adapter = PromptTemplateAdapter()
+    assert adapter.wrap("Hello") == "Hello"
+
+
+def test_unknown_model_falls_back_to_default():
+    adapter = PromptTemplateAdapter(model_family="unknown_model")
+    assert adapter.wrap("Hello") == "Hello"


### PR DESCRIPTION
### Related Issues

- added prompt template adaptor in accordance with the open issue https://github.com/deepset-ai/haystack-core-integrations/issues/1635

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Added the PromptTemplate Adaptor that wraps the user prompt under the custom model templates. This makes the job of the DSPy model better at making the prompts LLM ready.
This is not a component but a helper class that may be used by the DSPyChatGenerator and the DSPyProgramRunner.
Additional models can be internally added with the templates into the dictionary using a function whenever required.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Ran test for every part of the code and checked for the working functionality. Added the test file to the branch.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
Although I understand the earlier raised concern: "since it still requires users to understand DSPy's optimization concepts, I am not sure it adds much value on top of DSPy," I think this is still relevant since the user never really interacts with this like a component, but the algorithm extracts the model used by the user (which they were already mentioning), and uses the same model internally to wrap the prompt. This removes the concern of the user needing to understand DSPy's optimization concepts.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
