### PR TITLE
feat: Add better language support presidio

### DIFF
--- a/integrations/presidio/src/haystack_integrations/components/common/presidio/__init__.py
+++ b/integrations/presidio/src/haystack_integrations/components/common/presidio/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/presidio/src/haystack_integrations/components/common/presidio/utils.py
+++ b/integrations/presidio/src/haystack_integrations/components/common/presidio/utils.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Maps ISO 639-1 language codes to the largest available spaCy model for that language.
+# Used to automatically configure the NLP engine when only `language` is specified.
+# See https://spacy.io/models for the full list of available models.
+SPACY_DEFAULT_MODELS: dict[str, str] = {
+    "ca": "ca_core_news_lg",
+    "zh": "zh_core_web_lg",
+    "hr": "hr_core_news_lg",
+    "da": "da_core_news_lg",
+    "nl": "nl_core_news_lg",
+    "en": "en_core_web_lg",
+    "fi": "fi_core_news_lg",
+    "fr": "fr_core_news_lg",
+    "de": "de_core_news_lg",
+    "el": "el_core_news_lg",
+    "it": "it_core_news_lg",
+    "ja": "ja_core_news_lg",
+    "ko": "ko_core_news_lg",
+    "lt": "lt_core_news_lg",
+    "mk": "mk_core_news_lg",
+    "nb": "nb_core_news_lg",
+    "pl": "pl_core_news_lg",
+    "pt": "pt_core_news_lg",
+    "ro": "ro_core_news_lg",
+    "ru": "ru_core_news_lg",
+    "sl": "sl_core_news_lg",
+    "es": "es_core_news_lg",
+    "sv": "sv_core_news_lg",
+    "uk": "uk_core_news_lg",
+}

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
@@ -112,9 +112,7 @@ class PresidioEntityExtractor:
                 raise ValueError(msg)
             models = [{"lang_code": self.language, "model_name": self.SPACY_DEFAULT_MODELS[self.language]}]
 
-        nlp_engine = NlpEngineProvider(
-            nlp_configuration={"nlp_engine_name": "spacy", "models": models}
-        ).create_engine()
+        nlp_engine = NlpEngineProvider(nlp_configuration={"nlp_engine_name": "spacy", "models": models}).create_engine()
         supported_languages = [m["lang_code"] for m in models]
         self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
 

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
@@ -54,6 +54,8 @@ class PresidioEntityExtractor:
 
         :param language:
             Language code for PII detection. Defaults to `"en"`.
+            Presidio's default NLP engine only includes an English spaCy model. For non-English languages,
+            use the `models` parameter to specify which spaCy model to load for that language.
             See [Presidio supported languages](https://microsoft.github.io/presidio/analyzer/languages/).
         :param entities:
             List of PII entity types to detect (e.g. `["PERSON", "EMAIL_ADDRESS"]`).

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
@@ -3,42 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import replace
+from typing import ClassVar
 
 from haystack import Document, component, logging
 from presidio_analyzer import AnalyzerEngine
 from presidio_analyzer.nlp_engine import NlpEngineProvider
 
-logger = logging.getLogger(__name__)
+from haystack_integrations.components.common.presidio.utils import SPACY_DEFAULT_MODELS as _SPACY_DEFAULT_MODELS
 
-# Maps ISO 639-1 language codes to the largest available spaCy model for that language.
-# Used to automatically configure the NLP engine when only `language` is specified.
-# See https://spacy.io/models for the full list of available models.
-SPACY_DEFAULT_MODELS: dict[str, str] = {
-    "ca": "ca_core_news_lg",
-    "zh": "zh_core_web_lg",
-    "hr": "hr_core_news_lg",
-    "da": "da_core_news_lg",
-    "nl": "nl_core_news_lg",
-    "en": "en_core_web_lg",
-    "fi": "fi_core_news_lg",
-    "fr": "fr_core_news_lg",
-    "de": "de_core_news_lg",
-    "el": "el_core_news_lg",
-    "it": "it_core_news_lg",
-    "ja": "ja_core_news_lg",
-    "ko": "ko_core_news_lg",
-    "lt": "lt_core_news_lg",
-    "mk": "mk_core_news_lg",
-    "nb": "nb_core_news_lg",
-    "pl": "pl_core_news_lg",
-    "pt": "pt_core_news_lg",
-    "ro": "ro_core_news_lg",
-    "ru": "ru_core_news_lg",
-    "sl": "sl_core_news_lg",
-    "es": "es_core_news_lg",
-    "sv": "sv_core_news_lg",
-    "uk": "uk_core_news_lg",
-}
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -69,6 +42,13 @@ class PresidioEntityExtractor:
     # [{"entity_type": "PERSON", "start": 8, "end": 13, "score": 0.85},
     #  {"entity_type": "EMAIL_ADDRESS", "start": 17, "end": 34, "score": 1.0}]
     ```
+    """
+
+    SPACY_DEFAULT_MODELS: ClassVar[dict[str, str]] = _SPACY_DEFAULT_MODELS
+    """Mapping from ISO 639-1 language code to the largest available spaCy model for that language.
+
+    Used to automatically select an NLP model when `models` is not specified.
+    See https://spacy.io/models for the full list of available spaCy models.
     """
 
     def __init__(
@@ -122,15 +102,15 @@ class PresidioEntityExtractor:
 
         models = self.models
         if models is None:
-            if self.language not in SPACY_DEFAULT_MODELS:
-                supported = ", ".join(sorted(SPACY_DEFAULT_MODELS))
+            if self.language not in self.SPACY_DEFAULT_MODELS:
+                supported = ", ".join(sorted(self.SPACY_DEFAULT_MODELS))
                 msg = (
                     f"No default spaCy model is available for language '{self.language}'. "
                     f"Use the `models` parameter to specify a custom model. "
                     f"Languages with built-in support: {supported}."
                 )
                 raise ValueError(msg)
-            models = [{"lang_code": self.language, "model_name": SPACY_DEFAULT_MODELS[self.language]}]
+            models = [{"lang_code": self.language, "model_name": self.SPACY_DEFAULT_MODELS[self.language]}]
 
         nlp_engine = NlpEngineProvider(
             nlp_configuration={"nlp_engine_name": "spacy", "models": models}

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
@@ -10,6 +10,36 @@ from presidio_analyzer.nlp_engine import NlpEngineProvider
 
 logger = logging.getLogger(__name__)
 
+# Maps ISO 639-1 language codes to the largest available spaCy model for that language.
+# Used to automatically configure the NLP engine when only `language` is specified.
+# See https://spacy.io/models for the full list of available models.
+SPACY_DEFAULT_MODELS: dict[str, str] = {
+    "ca": "ca_core_news_lg",
+    "zh": "zh_core_web_lg",
+    "hr": "hr_core_news_lg",
+    "da": "da_core_news_lg",
+    "nl": "nl_core_news_lg",
+    "en": "en_core_web_lg",
+    "fi": "fi_core_news_lg",
+    "fr": "fr_core_news_lg",
+    "de": "de_core_news_lg",
+    "el": "el_core_news_lg",
+    "it": "it_core_news_lg",
+    "ja": "ja_core_news_lg",
+    "ko": "ko_core_news_lg",
+    "lt": "lt_core_news_lg",
+    "mk": "mk_core_news_lg",
+    "nb": "nb_core_news_lg",
+    "pl": "pl_core_news_lg",
+    "pt": "pt_core_news_lg",
+    "ro": "ro_core_news_lg",
+    "ru": "ru_core_news_lg",
+    "sl": "sl_core_news_lg",
+    "es": "es_core_news_lg",
+    "sv": "sv_core_news_lg",
+    "uk": "uk_core_news_lg",
+}
+
 
 @component
 class PresidioEntityExtractor:
@@ -53,9 +83,10 @@ class PresidioEntityExtractor:
         Initializes the PresidioEntityExtractor.
 
         :param language:
-            Language code for PII detection. Defaults to `"en"`.
-            Presidio's default NLP engine only includes an English spaCy model. For non-English languages,
-            use the `models` parameter to specify which spaCy model to load for that language.
+            ISO 639-1 language code for PII detection. Defaults to `"en"`.
+            For languages in the built-in mapping (e.g. `"de"`, `"fr"`, `"es"`), the appropriate
+            spaCy model is loaded automatically at warm-up time — no need to set `models`.
+            For unsupported languages, use the `models` parameter to configure a custom model.
             See [Presidio supported languages](https://microsoft.github.io/presidio/analyzer/languages/).
         :param entities:
             List of PII entity types to detect (e.g. `["PERSON", "EMAIL_ADDRESS"]`).
@@ -65,11 +96,12 @@ class PresidioEntityExtractor:
             Minimum confidence score (0-1) for a detected entity to be included. Defaults to `0.35`.
             See [Presidio analyzer documentation](https://microsoft.github.io/presidio/analyzer/).
         :param models:
-            List of spaCy model configurations for language support.
+            Advanced override: list of spaCy model configurations.
             Each entry must contain `"lang_code"` and `"model_name"` keys,
-            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_lg"}]`.
-            The corresponding spaCy model will be loaded at warm-up time.
-            If `None`, Presidio's default English model (`en_core_web_lg`) is used.
+            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_md"}]`.
+            Use this only when you need a specific model variant or a language not covered by the
+            built-in mapping. If `None`, the model is selected automatically from `SPACY_DEFAULT_MODELS`
+            based on `language`.
         """
         self.language = language
         self.entities = entities
@@ -88,14 +120,23 @@ class PresidioEntityExtractor:
         if self._is_warmed_up:
             return
 
-        if self.models:
-            nlp_engine = NlpEngineProvider(
-                nlp_configuration={"nlp_engine_name": "spacy", "models": self.models}
-            ).create_engine()
-            supported_languages = [m["lang_code"] for m in self.models]
-            self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
-        else:
-            self._analyzer = AnalyzerEngine(supported_languages=[self.language])
+        models = self.models
+        if models is None:
+            if self.language not in SPACY_DEFAULT_MODELS:
+                supported = ", ".join(sorted(SPACY_DEFAULT_MODELS))
+                msg = (
+                    f"No default spaCy model is available for language '{self.language}'. "
+                    f"Use the `models` parameter to specify a custom model. "
+                    f"Languages with built-in support: {supported}."
+                )
+                raise ValueError(msg)
+            models = [{"lang_code": self.language, "model_name": SPACY_DEFAULT_MODELS[self.language]}]
+
+        nlp_engine = NlpEngineProvider(
+            nlp_configuration={"nlp_engine_name": "spacy", "models": models}
+        ).create_engine()
+        supported_languages = [m["lang_code"] for m in models]
+        self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
 
         self._is_warmed_up = True
 

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 
 from haystack import Document, component, logging
 from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer.nlp_engine import NlpEngineProvider
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ class PresidioEntityExtractor:
         language: str = "en",
         entities: list[str] | None = None,
         score_threshold: float = 0.35,
+        models: list[dict[str, str]] | None = None,
     ) -> None:
         """
         Initializes the PresidioEntityExtractor.
@@ -60,10 +62,17 @@ class PresidioEntityExtractor:
         :param score_threshold:
             Minimum confidence score (0-1) for a detected entity to be included. Defaults to `0.35`.
             See [Presidio analyzer documentation](https://microsoft.github.io/presidio/analyzer/).
+        :param models:
+            List of spaCy model configurations for language support.
+            Each entry must contain `"lang_code"` and `"model_name"` keys,
+            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_lg"}]`.
+            The corresponding spaCy model will be loaded at warm-up time.
+            If `None`, Presidio's default English model (`en_core_web_lg`) is used.
         """
         self.language = language
         self.entities = entities
         self.score_threshold = score_threshold
+        self.models = models
         self._analyzer: AnalyzerEngine | None = None
         self._is_warmed_up = False
 
@@ -77,7 +86,14 @@ class PresidioEntityExtractor:
         if self._is_warmed_up:
             return
 
-        self._analyzer = AnalyzerEngine()
+        if self.models:
+            nlp_engine = NlpEngineProvider(
+                nlp_configuration={"nlp_engine_name": "spacy", "models": self.models}
+            ).create_engine()
+            supported_languages = [m["lang_code"] for m in self.models]
+            self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
+        else:
+            self._analyzer = AnalyzerEngine(supported_languages=[self.language])
 
         self._is_warmed_up = True
 

--- a/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
+++ b/integrations/presidio/src/haystack_integrations/components/extractors/presidio/presidio_entity_extractor.py
@@ -48,7 +48,7 @@ class PresidioEntityExtractor:
     """Mapping from ISO 639-1 language code to the largest available spaCy model for that language.
 
     Used to automatically select an NLP model when `models` is not specified.
-    See https://spacy.io/models for the full list of available spaCy models.
+    See [spaCy documentation](https://spacy.io/models) for the full list of available spaCy models.
     """
 
     def __init__(

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
@@ -110,9 +110,7 @@ class PresidioDocumentCleaner:
                 raise ValueError(msg)
             models = [{"lang_code": self.language, "model_name": self.SPACY_DEFAULT_MODELS[self.language]}]
 
-        nlp_engine = NlpEngineProvider(
-            nlp_configuration={"nlp_engine_name": "spacy", "models": models}
-        ).create_engine()
+        nlp_engine = NlpEngineProvider(nlp_configuration={"nlp_engine_name": "spacy", "models": models}).create_engine()
         supported_languages = [m["lang_code"] for m in models]
         self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
         self._anonymizer = AnonymizerEngine()

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
@@ -45,7 +45,7 @@ class PresidioDocumentCleaner:
     """Mapping from ISO 639-1 language code to the largest available spaCy model for that language.
 
     Used to automatically select an NLP model when `models` is not specified.
-    See https://spacy.io/models for the full list of available spaCy models.
+    See [spaCy documentation](https://spacy.io/models) for the full list of available spaCy models.
     """
 
     def __init__(

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
@@ -50,6 +50,8 @@ class PresidioDocumentCleaner:
 
         :param language:
             Language code for PII detection. Defaults to `"en"`.
+            Presidio's default NLP engine only includes an English spaCy model. For non-English languages,
+            use the `models` parameter to specify which spaCy model to load for that language.
             See [Presidio supported languages](https://microsoft.github.io/presidio/analyzer/languages/).
         :param entities:
             List of PII entity types to detect and anonymize (e.g. `["PERSON", "EMAIL_ADDRESS"]`).

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
@@ -2,42 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import ClassVar
+
 from haystack import Document, component, logging
 from presidio_analyzer import AnalyzerEngine
 from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_anonymizer import AnonymizerEngine
 
-logger = logging.getLogger(__name__)
+from haystack_integrations.components.common.presidio.utils import SPACY_DEFAULT_MODELS as _SPACY_DEFAULT_MODELS
 
-# Maps ISO 639-1 language codes to the largest available spaCy model for that language.
-# Used to automatically configure the NLP engine when only `language` is specified.
-# See https://spacy.io/models for the full list of available models.
-SPACY_DEFAULT_MODELS: dict[str, str] = {
-    "ca": "ca_core_news_lg",
-    "zh": "zh_core_web_lg",
-    "hr": "hr_core_news_lg",
-    "da": "da_core_news_lg",
-    "nl": "nl_core_news_lg",
-    "en": "en_core_web_lg",
-    "fi": "fi_core_news_lg",
-    "fr": "fr_core_news_lg",
-    "de": "de_core_news_lg",
-    "el": "el_core_news_lg",
-    "it": "it_core_news_lg",
-    "ja": "ja_core_news_lg",
-    "ko": "ko_core_news_lg",
-    "lt": "lt_core_news_lg",
-    "mk": "mk_core_news_lg",
-    "nb": "nb_core_news_lg",
-    "pl": "pl_core_news_lg",
-    "pt": "pt_core_news_lg",
-    "ro": "ro_core_news_lg",
-    "ru": "ru_core_news_lg",
-    "sl": "sl_core_news_lg",
-    "es": "es_core_news_lg",
-    "sv": "sv_core_news_lg",
-    "uk": "uk_core_news_lg",
-}
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -65,6 +39,13 @@ class PresidioDocumentCleaner:
     print(result["documents"][0].content)
     # My name is <PERSON> and my email is <EMAIL_ADDRESS>
     ```
+    """
+
+    SPACY_DEFAULT_MODELS: ClassVar[dict[str, str]] = _SPACY_DEFAULT_MODELS
+    """Mapping from ISO 639-1 language code to the largest available spaCy model for that language.
+
+    Used to automatically select an NLP model when `models` is not specified.
+    See https://spacy.io/models for the full list of available spaCy models.
     """
 
     def __init__(
@@ -119,15 +100,15 @@ class PresidioDocumentCleaner:
 
         models = self.models
         if models is None:
-            if self.language not in SPACY_DEFAULT_MODELS:
-                supported = ", ".join(sorted(SPACY_DEFAULT_MODELS))
+            if self.language not in self.SPACY_DEFAULT_MODELS:
+                supported = ", ".join(sorted(self.SPACY_DEFAULT_MODELS))
                 msg = (
                     f"No default spaCy model is available for language '{self.language}'. "
                     f"Use the `models` parameter to specify a custom model. "
                     f"Languages with built-in support: {supported}."
                 )
                 raise ValueError(msg)
-            models = [{"lang_code": self.language, "model_name": SPACY_DEFAULT_MODELS[self.language]}]
+            models = [{"lang_code": self.language, "model_name": self.SPACY_DEFAULT_MODELS[self.language]}]
 
         nlp_engine = NlpEngineProvider(
             nlp_configuration={"nlp_engine_name": "spacy", "models": models}

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
@@ -4,6 +4,7 @@
 
 from haystack import Document, component, logging
 from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_anonymizer import AnonymizerEngine
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ class PresidioDocumentCleaner:
         language: str = "en",
         entities: list[str] | None = None,
         score_threshold: float = 0.35,
+        models: list[dict[str, str]] | None = None,
     ) -> None:
         """
         Initializes the PresidioDocumentCleaner.
@@ -56,10 +58,17 @@ class PresidioDocumentCleaner:
         :param score_threshold:
             Minimum confidence score (0-1) for a detected entity to be anonymized. Defaults to `0.35`.
             See [Presidio analyzer documentation](https://microsoft.github.io/presidio/analyzer/).
+        :param models:
+            List of spaCy model configurations for language support.
+            Each entry must contain `"lang_code"` and `"model_name"` keys,
+            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_lg"}]`.
+            The corresponding spaCy model will be loaded at warm-up time.
+            If `None`, Presidio's default English model (`en_core_web_lg`) is used.
         """
         self.language = language
         self.entities = entities
         self.score_threshold = score_threshold
+        self.models = models
         self._analyzer: AnalyzerEngine | None = None
         self._anonymizer: AnonymizerEngine | None = None
         self._is_warmed_up = False
@@ -74,7 +83,14 @@ class PresidioDocumentCleaner:
         if self._is_warmed_up:
             return
 
-        self._analyzer = AnalyzerEngine()
+        if self.models:
+            nlp_engine = NlpEngineProvider(
+                nlp_configuration={"nlp_engine_name": "spacy", "models": self.models}
+            ).create_engine()
+            supported_languages = [m["lang_code"] for m in self.models]
+            self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
+        else:
+            self._analyzer = AnalyzerEngine(supported_languages=[self.language])
         self._anonymizer = AnonymizerEngine()
 
         self._is_warmed_up = True

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_document_cleaner.py
@@ -9,6 +9,36 @@ from presidio_anonymizer import AnonymizerEngine
 
 logger = logging.getLogger(__name__)
 
+# Maps ISO 639-1 language codes to the largest available spaCy model for that language.
+# Used to automatically configure the NLP engine when only `language` is specified.
+# See https://spacy.io/models for the full list of available models.
+SPACY_DEFAULT_MODELS: dict[str, str] = {
+    "ca": "ca_core_news_lg",
+    "zh": "zh_core_web_lg",
+    "hr": "hr_core_news_lg",
+    "da": "da_core_news_lg",
+    "nl": "nl_core_news_lg",
+    "en": "en_core_web_lg",
+    "fi": "fi_core_news_lg",
+    "fr": "fr_core_news_lg",
+    "de": "de_core_news_lg",
+    "el": "el_core_news_lg",
+    "it": "it_core_news_lg",
+    "ja": "ja_core_news_lg",
+    "ko": "ko_core_news_lg",
+    "lt": "lt_core_news_lg",
+    "mk": "mk_core_news_lg",
+    "nb": "nb_core_news_lg",
+    "pl": "pl_core_news_lg",
+    "pt": "pt_core_news_lg",
+    "ro": "ro_core_news_lg",
+    "ru": "ru_core_news_lg",
+    "sl": "sl_core_news_lg",
+    "es": "es_core_news_lg",
+    "sv": "sv_core_news_lg",
+    "uk": "uk_core_news_lg",
+}
+
 
 @component
 class PresidioDocumentCleaner:
@@ -49,9 +79,10 @@ class PresidioDocumentCleaner:
         Initializes the PresidioDocumentCleaner.
 
         :param language:
-            Language code for PII detection. Defaults to `"en"`.
-            Presidio's default NLP engine only includes an English spaCy model. For non-English languages,
-            use the `models` parameter to specify which spaCy model to load for that language.
+            ISO 639-1 language code for PII detection. Defaults to `"en"`.
+            For languages in the built-in mapping (e.g. `"de"`, `"fr"`, `"es"`), the appropriate
+            spaCy model is loaded automatically at warm-up time — no need to set `models`.
+            For unsupported languages, use the `models` parameter to configure a custom model.
             See [Presidio supported languages](https://microsoft.github.io/presidio/analyzer/languages/).
         :param entities:
             List of PII entity types to detect and anonymize (e.g. `["PERSON", "EMAIL_ADDRESS"]`).
@@ -61,11 +92,12 @@ class PresidioDocumentCleaner:
             Minimum confidence score (0-1) for a detected entity to be anonymized. Defaults to `0.35`.
             See [Presidio analyzer documentation](https://microsoft.github.io/presidio/analyzer/).
         :param models:
-            List of spaCy model configurations for language support.
+            Advanced override: list of spaCy model configurations.
             Each entry must contain `"lang_code"` and `"model_name"` keys,
-            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_lg"}]`.
-            The corresponding spaCy model will be loaded at warm-up time.
-            If `None`, Presidio's default English model (`en_core_web_lg`) is used.
+            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_md"}]`.
+            Use this only when you need a specific model variant or a language not covered by the
+            built-in mapping. If `None`, the model is selected automatically from `SPACY_DEFAULT_MODELS`
+            based on `language`.
         """
         self.language = language
         self.entities = entities
@@ -85,14 +117,23 @@ class PresidioDocumentCleaner:
         if self._is_warmed_up:
             return
 
-        if self.models:
-            nlp_engine = NlpEngineProvider(
-                nlp_configuration={"nlp_engine_name": "spacy", "models": self.models}
-            ).create_engine()
-            supported_languages = [m["lang_code"] for m in self.models]
-            self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
-        else:
-            self._analyzer = AnalyzerEngine(supported_languages=[self.language])
+        models = self.models
+        if models is None:
+            if self.language not in SPACY_DEFAULT_MODELS:
+                supported = ", ".join(sorted(SPACY_DEFAULT_MODELS))
+                msg = (
+                    f"No default spaCy model is available for language '{self.language}'. "
+                    f"Use the `models` parameter to specify a custom model. "
+                    f"Languages with built-in support: {supported}."
+                )
+                raise ValueError(msg)
+            models = [{"lang_code": self.language, "model_name": SPACY_DEFAULT_MODELS[self.language]}]
+
+        nlp_engine = NlpEngineProvider(
+            nlp_configuration={"nlp_engine_name": "spacy", "models": models}
+        ).create_engine()
+        supported_languages = [m["lang_code"] for m in models]
+        self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
         self._anonymizer = AnonymizerEngine()
 
         self._is_warmed_up = True

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
@@ -47,6 +47,8 @@ class PresidioTextCleaner:
 
         :param language:
             Language code for PII detection. Defaults to `"en"`.
+            Presidio's default NLP engine only includes an English spaCy model. For non-English languages,
+            use the `models` parameter to specify which spaCy model to load for that language.
             See [Presidio supported languages](https://microsoft.github.io/presidio/analyzer/languages/).
         :param entities:
             List of PII entity types to detect and anonymize (e.g. `["PERSON", "PHONE_NUMBER"]`).

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
@@ -9,6 +9,36 @@ from presidio_anonymizer import AnonymizerEngine
 
 logger = logging.getLogger(__name__)
 
+# Maps ISO 639-1 language codes to the largest available spaCy model for that language.
+# Used to automatically configure the NLP engine when only `language` is specified.
+# See https://spacy.io/models for the full list of available models.
+SPACY_DEFAULT_MODELS: dict[str, str] = {
+    "ca": "ca_core_news_lg",
+    "zh": "zh_core_web_lg",
+    "hr": "hr_core_news_lg",
+    "da": "da_core_news_lg",
+    "nl": "nl_core_news_lg",
+    "en": "en_core_web_lg",
+    "fi": "fi_core_news_lg",
+    "fr": "fr_core_news_lg",
+    "de": "de_core_news_lg",
+    "el": "el_core_news_lg",
+    "it": "it_core_news_lg",
+    "ja": "ja_core_news_lg",
+    "ko": "ko_core_news_lg",
+    "lt": "lt_core_news_lg",
+    "mk": "mk_core_news_lg",
+    "nb": "nb_core_news_lg",
+    "pl": "pl_core_news_lg",
+    "pt": "pt_core_news_lg",
+    "ro": "ro_core_news_lg",
+    "ru": "ru_core_news_lg",
+    "sl": "sl_core_news_lg",
+    "es": "es_core_news_lg",
+    "sv": "sv_core_news_lg",
+    "uk": "uk_core_news_lg",
+}
+
 
 @component
 class PresidioTextCleaner:
@@ -46,9 +76,10 @@ class PresidioTextCleaner:
         Initializes the PresidioTextCleaner.
 
         :param language:
-            Language code for PII detection. Defaults to `"en"`.
-            Presidio's default NLP engine only includes an English spaCy model. For non-English languages,
-            use the `models` parameter to specify which spaCy model to load for that language.
+            ISO 639-1 language code for PII detection. Defaults to `"en"`.
+            For languages in the built-in mapping (e.g. `"de"`, `"fr"`, `"es"`), the appropriate
+            spaCy model is loaded automatically at warm-up time — no need to set `models`.
+            For unsupported languages, use the `models` parameter to configure a custom model.
             See [Presidio supported languages](https://microsoft.github.io/presidio/analyzer/languages/).
         :param entities:
             List of PII entity types to detect and anonymize (e.g. `["PERSON", "PHONE_NUMBER"]`).
@@ -58,11 +89,12 @@ class PresidioTextCleaner:
             Minimum confidence score (0-1) for a detected entity to be anonymized. Defaults to `0.35`.
             See [Presidio analyzer documentation](https://microsoft.github.io/presidio/analyzer/).
         :param models:
-            List of spaCy model configurations for language support.
+            Advanced override: list of spaCy model configurations.
             Each entry must contain `"lang_code"` and `"model_name"` keys,
-            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_lg"}]`.
-            The corresponding spaCy model will be loaded at warm-up time.
-            If `None`, Presidio's default English model (`en_core_web_lg`) is used.
+            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_md"}]`.
+            Use this only when you need a specific model variant or a language not covered by the
+            built-in mapping. If `None`, the model is selected automatically from `SPACY_DEFAULT_MODELS`
+            based on `language`.
         """
         self.language = language
         self.entities = entities
@@ -82,14 +114,23 @@ class PresidioTextCleaner:
         if self._is_warmed_up:
             return
 
-        if self.models:
-            nlp_engine = NlpEngineProvider(
-                nlp_configuration={"nlp_engine_name": "spacy", "models": self.models}
-            ).create_engine()
-            supported_languages = [m["lang_code"] for m in self.models]
-            self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
-        else:
-            self._analyzer = AnalyzerEngine(supported_languages=[self.language])
+        models = self.models
+        if models is None:
+            if self.language not in SPACY_DEFAULT_MODELS:
+                supported = ", ".join(sorted(SPACY_DEFAULT_MODELS))
+                msg = (
+                    f"No default spaCy model is available for language '{self.language}'. "
+                    f"Use the `models` parameter to specify a custom model. "
+                    f"Languages with built-in support: {supported}."
+                )
+                raise ValueError(msg)
+            models = [{"lang_code": self.language, "model_name": SPACY_DEFAULT_MODELS[self.language]}]
+
+        nlp_engine = NlpEngineProvider(
+            nlp_configuration={"nlp_engine_name": "spacy", "models": models}
+        ).create_engine()
+        supported_languages = [m["lang_code"] for m in models]
+        self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
         self._anonymizer = AnonymizerEngine()
 
         self._is_warmed_up = True

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
@@ -2,42 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import ClassVar
+
 from haystack import component, logging
 from presidio_analyzer import AnalyzerEngine
 from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_anonymizer import AnonymizerEngine
 
-logger = logging.getLogger(__name__)
+from haystack_integrations.components.common.presidio.utils import SPACY_DEFAULT_MODELS as _SPACY_DEFAULT_MODELS
 
-# Maps ISO 639-1 language codes to the largest available spaCy model for that language.
-# Used to automatically configure the NLP engine when only `language` is specified.
-# See https://spacy.io/models for the full list of available models.
-SPACY_DEFAULT_MODELS: dict[str, str] = {
-    "ca": "ca_core_news_lg",
-    "zh": "zh_core_web_lg",
-    "hr": "hr_core_news_lg",
-    "da": "da_core_news_lg",
-    "nl": "nl_core_news_lg",
-    "en": "en_core_web_lg",
-    "fi": "fi_core_news_lg",
-    "fr": "fr_core_news_lg",
-    "de": "de_core_news_lg",
-    "el": "el_core_news_lg",
-    "it": "it_core_news_lg",
-    "ja": "ja_core_news_lg",
-    "ko": "ko_core_news_lg",
-    "lt": "lt_core_news_lg",
-    "mk": "mk_core_news_lg",
-    "nb": "nb_core_news_lg",
-    "pl": "pl_core_news_lg",
-    "pt": "pt_core_news_lg",
-    "ro": "ro_core_news_lg",
-    "ru": "ru_core_news_lg",
-    "sl": "sl_core_news_lg",
-    "es": "es_core_news_lg",
-    "sv": "sv_core_news_lg",
-    "uk": "uk_core_news_lg",
-}
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -62,6 +36,13 @@ class PresidioTextCleaner:
     print(result["texts"][0])
     # Hi, I am <PERSON>, call me at <PHONE_NUMBER>
     ```
+    """
+
+    SPACY_DEFAULT_MODELS: ClassVar[dict[str, str]] = _SPACY_DEFAULT_MODELS
+    """Mapping from ISO 639-1 language code to the largest available spaCy model for that language.
+
+    Used to automatically select an NLP model when `models` is not specified.
+    See https://spacy.io/models for the full list of available spaCy models.
     """
 
     def __init__(
@@ -116,15 +97,15 @@ class PresidioTextCleaner:
 
         models = self.models
         if models is None:
-            if self.language not in SPACY_DEFAULT_MODELS:
-                supported = ", ".join(sorted(SPACY_DEFAULT_MODELS))
+            if self.language not in self.SPACY_DEFAULT_MODELS:
+                supported = ", ".join(sorted(self.SPACY_DEFAULT_MODELS))
                 msg = (
                     f"No default spaCy model is available for language '{self.language}'. "
                     f"Use the `models` parameter to specify a custom model. "
                     f"Languages with built-in support: {supported}."
                 )
                 raise ValueError(msg)
-            models = [{"lang_code": self.language, "model_name": SPACY_DEFAULT_MODELS[self.language]}]
+            models = [{"lang_code": self.language, "model_name": self.SPACY_DEFAULT_MODELS[self.language]}]
 
         nlp_engine = NlpEngineProvider(
             nlp_configuration={"nlp_engine_name": "spacy", "models": models}

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
@@ -107,9 +107,7 @@ class PresidioTextCleaner:
                 raise ValueError(msg)
             models = [{"lang_code": self.language, "model_name": self.SPACY_DEFAULT_MODELS[self.language]}]
 
-        nlp_engine = NlpEngineProvider(
-            nlp_configuration={"nlp_engine_name": "spacy", "models": models}
-        ).create_engine()
+        nlp_engine = NlpEngineProvider(nlp_configuration={"nlp_engine_name": "spacy", "models": models}).create_engine()
         supported_languages = [m["lang_code"] for m in models]
         self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
         self._anonymizer = AnonymizerEngine()

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
@@ -42,7 +42,7 @@ class PresidioTextCleaner:
     """Mapping from ISO 639-1 language code to the largest available spaCy model for that language.
 
     Used to automatically select an NLP model when `models` is not specified.
-    See https://spacy.io/models for the full list of available spaCy models.
+    See [spaCy documentation](https://spacy.io/models) for the full list of available spaCy models.
     """
 
     def __init__(

--- a/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
+++ b/integrations/presidio/src/haystack_integrations/components/preprocessors/presidio/presidio_text_cleaner.py
@@ -4,6 +4,7 @@
 
 from haystack import component, logging
 from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_anonymizer import AnonymizerEngine
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class PresidioTextCleaner:
         language: str = "en",
         entities: list[str] | None = None,
         score_threshold: float = 0.35,
+        models: list[dict[str, str]] | None = None,
     ) -> None:
         """
         Initializes the PresidioTextCleaner.
@@ -53,10 +55,17 @@ class PresidioTextCleaner:
         :param score_threshold:
             Minimum confidence score (0-1) for a detected entity to be anonymized. Defaults to `0.35`.
             See [Presidio analyzer documentation](https://microsoft.github.io/presidio/analyzer/).
+        :param models:
+            List of spaCy model configurations for language support.
+            Each entry must contain `"lang_code"` and `"model_name"` keys,
+            e.g. `[{"lang_code": "fr", "model_name": "fr_core_news_lg"}]`.
+            The corresponding spaCy model will be loaded at warm-up time.
+            If `None`, Presidio's default English model (`en_core_web_lg`) is used.
         """
         self.language = language
         self.entities = entities
         self.score_threshold = score_threshold
+        self.models = models
         self._analyzer: AnalyzerEngine | None = None
         self._anonymizer: AnonymizerEngine | None = None
         self._is_warmed_up = False
@@ -71,7 +80,14 @@ class PresidioTextCleaner:
         if self._is_warmed_up:
             return
 
-        self._analyzer = AnalyzerEngine()
+        if self.models:
+            nlp_engine = NlpEngineProvider(
+                nlp_configuration={"nlp_engine_name": "spacy", "models": self.models}
+            ).create_engine()
+            supported_languages = [m["lang_code"] for m in self.models]
+            self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=supported_languages)
+        else:
+            self._analyzer = AnalyzerEngine(supported_languages=[self.language])
         self._anonymizer = AnonymizerEngine()
 
         self._is_warmed_up = True

--- a/integrations/presidio/tests/test_presidio_document_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_document_cleaner.py
@@ -54,16 +54,32 @@ class TestPresidioDocumentCleaner:
         assert cleaner.score_threshold == 0.6
         assert cleaner.models == models
 
-    def test_warm_up(self):
+    def test_warm_up_auto_model(self):
         cleaner = PresidioDocumentCleaner(language="en")
+        mock_nlp_engine = MagicMock()
         with (
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.NlpEngineProvider"
+            ) as mock_provider_cls,
             patch(
                 "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnalyzerEngine"
             ) as mock_analyzer_cls,
             patch("haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnonymizerEngine"),
         ):
+            mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
             cleaner.warm_up()
-            mock_analyzer_cls.assert_called_once_with(supported_languages=["en"])
+            mock_provider_cls.assert_called_once_with(
+                nlp_configuration={
+                    "nlp_engine_name": "spacy",
+                    "models": [{"lang_code": "en", "model_name": "en_core_web_lg"}],
+                }
+            )
+            mock_analyzer_cls.assert_called_once_with(nlp_engine=mock_nlp_engine, supported_languages=["en"])
+
+    def test_warm_up_unknown_language_raises(self):
+        cleaner = PresidioDocumentCleaner(language="xx")
+        with pytest.raises(ValueError, match="No default spaCy model is available for language 'xx'"):
+            cleaner.warm_up()
 
     def test_warm_up_with_models(self):
         models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
@@ -187,10 +203,7 @@ class TestPresidioDocumentCleaner:
 
     @pytest.mark.integration
     def test_run_integration_german(self):
-        cleaner = PresidioDocumentCleaner(
-            language="de",
-            models=[{"lang_code": "de", "model_name": "de_core_news_lg"}],
-        )
+        cleaner = PresidioDocumentCleaner(language="de")
         cleaner.warm_up()
         docs = [Document(content="Mein Name ist Hans Müller und meine E-Mail ist hans@example.com")]
         result = cleaner.run(documents=docs)

--- a/integrations/presidio/tests/test_presidio_document_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_document_cleaner.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from haystack import Document
@@ -18,6 +18,7 @@ class TestPresidioDocumentCleaner:
         assert cleaner.language == "en"
         assert cleaner.entities is None
         assert cleaner.score_threshold == 0.35
+        assert cleaner.models is None
 
     def test_init_custom_params(self):
         cleaner = PresidioDocumentCleaner(language="de", entities=["PERSON"], score_threshold=0.7)
@@ -48,6 +49,36 @@ class TestPresidioDocumentCleaner:
         assert cleaner.language == "de"
         assert cleaner.entities == ["PERSON"]
         assert cleaner.score_threshold == 0.6
+
+    def test_warm_up(self):
+        cleaner = PresidioDocumentCleaner(language="en")
+        with patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnalyzerEngine"
+        ) as mock_analyzer_cls, patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnonymizerEngine"
+        ):
+            cleaner.warm_up()
+            mock_analyzer_cls.assert_called_once_with(supported_languages=["en"])
+
+    def test_warm_up_with_models(self):
+        models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
+        cleaner = PresidioDocumentCleaner(language="fr", models=models)
+        mock_nlp_engine = MagicMock()
+        with patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.NlpEngineProvider"
+        ) as mock_provider_cls, patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnalyzerEngine"
+        ) as mock_analyzer_cls, patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnonymizerEngine"
+        ):
+            mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
+            cleaner.warm_up()
+            mock_provider_cls.assert_called_once_with(
+                nlp_configuration={"nlp_engine_name": "spacy", "models": models}
+            )
+            mock_analyzer_cls.assert_called_once_with(
+                nlp_engine=mock_nlp_engine, supported_languages=["fr"]
+            )
 
     def _make_cleaner_with_mocks(self, **kwargs):
         """Return a cleaner with mocked engines so unit tests don't load real NLP models."""

--- a/integrations/presidio/tests/test_presidio_document_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_document_cleaner.py
@@ -27,28 +27,32 @@ class TestPresidioDocumentCleaner:
         assert cleaner.score_threshold == 0.7
 
     def test_to_dict(self):
-        cleaner = PresidioDocumentCleaner(language="en", entities=["EMAIL_ADDRESS"], score_threshold=0.5)
+        models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
+        cleaner = PresidioDocumentCleaner(language="fr", entities=["EMAIL_ADDRESS"], score_threshold=0.5, models=models)
         data = component_to_dict(cleaner, "PresidioDocumentCleaner")
         expected_type = (
             "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.PresidioDocumentCleaner"
         )
         assert data["type"] == expected_type
-        assert data["init_parameters"]["language"] == "en"
+        assert data["init_parameters"]["language"] == "fr"
         assert data["init_parameters"]["entities"] == ["EMAIL_ADDRESS"]
         assert data["init_parameters"]["score_threshold"] == 0.5
+        assert data["init_parameters"]["models"] == models
 
     def test_from_dict(self):
+        models = [{"lang_code": "de", "model_name": "de_core_news_lg"}]
         data = {
             "type": (
                 "haystack_integrations.components.preprocessors.presidio"
                 ".presidio_document_cleaner.PresidioDocumentCleaner"
             ),
-            "init_parameters": {"language": "de", "entities": ["PERSON"], "score_threshold": 0.6},
+            "init_parameters": {"language": "de", "entities": ["PERSON"], "score_threshold": 0.6, "models": models},
         }
         cleaner = component_from_dict(PresidioDocumentCleaner, data, "PresidioDocumentCleaner")
         assert cleaner.language == "de"
         assert cleaner.entities == ["PERSON"]
         assert cleaner.score_threshold == 0.6
+        assert cleaner.models == models
 
     def test_warm_up(self):
         cleaner = PresidioDocumentCleaner(language="en")

--- a/integrations/presidio/tests/test_presidio_document_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_document_cleaner.py
@@ -185,3 +185,17 @@ class TestPresidioDocumentCleaner:
         assert len(result["documents"]) == 1
         assert "John Smith" not in result["documents"][0].content
         assert "john@example.com" not in result["documents"][0].content
+
+    @pytest.mark.integration
+    def test_run_integration_german(self):
+        cleaner = PresidioDocumentCleaner(
+            language="de",
+            models=[{"lang_code": "de", "model_name": "de_core_news_lg"}],
+        )
+        cleaner.warm_up()
+        docs = [Document(content="Mein Name ist Hans Müller und meine E-Mail ist hans@example.com")]
+        result = cleaner.run(documents=docs)
+
+        assert len(result["documents"]) == 1
+        assert "Hans Müller" not in result["documents"][0].content
+        assert "hans@example.com" not in result["documents"][0].content

--- a/integrations/presidio/tests/test_presidio_document_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_document_cleaner.py
@@ -56,10 +56,11 @@ class TestPresidioDocumentCleaner:
 
     def test_warm_up(self):
         cleaner = PresidioDocumentCleaner(language="en")
-        with patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnalyzerEngine"
-        ) as mock_analyzer_cls, patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnonymizerEngine"
+        with (
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnalyzerEngine"
+            ) as mock_analyzer_cls,
+            patch("haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnonymizerEngine"),
         ):
             cleaner.warm_up()
             mock_analyzer_cls.assert_called_once_with(supported_languages=["en"])
@@ -68,21 +69,19 @@ class TestPresidioDocumentCleaner:
         models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
         cleaner = PresidioDocumentCleaner(language="fr", models=models)
         mock_nlp_engine = MagicMock()
-        with patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.NlpEngineProvider"
-        ) as mock_provider_cls, patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnalyzerEngine"
-        ) as mock_analyzer_cls, patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnonymizerEngine"
+        with (
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.NlpEngineProvider"
+            ) as mock_provider_cls,
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnalyzerEngine"
+            ) as mock_analyzer_cls,
+            patch("haystack_integrations.components.preprocessors.presidio.presidio_document_cleaner.AnonymizerEngine"),
         ):
             mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
             cleaner.warm_up()
-            mock_provider_cls.assert_called_once_with(
-                nlp_configuration={"nlp_engine_name": "spacy", "models": models}
-            )
-            mock_analyzer_cls.assert_called_once_with(
-                nlp_engine=mock_nlp_engine, supported_languages=["fr"]
-            )
+            mock_provider_cls.assert_called_once_with(nlp_configuration={"nlp_engine_name": "spacy", "models": models})
+            mock_analyzer_cls.assert_called_once_with(nlp_engine=mock_nlp_engine, supported_languages=["fr"])
 
     def _make_cleaner_with_mocks(self, **kwargs):
         """Return a cleaner with mocked engines so unit tests don't load real NLP models."""

--- a/integrations/presidio/tests/test_presidio_entity_extractor.py
+++ b/integrations/presidio/tests/test_presidio_entity_extractor.py
@@ -32,19 +32,18 @@ class TestPresidioEntityExtractor:
         models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
         extractor = PresidioEntityExtractor(language="fr", models=models)
         mock_nlp_engine = MagicMock()
-        with patch(
-            "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.NlpEngineProvider"
-        ) as mock_provider_cls, patch(
-            "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.AnalyzerEngine"
-        ) as mock_analyzer_cls:
+        with (
+            patch(
+                "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.NlpEngineProvider"
+            ) as mock_provider_cls,
+            patch(
+                "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.AnalyzerEngine"
+            ) as mock_analyzer_cls,
+        ):
             mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
             extractor.warm_up()
-            mock_provider_cls.assert_called_once_with(
-                nlp_configuration={"nlp_engine_name": "spacy", "models": models}
-            )
-            mock_analyzer_cls.assert_called_once_with(
-                nlp_engine=mock_nlp_engine, supported_languages=["fr"]
-            )
+            mock_provider_cls.assert_called_once_with(nlp_configuration={"nlp_engine_name": "spacy", "models": models})
+            mock_analyzer_cls.assert_called_once_with(nlp_engine=mock_nlp_engine, supported_languages=["fr"])
 
     def _make_extractor_with_mocks(self, **kwargs):
         """Return an extractor with a mocked analyzer so unit tests don't load real NLP models."""
@@ -72,7 +71,12 @@ class TestPresidioEntityExtractor:
             "type": (
                 "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.PresidioEntityExtractor"
             ),
-            "init_parameters": {"language": "fr", "entities": ["EMAIL_ADDRESS"], "score_threshold": 0.5, "models": models},
+            "init_parameters": {
+                "language": "fr",
+                "entities": ["EMAIL_ADDRESS"],
+                "score_threshold": 0.5,
+                "models": models,
+            },
         }
         extractor = component_from_dict(PresidioEntityExtractor, data, "PresidioEntityExtractor")
         assert extractor.entities == ["EMAIL_ADDRESS"]

--- a/integrations/presidio/tests/test_presidio_entity_extractor.py
+++ b/integrations/presidio/tests/test_presidio_entity_extractor.py
@@ -156,3 +156,18 @@ class TestPresidioEntityExtractor:
         entities = result["documents"][0].meta["entities"]
         entity_types = [e["entity_type"] for e in entities]
         assert "EMAIL_ADDRESS" in entity_types
+
+    @pytest.mark.integration
+    def test_run_integration_german(self):
+        extractor = PresidioEntityExtractor(
+            language="de",
+            models=[{"lang_code": "de", "model_name": "de_core_news_lg"}],
+        )
+        extractor.warm_up()
+        docs = [Document(content="Kontaktieren Sie Hans Müller unter hans@example.com")]
+        result = extractor.run(documents=docs)
+
+        entities = result["documents"][0].meta["entities"]
+        entity_types = [e["entity_type"] for e in entities]
+        assert "EMAIL_ADDRESS" in entity_types
+        assert "PERSON" in entity_types

--- a/integrations/presidio/tests/test_presidio_entity_extractor.py
+++ b/integrations/presidio/tests/test_presidio_entity_extractor.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from haystack import Document
@@ -18,6 +18,33 @@ class TestPresidioEntityExtractor:
         assert extractor.language == "en"
         assert extractor.entities is None
         assert extractor.score_threshold == 0.35
+        assert extractor.models is None
+
+    def test_warm_up(self):
+        extractor = PresidioEntityExtractor(language="fr")
+        with patch(
+            "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.AnalyzerEngine"
+        ) as mock_analyzer_cls:
+            extractor.warm_up()
+            mock_analyzer_cls.assert_called_once_with(supported_languages=["fr"])
+
+    def test_warm_up_with_models(self):
+        models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
+        extractor = PresidioEntityExtractor(language="fr", models=models)
+        mock_nlp_engine = MagicMock()
+        with patch(
+            "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.NlpEngineProvider"
+        ) as mock_provider_cls, patch(
+            "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.AnalyzerEngine"
+        ) as mock_analyzer_cls:
+            mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
+            extractor.warm_up()
+            mock_provider_cls.assert_called_once_with(
+                nlp_configuration={"nlp_engine_name": "spacy", "models": models}
+            )
+            mock_analyzer_cls.assert_called_once_with(
+                nlp_engine=mock_nlp_engine, supported_languages=["fr"]
+            )
 
     def _make_extractor_with_mocks(self, **kwargs):
         """Return an extractor with a mocked analyzer so unit tests don't load real NLP models."""

--- a/integrations/presidio/tests/test_presidio_entity_extractor.py
+++ b/integrations/presidio/tests/test_presidio_entity_extractor.py
@@ -54,24 +54,29 @@ class TestPresidioEntityExtractor:
         return extractor
 
     def test_to_dict(self):
-        extractor = PresidioEntityExtractor(language="en", entities=["PERSON"], score_threshold=0.6)
+        models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
+        extractor = PresidioEntityExtractor(language="fr", entities=["PERSON"], score_threshold=0.6, models=models)
         data = component_to_dict(extractor, "PresidioEntityExtractor")
         expected_type = (
             "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.PresidioEntityExtractor"
         )
         assert data["type"] == expected_type
+        assert data["init_parameters"]["language"] == "fr"
         assert data["init_parameters"]["entities"] == ["PERSON"]
         assert data["init_parameters"]["score_threshold"] == 0.6
+        assert data["init_parameters"]["models"] == models
 
     def test_from_dict(self):
+        models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
         data = {
             "type": (
                 "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.PresidioEntityExtractor"
             ),
-            "init_parameters": {"language": "en", "entities": ["EMAIL_ADDRESS"], "score_threshold": 0.5},
+            "init_parameters": {"language": "fr", "entities": ["EMAIL_ADDRESS"], "score_threshold": 0.5, "models": models},
         }
         extractor = component_from_dict(PresidioEntityExtractor, data, "PresidioEntityExtractor")
         assert extractor.entities == ["EMAIL_ADDRESS"]
+        assert extractor.models == models
 
     def test_run_extracts_entities_into_metadata(self):
         extractor = self._make_extractor_with_mocks()

--- a/integrations/presidio/tests/test_presidio_entity_extractor.py
+++ b/integrations/presidio/tests/test_presidio_entity_extractor.py
@@ -20,13 +20,31 @@ class TestPresidioEntityExtractor:
         assert extractor.score_threshold == 0.35
         assert extractor.models is None
 
-    def test_warm_up(self):
+    def test_warm_up_auto_model(self):
         extractor = PresidioEntityExtractor(language="fr")
-        with patch(
-            "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.AnalyzerEngine"
-        ) as mock_analyzer_cls:
+        mock_nlp_engine = MagicMock()
+        with (
+            patch(
+                "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.NlpEngineProvider"
+            ) as mock_provider_cls,
+            patch(
+                "haystack_integrations.components.extractors.presidio.presidio_entity_extractor.AnalyzerEngine"
+            ) as mock_analyzer_cls,
+        ):
+            mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
             extractor.warm_up()
-            mock_analyzer_cls.assert_called_once_with(supported_languages=["fr"])
+            mock_provider_cls.assert_called_once_with(
+                nlp_configuration={
+                    "nlp_engine_name": "spacy",
+                    "models": [{"lang_code": "fr", "model_name": "fr_core_news_lg"}],
+                }
+            )
+            mock_analyzer_cls.assert_called_once_with(nlp_engine=mock_nlp_engine, supported_languages=["fr"])
+
+    def test_warm_up_unknown_language_raises(self):
+        extractor = PresidioEntityExtractor(language="xx")
+        with pytest.raises(ValueError, match="No default spaCy model is available for language 'xx'"):
+            extractor.warm_up()
 
     def test_warm_up_with_models(self):
         models = [{"lang_code": "fr", "model_name": "fr_core_news_lg"}]
@@ -163,10 +181,7 @@ class TestPresidioEntityExtractor:
 
     @pytest.mark.integration
     def test_run_integration_german(self):
-        extractor = PresidioEntityExtractor(
-            language="de",
-            models=[{"lang_code": "de", "model_name": "de_core_news_lg"}],
-        )
+        extractor = PresidioEntityExtractor(language="de")
         extractor.warm_up()
         docs = [Document(content="Kontaktieren Sie Hans Müller unter hans@example.com")]
         result = extractor.run(documents=docs)

--- a/integrations/presidio/tests/test_presidio_text_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_text_cleaner.py
@@ -43,10 +43,11 @@ class TestPresidioTextCleaner:
 
     def test_warm_up(self):
         cleaner = PresidioTextCleaner(language="es")
-        with patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnalyzerEngine"
-        ) as mock_analyzer_cls, patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnonymizerEngine"
+        with (
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnalyzerEngine"
+            ) as mock_analyzer_cls,
+            patch("haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnonymizerEngine"),
         ):
             cleaner.warm_up()
             mock_analyzer_cls.assert_called_once_with(supported_languages=["es"])
@@ -55,21 +56,19 @@ class TestPresidioTextCleaner:
         models = [{"lang_code": "es", "model_name": "es_core_news_lg"}]
         cleaner = PresidioTextCleaner(language="es", models=models)
         mock_nlp_engine = MagicMock()
-        with patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.NlpEngineProvider"
-        ) as mock_provider_cls, patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnalyzerEngine"
-        ) as mock_analyzer_cls, patch(
-            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnonymizerEngine"
+        with (
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.NlpEngineProvider"
+            ) as mock_provider_cls,
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnalyzerEngine"
+            ) as mock_analyzer_cls,
+            patch("haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnonymizerEngine"),
         ):
             mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
             cleaner.warm_up()
-            mock_provider_cls.assert_called_once_with(
-                nlp_configuration={"nlp_engine_name": "spacy", "models": models}
-            )
-            mock_analyzer_cls.assert_called_once_with(
-                nlp_engine=mock_nlp_engine, supported_languages=["es"]
-            )
+            mock_provider_cls.assert_called_once_with(nlp_configuration={"nlp_engine_name": "spacy", "models": models})
+            mock_analyzer_cls.assert_called_once_with(nlp_engine=mock_nlp_engine, supported_languages=["es"])
 
     def _make_cleaner_with_mocks(self, **kwargs):
         """Return a cleaner with mocked engines so unit tests don't load real NLP models."""

--- a/integrations/presidio/tests/test_presidio_text_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_text_cleaner.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from haystack.core.serialization import component_from_dict, component_to_dict
@@ -17,6 +17,7 @@ class TestPresidioTextCleaner:
         assert cleaner.language == "en"
         assert cleaner.entities is None
         assert cleaner.score_threshold == 0.35
+        assert cleaner.models is None
 
     def test_to_dict(self):
         cleaner = PresidioTextCleaner(language="en", entities=["PHONE_NUMBER"], score_threshold=0.5)
@@ -34,6 +35,36 @@ class TestPresidioTextCleaner:
         }
         cleaner = component_from_dict(PresidioTextCleaner, data, "PresidioTextCleaner")
         assert cleaner.score_threshold == 0.4
+
+    def test_warm_up(self):
+        cleaner = PresidioTextCleaner(language="es")
+        with patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnalyzerEngine"
+        ) as mock_analyzer_cls, patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnonymizerEngine"
+        ):
+            cleaner.warm_up()
+            mock_analyzer_cls.assert_called_once_with(supported_languages=["es"])
+
+    def test_warm_up_with_models(self):
+        models = [{"lang_code": "es", "model_name": "es_core_news_lg"}]
+        cleaner = PresidioTextCleaner(language="es", models=models)
+        mock_nlp_engine = MagicMock()
+        with patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.NlpEngineProvider"
+        ) as mock_provider_cls, patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnalyzerEngine"
+        ) as mock_analyzer_cls, patch(
+            "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnonymizerEngine"
+        ):
+            mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
+            cleaner.warm_up()
+            mock_provider_cls.assert_called_once_with(
+                nlp_configuration={"nlp_engine_name": "spacy", "models": models}
+            )
+            mock_analyzer_cls.assert_called_once_with(
+                nlp_engine=mock_nlp_engine, supported_languages=["es"]
+            )
 
     def _make_cleaner_with_mocks(self, **kwargs):
         """Return a cleaner with mocked engines so unit tests don't load real NLP models."""

--- a/integrations/presidio/tests/test_presidio_text_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_text_cleaner.py
@@ -20,21 +20,26 @@ class TestPresidioTextCleaner:
         assert cleaner.models is None
 
     def test_to_dict(self):
-        cleaner = PresidioTextCleaner(language="en", entities=["PHONE_NUMBER"], score_threshold=0.5)
+        models = [{"lang_code": "es", "model_name": "es_core_news_lg"}]
+        cleaner = PresidioTextCleaner(language="es", entities=["PHONE_NUMBER"], score_threshold=0.5, models=models)
         data = component_to_dict(cleaner, "PresidioTextCleaner")
         assert (
             data["type"]
             == "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.PresidioTextCleaner"
         )
+        assert data["init_parameters"]["language"] == "es"
         assert data["init_parameters"]["entities"] == ["PHONE_NUMBER"]
+        assert data["init_parameters"]["models"] == models
 
     def test_from_dict(self):
+        models = [{"lang_code": "es", "model_name": "es_core_news_lg"}]
         data = {
             "type": "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.PresidioTextCleaner",
-            "init_parameters": {"language": "en", "entities": None, "score_threshold": 0.4},
+            "init_parameters": {"language": "es", "entities": None, "score_threshold": 0.4, "models": models},
         }
         cleaner = component_from_dict(PresidioTextCleaner, data, "PresidioTextCleaner")
         assert cleaner.score_threshold == 0.4
+        assert cleaner.models == models
 
     def test_warm_up(self):
         cleaner = PresidioTextCleaner(language="es")

--- a/integrations/presidio/tests/test_presidio_text_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_text_cleaner.py
@@ -131,3 +131,16 @@ class TestPresidioTextCleaner:
         assert len(result["texts"]) == 1
         assert "Alice" not in result["texts"][0]
         assert "212-555-5678" not in result["texts"][0]
+
+    @pytest.mark.integration
+    def test_run_integration_german(self):
+        cleaner = PresidioTextCleaner(
+            language="de",
+            models=[{"lang_code": "de", "model_name": "de_core_news_lg"}],
+        )
+        cleaner.warm_up()
+        result = cleaner.run(texts=["Hallo, ich bin Thomas Schmidt und meine E-Mail ist thomas@example.com"])
+
+        assert len(result["texts"]) == 1
+        assert "Thomas Schmidt" not in result["texts"][0]
+        assert "thomas@example.com" not in result["texts"][0]

--- a/integrations/presidio/tests/test_presidio_text_cleaner.py
+++ b/integrations/presidio/tests/test_presidio_text_cleaner.py
@@ -41,16 +41,32 @@ class TestPresidioTextCleaner:
         assert cleaner.score_threshold == 0.4
         assert cleaner.models == models
 
-    def test_warm_up(self):
+    def test_warm_up_auto_model(self):
         cleaner = PresidioTextCleaner(language="es")
+        mock_nlp_engine = MagicMock()
         with (
+            patch(
+                "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.NlpEngineProvider"
+            ) as mock_provider_cls,
             patch(
                 "haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnalyzerEngine"
             ) as mock_analyzer_cls,
             patch("haystack_integrations.components.preprocessors.presidio.presidio_text_cleaner.AnonymizerEngine"),
         ):
+            mock_provider_cls.return_value.create_engine.return_value = mock_nlp_engine
             cleaner.warm_up()
-            mock_analyzer_cls.assert_called_once_with(supported_languages=["es"])
+            mock_provider_cls.assert_called_once_with(
+                nlp_configuration={
+                    "nlp_engine_name": "spacy",
+                    "models": [{"lang_code": "es", "model_name": "es_core_news_lg"}],
+                }
+            )
+            mock_analyzer_cls.assert_called_once_with(nlp_engine=mock_nlp_engine, supported_languages=["es"])
+
+    def test_warm_up_unknown_language_raises(self):
+        cleaner = PresidioTextCleaner(language="xx")
+        with pytest.raises(ValueError, match="No default spaCy model is available for language 'xx'"):
+            cleaner.warm_up()
 
     def test_warm_up_with_models(self):
         models = [{"lang_code": "es", "model_name": "es_core_news_lg"}]
@@ -133,10 +149,7 @@ class TestPresidioTextCleaner:
 
     @pytest.mark.integration
     def test_run_integration_german(self):
-        cleaner = PresidioTextCleaner(
-            language="de",
-            models=[{"lang_code": "de", "model_name": "de_core_news_lg"}],
-        )
+        cleaner = PresidioTextCleaner(language="de")
         cleaner.warm_up()
         result = cleaner.run(texts=["Hallo, ich bin Thomas Schmidt und meine E-Mail ist thomas@example.com"])
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update the presidio integration to properly pass `language` to the `supported_languages` param of `AnalyzerEngine` and add a new param called `models` which is required if using languages other than English to tell Presidio what model to use to power the NlpEngine.

For example, to run the document cleaner in german this now works and the german model is automatically downloaded at warm up time. 
```python
from haystack import Document
from haystack_integrations.components.preprocessors.presidio import PresidioDocumentCleaner

cleaner = PresidioDocumentCleaner(
    language="de",
    models=[{"lang_code": "de", "model_name": "de_core_news_lg"}],
)
cleaner.warm_up()
docs = [Document(content="Mein Name ist Hans Müller und meine E-Mail ist hans@example.com")]
result = cleaner.run(documents=docs)
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added unit and integration tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
