### PR TITLE
refactor!: Fix import path for entity extractor

### DIFF
--- a/integrations/presidio/pydoc/config_docusaurus.yml
+++ b/integrations/presidio/pydoc/config_docusaurus.yml
@@ -1,8 +1,8 @@
 loaders:
   - modules:
+      - haystack_integrations.components.extractors.presidio.presidio_entity_extractor
       - haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner
       - haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner
-      - haystack_integrations.components.preprocessors.presidio.presidio_entity_extractor
     search_path: [../src]
 processors:
   - type: filter

--- a/integrations/presidio/pyproject.toml
+++ b/integrations/presidio/pyproject.toml
@@ -70,7 +70,7 @@ integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
-types = "mypy -p haystack_integrations.components.preprocessors.presidio {args}"
+types = "mypy -p haystack_integrations.components.preprocessors.presidio {args} -p haystack_integrations.components.extractors.presidio {args}"
 
 [tool.mypy]
 install_types = true

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/__init__.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack_integrations.components.extractors.presidio.presidio_entity_extractor import PresidioEntityExtractor
+
+__all__ = ["PresidioEntityExtractor"]

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
@@ -30,7 +30,7 @@ class PresidioEntityExtractor:
 
     ```python
     from haystack import Document
-    from haystack_integrations.components.preprocessors.presidio import PresidioEntityExtractor
+    from haystack_integrations.components.extractors.presidio import PresidioEntityExtractor
 
     extractor = PresidioEntityExtractor()
     result = extractor.run(documents=[Document(content="Contact Alice at alice@example.com")])

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/__init__.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/__init__.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner import PresidioDocumentCleaner
-from haystack_integrations.components.preprocessors.presidio.presidio_entity_extractor import PresidioEntityExtractor
 from haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner import PresidioTextCleaner
 
-__all__ = ["PresidioDocumentCleaner", "PresidioEntityExtractor", "PresidioTextCleaner"]
+__all__ = ["PresidioDocumentCleaner", "PresidioTextCleaner"]

--- a/integrations/presidio/tests/test_presidio_entity_extractor.py
+++ b/integrations/presidio/tests/test_presidio_entity_extractor.py
@@ -9,7 +9,7 @@ import pytest
 from haystack import Document
 from haystack.core.serialization import component_from_dict, component_to_dict
 
-from haystack_integrations.components.preprocessors.presidio import PresidioEntityExtractor
+from haystack_integrations.components.extractors.presidio import PresidioEntityExtractor
 
 
 class TestPresidioEntityExtractor:
@@ -30,7 +30,7 @@ class TestPresidioEntityExtractor:
         extractor = PresidioEntityExtractor(language="en", entities=["PERSON"], score_threshold=0.6)
         data = component_to_dict(extractor, "PresidioEntityExtractor")
         expected_type = (
-            "haystack_integrations.components.preprocessors.presidio.presidio_entity_extractor.PresidioEntityExtractor"
+            "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.PresidioEntityExtractor"
         )
         assert data["type"] == expected_type
         assert data["init_parameters"]["entities"] == ["PERSON"]
@@ -39,7 +39,7 @@ class TestPresidioEntityExtractor:
     def test_from_dict(self):
         data = {
             "type": (
-                "haystack_integrations.components.preprocessors.presidio"
+                "haystack_integrations.components.extractors.presidio"
                 ".presidio_entity_extractor.PresidioEntityExtractor"
             ),
             "init_parameters": {"language": "en", "entities": ["EMAIL_ADDRESS"], "score_threshold": 0.5},

--- a/integrations/presidio/tests/test_presidio_entity_extractor.py
+++ b/integrations/presidio/tests/test_presidio_entity_extractor.py
@@ -39,8 +39,7 @@ class TestPresidioEntityExtractor:
     def test_from_dict(self):
         data = {
             "type": (
-                "haystack_integrations.components.extractors.presidio"
-                ".presidio_entity_extractor.PresidioEntityExtractor"
+                "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.PresidioEntityExtractor"
             ),
             "init_parameters": {"language": "en", "entities": ["EMAIL_ADDRESS"], "score_threshold": 0.5},
         }


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Move the entity extractor in the presidio integration into the extractors category which is consistent with the Haystack package

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Updated tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
