### PR TITLE
chore: fix 'occured' -> 'occurred' in validation error message

### DIFF
--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -210,7 +210,7 @@ class RagasEvaluator:
                 actual_type = type(err["input"]).__name__
                 example = self._get_example_input(haystack_field)
                 error_message = (
-                    f"Validation error occured while running RagasEvaluator Component:\n"
+                    f"Validation error occurred while running RagasEvaluator Component:\n"
                     f"The '{haystack_field}' field expected '{type_desc}', "
                     f"but got '{actual_type}'.\n"
                     f"Hint: Provide {example}"


### PR DESCRIPTION
Error message in `integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py` line 213 reads `Validation error occured while running`. Fixed to `occurred`. String-literal-only change.