### PR TITLE
fix: docling validation error

### DIFF
--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+from docling_core.types.doc.document import SectionHeaderItem
 from docling_core.types.io import DocumentStream
 from haystack import Document, component
 from haystack.components.converters.utils import normalize_metadata
@@ -17,6 +18,22 @@ from haystack.dataclasses import ByteStream
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
 from docling.document_converter import DocumentConverter
+
+# Matches the upstream `LevelNumber` constraint: `Annotated[int, Field(ge=1, le=100)]`
+_MAX_SECTION_LEVEL = 100
+
+
+def _clamp_section_header_levels(dl_doc: DoclingDocument) -> None:
+    """
+    Cap any SectionHeaderItem.level that exceeds the upstream maximum (100) in-place.
+
+    Docling's DocumentConverter uses model_construct() internally, which bypasses Pydantic
+    validation and can produce SectionHeaderItem instances with level > 100. Subsequent
+    operations (chunking, export) that re-validate the model then raise a validation error.
+    """
+    for i, item in enumerate(dl_doc.texts):
+        if isinstance(item, SectionHeaderItem) and item.level > _MAX_SECTION_LEVEL:
+            dl_doc.texts[i] = item.model_copy(update={"level": _MAX_SECTION_LEVEL})
 
 
 def _bytestream_to_document_stream(source: ByteStream) -> DocumentStream:
@@ -172,6 +189,8 @@ class DoclingConverter:
             else:
                 dl_doc = self._converter_instance.convert(source=source, **self.convert_kwargs).document
                 merged_meta = source_meta
+
+            _clamp_section_header_levels(dl_doc)
 
             if self.export_type == ExportType.DOC_CHUNKS:
                 chunk_iter = self._chunker_instance.chunk(dl_doc=dl_doc)

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from docling_core.types.doc.document import DocItemLabel, RefItem, SectionHeaderItem
+from docling_core.types.doc.document import DocItemLabel, SectionHeaderItem
 from docling_core.types.io import DocumentStream
 from haystack.core.serialization import component_from_dict, component_to_dict
 from haystack.dataclasses import ByteStream

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -26,14 +26,14 @@ def test_run_doc_chunks_minimal() -> None:
     meta_extractor_mock = MagicMock()
 
     converter_mock.convert.side_effect = [
-        SimpleNamespace(document="dl-doc-for-file-a.pdf"),
-        SimpleNamespace(document="dl-doc-for-file-b.pdf"),
+        SimpleNamespace(document=SimpleNamespace(texts=[], name="dl-doc-for-file-a.pdf")),
+        SimpleNamespace(document=SimpleNamespace(texts=[], name="dl-doc-for-file-b.pdf")),
     ]
 
     def chunk_side_effect(dl_doc: Any) -> list[SimpleNamespace]:
         return [
-            SimpleNamespace(text=f"chunk-1-of-{dl_doc}"),
-            SimpleNamespace(text=f"chunk-2-of-{dl_doc}"),
+            SimpleNamespace(text=f"chunk-1-of-{dl_doc.name}"),
+            SimpleNamespace(text=f"chunk-2-of-{dl_doc.name}"),
         ]
 
     chunker_mock.chunk.side_effect = chunk_side_effect
@@ -231,7 +231,7 @@ def test_run_with_sources_parameter() -> None:
     chunker_mock = MagicMock()
     meta_extractor_mock = MagicMock()
 
-    converter_mock.convert.return_value = SimpleNamespace(document="dl-doc")
+    converter_mock.convert.return_value = SimpleNamespace(document=SimpleNamespace(texts=[]))
     chunker_mock.chunk.return_value = [SimpleNamespace(text="chunk-1")]
     chunker_mock.contextualize.return_value = "contextualized-chunk-1"
     meta_extractor_mock.extract_chunk_meta.return_value = {}
@@ -252,7 +252,7 @@ def test_run_paths_deprecated() -> None:
     chunker_mock = MagicMock()
     meta_extractor_mock = MagicMock()
 
-    converter_mock.convert.return_value = SimpleNamespace(document="dl-doc")
+    converter_mock.convert.return_value = SimpleNamespace(document=SimpleNamespace(texts=[]))
     chunker_mock.chunk.return_value = [SimpleNamespace(text="chunk-1")]
     chunker_mock.contextualize.return_value = "contextualized-chunk-1"
     meta_extractor_mock.extract_chunk_meta.return_value = {}
@@ -278,10 +278,10 @@ def test_run_meta_single_dict_doc_chunks() -> None:
     meta_extractor_mock = MagicMock()
 
     converter_mock.convert.side_effect = [
-        SimpleNamespace(document="dl-doc-a"),
-        SimpleNamespace(document="dl-doc-b"),
+        SimpleNamespace(document=SimpleNamespace(texts=[], name="dl-doc-a")),
+        SimpleNamespace(document=SimpleNamespace(texts=[], name="dl-doc-b")),
     ]
-    chunker_mock.chunk.side_effect = lambda dl_doc: [SimpleNamespace(text=f"chunk-of-{dl_doc}")]
+    chunker_mock.chunk.side_effect = lambda dl_doc: [SimpleNamespace(text=f"chunk-of-{dl_doc.name}")]
     chunker_mock.contextualize.side_effect = lambda chunk: chunk.text
     meta_extractor_mock.extract_chunk_meta.return_value = {"extractor_key": "extractor_val"}
 

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -7,12 +7,16 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from docling_core.types.doc.document import DocItemLabel, RefItem, SectionHeaderItem
 from docling_core.types.io import DocumentStream
 from haystack.core.serialization import component_from_dict, component_to_dict
 from haystack.dataclasses import ByteStream
 
 from haystack_integrations.components.converters.docling import DoclingConverter, ExportType
-from haystack_integrations.components.converters.docling.converter import _bytestream_to_document_stream
+from haystack_integrations.components.converters.docling.converter import (
+    _bytestream_to_document_stream,
+    _clamp_section_header_levels,
+)
 
 
 def test_run_doc_chunks_minimal() -> None:
@@ -441,3 +445,92 @@ class TestBytestreamToDocumentStream:
         ds = _bytestream_to_document_stream(bs)
         assert isinstance(ds, DocumentStream)
         assert isinstance(ds.stream, BytesIO)
+
+
+def _make_section_header(level: int) -> SectionHeaderItem:
+    """Build a SectionHeaderItem bypassing Pydantic validation, mirroring how Docling builds documents internally."""
+    return SectionHeaderItem.model_construct(
+        self_ref="#/texts/0",
+        orig="Heading text",
+        text="Heading text",
+        label=DocItemLabel.SECTION_HEADER,
+        level=level,
+    )
+
+
+class TestClampSectionHeaderLevels:
+    def test_caps_level_above_100(self) -> None:
+        dl_doc = MagicMock()
+        header = _make_section_header(level=110)
+        dl_doc.texts = [header]
+
+        _clamp_section_header_levels(dl_doc)
+
+        assert dl_doc.texts[0].level == 100
+
+    def test_leaves_level_at_100_unchanged(self) -> None:
+        dl_doc = MagicMock()
+        header = _make_section_header(level=100)
+        dl_doc.texts = [header]
+
+        _clamp_section_header_levels(dl_doc)
+
+        assert dl_doc.texts[0].level == 100
+
+    def test_leaves_level_below_100_unchanged(self) -> None:
+        dl_doc = MagicMock()
+        header = _make_section_header(level=3)
+        dl_doc.texts = [header]
+
+        _clamp_section_header_levels(dl_doc)
+
+        assert dl_doc.texts[0].level == 3
+
+    def test_non_section_header_items_are_not_modified(self) -> None:
+        dl_doc = MagicMock()
+        other_item = MagicMock(spec=[])
+        dl_doc.texts = [other_item]
+
+        _clamp_section_header_levels(dl_doc)
+
+        assert dl_doc.texts[0] is other_item
+
+    def test_multiple_items_only_caps_offending_ones(self) -> None:
+        dl_doc = MagicMock()
+        normal = _make_section_header(level=2)
+        over_limit = _make_section_header(level=110)
+        other_item = MagicMock(spec=[])
+        dl_doc.texts = [normal, over_limit, other_item]
+
+        _clamp_section_header_levels(dl_doc)
+
+        assert dl_doc.texts[0].level == 2
+        assert dl_doc.texts[1].level == 100
+        assert dl_doc.texts[2] is other_item
+
+
+def test_run_doc_chunks_with_high_section_header_level() -> None:
+    """DoclingConverter must not raise when the converted document contains a SectionHeaderItem with level > 100."""
+    converter_mock = MagicMock()
+    chunker_mock = MagicMock()
+    meta_extractor_mock = MagicMock()
+
+    dl_doc = MagicMock()
+    header = _make_section_header(level=110)
+    dl_doc.texts = [header]
+    converter_mock.convert.return_value = SimpleNamespace(document=dl_doc)
+    chunker_mock.chunk.return_value = [SimpleNamespace(text="chunk-1")]
+    chunker_mock.contextualize.return_value = "contextualized-chunk-1"
+    meta_extractor_mock.extract_chunk_meta.return_value = {}
+
+    converter = DoclingConverter(
+        converter=converter_mock,
+        export_type=ExportType.DOC_CHUNKS,
+        chunker=chunker_mock,
+        meta_extractor=meta_extractor_mock,
+    )
+
+    result = converter.run(sources=["document.docx"])
+
+    assert len(result["documents"]) == 1
+    assert dl_doc.texts[0].level == 100


### PR DESCRIPTION
## Summary

Fix a `ValidationError` raised by `DoclingConverter.run` when processing documents that contain section headers with a heading level greater than 100.

Docling's `DocumentConverter` builds its internal document representation using `model_construct()`, which bypasses Pydantic validation. This allows `SectionHeaderItem.level` to hold values above the upstream `LevelNumber` maximum of 100. The error surfaces later in `DoclingConverter.run` when the document is passed to chunking or export operations that trigger Pydantic re-validation.

**Changes:**
- Added `_clamp_section_header_levels(dl_doc)` helper that iterates `dl_doc.texts` and replaces any `SectionHeaderItem` with `level > 100` with a valid copy capped at 100 (using `model_copy`, not direct mutation). The cap of 100 matches the `LevelNumber` constraint in `docling-core`.
- The helper is called immediately after each document is converted, before any export path (DOC_CHUNKS, MARKDOWN, JSON), so all three paths benefit.
- Updated existing tests whose mocks passed plain strings as `document` objects — these are now proper `SimpleNamespace(texts=[])` objects so the new iteration over `dl_doc.texts` doesn't fail.
- Added `TestClampSectionHeaderLevels` unit tests covering: level capped, level unchanged at/below 100, non-`SectionHeaderItem` entries left untouched, mixed-item lists.
- Added `test_run_doc_chunks_with_high_section_header_level` end-to-end unit test verifying the converter completes without error and the level is capped in the output.

## Test plan

- [ ] `hatch run test:unit` passes (33 tests)
- [ ] `hatch run test:types` passes
- [ ] `hatch run fmt` produces no changes