### PR TITLE
test(qdrant): replace in-place Document mutations with dataclasses.replace()

### DIFF
--- a/integrations/qdrant/CHANGELOG.md
+++ b/integrations/qdrant/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### 🧪 Testing
+
+- Replace in-place `Document` dataclass mutations with `dataclasses.replace()` in sparse embedding retriever tests (#3180)
+
 ## [integrations/qdrant-v10.3.0] - 2026-03-23
 
 ### 📚 Documentation

--- a/integrations/qdrant/tests/test_sparse_embedding_retriever.py
+++ b/integrations/qdrant/tests/test_sparse_embedding_retriever.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import pytest
 from haystack.dataclasses import Document, SparseEmbedding
 from haystack.document_stores.types import FilterPolicy
@@ -153,9 +155,9 @@ class TestQdrantSparseEmbeddingRetrieverIntegration(FilterableDocsFixtureMixin):
         document_store = QdrantDocumentStore(location=":memory:", index="Boi", use_sparse_embeddings=True)
 
         # Add fake sparse embedding to documents
-        for doc in filterable_docs:
-            doc.sparse_embedding = generate_sparse_embedding()
-
+        filterable_docs = [
+            dataclasses.replace(doc, sparse_embedding=generate_sparse_embedding()) for doc in filterable_docs
+        ]
         document_store.write_documents(filterable_docs)
         retriever = QdrantSparseEmbeddingRetriever(document_store=document_store)
         sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
@@ -173,9 +175,10 @@ class TestQdrantSparseEmbeddingRetrieverIntegration(FilterableDocsFixtureMixin):
         document_store = QdrantDocumentStore(location=":memory:", index="Boi", use_sparse_embeddings=True)
 
         # Add fake sparse embedding to documents
-        for index, doc in enumerate(filterable_docs):
-            doc.sparse_embedding = generate_sparse_embedding()
-            doc.meta = {"group_field": index // 2}  # So at least two docs have same group each time
+        filterable_docs = [
+            dataclasses.replace(doc, sparse_embedding=generate_sparse_embedding(), meta={"group_field": index // 2})
+            for index, doc in enumerate(filterable_docs)
+        ]  # So at least two docs have same group each time
         document_store.write_documents(filterable_docs)
         retriever = QdrantSparseEmbeddingRetriever(document_store=document_store)
         sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
@@ -197,9 +200,9 @@ class TestQdrantSparseEmbeddingRetrieverIntegration(FilterableDocsFixtureMixin):
         document_store = QdrantDocumentStore(location=":memory:", index="Boi", use_sparse_embeddings=True)
 
         # Add fake sparse embedding to documents
-        for doc in filterable_docs:
-            doc.sparse_embedding = generate_sparse_embedding()
-
+        filterable_docs = [
+            dataclasses.replace(doc, sparse_embedding=generate_sparse_embedding()) for doc in filterable_docs
+        ]
         await document_store.write_documents_async(filterable_docs)
         retriever = QdrantSparseEmbeddingRetriever(document_store=document_store)
         sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])
@@ -218,9 +221,10 @@ class TestQdrantSparseEmbeddingRetrieverIntegration(FilterableDocsFixtureMixin):
         document_store = QdrantDocumentStore(location=":memory:", index="Boi", use_sparse_embeddings=True)
 
         # Add fake sparse embedding to documents
-        for index, doc in enumerate(filterable_docs):
-            doc.sparse_embedding = generate_sparse_embedding()
-            doc.meta = {"group_field": index // 2}  # So at least two docs have same group each time
+        filterable_docs = [
+            dataclasses.replace(doc, sparse_embedding=generate_sparse_embedding(), meta={"group_field": index // 2})
+            for index, doc in enumerate(filterable_docs)
+        ]  # So at least two docs have same group each time
         await document_store.write_documents_async(filterable_docs)
         retriever = QdrantSparseEmbeddingRetriever(document_store=document_store)
         sparse_embedding = SparseEmbedding(indices=[0, 1, 2, 3], values=[0.1, 0.8, 0.05, 0.33])


### PR DESCRIPTION
## Summary

partially addresses deepset-ai/haystack#11084 (partial — Qdrant).

After the in-place mutation warning was added to `Document` in deepset-ai/haystack#10650, four tests in `QdrantSparseEmbeddingRetrieverIntegration` trigger `DeprecationWarning` by mutating `Document.sparse_embedding` and `Document.meta` directly after construction.

**Affected tests and mutations:**

| Test | Field mutated |
|---|---|
| `test_run` | `doc.sparse_embedding` |
| `test_run_with_group_by` | `doc.sparse_embedding`, `doc.meta` |
| `test_run_async` | `doc.sparse_embedding` |
| `test_run_with_group_by_async` | `doc.sparse_embedding`, `doc.meta` |

**Fix:** replace all for-loop field assignments with `dataclasses.replace()` list comprehensions:

```python
# Before
for doc in filterable_docs:
    doc.sparse_embedding = generate_sparse_embedding()

# After
filterable_docs = [
    dataclasses.replace(doc, sparse_embedding=generate_sparse_embedding()) for doc in filterable_docs
]
```

## Test plan

- [ ] Run `pytest -m "integration" integrations/qdrant/tests/test_sparse_embedding_retriever.py` — should pass with zero `DeprecationWarning` about in-place mutations