### PR TITLE
fix: remove document mutation from weaviate tests

### DIFF
--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -6,6 +6,7 @@ import base64
 import logging
 import os
 from collections.abc import Generator
+from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -373,7 +374,7 @@ class TestWeaviateDocumentStore(
         assert document_store.write_documents([doc]) == 1
         assert document_store.count_documents() == 1
 
-        doc.content = "test doc 2"
+        doc = replace(doc, content="test doc 2")
         assert document_store.write_documents([doc]) == 1
         assert document_store.count_documents() == 1
 

--- a/integrations/weaviate/tests/test_document_store_async.py
+++ b/integrations/weaviate/tests/test_document_store_async.py
@@ -4,6 +4,7 @@
 
 import logging
 from collections.abc import AsyncGenerator
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -100,7 +101,7 @@ class TestWeaviateDocumentStoreAsync:
         assert await document_store.write_documents_async([doc]) == 1
         assert await document_store.count_documents_async() == 1
 
-        doc.content = "test doc 2"
+        doc = replace(doc, content="test doc 2")
         assert await document_store.write_documents_async([doc]) == 1
         assert await document_store.count_documents_async() == 1
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/11088

### Proposed Changes:

Ensure to use `replace()` instead of mutating docs in place.

### How did you test it?

Before change:
```
➜  weaviate git:(weaviate-mutate) hatch run test:all tests/test_document_store.py::TestWeaviateDocumentStore::test_write_documents                 
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.12.10, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/apple/Documents/haystack-core-integrations/integrations/weaviate
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.3.0, rerunfailures-16.1, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                       

tests/test_document_store.py .                                                                                                                                                                   [100%]

=========================================================================================== warnings summary ===========================================================================================
tests/test_document_store.py::TestWeaviateDocumentStore::test_write_documents
  /Users/apple/Documents/haystack-core-integrations/integrations/weaviate/tests/test_document_store.py:376: Warning: Mutating attribute 'content' on an instance of 'Document' can lead to unexpected behavior by affecting other parts of the pipeline that use the same dataclass instance. Use `dataclasses.replace(instance, content=new_value)` instead. See https://docs.haystack.deepset.ai/docs/custom-components#requirements for details.
    doc.content = "test doc 2"

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 1 passed, 1 warning in 3.64s =====================================================================================
➜  weaviate git:(weaviate-mutate) hatch run test:all tests/test_document_store_async.py::TestWeaviateDocumentStoreAsync::test_write_documents_async
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.12.10, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/apple/Documents/haystack-core-integrations/integrations/weaviate
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.3.0, rerunfailures-16.1, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                       

tests/test_document_store_async.py .                                                                                                                                                             [100%]

=========================================================================================== warnings summary ===========================================================================================
```

After change:
```
➜  weaviate git:(weaviate-mutate) ✗ hatch run test:all tests/test_document_store.py::TestWeaviateDocumentStore::test_write_documents                 
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.12.10, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/apple/Documents/haystack-core-integrations/integrations/weaviate
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.3.0, rerunfailures-16.1, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                       

tests/test_document_store.py .                                                                                                                                                                   [100%]

========================================================================================== 1 passed in 3.35s ===========================================================================================
➜  weaviate git:(weaviate-mutate) ✗ hatch run test:all tests/test_document_store_async.py::TestWeaviateDocumentStoreAsync::test_write_documents_async
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.12.10, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/apple/Documents/haystack-core-integrations/integrations/weaviate
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.3.0, rerunfailures-16.1, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                       

tests/test_document_store_async.py .                                                                                                                                                             [100%]

========================================================================================== 1 passed in 3.01s ===========================================================================================
```

### Notes for the reviewer


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
