### PR TITLE
test: fix MCP flaky tests

### DIFF
--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -59,11 +59,11 @@ def test_extract_first_text_element():
 
 
 def test_async_executor_run_raises_timeout_error():
-    async def slow() -> None:
-        await asyncio.sleep(0.05)
+    async def never() -> None:
+        await asyncio.Event().wait()
 
     with pytest.raises(TimeoutError, match="timed out"):
-        AsyncExecutor.get_instance().run(slow(), timeout=0.01)
+        AsyncExecutor.get_instance().run(never(), timeout=0.01)
 
 
 class TestMCPTool:
@@ -468,7 +468,7 @@ class TestMCPTool:
         mcp_tool_cleanup(tool)
 
         async def hanging(*_args, **_kwargs):
-            await asyncio.sleep(0.05)
+            await asyncio.Event().wait()
 
         tool._client.call_tool = hanging
         tool._invocation_timeout = 0.01


### PR DESCRIPTION
### Related Issues

- failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/24753351730/job/72454761621

On GitHub runners, it might happen that a timeout of 0.01s does not trigger on a 0.05s sleep because of scheduling delays

### Proposed Changes:
- use a hanging event instead of sleep

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
