### PR TITLE
test: tavily - add 2 unit tests

### DIFF
--- a/integrations/tavily/tests/test_tavily_websearch.py
+++ b/integrations/tavily/tests/test_tavily_websearch.py
@@ -164,6 +164,19 @@ class TestTavilyWebSearch:
         assert result["documents"] == []
         assert result["links"] == []
 
+    def test_run_raises_runtime_error_when_warm_up_fails_to_initialize_client(self, monkeypatch):
+        ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        monkeypatch.setattr(ws, "warm_up", lambda: None)
+        with pytest.raises(RuntimeError, match="TavilyWebSearch client failed to initialize"):
+            ws.run(query="test")
+
+    @pytest.mark.asyncio
+    async def test_run_async_raises_runtime_error_when_warm_up_fails_to_initialize_client(self, monkeypatch):
+        ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        monkeypatch.setattr(ws, "warm_up", lambda: None)
+        with pytest.raises(RuntimeError, match="TavilyWebSearch async client failed to initialize"):
+            await ws.run_async(query="test")
+
     @pytest.mark.skipif(
         not os.environ.get("TAVILY_API_KEY"),
         reason="Export TAVILY_API_KEY to run integration tests.",


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/275

### Proposed Changes:

- add 2 more unit tests for Tavily, focusing on uncovered code paths

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
