### PR TITLE
test: Jina - add unit tests

### DIFF
--- a/integrations/jina/tests/test_document_image_embedder.py
+++ b/integrations/jina/tests/test_document_image_embedder.py
@@ -240,6 +240,39 @@ class TestJinaDocumentImageEmbedder:
                 assert len(call_args_list[1][1]["json"]["input"]) == 5  # Second batch: 5 images
                 assert len(call_args_list[2][1]["json"]["input"]) == 2  # Third batch: 2 images
 
+    @patch("haystack_integrations.components.embedders.jina.document_image_embedder._extract_image_sources_info")
+    def test_extract_images_pdf_missing_page_number_raises_value_error(self, mock_extract_info):
+        documents = [Document(content="PDF doc", meta={"file_path": "test.pdf"})]
+        mock_extract_info.return_value = [{"path": "test.pdf", "mime_type": "application/pdf"}]
+
+        embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
+        with pytest.raises(ValueError, match="Page number is required for PDF document at index 0"):
+            embedder._extract_images_to_embed(documents)
+
+    @patch("haystack_integrations.components.embedders.jina.document_image_embedder._extract_image_sources_info")
+    @patch("haystack_integrations.components.embedders.jina.document_image_embedder._batch_convert_pdf_pages_to_images")
+    def test_extract_images_pdf_conversion_silent_failure_raises_runtime_error(
+        self, mock_batch_convert, mock_extract_info
+    ):
+        documents = [Document(content="PDF doc", meta={"file_path": "test.pdf", "page_number": 1})]
+        mock_extract_info.return_value = [{"path": "test.pdf", "mime_type": "application/pdf", "page_number": 1}]
+        # PDF conversion returns empty dict: image stays None without raising
+        mock_batch_convert.return_value = {}
+
+        embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
+        with pytest.raises(RuntimeError, match="Conversion failed for some documents"):
+            embedder._extract_images_to_embed(documents)
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_connection_error(self):
+        documents = [Document(content="img", meta={"file_path": "test.jpg"})]
+        embedder = JinaDocumentImageEmbedder(api_key=Secret.from_token("fake-api-key"))
+
+        with patch.object(embedder, "_extract_images_to_embed", return_value=["data:image/jpeg;base64,x"]):
+            with patch("httpx.AsyncClient.post", side_effect=Exception("Connection failed")):
+                with pytest.raises(RuntimeError, match="Error calling Jina API: Connection failed"):
+                    await embedder.run_async(documents=documents)
+
     @pytest.mark.asyncio
     async def test_run_async_with_successful_request(self):
         documents = [Document(content="Test image", meta={"file_path": "test.jpg"})]

--- a/integrations/jina/tests/test_ranker.py
+++ b/integrations/jina/tests/test_ranker.py
@@ -53,6 +53,30 @@ class TestJinaRanker:
         with pytest.raises(ValueError):
             JinaRanker()
 
+    def test_init_fails_with_invalid_top_k(self):
+        with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
+            JinaRanker(api_key=Secret.from_token("fake-api-key"), top_k=0)
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("JINA_API_KEY", "fake-api-key")
+        data = {
+            "type": "haystack_integrations.components.rankers.jina.ranker.JinaRanker",
+            "init_parameters": {
+                "api_key": {"env_vars": ["JINA_API_KEY"], "strict": True, "type": "env_var"},
+                "model": "model",
+                "base_url": "https://my.custom.url/v1/rerank",
+                "top_k": 5,
+                "score_threshold": 0.3,
+            },
+        }
+        ranker = JinaRanker.from_dict(data)
+
+        assert ranker.api_key == Secret.from_env_var("JINA_API_KEY")
+        assert ranker.model == "model"
+        assert ranker.base_url == "https://my.custom.url/v1/rerank"
+        assert ranker.top_k == 5
+        assert ranker.score_threshold == 0.3
+
     def test_to_dict(self, monkeypatch):
         monkeypatch.setenv("JINA_API_KEY", "fake-api-key")
         component = JinaRanker()
@@ -189,6 +213,34 @@ class TestJinaRanker:
 
         assert result["documents"] is not None
         assert not result["documents"]  # empty list
+
+    def test_run_raises_runtime_error_on_api_error(self):
+        mock_response = httpx.Response(400, json={"detail": "Bad request"})
+        with patch("httpx.Client.post", return_value=mock_response):
+            ranker = JinaRanker(api_key=Secret.from_token("fake-api-key"))
+            with pytest.raises(RuntimeError, match="Bad request"):
+                ranker.run(query="q", documents=[Document(content="doc")])
+
+    def test_run_with_score_threshold_filters_results(self):
+        docs = [Document(content=f"doc {i}") for i in range(4)]
+
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
+            ranker = JinaRanker(api_key=Secret.from_token("fake-api-key"), score_threshold=2.5)
+            result = ranker.run(query="q", documents=docs)
+
+        # mock assigns scores len(docs)-i, so for 4 docs scores are 4, 3, 2, 1 - only first two pass
+        ranked = result["documents"]
+        assert len(ranked) == 2
+        assert all(doc.score >= 2.5 for doc in ranked)
+
+    def test_run_with_top_k_truncates_results(self):
+        docs = [Document(content=f"doc {i}") for i in range(5)]
+
+        with patch("httpx.Client.post", side_effect=mock_httpx_post_response):
+            ranker = JinaRanker(api_key=Secret.from_token("fake-api-key"))
+            result = ranker.run(query="q", documents=docs, top_k=2)
+
+        assert len(result["documents"]) == 2
 
     @pytest.mark.skipif(not os.environ.get("JINA_API_KEY", None), reason="JINA_API_KEY env var not set")
     @pytest.mark.integration

--- a/integrations/jina/tests/test_reader_connector.py
+++ b/integrations/jina/tests/test_reader_connector.py
@@ -116,6 +116,25 @@ class TestJinaReaderConnector:
         assert document.meta["title"] == "Mocked Title"
         assert document.meta["url"] == "https://example.com"
 
+    def test_run_with_raw_response(self, monkeypatch):
+        monkeypatch.setenv("JINA_API_KEY", "test-api-key")
+        mock_response = httpx.Response(
+            200,
+            text="raw page content",
+            headers={"Content-Type": "text/plain"},
+        )
+
+        with patch("httpx.Client.get", return_value=mock_response) as mock_get:
+            reader = JinaReaderConnector(mode="read", json_response=False)
+            result = reader.run(query="https://example.com")
+
+        # no Accept: application/json header when raw response is requested
+        assert "Accept" not in mock_get.call_args[1]["headers"]
+
+        document = result["documents"][0]
+        assert document.content == "raw page content"
+        assert document.meta == {"content_type": "text/plain", "query": "https://example.com"}
+
     @pytest.mark.asyncio
     async def test_run_async_with_mocked_response(self, monkeypatch):
         monkeypatch.setenv("JINA_API_KEY", "test-api-key")

--- a/integrations/jina/tests/test_text_embedder.py
+++ b/integrations/jina/tests/test_text_embedder.py
@@ -58,6 +58,32 @@ class TestJinaTextEmbedder:
             },
         }
 
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("JINA_API_KEY", "fake-api-key")
+        data = {
+            "type": "haystack_integrations.components.embedders.jina.text_embedder.JinaTextEmbedder",
+            "init_parameters": {
+                "api_key": {"env_vars": ["JINA_API_KEY"], "strict": True, "type": "env_var"},
+                "model": "model",
+                "base_url": "https://my.custom.url/v1/embeddings",
+                "prefix": "prefix",
+                "suffix": "suffix",
+                "task": "retrieval.query",
+                "dimensions": 1024,
+                "late_chunking": True,
+            },
+        }
+        embedder = JinaTextEmbedder.from_dict(data)
+
+        assert embedder.api_key == Secret.from_env_var("JINA_API_KEY")
+        assert embedder.model_name == "model"
+        assert embedder.base_url == "https://my.custom.url/v1/embeddings"
+        assert embedder.prefix == "prefix"
+        assert embedder.suffix == "suffix"
+        assert embedder.task == "retrieval.query"
+        assert embedder.dimensions == 1024
+        assert embedder.late_chunking is True
+
     def test_to_dict_with_custom_init_parameters(self, monkeypatch):
         monkeypatch.setenv("JINA_API_KEY", "fake-api-key")
         component = JinaTextEmbedder(


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/275

### Proposed Changes:

- add a few unit tests for jina, focusing on uncovered code paths

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
