### PR TITLE
fix: remove double-wrapping of tools_cachepoint_config in _format_tools

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -93,7 +93,7 @@ def _format_tools(
         )
 
     if tools_cachepoint_config:
-        tool_specs.append({"cachePoint": tools_cachepoint_config})
+        tool_specs.append(tools_cachepoint_config)
 
     return {"tools": tool_specs}
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -67,7 +67,7 @@ def tools():
 
 class TestAmazonBedrockChatGeneratorUtils:
     def test_format_tools(self, tools):
-        formatted_tool = _format_tools(tools, tools_cachepoint_config={"type": "default"})
+        formatted_tool = _format_tools(tools, tools_cachepoint_config={"cachePoint": {"type": "default"}})
         assert formatted_tool == {
             "tools": [
                 {


### PR DESCRIPTION
## Summary

Fixes #3181

- `AmazonBedrockChatGenerator.__init__` calls `_validate_and_format_cache_point` which wraps `{"type": "default"}` → `{"cachePoint": {"type": "default"}}` and stores it as `self.tools_cachepoint_config`
- `_format_tools` was then wrapping it a **second time**, producing `{"cachePoint": {"cachePoint": {"type": "default"}}}` which Bedrock rejects with `ParamValidationError`
- Fix: append `tools_cachepoint_config` directly in `_format_tools` since it is already in Bedrock format by the time it arrives
- Updated the existing `test_format_tools` test to pass the pre-formatted value (matching real call flow)

## Test plan

- [x] Existing unit tests pass (291 passed)
- [x] `test_format_tools` updated to reflect actual call flow (pre-wrapped value passed to `_format_tools`)