### PR TITLE
fix(amazon-bedrock): prevent double-wrapping of tools_cachepoint_config in _format_tools

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -93,7 +93,7 @@ def _format_tools(
         )
 
     if tools_cachepoint_config:
-        tool_specs.append({"cachePoint": tools_cachepoint_config})
+        tool_specs.append(tools_cachepoint_config)
 
     return {"tools": tool_specs}
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -67,7 +67,7 @@ def tools():
 
 class TestAmazonBedrockChatGeneratorUtils:
     def test_format_tools(self, tools):
-        formatted_tool = _format_tools(tools, tools_cachepoint_config={"type": "default"})
+        formatted_tool = _format_tools(tools, tools_cachepoint_config={"cachePoint": {"type": "default"}})
         assert formatted_tool == {
             "tools": [
                 {
@@ -102,6 +102,22 @@ class TestAmazonBedrockChatGeneratorUtils:
                 {"cachePoint": {"type": "default"}},
             ],
         }
+
+    def test_format_tools_does_not_double_wrap_cachepoint(self, tools):
+        # Regression test for https://github.com/deepset-ai/haystack-core-integrations/issues/3181
+        # __init__ pre-formats tools_cachepoint_config via _validate_and_format_cache_point,
+        # so _format_tools must append it as-is without an extra cachePoint wrapper.
+        from haystack_integrations.components.generators.amazon_bedrock.chat.utils import (
+            _validate_and_format_cache_point,
+        )
+
+        formatted_config = _validate_and_format_cache_point({"type": "default"})
+        assert formatted_config == {"cachePoint": {"type": "default"}}
+
+        result = _format_tools(tools, tools_cachepoint_config=formatted_config)
+        cache_entries = [e for e in result["tools"] if "cachePoint" in e]
+        assert len(cache_entries) == 1
+        assert cache_entries[0] == {"cachePoint": {"type": "default"}}
 
     def test_convert_file_content_to_bedrock_format_no_mime_type(self):
         file_content = FileContent(

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -107,9 +107,6 @@ class TestAmazonBedrockChatGeneratorUtils:
         # Regression test for https://github.com/deepset-ai/haystack-core-integrations/issues/3181
         # __init__ pre-formats tools_cachepoint_config via _validate_and_format_cache_point,
         # so _format_tools must append it as-is without an extra cachePoint wrapper.
-        from haystack_integrations.components.generators.amazon_bedrock.chat.utils import (
-            _validate_and_format_cache_point,
-        )
 
         formatted_config = _validate_and_format_cache_point({"type": "default"})
         assert formatted_config == {"cachePoint": {"type": "default"}}


### PR DESCRIPTION
## Summary

Fixes #3181

`AmazonBedrockChatGenerator.__init__` pre-formats `tools_cachepoint_config` via `_validate_and_format_cache_point`, converting the user-supplied `{"type": "default"}` to `{"cachePoint": {"type": "default"}}` and storing it as `self.tools_cachepoint_config`.

`_format_tools` then received this already-formatted value and wrapped it a second time:

```python
# before (broken)
tool_specs.append({"cachePoint": tools_cachepoint_config})
# → sent {"cachePoint": {"cachePoint": {"type": "default"}}} to Bedrock → ParamValidationError
```

**Fix:** append `tools_cachepoint_config` as-is since callers always pass the pre-formatted value:

```python
# after (fixed)
tool_specs.append(tools_cachepoint_config)
# → sends {"cachePoint": {"type": "default"}} to Bedrock ✓
```

## Changes

- `utils.py`: remove the extra `{"cachePoint": ...}` wrapper in `_format_tools`
- `test_chat_generator_utils.py`: update existing `test_format_tools` to pass the pre-formatted value (matching real call path from `__init__`); add `test_format_tools_does_not_double_wrap_cachepoint` regression test that chains `_validate_and_format_cache_point` → `_format_tools` and asserts a single non-nested `cachePoint` entry

## How to verify (no API key needed)

```python
from haystack_integrations.components.generators.amazon_bedrock.chat.utils import (
    _validate_and_format_cache_point,
    _format_tools,
)
from haystack.tools import Tool

def think(thought: str) -> str:
    """Think step."""
    return ""

tool = Tool.from_function(think)
formatted = _validate_and_format_cache_point({"type": "default"})
result = _format_tools([tool], tools_cachepoint_config=formatted)
print(result["tools"][-1])
# before fix: {"cachePoint": {"cachePoint": {"type": "default"}}}
# after fix:  {"cachePoint": {"type": "default"}}  ✓
```