### PR TITLE
tests: Add explicit integration test for structured output

### DIFF
--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -1315,6 +1316,54 @@ class TestAnthropicChatGenerator:
 
         assert message.text
         assert "no" in message.text.lower()
+
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY", None),
+        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_with_json_structured_output(self):
+        """
+        Integration test that the AnthropicChatGenerator component returns valid JSON
+        when output_config.format with a json_schema is passed via generation_kwargs.
+        """
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+                "plan_interest": {"type": "string"},
+                "demo_requested": {"type": "boolean"},
+            },
+            "required": ["name", "email", "plan_interest", "demo_requested"],
+            "additionalProperties": False,
+        }
+
+        component = AnthropicChatGenerator(
+            generation_kwargs={
+                "output_config": {"format": {"type": "json_schema", "schema": schema}},
+            }
+        )
+        results = component.run(
+            messages=[
+                ChatMessage.from_user(
+                    "Extract the key information from this email: "
+                    "John Smith (john@example.com) is interested in our Enterprise plan "
+                    "and wants to schedule a demo for next Tuesday at 2pm."
+                )
+            ]
+        )
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert message.meta["finish_reason"] == "stop"
+
+        parsed = json.loads(message.text)
+        assert parsed["name"] == "John Smith"
+        assert parsed["email"] == "john@example.com"
+        assert "enterprise" in parsed["plan_interest"].lower()
+        assert parsed["demo_requested"] is True
 
     @pytest.mark.integration
     @pytest.mark.skipif(


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

@ju-gu had some issues with structured outputs in our Anthropic integration. It looks to already work as expected which is good but I decided to add an explicit integration test so we can ensure the behavior continues to work in the future. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

@ju-gu could you double check how you specified output_config in your pipeline? 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
