### PR TITLE
refactor(pinecone): make get_metadata_field_min_max more consistent; use async DocumentStore mixin tests

### DIFF
--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.26.1",
+  "haystack-ai>=2.28.0",
   "pinecone[asyncio]>=7.0.0",
 ]
 

--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -869,8 +869,7 @@ class PineconeDocumentStore:
                     values.append(value)
 
         if not values:
-            msg = f"No values found for metadata field '{metadata_field}'"
-            raise ValueError(msg)
+            return {"min": None, "max": None}
 
         result = {"min": min(values), "max": max(values)}
 
@@ -1037,8 +1036,8 @@ class PineconeDocumentStore:
         Subject to Pinecone's TOP_K_LIMIT of 1000 documents.
 
         :param metadata_field: The metadata field name to analyze.
-        :returns: Dictionary with 'min' and 'max' keys.
-        :raises ValueError: If the field doesn't exist or has no values.
+        :returns: Dictionary with 'min' and 'max' keys. Both values are None if the field has no
+            values (empty store, field absent, or unsupported field type).
         """
         documents = self.filter_documents(filters=None)
         return self._get_metadata_field_min_max_impl(documents, metadata_field)
@@ -1056,8 +1055,8 @@ class PineconeDocumentStore:
         Subject to Pinecone's TOP_K_LIMIT of 1000 documents.
 
         :param metadata_field: The metadata field name to analyze.
-        :returns: Dictionary with 'min' and 'max' keys.
-        :raises ValueError: If the field doesn't exist or has no values.
+        :returns: Dictionary with 'min' and 'max' keys. Both values are None if the field has no
+            values (empty store, field absent, or unsupported field type).
         """
         documents = await self.filter_documents_async(filters=None)
         return self._get_metadata_field_min_max_impl(documents, metadata_field)

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -279,15 +279,13 @@ def test_get_metadata_fields_info_impl_type_inference(documents, expected, warni
         assert warning_fragment in caplog.text
 
 
-def test_get_metadata_field_min_max_impl_strips_meta_prefix_and_errors():
+def test_get_metadata_field_min_max_impl_strips_meta_prefix_and_handles_missing():
     docs = [
         Document(content="a", meta={"priority": 1}),
         Document(content="b", meta={"priority": 5}),
     ]
     assert PineconeDocumentStore._get_metadata_field_min_max_impl(docs, "meta.priority") == {"min": 1, "max": 5}
-
-    with pytest.raises(ValueError, match="No values found"):
-        PineconeDocumentStore._get_metadata_field_min_max_impl(docs, "missing")
+    assert PineconeDocumentStore._get_metadata_field_min_max_impl(docs, "missing") == {"min": None, "max": None}
 
 
 def test_get_metadata_field_unique_values_impl_pagination_search_and_lists():
@@ -523,11 +521,6 @@ class TestDocumentStore(
         assert min_max["min"] == "Alpha"
         assert min_max["max"] == "Zebra"
 
-    def test_get_metadata_field_min_max_empty_collection(self, document_store: PineconeDocumentStore):
-        assert document_store.count_documents() == 0
-        with pytest.raises(ValueError, match="No values found"):
-            document_store.get_metadata_field_min_max("priority")
-
     def test_get_metadata_field_min_max_no_values(self, document_store: PineconeDocumentStore):
         docs = [
             Document(content="Doc 1", meta={"tags": ["tag1", "tag2"]}),
@@ -535,13 +528,11 @@ class TestDocumentStore(
         ]
         document_store.write_documents(docs)
 
-        # Try to get min/max for unsupported field type (list)
-        with pytest.raises(ValueError, match="No values found"):
-            document_store.get_metadata_field_min_max("tags")
+        # Unsupported field type (list) — no comparable values collected
+        assert document_store.get_metadata_field_min_max("tags") == {"min": None, "max": None}
 
-        # Try to get min/max for non-existent field
-        with pytest.raises(ValueError, match="No values found"):
-            document_store.get_metadata_field_min_max("nonexistent")
+        # Non-existent field
+        assert document_store.get_metadata_field_min_max("nonexistent") == {"min": None, "max": None}
 
     def test_get_metadata_field_unique_values(self, document_store: PineconeDocumentStore):
         docs = [

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -6,9 +6,24 @@ import os
 
 import numpy as np
 import pytest
+import pytest_asyncio
 from haystack import Document
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.retrievers import SentenceWindowRetriever
+from haystack.testing.document_store_async import (
+    CountDocumentsAsyncTest,
+    CountDocumentsByFilterAsyncTest,
+    CountUniqueMetadataByFilterAsyncTest,
+    DeleteAllAsyncTest,
+    DeleteByFilterAsyncTest,
+    DeleteDocumentsAsyncTest,
+    FilterDocumentsAsyncTest,
+    GetMetadataFieldMinMaxAsyncTest,
+    GetMetadataFieldsInfoAsyncTest,
+    GetMetadataFieldUniqueValuesAsyncTest,
+    UpdateByFilterAsyncTest,
+    WriteDocumentsAsyncTest,
+)
 
 from haystack_integrations.components.retrievers.pinecone import PineconeEmbeddingRetriever
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
@@ -17,71 +32,31 @@ from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 @pytest.mark.integration
 @pytest.mark.asyncio
 @pytest.mark.skipif(not os.environ.get("PINECONE_API_KEY"), reason="PINECONE_API_KEY not set")
-class TestDocumentStoreAsync:
-    async def test_write_documents(self, document_store_async: PineconeDocumentStore):
-        docs = [Document(id="1")]
+class TestDocumentStoreAsync(
+    WriteDocumentsAsyncTest,
+    CountDocumentsAsyncTest,
+    FilterDocumentsAsyncTest,
+    CountDocumentsByFilterAsyncTest,
+    CountUniqueMetadataByFilterAsyncTest,
+    DeleteDocumentsAsyncTest,
+    DeleteAllAsyncTest,
+    DeleteByFilterAsyncTest,
+    UpdateByFilterAsyncTest,
+    GetMetadataFieldsInfoAsyncTest,
+    GetMetadataFieldMinMaxAsyncTest,
+    GetMetadataFieldUniqueValuesAsyncTest,
+):
+    @pytest_asyncio.fixture
+    async def document_store(self, document_store_async: PineconeDocumentStore):
+        return document_store_async
 
-        assert await document_store_async.write_documents_async(docs) == 1
-
-    async def test_write_documents_invalid_input(self, document_store_async: PineconeDocumentStore):
-        """Test write_documents() fails when providing unexpected input."""
-        with pytest.raises(ValueError):
-            await document_store_async.write_documents_async(["not a document for sure"])  # type: ignore
-        with pytest.raises(ValueError):
-            await document_store_async.write_documents_async("not a list actually")  # type: ignore
-
-    async def test_count_documents(self, document_store_async: PineconeDocumentStore):
-        await document_store_async.write_documents_async(
-            [
-                Document(content="test doc 1"),
-                Document(content="test doc 2"),
-                Document(content="test doc 3"),
-            ]
+    @pytest.mark.asyncio
+    async def test_count_not_empty_async(self, document_store: PineconeDocumentStore):
+        # Override: haystack v2.28.0 is missing @staticmethod on this mixin method.
+        await document_store.write_documents_async(
+            [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
         )
-        assert await document_store_async.count_documents_async() == 3
-
-    async def test_filter_documents(self, document_store_async: PineconeDocumentStore):
-        filterable_docs = [
-            Document(
-                content="1",
-                meta={
-                    "number": -10,
-                },
-            ),
-            Document(
-                content="2",
-                meta={
-                    "number": 100,
-                },
-            ),
-        ]
-        await document_store_async.write_documents_async(filterable_docs)
-        result = await document_store_async.filter_documents_async(
-            filters={"field": "meta.number", "operator": "==", "value": 100}
-        )
-
-        assert result == [d for d in filterable_docs if d.meta.get("number") == 100]
-
-    async def test_delete_documents(self, document_store_async: PineconeDocumentStore):
-        doc = Document(content="test doc")
-        await document_store_async.write_documents_async([doc])
-        assert await document_store_async.count_documents_async() == 1
-
-        await document_store_async.delete_documents_async([doc.id])
-        assert await document_store_async.count_documents_async() == 0
-
-    async def test_delete_all_documents_async(self, document_store_async: PineconeDocumentStore):
-        docs = [Document(content="first doc"), Document(content="second doc")]
-        await document_store_async.write_documents_async(docs)
-        assert await document_store_async.count_documents_async() == 2
-
-        await document_store_async.delete_all_documents_async()
-        assert await document_store_async.count_documents_async() == 0
-
-    async def test_delete_all_documents_async_empty_collection(self, document_store_async: PineconeDocumentStore):
-        assert await document_store_async.count_documents_async() == 0
-        await document_store_async.delete_all_documents_async()
-        assert await document_store_async.count_documents_async() == 0
+        assert await document_store.count_documents_async() == 3
 
     async def test_embedding_retrieval(self, document_store_async: PineconeDocumentStore):
         query_embedding = [0.1] * 768
@@ -143,214 +118,3 @@ class TestDocumentStoreAsync:
         result = sentence_window_retriever.run(retrieved_documents=[retrieved_doc["documents"][0]])
 
         assert len(result["context_windows"]) == 1
-
-    async def test_delete_by_filter_async(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A"}),
-            Document(content="Doc 2", meta={"category": "B"}),
-            Document(content="Doc 3", meta={"category": "A"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # delete documents with category="A"
-        deleted_count = await document_store_async.delete_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}
-        )
-        assert deleted_count == 2
-        assert await document_store_async.count_documents_async() == 1
-
-        # only category B remains
-        remaining_docs = await document_store_async.filter_documents_async()
-        assert len(remaining_docs) == 1
-        assert remaining_docs[0].meta["category"] == "B"
-
-    async def test_delete_by_filter_async_no_matches(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A"}),
-            Document(content="Doc 2", meta={"category": "B"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # delete documents with category="C" (no matches)
-        deleted_count = await document_store_async.delete_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "C"}
-        )
-        assert deleted_count == 0
-        assert await document_store_async.count_documents_async() == 2
-
-    async def test_update_by_filter_async(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "draft"}),
-            Document(content="Doc 2", meta={"category": "B", "status": "draft"}),
-            Document(content="Doc 3", meta={"category": "A", "status": "draft"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-        assert await document_store_async.count_documents_async() == 3
-
-        # update status for category="A" documents
-        updated_count = await document_store_async.update_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}, meta={"status": "published"}
-        )
-        assert updated_count == 2
-
-        published_docs = await document_store_async.filter_documents_async(
-            filters={"field": "meta.status", "operator": "==", "value": "published"}
-        )
-        assert len(published_docs) == 2
-        for doc in published_docs:
-            assert doc.meta["category"] == "A"
-            assert doc.meta["status"] == "published"
-
-    async def test_update_by_filter_async_multiple_fields(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "draft", "priority": "low"}),
-            Document(content="Doc 2", meta={"category": "B", "status": "draft", "priority": "low"}),
-            Document(content="Doc 3", meta={"category": "A", "status": "draft", "priority": "low"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # update multiple fields for category="A" documents
-        updated_count = await document_store_async.update_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"},
-            meta={"status": "published", "priority": "high"},
-        )
-        assert updated_count == 2
-
-        # verify the updates
-        published_docs = await document_store_async.filter_documents_async(
-            filters={"field": "meta.status", "operator": "==", "value": "published"}
-        )
-        assert len(published_docs) == 2
-        for doc in published_docs:
-            assert doc.meta["category"] == "A"
-            assert doc.meta["status"] == "published"
-            assert doc.meta["priority"] == "high"
-
-    async def test_update_by_filter_async_no_matches(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A"}),
-            Document(content="Doc 2", meta={"category": "B"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # try to update documents with category="C" (no matches)
-        updated_count = await document_store_async.update_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "C"}, meta={"status": "published"}
-        )
-        assert updated_count == 0
-        assert await document_store_async.count_documents_async() == 2
-
-    async def test_count_documents_by_filter_async(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "draft"}),
-            Document(content="Doc 2", meta={"category": "B", "status": "published"}),
-            Document(content="Doc 3", meta={"category": "A", "status": "published"}),
-            Document(content="Doc 4", meta={"category": "A", "status": "draft"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # Count documents with category="A"
-        count = await document_store_async.count_documents_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}
-        )
-        assert count == 3
-
-        # Count documents with status="published"
-        count = await document_store_async.count_documents_by_filter_async(
-            filters={"field": "meta.status", "operator": "==", "value": "published"}
-        )
-        assert count == 2
-
-    async def test_count_unique_metadata_by_filter_async(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "author": "Alice", "priority": 1}),
-            Document(content="Doc 2", meta={"category": "B", "author": "Bob", "priority": 2}),
-            Document(content="Doc 3", meta={"category": "A", "author": "Alice", "priority": 1}),
-            Document(content="Doc 4", meta={"category": "C", "author": "Charlie", "priority": 3}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # Count unique values without filter
-        counts = await document_store_async.count_unique_metadata_by_filter_async(
-            filters={}, metadata_fields=["category", "author"]
-        )
-        assert counts["category"] == 3  # A, B, C
-        assert counts["author"] == 3  # Alice, Bob, Charlie
-
-    async def test_get_metadata_fields_info_async(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(
-                content="Doc 1",
-                meta={"category": "A", "priority": 1, "is_published": True, "tags": ["tag1", "tag2"]},
-            ),
-            Document(content="Doc 2", meta={"category": "B", "priority": 2, "is_published": False}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        field_info = await document_store_async.get_metadata_fields_info_async()
-
-        # Check content field
-        assert "content" in field_info
-        assert field_info["content"]["type"] == "text"
-
-        # Check metadata fields
-        assert field_info["category"]["type"] == "keyword"
-        assert field_info["priority"]["type"] == "long"
-        assert field_info["is_published"]["type"] == "boolean"
-        assert field_info["tags"]["type"] == "keyword"
-
-    async def test_get_metadata_field_min_max_async(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"priority": 1, "score": 85.5, "active": True, "category": "Zebra"}),
-            Document(content="Doc 2", meta={"priority": 5, "score": 92.3, "active": False, "category": "Alpha"}),
-            Document(content="Doc 3", meta={"priority": 3, "score": 78.9, "active": True, "category": "Beta"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # Get min/max for numeric field (int)
-        min_max = await document_store_async.get_metadata_field_min_max_async("priority")
-        assert min_max["min"] == 1
-        assert min_max["max"] == 5
-
-        # Get min/max for numeric field (float)
-        min_max = await document_store_async.get_metadata_field_min_max_async("score")
-        assert min_max["min"] == 78.9
-        assert min_max["max"] == 92.3
-
-        # Get min/max for boolean field
-        min_max = await document_store_async.get_metadata_field_min_max_async("active")
-        assert min_max["min"] is False
-        assert min_max["max"] is True
-
-        # Get min/max for string field (alphabetical ordering)
-        min_max = await document_store_async.get_metadata_field_min_max_async("category")
-        assert min_max["min"] == "Alpha"
-        assert min_max["max"] == "Zebra"
-
-    async def test_get_metadata_field_unique_values_async(self, document_store_async: PineconeDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "Alpha"}),
-            Document(content="Doc 2", meta={"category": "Beta"}),
-            Document(content="Doc 3", meta={"category": "Gamma"}),
-            Document(content="Doc 4", meta={"category": "Alpha"}),
-            Document(content="Doc 5", meta={"category": "Delta"}),
-        ]
-        await document_store_async.write_documents_async(docs)
-
-        # Get all unique values
-        values, total = await document_store_async.get_metadata_field_unique_values_async("category", size=10)
-        assert total == 4  # Alpha, Beta, Delta, Gamma
-        assert len(values) == 4
-        assert set(values) == {"Alpha", "Beta", "Delta", "Gamma"}
-
-        # Test pagination
-        values, total = await document_store_async.get_metadata_field_unique_values_async("category", from_=0, size=2)
-        assert total == 4
-        assert len(values) == 2  # First 2 values
-
-        # Test search term
-        values, total = await document_store_async.get_metadata_field_unique_values_async(
-            "category", search_term="ta", size=10
-        )
-        assert total == 2  # Beta and Delta contain "ta"
-        assert set(values) == {"Beta", "Delta"}

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -52,9 +53,16 @@ class TestDocumentStoreAsync(
 
     @staticmethod
     def assert_documents_are_equal(received: list[Document], expected: list[Document]):
-        # Pinecone returns documents ordered by similarity to the dummy vector, not by insertion
-        # order. Sort both lists by id before comparing to make the assertion order-independent.
-        assert sorted(received, key=lambda d: d.id) == sorted(expected, key=lambda d: d.id)
+        # Pinecone stores vectors as float32; round-tripped embeddings may differ by a small
+        # floating-point epsilon from the float64 originals. Compare sorted by ID (Pinecone
+        # returns by similarity, not insertion order) and ignore exact embedding values,
+        # verifying only that embedding presence matches.
+        received_sorted = sorted(received, key=lambda d: d.id)
+        expected_sorted = sorted(expected, key=lambda d: d.id)
+        assert len(received_sorted) == len(expected_sorted)
+        for recv, exp in zip(received_sorted, expected_sorted):
+            assert (recv.embedding is not None) == (exp.embedding is not None)
+            assert replace(recv, embedding=None) == replace(exp, embedding=None)
 
     @pytest.mark.asyncio
     async def test_count_not_empty_async(self, document_store: PineconeDocumentStore):

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -55,13 +55,16 @@ class TestDocumentStoreAsync(
     def assert_documents_are_equal(received: list[Document], expected: list[Document]):
         # Pinecone stores vectors as float32; round-tripped embeddings may differ by a small
         # floating-point epsilon from the float64 originals. Compare sorted by ID (Pinecone
-        # returns by similarity, not insertion order) and ignore exact embedding values,
-        # verifying only that embedding presence matches.
+        # returns by similarity, not insertion order), check embeddings with tolerance, and
+        # compare the remaining fields exactly.
         received_sorted = sorted(received, key=lambda d: d.id)
         expected_sorted = sorted(expected, key=lambda d: d.id)
         assert len(received_sorted) == len(expected_sorted)
         for recv, exp in zip(received_sorted, expected_sorted, strict=True):
-            assert (recv.embedding is not None) == (exp.embedding is not None)
+            if recv.embedding is None or exp.embedding is None:
+                assert recv.embedding == exp.embedding
+            else:
+                assert recv.embedding == pytest.approx(exp.embedding, rel=1e-6, abs=1e-6)
             assert replace(recv, embedding=None) == replace(exp, embedding=None)
 
     @pytest.mark.asyncio
@@ -86,13 +89,6 @@ class TestDocumentStoreAsync(
 
     @pytest.mark.skip(reason="Pinecone creates a namespace only when the first document is written")
     async def test_delete_documents_empty_document_store_async(self, document_store: PineconeDocumentStore): ...
-
-    @pytest.mark.asyncio
-    async def test_get_metadata_field_min_max_empty_collection_async(self, document_store: PineconeDocumentStore):
-        # Override: Pinecone raises ValueError on an empty collection rather than returning None.
-        assert await document_store.count_documents_async() == 0
-        with pytest.raises(ValueError, match="No values found"):
-            await document_store.get_metadata_field_min_max_async("priority")
 
     async def test_embedding_retrieval(self, document_store_async: PineconeDocumentStore):
         query_embedding = [0.1] * 768

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -50,6 +50,12 @@ class TestDocumentStoreAsync(
     async def document_store(self, document_store_async: PineconeDocumentStore):
         return document_store_async
 
+    @staticmethod
+    def assert_documents_are_equal(received: list[Document], expected: list[Document]):
+        # Pinecone returns documents ordered by similarity to the dummy vector, not by insertion
+        # order. Sort both lists by id before comparing to make the assertion order-independent.
+        assert sorted(received, key=lambda d: d.id) == sorted(expected, key=lambda d: d.id)
+
     @pytest.mark.asyncio
     async def test_count_not_empty_async(self, document_store: PineconeDocumentStore):
         # Override: haystack v2.28.0 is missing @staticmethod on this mixin method.
@@ -57,6 +63,28 @@ class TestDocumentStoreAsync(
             [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
         )
         assert await document_store.count_documents_async() == 3
+
+    @pytest.mark.asyncio
+    async def test_write_documents_async(self, document_store: PineconeDocumentStore):
+        # Override: Pinecone always upserts; behaviour with DuplicatePolicy.NONE is overwrite.
+        docs = [Document(id="1")]
+        assert await document_store.write_documents_async(docs) == 1
+
+    @pytest.mark.skip(reason="Pinecone only supports UPSERT operations")
+    async def test_write_documents_duplicate_fail_async(self, document_store: PineconeDocumentStore): ...
+
+    @pytest.mark.skip(reason="Pinecone only supports UPSERT operations")
+    async def test_write_documents_duplicate_skip_async(self, document_store: PineconeDocumentStore): ...
+
+    @pytest.mark.skip(reason="Pinecone creates a namespace only when the first document is written")
+    async def test_delete_documents_empty_document_store_async(self, document_store: PineconeDocumentStore): ...
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_field_min_max_empty_collection_async(self, document_store: PineconeDocumentStore):
+        # Override: Pinecone raises ValueError on an empty collection rather than returning None.
+        assert await document_store.count_documents_async() == 0
+        with pytest.raises(ValueError, match="No values found"):
+            await document_store.get_metadata_field_min_max_async("priority")
 
     async def test_embedding_retrieval(self, document_store_async: PineconeDocumentStore):
         query_embedding = [0.1] * 768

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -60,7 +60,7 @@ class TestDocumentStoreAsync(
         received_sorted = sorted(received, key=lambda d: d.id)
         expected_sorted = sorted(expected, key=lambda d: d.id)
         assert len(received_sorted) == len(expected_sorted)
-        for recv, exp in zip(received_sorted, expected_sorted):
+        for recv, exp in zip(received_sorted, expected_sorted, strict=True):
             assert (recv.embedding is not None) == (exp.embedding is not None)
             assert replace(recv, embedding=None) == replace(exp, embedding=None)
 


### PR DESCRIPTION
### Related Issues

- fixes #3051

### Proposed Changes:

Replaces 17 duplicate async test methods in `TestDocumentStoreAsync` with the generic mixin classes from `haystack.testing.document_store_async` (available since haystack-ai 2.28.0).

**Mixins added:**
- `WriteDocumentsAsyncTest`
- `CountDocumentsAsyncTest`
- `FilterDocumentsAsyncTest`
- `CountDocumentsByFilterAsyncTest`
- `CountUniqueMetadataByFilterAsyncTest`
- `DeleteDocumentsAsyncTest`
- `DeleteAllAsyncTest`
- `DeleteByFilterAsyncTest`
- `UpdateByFilterAsyncTest`
- `GetMetadataFieldsInfoAsyncTest`
- `GetMetadataFieldMinMaxAsyncTest`
- `GetMetadataFieldUniqueValuesAsyncTest`

**Preserved (Pinecone-specific):**
- `test_embedding_retrieval` — exercises `_embedding_retrieval_async` with real vectors
- `test_close` — verifies the async index lifecycle (`close_async` / re-initialize)
- `test_sentence_window_retriever` — end-to-end retrieval with `SentenceWindowRetriever`

**Version bump:** `haystack-ai>=2.26.1` → `>=2.28.0` (required for `haystack.testing.document_store_async` module).

**Note:** `test_count_not_empty_async` is overridden to work around a missing `@staticmethod` on the mixin method in haystack v2.28.0 (fixed in haystack main, tracked in deepset-ai/haystack#11174).

### How did you test it?

- Integration tests run against a live Pinecone index via CI (`pytest -v -m integration`)
- Mixin-inherited tests provide equivalent coverage for the removed methods
- Pinecone-specific tests (embedding, close lifecycle, sentence window) still run

### Notes for the reviewer

The class-level `document_store` fixture delegates to the conftest's `document_store_async` fixture (which already wraps `write_documents_async`, `delete_documents_async`, and `delete_all_documents_async` with `asyncio.sleep` for Pinecone's eventual consistency). This keeps the sleep behaviour intact for all mixin tests without duplicating fixture code.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `refactor:`