### PR TITLE
test: Qdrant - add more unit tests

### DIFF
--- a/integrations/qdrant/tests/test_converters.py
+++ b/integrations/qdrant/tests/test_converters.py
@@ -1,4 +1,7 @@
+from types import SimpleNamespace
+
 import numpy as np
+import pytest
 from haystack.dataclasses import Document, SparseEmbedding
 from qdrant_client.http import models as rest
 
@@ -124,3 +127,18 @@ def test_convert_haystack_documents_to_qdrant_points_with_sparse_no_vectors():
     doc = Document(content="hello")
     points = convert_haystack_documents_to_qdrant_points([doc], use_sparse_embeddings=True)
     assert points[0].vector == {}
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [
+        {DENSE_VECTORS_NAME: [0.1, 0.2]},
+        {DENSE_VECTORS_NAME: [0.1, 0.2], SPARSE_VECTORS_NAME: {"indices": [0], "values": [0.5]}},
+    ],
+    ids=["no_sparse_key", "sparse_value_not_sparse_vector_instance"],
+)
+def test_point_to_document_sparse_vector_edge_cases(vector):
+    point = SimpleNamespace(id="x", payload={"id": "x", "content": "x"}, vector=vector)
+    document = convert_qdrant_point_to_haystack_document(point, use_sparse_embeddings=True)
+    assert document.embedding == [0.1, 0.2]
+    assert document.sparse_embedding is None

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -342,6 +342,34 @@ class TestQdrantDocumentStoreUnit:
         assert batches == [(1, 2), (3, 4), (5,)]
         assert list(get_batches_from_generator([], 2)) == []
 
+    def test_query_by_sparse_raises_when_sparse_disabled(self):
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=False)
+        sparse_embedding = SparseEmbedding(indices=[0, 1], values=[0.1, 0.2])
+        with pytest.raises(QdrantStoreError, match="use_sparse_embeddings=False"):
+            document_store._query_by_sparse(query_sparse_embedding=sparse_embedding)
+
+    @pytest.mark.parametrize(
+        ("method_name", "args", "expected"),
+        [
+            ("count_documents", (), 0),
+            ("count_documents_by_filter", ({},), 0),
+            ("get_metadata_fields_info", (), {}),
+            ("get_metadata_field_min_max", ("score",), {}),
+            ("count_unique_metadata_by_filter", ({}, ["category"]), {"category": 0}),
+            ("get_metadata_field_unique_values", ("category",), []),
+        ],
+    )
+    def test_metadata_methods_swallow_client_errors(self, method_name, args, expected):
+        document_store = QdrantDocumentStore(location=":memory:")
+        document_store._initialize_client()
+        err = ValueError("boom")
+        with (
+            patch.object(document_store._client, "count", side_effect=err),
+            patch.object(document_store._client, "scroll", side_effect=err),
+            patch.object(document_store._client, "get_collection", side_effect=err),
+        ):
+            assert getattr(document_store, method_name)(*args) == expected
+
 
 @pytest.mark.integration
 class TestQdrantDocumentStore(

--- a/integrations/qdrant/tests/test_document_store_async.py
+++ b/integrations/qdrant/tests/test_document_store_async.py
@@ -110,6 +110,43 @@ class TestQdrantDocumentStoreAsyncUnit:
             with pytest.raises(ValueError, match="different similarity"):
                 await document_store._set_up_collection_async("test_collection", 768, False, "cosine", False, False)
 
+    async def test_query_by_sparse_async_raises_when_sparse_disabled(self):
+        document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=False)
+        sparse_embedding = SparseEmbedding(indices=[0, 1], values=[0.1, 0.2])
+        with pytest.raises(QdrantStoreError, match="use_sparse_embeddings=False"):
+            await document_store._query_by_sparse_async(query_sparse_embedding=sparse_embedding)
+
+    async def test_delete_documents_async_invokes_client_and_handles_key_error(self):
+        document_store = QdrantDocumentStore(location=":memory:")
+        await document_store._initialize_async_client()
+        with patch.object(document_store._async_client, "delete") as mock_delete:
+            await document_store.delete_documents_async(["doc-1", "doc-2"])
+            mock_delete.assert_awaited_once()
+        with patch.object(document_store._async_client, "delete", side_effect=KeyError("missing")):
+            await document_store.delete_documents_async(["doc-1"])
+
+    @pytest.mark.parametrize(
+        ("method_name", "args", "expected"),
+        [
+            ("count_documents_async", (), 0),
+            ("count_documents_by_filter_async", ({},), 0),
+            ("get_metadata_fields_info_async", (), {}),
+            ("get_metadata_field_min_max_async", ("score",), {}),
+            ("count_unique_metadata_by_filter_async", ({}, ["category"]), {"category": 0}),
+            ("get_metadata_field_unique_values_async", ("category",), []),
+        ],
+    )
+    async def test_metadata_methods_async_absorb_client_errors(self, method_name, args, expected):
+        document_store = QdrantDocumentStore(location=":memory:")
+        await document_store._initialize_async_client()
+        err = ValueError("boom")
+        with (
+            patch.object(document_store._async_client, "count", side_effect=err),
+            patch.object(document_store._async_client, "scroll", side_effect=err),
+            patch.object(document_store._async_client, "get_collection", side_effect=err),
+        ):
+            assert await getattr(document_store, method_name)(*args) == expected
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio

--- a/integrations/qdrant/tests/test_embedding_retriever.py
+++ b/integrations/qdrant/tests/test_embedding_retriever.py
@@ -126,6 +126,26 @@ class TestQdrantRetriever:
         assert retriever._group_by is None
         assert retriever._group_size is None
 
+    def test_from_dict_no_filter_policy(self):
+        data = {
+            "type": "haystack_integrations.components.retrievers.qdrant.retriever.QdrantEmbeddingRetriever",
+            "init_parameters": {
+                "document_store": {
+                    "init_parameters": {"location": ":memory:", "index": "test"},
+                    "type": "haystack_integrations.document_stores.qdrant.document_store.QdrantDocumentStore",
+                },
+                "filters": None,
+                "top_k": 5,
+                "scale_score": False,
+                "return_embedding": True,
+                "score_threshold": None,
+                "group_by": None,
+                "group_size": None,
+            },
+        }
+        retriever = QdrantEmbeddingRetriever.from_dict(data)
+        assert retriever._filter_policy == FilterPolicy.REPLACE  # defaults to REPLACE
+
     def test_run(self):
         mock_store = Mock(spec=QdrantDocumentStore)
         mock_store._query_by_embedding.return_value = [Document(content="doc", embedding=[0.1, 0.2])]


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/275 (previously added tests did not reach the 90% target)

### Proposed Changes:

- add a few more unit tests for Qdrant, focusing on uncovered code paths

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
