### PR TITLE
feat: add score_threshold parameter to FastembedRanker

### DIFF
--- a/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
+++ b/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
@@ -48,6 +48,7 @@ class FastembedRanker:
         local_files_only: bool = False,
         meta_fields_to_embed: list[str] | None = None,
         meta_data_separator: str = "\n",
+        score_threshold: float | None = None,
     ) -> None:
         """
         Creates an instance of the 'FastembedRanker'.
@@ -68,6 +69,8 @@ class FastembedRanker:
             with the document content for reranking.
         :param meta_data_separator: Separator used to concatenate the meta fields
             to the Document content.
+        :param score_threshold: If provided, only documents with a score above the threshold are returned.
+            Applied after `top_k`, so the output may contain fewer than `top_k` documents.
         """
         if top_k <= 0:
             msg = f"top_k must be > 0, but got {top_k}"
@@ -82,6 +85,7 @@ class FastembedRanker:
         self.local_files_only = local_files_only
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.meta_data_separator = meta_data_separator
+        self.score_threshold = score_threshold
         self._model: TextCrossEncoder | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -102,6 +106,7 @@ class FastembedRanker:
             local_files_only=self.local_files_only,
             meta_fields_to_embed=self.meta_fields_to_embed,
             meta_data_separator=self.meta_data_separator,
+            score_threshold=self.score_threshold,
         )
 
     @classmethod
@@ -200,5 +205,9 @@ class FastembedRanker:
         sorted_doc_scores = sorted(doc_scores, key=lambda x: x[1], reverse=True)
 
         top_k_documents = [replace(doc, score=score) for doc, score in sorted_doc_scores[:top_k]]
+
+        score_threshold = self.score_threshold
+        if score_threshold is not None:
+            top_k_documents = [doc for doc in top_k_documents if doc.score is not None and doc.score >= score_threshold]
 
         return {"documents": top_k_documents}

--- a/integrations/fastembed/tests/test_fastembed_ranker.py
+++ b/integrations/fastembed/tests/test_fastembed_ranker.py
@@ -28,6 +28,7 @@ class TestFastembedRanker:
         assert not ranker.local_files_only
         assert ranker.meta_fields_to_embed == []
         assert ranker.meta_data_separator == "\n"
+        assert ranker.score_threshold is None
 
     def test_init_with_parameters(self):
         """
@@ -43,6 +44,7 @@ class TestFastembedRanker:
             local_files_only=True,
             meta_fields_to_embed=["test_field"],
             meta_data_separator=" | ",
+            score_threshold=0.5,
         )
         assert ranker.model_name == "BAAI/bge-reranker-base"
         assert ranker.top_k == 64
@@ -53,6 +55,7 @@ class TestFastembedRanker:
         assert ranker.local_files_only
         assert ranker.meta_fields_to_embed == ["test_field"]
         assert ranker.meta_data_separator == " | "
+        assert ranker.score_threshold == 0.5
 
     def test_init_with_incorrect_input(self):
         """
@@ -88,6 +91,7 @@ class TestFastembedRanker:
                 "local_files_only": False,
                 "meta_fields_to_embed": [],
                 "meta_data_separator": "\n",
+                "score_threshold": None,
             },
         }
 
@@ -105,6 +109,7 @@ class TestFastembedRanker:
             local_files_only=True,
             meta_fields_to_embed=["test_field"],
             meta_data_separator=" | ",
+            score_threshold=0.5,
         )
         ranker_dict = ranker.to_dict()
         assert ranker_dict == {
@@ -119,6 +124,7 @@ class TestFastembedRanker:
                 "local_files_only": True,
                 "meta_fields_to_embed": ["test_field"],
                 "meta_data_separator": " | ",
+                "score_threshold": 0.5,
             },
         }
 
@@ -138,6 +144,7 @@ class TestFastembedRanker:
                 "local_files_only": False,
                 "meta_fields_to_embed": [],
                 "meta_data_separator": "\n",
+                "score_threshold": None,
             },
         }
         ranker = default_from_dict(FastembedRanker, ranker_dict)
@@ -150,6 +157,7 @@ class TestFastembedRanker:
         assert not ranker.local_files_only
         assert ranker.meta_fields_to_embed == []
         assert ranker.meta_data_separator == "\n"
+        assert ranker.score_threshold is None
 
     def test_from_dict_with_custom_init_parameters(self):
         """
@@ -167,6 +175,7 @@ class TestFastembedRanker:
                 "local_files_only": True,
                 "meta_fields_to_embed": ["test_field"],
                 "meta_data_separator": " | ",
+                "score_threshold": 0.5,
             },
         }
         ranker = default_from_dict(FastembedRanker, ranker_dict)
@@ -179,6 +188,7 @@ class TestFastembedRanker:
         assert ranker.local_files_only
         assert ranker.meta_fields_to_embed == ["test_field"]
         assert ranker.meta_data_separator == " | "
+        assert ranker.score_threshold == 0.5
 
     def test_run_incorrect_input_format(self):
         """
@@ -256,6 +266,20 @@ class TestFastembedRanker:
             batch_size=64,
             parallel=None,
         )
+
+    def test_run_with_score_threshold(self):
+        """
+        Tests that documents below score_threshold are filtered out.
+        """
+        ranker = FastembedRanker(model_name="model_name", score_threshold=0.5)
+        ranker._model = MagicMock()
+        ranker._model.rerank.return_value = [0.9, 0.3, 0.7]
+
+        documents = [Document(content=f"doc {i}") for i in range(3)]
+        result = ranker.run(query="test", documents=documents)
+
+        assert len(result["documents"]) == 2
+        assert all(doc.score >= 0.5 for doc in result["documents"])
 
     def test_run_calls_warm_up(self):
         """


### PR DESCRIPTION
Adds score_threshold init parameter to FastembedRanker. When set, documents with score below the threshold are filtered out after ranking.

This parameter is useful in RAG pipelines to filter out low-relevance documents before passing them to the LLM.

### Related Issues

- closes #3232

### Proposed Changes:

  - Add `score_threshold: float | None = None` init parameter to `FastembedRanker`
  - When set, documents with `score < score_threshold` are filtered out after ranking
  - `None` (default) preserves current behavior
  - Include the new parameter in `to_dict()` / `from_dict()`

### How did you test it?

  - Added `test_run_with_score_threshold` (mocked model) to verify filtering works
  - Updated existing init and serialization tests to cover the new parameter
  - Existing integration test still passes with the real model
  - All unit tests, lint, and format checks pass locally

### Notes for the reviewer

N/A

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
