### PR TITLE
chore: exclude newer kreuzberg dependency versions due to license change

### DIFF
--- a/integrations/kreuzberg/pyproject.toml
+++ b/integrations/kreuzberg/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "haystack-ai>=2.22.0",
-    "kreuzberg>=4.4.6,<=4.7.4",
+    "kreuzberg>=4.4.6,<=4.7.4", # 4.7.4 is the last version with MIT license
 ]
 
 [project.urls]

--- a/integrations/kreuzberg/pyproject.toml
+++ b/integrations/kreuzberg/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "haystack-ai>=2.22.0",
-    "kreuzberg>=4.4.6",
+    "kreuzberg>=4.4.6,<=4.7.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

Closes https://github.com/deepset-ai/haystack-private/issues/318

Kreuzberg silently changed its license from MIT to Elastic License 2.0 (ELv2) in this commit: https://github.com/kreuzberg-dev/kreuzberg/commit/3dd34ce5cd04a0d7ccba2630c21f2c734cfed8fe

[4.7.4 release notes](https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.7.4) (last release under MIT license) and [4.8.0 release notes](https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.0) (first release under Elastic License) fail to mention the license change. 

Kreuzberg posts from earlier this year claimed that "Kreuzberg is and will remain MIT-licensed." ([reddit](https://www.reddit.com/r/kreuzberg_dev/comments/1qa7dkv/announcing_kreuzberg_v4/), [dev community](https://dev.to/t_ivanova/announcing-kreuzberg-v4-55ia)). From https://www.reddit.com/r/Rag/comments/1pn2fxv/kreuzberg_v400rc8_is_available :

> No. Kreuzberg is and will remain MIT-licensed open source.
However, we are building Kreuzberg.cloud - a commercial SaaS and self-hosted document intelligence solution built on top of Kreuzberg. This follows the proven open-core model: the library stays free and open, while we offer a cloud service for teams that want managed infrastructure, APIs, and enterprise features.
Will Kreuzberg become commercially licensed? Absolutely not. There is no BSL (Business Source License) in Kreuzberg's future. The library was MIT-licensed and will remain MIT-licensed. We're building the commercial offering as a separate product around the core library, not by restricting the library itself.

### Proposed Changes:

- Restrict kreuzberg dependency version range to 4.6.0 - 4.7.4. The latter was the last version released under MIT license.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

https://github.com/kreuzberg-dev/kreuzberg/tree/main/packages/python#license still mentions MIT license.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
