### PR TITLE
test: Bedrock - increase unit tests coverage

### DIFF
--- a/integrations/amazon_bedrock/tests/test_document_image_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_document_image_embedder.py
@@ -267,6 +267,79 @@ class TestAmazonBedrockDocumentImageEmbedder:
         with pytest.raises(ValueError):
             AmazonBedrockDocumentImageEmbedder(model="cohere.embed-english-v3", embedding_types=["float", "int8"])
 
+    def test_run_cohere_end_to_end(self, mock_boto3_session, image_paths):
+        embedder = AmazonBedrockDocumentImageEmbedder(model="cohere.embed-english-v3")
+
+        def mock_invoke_model(*args, **kwargs):
+            return {"body": io.StringIO('{"embeddings": [[0.1, 0.2, 0.3]]}')}
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            docs = [Document(content="cat", meta={"file_path": str(image_paths[0])})]
+            result = embedder.run(documents=docs)
+
+        assert len(result["documents"]) == 1
+        assert result["documents"][0].embedding == [0.1, 0.2, 0.3]
+        assert result["documents"][0].meta["embedding_source"] == {
+            "type": "image",
+            "file_path_meta_field": "file_path",
+        }
+
+    def test_run_titan_end_to_end(self, mock_boto3_session, image_paths):
+        embedder = AmazonBedrockDocumentImageEmbedder(model="amazon.titan-embed-image-v1")
+
+        def mock_invoke_model(*args, **kwargs):
+            return {"body": io.StringIO('{"embedding": [0.4, 0.5]}')}
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            docs = [Document(content="apple", meta={"file_path": str(image_paths[0])})]
+            result = embedder.run(documents=docs)
+
+        assert result["documents"][0].embedding == [0.4, 0.5]
+
+    def test_run_with_pdf_cohere(self, mock_boto3_session, image_paths):
+        embedder = AmazonBedrockDocumentImageEmbedder(model="cohere.embed-english-v3")
+
+        def mock_invoke_model(*args, **kwargs):
+            return {"body": io.StringIO('{"embeddings": [[0.9]]}')}
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            pdf_doc = Document(content="pdf", meta={"file_path": str(image_paths[2]), "page_number": 1})
+            result = embedder.run(documents=[pdf_doc])
+
+        assert result["documents"][0].embedding == [0.9]
+        body_sent = mock_client.invoke_model.call_args.kwargs["body"]
+        assert "data:application/pdf;base64," in body_sent
+
+    def test_embed_titan_with_embedding_config(self, mock_boto3_session, image_paths):
+        embedder = AmazonBedrockDocumentImageEmbedder(
+            model="amazon.titan-embed-image-v1",
+            embeddingConfig={"outputEmbeddingLength": 256},
+        )
+
+        def mock_invoke_model(*args, **kwargs):
+            return {"body": io.StringIO('{"embedding": [0.1]}')}
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            embedder._embed_titan(images=["fake_base64"])
+
+        body_sent = mock_client.invoke_model.call_args.kwargs["body"]
+        assert '"embeddingConfig": {"outputEmbeddingLength": 256}' in body_sent
+
+    def test_embed_titan_invocation_error(self, mock_boto3_session):
+        embedder = AmazonBedrockDocumentImageEmbedder(model="amazon.titan-embed-image-v1")
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = ClientError(
+                error_response={"Error": {"Code": "x", "Message": "y"}},
+                operation_name="invoke_model",
+            )
+            with pytest.raises(AmazonBedrockInferenceError):
+                embedder._embed_titan(images=["fake_base64"])
+
     @pytest.mark.integration
     @pytest.mark.skipif(
         not os.getenv("AWS_ACCESS_KEY_ID")

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -2,10 +2,12 @@ from typing import Any
 from unittest.mock import MagicMock, call
 
 import pytest
+from botocore.exceptions import ClientError
 from haystack.dataclasses import StreamingChunk
 
 from haystack_integrations.common.amazon_bedrock.errors import (
     AmazonBedrockConfigurationError,
+    AmazonBedrockInferenceError,
 )
 from haystack_integrations.components.generators.amazon_bedrock import (
     AmazonBedrockGenerator,
@@ -288,6 +290,62 @@ def test_get_model_adapter_model_family_over_auto_detection():
         model="cohere.command-text-v14", model_family="anthropic.claude"
     )
     assert model_adapter == AnthropicClaudeAdapter
+
+
+def test_truncate_parameter_warns(mock_boto3_session, recwarn):
+    AmazonBedrockGenerator(model="anthropic.claude-v2", truncate=True)
+    assert any("truncate" in str(w.message) for w in recwarn.list)
+
+
+def test_init_connection_error(mock_boto3_session):
+    mock_boto3_session.side_effect = Exception("boom")
+    with pytest.raises(AmazonBedrockConfigurationError):
+        AmazonBedrockGenerator(model="anthropic.claude-v2")
+
+
+def test_run_with_streaming_callback(mock_boto3_session):
+    generator = AmazonBedrockGenerator(model="anthropic.claude-v2")
+    mock_client = mock_boto3_session.return_value.client.return_value
+
+    stream_body = MagicMock()
+    stream_body.__iter__.return_value = [
+        {"chunk": {"bytes": b'{"type": "content_block_start", "content_block": {"type": "text"}, "index": 0}'}},
+        {"chunk": {"bytes": b'{"delta": {"text": "hello"}}'}},
+    ]
+    mock_client.invoke_model_with_response_stream.return_value = {
+        "body": stream_body,
+        "ResponseMetadata": {"RequestId": "req-1"},
+    }
+
+    callback = MagicMock()
+    result = generator.run("Hello", streaming_callback=callback)
+
+    mock_client.invoke_model_with_response_stream.assert_called_once()
+    assert result["meta"]["RequestId"] == "req-1"
+    callback.assert_called()
+
+
+def test_run_client_error(mock_boto3_session):
+    generator = AmazonBedrockGenerator(model="anthropic.claude-v2")
+    mock_client = mock_boto3_session.return_value.client.return_value
+    mock_client.invoke_model.side_effect = ClientError(
+        error_response={"Error": {"Code": "x", "Message": "y"}}, operation_name="invoke_model"
+    )
+
+    with pytest.raises(AmazonBedrockInferenceError):
+        generator.run("Hello")
+
+
+def test_from_dict_with_streaming_callback(mock_boto3_session):
+    data = {
+        "type": "haystack_integrations.components.generators.amazon_bedrock.generator.AmazonBedrockGenerator",
+        "init_parameters": {
+            "model": "anthropic.claude-v2",
+            "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+        },
+    }
+    generator = AmazonBedrockGenerator.from_dict(data)
+    assert generator.streaming_callback is not None
 
 
 class TestAnthropicClaudeAdapter:

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -1,10 +1,12 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 from haystack import Document
 from haystack.utils import Secret
 
 from haystack_integrations.common.amazon_bedrock.errors import (
+    AmazonBedrockConfigurationError,
     AmazonBedrockInferenceError,
 )
 from haystack_integrations.components.rankers.amazon_bedrock import AmazonBedrockRanker
@@ -114,3 +116,67 @@ def test_amazon_bedrock_ranker_empty_documents(mock_aws_session):
 
     # Check that we get back an empty list of documents
     assert len(result["documents"]) == 0
+
+
+def test_amazon_bedrock_ranker_empty_model():
+    with pytest.raises(ValueError, match="cannot be None or empty string"):
+        AmazonBedrockRanker(model="")
+
+
+def test_amazon_bedrock_ranker_connection_error():
+    with patch(
+        "haystack_integrations.components.rankers.amazon_bedrock.ranker.get_aws_session",
+        side_effect=Exception("boom"),
+    ):
+        with pytest.raises(AmazonBedrockConfigurationError):
+            AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
+
+
+def test_amazon_bedrock_ranker_invalid_top_k(mock_aws_session):
+    ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
+    with pytest.raises(ValueError, match="top_k must be > 0"):
+        ranker.run(query="q", documents=[Document(content="x")], top_k=-1)
+
+
+def test_amazon_bedrock_ranker_truncates_large_input(mock_aws_session, caplog):
+    ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
+    mock_aws_session.rerank.return_value = {"results": []}
+
+    docs = [Document(content=f"doc {i}") for i in range(1005)]
+    ranker.run(query="q", documents=docs)
+
+    sent_sources = mock_aws_session.rerank.call_args.kwargs["sources"]
+    assert len(sent_sources) == 1000
+    assert any("truncated" in record.message for record in caplog.records)
+
+
+def test_amazon_bedrock_ranker_client_error(mock_aws_session):
+    ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
+    mock_aws_session.rerank.side_effect = ClientError(
+        error_response={"Error": {"Code": "x", "Message": "y"}}, operation_name="rerank"
+    )
+    with pytest.raises(AmazonBedrockInferenceError, match="Could not perform inference"):
+        ranker.run(query="q", documents=[Document(content="x")])
+
+
+def test_amazon_bedrock_ranker_unexpected_response(mock_aws_session):
+    ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
+    mock_aws_session.rerank.return_value = {"unexpected_key": []}
+
+    with pytest.raises(AmazonBedrockInferenceError, match="Unexpected response format"):
+        ranker.run(query="q", documents=[Document(content="x")])
+
+
+def test_amazon_bedrock_ranker_meta_fields_to_embed(mock_aws_session):
+    ranker = AmazonBedrockRanker(
+        aws_region_name=Secret.from_token("us-west-2"),
+        meta_fields_to_embed=["title"],
+        meta_data_separator=" | ",
+    )
+    mock_aws_session.rerank.return_value = {"results": [{"index": 0, "relevanceScore": 0.5}]}
+
+    docs = [Document(content="body", meta={"title": "T"})]
+    ranker.run(query="q", documents=docs)
+
+    sent_text = mock_aws_session.rerank.call_args.kwargs["sources"][0]["inlineDocumentSource"]["textDocument"]["text"]
+    assert sent_text == "T | body"

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -261,6 +261,76 @@ class TestS3Downloader:
         mock_s3_storage.download.assert_called_once()
         assert mock_s3_storage.download.call_args.kwargs["key"] == "a.txt_suffix"
 
+    def test_init_missing_file_root_path(self, mock_boto3_session, monkeypatch):
+        monkeypatch.delenv("FILE_ROOT_PATH", raising=False)
+        with pytest.raises(ValueError, match="file_root_path"):
+            S3Downloader()
+
+    def test_init_file_root_path_from_env(self, mock_boto3_session, tmp_path, monkeypatch):
+        monkeypatch.setenv("FILE_ROOT_PATH", str(tmp_path))
+        d = S3Downloader()
+        assert Path(d.file_root_path) == tmp_path
+
+    def test_warm_up_initializes_storage(self, mock_boto3_session, tmp_path):
+        d = S3Downloader(file_root_path=str(tmp_path / "nested"))
+        with patch("haystack_integrations.components.downloaders.s3.s3_downloader.S3Storage.from_env") as mock_from_env:
+            mock_from_env.return_value = MagicMock(spec=S3Storage)
+            d.warm_up()
+            assert d._storage is not None
+            assert (tmp_path / "nested").is_dir()
+            mock_from_env.assert_called_once()
+
+    def test_run_skips_document_missing_file_name_meta(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        d = S3Downloader(file_root_path=str(tmp_path))
+        d._storage = mock_s3_storage
+
+        docs = [Document(meta={"file_id": str(uuid4())})]
+        out = d.run(documents=docs)
+        assert out["documents"] == []
+        mock_s3_storage.download.assert_not_called()
+
+    def test_run_file_already_cached(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        existing_file = tmp_path / "cached.txt"
+        existing_file.write_bytes(b"cached")
+
+        d = S3Downloader(file_root_path=str(tmp_path))
+        d._storage = mock_s3_storage
+
+        out = d.run(documents=[Document(meta={"file_name": "cached.txt"})])
+        assert out["documents"][0].meta["file_path"] == str(existing_file)
+        mock_s3_storage.download.assert_not_called()
+
+    def test_run_returns_empty_when_all_filtered(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        d = S3Downloader(file_root_path=str(tmp_path), file_extensions=[".txt"])
+        d._storage = mock_s3_storage
+
+        out = d.run(documents=[Document(meta={"file_name": "a.pdf"})])
+        assert out["documents"] == []
+        mock_s3_storage.download.assert_not_called()
+
+    def test_cleanup_cache_evicts_old_files(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        d = S3Downloader(file_root_path=str(tmp_path), max_cache_size=1)
+        d._storage = mock_s3_storage
+
+        stale = tmp_path / "stale.txt"
+        stale.write_bytes(b"stale")
+        os.utime(stale, (0, 0))
+
+        d.run(documents=[Document(meta={"file_name": "fresh.txt"})])
+
+        assert not stale.exists()
+
+    def test_from_dict_with_serialized_callable(self, mock_boto3_session, tmp_path):
+        data = {
+            "type": TYPE,
+            "init_parameters": {
+                "file_root_path": str(tmp_path),
+                "s3_key_generation_function": "tests.test_s3_downloader.s3_key_generation_function",
+            },
+        }
+        d = S3Downloader.from_dict(data)
+        assert d.s3_key_generation_function is s3_key_generation_function
+
     @pytest.mark.integration
     @pytest.mark.skipif(
         not os.environ.get("S3_DOWNLOADER_BUCKET", None),

--- a/integrations/amazon_bedrock/tests/test_s3_storage.py
+++ b/integrations/amazon_bedrock/tests/test_s3_storage.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+
+from haystack_integrations.common.s3.errors import S3ConfigurationError, S3StorageError
+from haystack_integrations.common.s3.utils import S3Storage
+
+
+def _client_error(code: int) -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": str(code), "Message": "err"}},
+        operation_name="download_file",
+    )
+
+
+class TestS3Storage:
+    def test_init_client_creation_error(self):
+        session = MagicMock()
+        session.client.side_effect = Exception("boom")
+
+        with pytest.raises(S3ConfigurationError, match="Failed to create S3 session client"):
+            S3Storage(s3_bucket="bucket", session=session)
+
+    def test_download_applies_prefix(self, tmp_path):
+        session = MagicMock()
+        storage = S3Storage(s3_bucket="bucket", session=session, s3_prefix="folder/")
+
+        storage.download(key="file.txt", local_file_path=tmp_path / "file.txt")
+
+        storage._client.download_file.assert_called_once_with("bucket", "folder/file.txt", str(tmp_path / "file.txt"))
+
+    def test_download_no_prefix(self, tmp_path):
+        session = MagicMock()
+        storage = S3Storage(s3_bucket="bucket", session=session)
+
+        storage.download(key="file.txt", local_file_path=tmp_path / "file.txt")
+
+        storage._client.download_file.assert_called_once_with("bucket", "file.txt", str(tmp_path / "file.txt"))
+
+    def test_download_missing_credentials(self, tmp_path):
+        session = MagicMock()
+        storage = S3Storage(s3_bucket="bucket", session=session)
+        storage._client.download_file.side_effect = NoCredentialsError()
+
+        with pytest.raises(S3ConfigurationError, match="Missing AWS credentials"):
+            storage.download(key="file.txt", local_file_path=tmp_path / "file.txt")
+
+    def test_download_forbidden(self, tmp_path):
+        session = MagicMock()
+        storage = S3Storage(s3_bucket="bucket", session=session)
+        storage._client.download_file.side_effect = _client_error(403)
+
+        with pytest.raises(S3ConfigurationError, match="Failed to access S3 bucket"):
+            storage.download(key="file.txt", local_file_path=tmp_path / "file.txt")
+
+    def test_download_not_found(self, tmp_path):
+        session = MagicMock()
+        storage = S3Storage(s3_bucket="bucket", session=session)
+        storage._client.download_file.side_effect = _client_error(404)
+
+        with pytest.raises(S3StorageError, match="does not exist"):
+            storage.download(key="file.txt", local_file_path=tmp_path / "file.txt")
+
+    def test_download_other_client_error(self, tmp_path):
+        session = MagicMock()
+        storage = S3Storage(s3_bucket="bucket", session=session)
+        storage._client.download_file.side_effect = _client_error(500)
+
+        with pytest.raises(S3StorageError, match="Failed to download file"):
+            storage.download(key="file.txt", local_file_path=tmp_path / "file.txt")
+
+    def test_from_env_success(self, monkeypatch):
+        monkeypatch.delenv("S3_DOWNLOADER_BUCKET", raising=False)
+        monkeypatch.setenv("MY_BUCKET_VAR", "my-bucket")
+        monkeypatch.setenv("S3_DOWNLOADER_PREFIX", "prefix/")
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:9000")
+        session = MagicMock()
+
+        storage = S3Storage.from_env(session=session, config=MagicMock(), s3_bucket_name_env="MY_BUCKET_VAR")
+
+        assert storage.s3_bucket == "my-bucket"
+        assert storage.s3_prefix == "prefix/"
+        assert storage.endpoint_url == "http://localhost:9000"
+
+    def test_from_env_missing_bucket(self, monkeypatch):
+        monkeypatch.delenv("S3_DOWNLOADER_BUCKET", raising=False)
+        session = MagicMock()
+
+        with pytest.raises(ValueError, match="Missing environment variable S3_DOWNLOADER_BUCKET"):
+            S3Storage.from_env(session=session, config=MagicMock())


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/275

### Proposed Changes:
- add unit tests to Bedrock integration, primarily focusing on uncovered components/code paths: https://htmlpreview.github.io/?https://github.com/deepset-ai/haystack-core-integrations/blob/python-coverage-comment-action-data-amazon_bedrock/htmlcov/index.html

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
