### PR TITLE
test: add MCP unit tests

### DIFF
--- a/integrations/mcp/tests/test_mcp_server_info.py
+++ b/integrations/mcp/tests/test_mcp_server_info.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from haystack.utils import Secret
@@ -428,3 +429,59 @@ class TestMCPServerInfo:
         assert any("Header 'X-API-Key' resolved to None" in record.message for record in caplog.records)
         # Verify the header is set to empty string
         assert client.headers == {"X-API-Key": ""}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "client_cls,transport_patch_target,transport_tuple,info_kwargs",
+        [
+            (
+                StreamableHttpClient,
+                "haystack_integrations.tools.mcp.mcp_tool.streamablehttp_client",
+                (MagicMock(), MagicMock(), MagicMock()),
+                {"url": "http://x/mcp", "token": "mytok"},
+            ),
+            (
+                SSEClient,
+                "haystack_integrations.tools.mcp.mcp_tool.sse_client",
+                (MagicMock(), MagicMock()),
+                {"url": "http://x/sse", "token": "mytok"},
+            ),
+        ],
+    )
+    async def test_http_client_connect_builds_auth_header_from_token(
+        self, client_cls, transport_patch_target, transport_tuple, info_kwargs
+    ):
+        info_cls = StreamableHttpServerInfo if client_cls is StreamableHttpClient else SSEServerInfo
+        info = info_cls(**info_kwargs)
+        client = client_cls(info)
+
+        with (
+            patch.object(client, "exit_stack") as mock_stack,
+            patch(transport_patch_target) as mock_transport,
+            patch.object(client, "_initialize_session_with_transport", new_callable=AsyncMock) as mock_init,
+        ):
+            mock_stack.enter_async_context = AsyncMock(return_value=transport_tuple)
+            mock_init.return_value = []
+
+            await client.connect()
+
+            _, kwargs = mock_transport.call_args
+            assert kwargs["headers"] == {"Authorization": "Bearer mytok"}
+
+    @pytest.mark.asyncio
+    async def test_sse_client_connect_prefers_custom_headers_over_token(self):
+        info = SSEServerInfo(url="http://x/sse", token="tok", headers={"X-Key": "val"})
+        client = SSEClient(info)
+
+        with (
+            patch.object(client, "exit_stack") as mock_stack,
+            patch("haystack_integrations.tools.mcp.mcp_tool.sse_client") as mock_sse,
+            patch.object(client, "_initialize_session_with_transport", new_callable=AsyncMock) as mock_init,
+        ):
+            mock_stack.enter_async_context = AsyncMock(return_value=(MagicMock(), MagicMock()))
+            mock_init.return_value = []
+
+            await client.connect()
+
+            _, kwargs = mock_sse.call_args
+            assert kwargs["headers"] == {"X-Key": "val"}

--- a/integrations/mcp/tests/test_mcp_timeout_reconnection.py
+++ b/integrations/mcp/tests/test_mcp_timeout_reconnection.py
@@ -20,7 +20,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from haystack_integrations.tools.mcp import MCPTool, SSEServerInfo
-from haystack_integrations.tools.mcp.mcp_tool import SSEClient
+from haystack_integrations.tools.mcp.mcp_tool import (
+    MCPConnectionError,
+    MCPInvocationError,
+    SSEClient,
+    StdioClient,
+    StreamableHttpServerInfo,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +70,70 @@ class TestMCPTimeoutReconnection:
 
         # Test that parameters are passed through correctly
         assert isinstance(client, SSEClient)
+
+    @pytest.mark.asyncio
+    async def test_call_tool_without_session_raises_connection_error(self):
+        client = StdioClient(command="echo")
+
+        with pytest.raises(MCPConnectionError):
+            await client.call_tool("any", {})
+
+    @pytest.mark.asyncio
+    async def test_call_tool_wraps_is_error_response_as_invocation_error(self):
+        client = StdioClient(command="echo")
+        client.session = AsyncMock()
+        bad_result = MagicMock()
+        bad_result.isError = True
+        bad_result.content = "server said no"
+        client.session.call_tool = AsyncMock(return_value=bad_result)
+
+        with pytest.raises(MCPInvocationError, match="server said no"):
+            await client.call_tool("x", {})
+
+    @pytest.mark.asyncio
+    async def test_call_tool_stdio_does_not_retry_on_connection_error(self):
+        client = StdioClient(command="echo", max_retries=2)
+        client.session = AsyncMock()
+        client.session.call_tool = AsyncMock(side_effect=ConnectionError("dead"))
+
+        with pytest.raises(MCPInvocationError, match="STDIO"):
+            await client.call_tool("x", {})
+
+        assert client.session.call_tool.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_call_tool_http_exhausts_retries_with_backoff(self):
+        info = StreamableHttpServerInfo(url="http://x/mcp", max_retries=2, base_delay=0.0, max_delay=0.0)
+        client = info.create_client()
+        client.session = AsyncMock()
+        client.session.call_tool = AsyncMock(side_effect=ConnectionError("lost"))
+        client.connect = AsyncMock()
+
+        with pytest.raises(MCPInvocationError, match="reconnection attempts"):
+            await client.call_tool("x", {})
+
+        assert client.session.call_tool.await_count == 3  # initial + 2 retries
+        assert client.connect.await_count == 2  # reconnection on the first two failures
+
+    @pytest.mark.asyncio
+    async def test_call_tool_http_reconnection_failures_raise_final_error(self):
+        info = StreamableHttpServerInfo(url="http://x/mcp", max_retries=1, base_delay=0.0, max_delay=0.0)
+        client = info.create_client()
+        client.session = AsyncMock()
+        client.session.call_tool = AsyncMock(side_effect=ConnectionError("lost"))
+        client.connect = AsyncMock(side_effect=RuntimeError("server gone"))
+
+        with pytest.raises(MCPInvocationError, match="reconnection attempts failed"):
+            await client.call_tool("x", {})
+
+    @pytest.mark.asyncio
+    async def test_call_tool_wraps_unexpected_exceptions(self):
+        client = StdioClient(command="echo")
+        client.session = AsyncMock()
+        client.session.call_tool = AsyncMock(side_effect=ValueError("nope"))
+
+        with pytest.raises(MCPInvocationError, match="nope"):
+            await client.call_tool("x", {})
 
     def test_retry_logic_with_mock(self):
         """Test retry logic using mocked SSE client (unit test)."""

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 import os
@@ -5,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from exceptiongroup import ExceptionGroup
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.core.pipeline import Pipeline
@@ -17,7 +19,15 @@ from haystack_integrations.tools.mcp import (
     MCPToolNotFoundError,
     StdioServerInfo,
 )
-from haystack_integrations.tools.mcp.mcp_tool import StdioClient, _extract_first_text_element
+from haystack_integrations.tools.mcp.mcp_tool import (
+    AsyncExecutor,
+    MCPClient,
+    MCPConnectionError,
+    MCPInvocationError,
+    StdioClient,
+    _extract_first_text_element,
+    _MCPClientSessionManager,
+)
 
 from .mcp_memory_transport import InMemoryServerInfo
 from .mcp_servers_fixtures import calculator_mcp, echo_mcp, image_mcp, state_calculator_mcp
@@ -46,6 +56,14 @@ def test_extract_first_text_element():
     extracted = _extract_first_text_element(tool_call_result)
 
     assert extracted == {"answer": 42}
+
+
+def test_async_executor_run_raises_timeout_error():
+    async def slow() -> None:
+        await asyncio.sleep(0.05)
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        AsyncExecutor.get_instance().run(slow(), timeout=0.01)
 
 
 class TestMCPTool:
@@ -422,6 +440,75 @@ class TestMCPTool:
         assert client.session is None
         assert client.stdio is None
         assert client.write is None
+
+    @pytest.mark.asyncio
+    async def test_initialize_session_wraps_errors_as_connection_error(self):
+        client = StdioClient(command="echo")
+
+        with patch.object(client.exit_stack, "enter_async_context", new_callable=AsyncMock) as mock_enter:
+            mock_enter.side_effect = RuntimeError("boom")
+            with pytest.raises(MCPConnectionError, match="Failed to connect to ctx"):
+                await client._initialize_session_with_transport((MagicMock(), MagicMock()), "ctx")
+
+    def test_mcp_tool_eager_connect_surfaces_exception_group_inner_message(self):
+        server_info = InMemoryServerInfo(server=calculator_mcp._mcp_server)
+        err = ExceptionGroup("outer", [RuntimeError("inner details")])
+
+        with patch(
+            "haystack_integrations.tools.mcp.mcp_tool._MCPClientSessionManager",
+            side_effect=err,
+        ):
+            with pytest.raises(MCPConnectionError, match="inner details"):
+                MCPTool(name="add", server_info=server_info, eager_connect=True)
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_ainvoke_raises_timeout_error(self, mcp_tool_cleanup):
+        server_info = InMemoryServerInfo(server=calculator_mcp._mcp_server)
+        tool = MCPTool(name="add", server_info=server_info, eager_connect=True)
+        mcp_tool_cleanup(tool)
+
+        async def hanging(*_args, **_kwargs):
+            await asyncio.sleep(0.05)
+
+        tool._client.call_tool = hanging
+        tool._invocation_timeout = 0.01
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            await tool.ainvoke(a=1, b=2)
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_ainvoke_wraps_unexpected_errors(self, mcp_tool_cleanup):
+        server_info = InMemoryServerInfo(server=calculator_mcp._mcp_server)
+        tool = MCPTool(name="add", server_info=server_info, eager_connect=True)
+        mcp_tool_cleanup(tool)
+
+        async def crash(*_args, **_kwargs):
+            message = "kaboom"
+            raise RuntimeError(message)
+
+        tool._client.call_tool = crash
+
+        with pytest.raises(MCPInvocationError, match="kaboom"):
+            await tool.ainvoke(a=1, b=2)
+
+    def test_mcp_tool_close_swallows_worker_stop_exceptions(self, mcp_tool_cleanup):
+        server_info = InMemoryServerInfo(server=calculator_mcp._mcp_server)
+        tool = MCPTool(name="add", server_info=server_info, eager_connect=True)
+        mcp_tool_cleanup(tool)
+
+        with patch.object(tool._worker, "stop", side_effect=RuntimeError("stop failed")):
+            tool.close()
+
+    def test_session_manager_propagates_connect_failures(self):
+        class BrokenClient(MCPClient):
+            async def connect(self):
+                message = "broken"
+                raise RuntimeError(message)
+
+        client = BrokenClient()
+
+        with pytest.raises(RuntimeError, match="broken"):
+            _MCPClientSessionManager(client, timeout=5.0)
 
     @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     @pytest.mark.integration

--- a/integrations/mcp/tests/test_mcp_toolset.py
+++ b/integrations/mcp/tests/test_mcp_toolset.py
@@ -7,6 +7,7 @@ import tempfile
 import time
 from unittest.mock import patch
 
+import httpx
 import pytest
 import pytest_asyncio
 from haystack import logging
@@ -486,6 +487,55 @@ class TestMCPToolset:
             assert tool.outputs_to_state is None
             assert tool.outputs_to_string is None
 
+    async def test_toolset_streamable_http_connect_error_reports_host_and_port(self):
+        server_info = StreamableHttpServerInfo(url="http://host.example:12345/mcp")
+
+        with (
+            patch(
+                "haystack_integrations.tools.mcp.mcp_toolset._MCPClientSessionManager",
+                side_effect=httpx.ConnectError("refused"),
+            ),
+            pytest.raises(MCPConnectionError) as exc_info,
+        ):
+            MCPToolset(server_info=server_info, eager_connect=True)
+
+        msg = str(exc_info.value)
+        assert "streamable HTTP" in msg
+        assert "host.example" in msg
+        assert "12345" in msg
+
+    async def test_toolset_sse_connect_error_tags_sse_transport(self):
+        server_info = SSEServerInfo(url="https://host.example/sse")
+
+        with (
+            patch(
+                "haystack_integrations.tools.mcp.mcp_toolset._MCPClientSessionManager",
+                side_effect=RuntimeError("generic failure"),
+            ),
+            pytest.raises(MCPConnectionError, match="SSE"),
+        ):
+            MCPToolset(server_info=server_info, eager_connect=True)
+
+    async def test_toolset_stdio_connect_error_shows_command(self):
+        server_info = StdioServerInfo(command="missing", args=["--foo"])
+
+        with (
+            patch(
+                "haystack_integrations.tools.mcp.mcp_toolset._MCPClientSessionManager",
+                side_effect=RuntimeError("no such file"),
+            ),
+            pytest.raises(MCPConnectionError, match="missing --foo"),
+        ):
+            MCPToolset(server_info=server_info, eager_connect=True)
+
+    async def test_toolset_close_swallows_worker_stop_exceptions(self, mcp_tool_cleanup):
+        server_info = InMemoryServerInfo(server=calculator_mcp._mcp_server)
+        toolset = MCPToolset(server_info=server_info, eager_connect=True)
+        mcp_tool_cleanup(toolset)
+
+        with patch.object(toolset._worker, "stop", side_effect=RuntimeError("stop failed")):
+            toolset.close()
+
     @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
     async def test_pipeline_warmup_with_mcp_toolset(self):
@@ -880,3 +930,13 @@ class TestStateConfigHelpers:
         assert deserialized["add"]["source"] == "content"
         assert callable(deserialized["add"]["handler"])
         assert deserialized["subtract"]["source"] == "diff"
+
+    @pytest.mark.parametrize("helper", [_serialize_state_config, _deserialize_state_config])
+    def test_state_config_helpers_skip_empty_tool_configs(self, helper):
+        config = {"keep": {"source": "x"}, "empty": {}, "none": None}
+
+        result = helper(config)
+
+        assert "keep" in result
+        assert "empty" not in result
+        assert "none" not in result


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/275

### Proposed Changes:

- add unit tests focusing mostly errors and uncovered paths (made with AI help)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
