### PR TITLE
feat: Add anthropic foundry support

### DIFF
--- a/integrations/anthropic/pydoc/config_docusaurus.yml
+++ b/integrations/anthropic/pydoc/config_docusaurus.yml
@@ -3,6 +3,7 @@ loaders:
       - haystack_integrations.components.generators.anthropic.generator
       - haystack_integrations.components.generators.anthropic.chat.chat_generator
       - haystack_integrations.components.generators.anthropic.chat.vertex_chat_generator
+      - haystack_integrations.components.generators.anthropic.chat.foundry_chat_generator
     search_path: [../src]
 processors:
   - type: filter

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "anthropic>=0.47.0"]
+dependencies = ["haystack-ai>=2.24.1", "anthropic>=0.74.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/anthropic#readme"

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/__init__.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/__init__.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from .chat.chat_generator import AnthropicChatGenerator
+from .chat.foundry_chat_generator import AnthropicFoundryChatGenerator
 from .chat.vertex_chat_generator import AnthropicVertexChatGenerator
 from .generator import AnthropicGenerator
 
-__all__ = ["AnthropicChatGenerator", "AnthropicGenerator", "AnthropicVertexChatGenerator"]
+__all__ = ["AnthropicChatGenerator", "AnthropicFoundryChatGenerator", "AnthropicGenerator", "AnthropicVertexChatGenerator"]

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/__init__.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/__init__.py
@@ -6,4 +6,9 @@ from .chat.foundry_chat_generator import AnthropicFoundryChatGenerator
 from .chat.vertex_chat_generator import AnthropicVertexChatGenerator
 from .generator import AnthropicGenerator
 
-__all__ = ["AnthropicChatGenerator", "AnthropicFoundryChatGenerator", "AnthropicGenerator", "AnthropicVertexChatGenerator"]
+__all__ = [
+    "AnthropicChatGenerator",
+    "AnthropicFoundryChatGenerator",
+    "AnthropicGenerator",
+    "AnthropicVertexChatGenerator",
+]

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -229,9 +229,8 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         """
         if not self._is_warmed_up:
             self.warm_up()
-        return super(AnthropicFoundryChatGenerator, self).run(
-            messages=messages, streaming_callback=streaming_callback,
-            generation_kwargs=generation_kwargs, tools=tools
+        return super().run(
+            messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
         )
 
     @component.output_types(replies=list[ChatMessage])
@@ -256,9 +255,8 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         """
         if not self._is_warmed_up:
             self.warm_up()
-        return await super(AnthropicFoundryChatGenerator, self).run_async(
-            messages=messages, streaming_callback=streaming_callback,
-            generation_kwargs=generation_kwargs, tools=tools
+        return await super().run_async(
+            messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -229,7 +229,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         """
         if not self._is_warmed_up:
             self.warm_up()
-        return super(AnthropicFoundryChatGenerator, self).run(
+        return super(AnthropicFoundryChatGenerator, self).run(  # noqa: UP008
             messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
         )
 
@@ -255,7 +255,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         """
         if not self._is_warmed_up:
             self.warm_up()
-        return await super(AnthropicFoundryChatGenerator, self).run_async(
+        return await super(AnthropicFoundryChatGenerator, self).run_async(  # noqa: UP008
             messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
         )
 

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -152,7 +152,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
 
         _check_duplicate_tool_names(flatten_tools_or_toolsets(tools))
 
-        self.api_key = api_key
+        self.api_key: Secret | None = api_key  # type: ignore[assignment]
         self.resource = resource or os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE")
         self.endpoint = endpoint
         self.model = model
@@ -229,7 +229,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         """
         if not self._is_warmed_up:
             self.warm_up()
-        return super().run(
+        return super(AnthropicFoundryChatGenerator, self).run(
             messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
         )
 
@@ -255,7 +255,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         """
         if not self._is_warmed_up:
             self.warm_up()
-        return await super().run_async(
+        return await super(AnthropicFoundryChatGenerator, self).run_async(
             messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
         )
 

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -91,7 +91,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
     def __init__(
         self,
         *,
-        api_key: Secret | None = Secret.from_env_var("ANTHROPIC_FOUNDRY_API_KEY", strict=False),  # noqa: B008
+        api_key: Secret | None = Secret.from_env_var("ANTHROPIC_FOUNDRY_API_KEY", strict=True),  # noqa: B008
         resource: str | None = None,
         endpoint: str | None = None,
         model: str = "claude-sonnet-4-5",

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.dataclasses import ChatMessage, StreamingChunk
+from haystack.dataclasses.streaming_chunk import StreamingCallbackT
+from haystack.tools import (
+    ToolsType,
+    _check_duplicate_tool_names,
+    deserialize_tools_or_toolset_inplace,
+    flatten_tools_or_toolsets,
+    serialize_tools_or_toolset,
+)
+from haystack.utils import (
+    Secret,
+    deserialize_callable,
+    deserialize_secrets_inplace,
+    serialize_callable,
+)
+
+from anthropic import AnthropicFoundry, AsyncAnthropicFoundry
+
+from .chat_generator import AnthropicChatGenerator
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
+    """
+    Enables text generation using Anthropic's Claude models via Azure Foundry.
+
+    A variety of Claude models (Opus, Sonnet, Haiku, and others) are available through Azure Foundry.
+
+    To use AnthropicFoundryChatGenerator, you must have an Azure subscription with Foundry enabled
+    and the desired Anthropic model deployed in your Foundry resource.
+
+    For more details, refer to the [Anthropic Foundry documentation](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/foundry.md).
+
+    Any valid text generation parameters for the Anthropic messaging API can be passed to
+    the AnthropicFoundry API. Users can provide these parameters directly to the component via
+    the `generation_kwargs` parameter in `__init__` or the `run` method.
+
+    For more details on the parameters supported by the Anthropic API, refer to the
+    Anthropic Message API [documentation](https://docs.anthropic.com/en/api/messages).
+
+    ```python
+    from haystack_integrations.components.generators.anthropic import AnthropicFoundryChatGenerator
+    from haystack.dataclasses import ChatMessage
+    from haystack.utils import Secret
+
+    messages = [ChatMessage.from_user("What's Natural Language Processing?")]
+
+    client = AnthropicFoundryChatGenerator(
+        model="claude-sonnet-4-5",
+        api_key=Secret.from_env_var("ANTHROPIC_FOUNDRY_API_KEY"),
+        resource="my-resource",
+    )
+
+    response = client.run(messages)
+    print(response)
+    >> {'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text=
+    >> "Natural Language Processing (NLP) is a field of artificial intelligence that
+    >> focuses on enabling computers to understand, interpret, and generate human language. It involves developing
+    >> techniques and algorithms to analyze and process text or speech data, allowing machines to comprehend and
+    >> communicate in natural languages like English, Spanish, or Chinese.")],
+    >> _name=None, _meta={'model': 'claude-sonnet-4-5', 'index': 0, 'finish_reason': 'end_turn',
+    >> 'usage': {'input_tokens': 15, 'output_tokens': 64}})]}
+    ```
+
+    For more details on supported models and their capabilities, refer to the Anthropic
+    [documentation](https://docs.anthropic.com/claude/docs/intro-to-claude).
+    """
+
+    SUPPORTED_MODELS: ClassVar[list[str]] = [
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-opus-4-5",
+        "claude-opus-4-1",
+        "claude-haiku-4-5",
+    ]
+    """A non-exhaustive list of chat models supported by this component.
+    The actual availability depends on your Azure Foundry resource configuration."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Secret | None = Secret.from_env_var("ANTHROPIC_FOUNDRY_API_KEY", strict=False),  # noqa: B008
+        resource: str | None = None,
+        endpoint: str | None = None,
+        model: str = "claude-sonnet-4-5",
+        streaming_callback: Callable[[StreamingChunk], None] | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        ignore_tools_thinking_messages: bool = True,
+        tools: ToolsType | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        azure_ad_token_provider: Callable[[], str] | None = None,
+    ) -> None:
+        """
+        Creates an instance of AnthropicFoundryChatGenerator.
+
+        :param api_key: The API key to use for authentication.
+            Defaults to the `ANTHROPIC_FOUNDRY_API_KEY` environment variable.
+            Can be `None` when using `azure_ad_token_provider` instead.
+        :param resource: The Foundry resource name. Can also be set via the `ANTHROPIC_FOUNDRY_RESOURCE`
+            environment variable. Either `resource` or `endpoint` must be provided.
+        :param endpoint: The full Foundry endpoint URL (e.g.,
+            "https://your-resource.openai.azure.com/anthropic").
+            Either `resource` or `endpoint` must be provided.
+        :param model: The name of the model to use (deployment name in Foundry).
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+            The callback function accepts StreamingChunk as an argument.
+        :param generation_kwargs: Other parameters to use for the model. These parameters are all sent directly to
+            the AnthropicFoundry endpoint. See Anthropic [documentation](https://docs.anthropic.com/claude/reference/messages_post)
+            for more details.
+            Supported generation_kwargs parameters are:
+            - `system`: The system message to be passed to the model.
+            - `max_tokens`: The maximum number of tokens to generate.
+            - `metadata`: A dictionary of metadata to be passed to the model.
+            - `stop_sequences`: A list of strings that the model should stop generating at.
+            - `temperature`: The temperature to use for sampling.
+            - `top_p`: The top_p value to use for nucleus sampling.
+            - `top_k`: The top_k value to use for top-k sampling.
+            - `extra_headers`: A dictionary of extra headers to be passed to the model (i.e. for beta features).
+        :param ignore_tools_thinking_messages: Anthropic's approach to tools (function calling) resolution involves a
+            "chain of thought" messages before returning the actual function names and parameters in a message. If
+            `ignore_tools_thinking_messages` is `True`, the generator will drop so-called thinking messages when tool
+            use is detected. See the Anthropic [tools](https://docs.anthropic.com/en/docs/tool-use#chain-of-thought-tool-use)
+            for more details.
+        :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
+            Each tool should have a unique name.
+        :param timeout:
+            Timeout for Anthropic client calls. If not set, it defaults to the default set by the Anthropic client.
+        :param max_retries:
+            Maximum number of retries to attempt for failed requests. If not set, it defaults to the default set by
+            the Anthropic client.
+        :param azure_ad_token_provider: A function that returns an Azure AD token for authentication.
+            Can be used instead of `api_key` for enhanced security.
+            See [Azure Identity documentation](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/overview)
+            for more details.
+        """
+        if api_key is None and azure_ad_token_provider is None:
+            msg = "Please provide an API key or an azure_ad_token_provider."
+            raise ValueError(msg)
+
+        _check_duplicate_tool_names(flatten_tools_or_toolsets(tools))
+
+        self.api_key = api_key
+        self.resource = resource or os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE")
+        self.endpoint = endpoint
+        self.model = model
+        self.generation_kwargs = generation_kwargs or {}
+        self.streaming_callback = streaming_callback
+        self.ignore_tools_thinking_messages = ignore_tools_thinking_messages
+        self.tools = tools
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.azure_ad_token_provider = azure_ad_token_provider
+
+        if not self.resource and not self.endpoint:
+            msg = (
+                "Either 'resource' or 'endpoint' must be provided. "
+                "Set ANTHROPIC_FOUNDRY_RESOURCE environment variable or pass resource/endpoint parameter."
+            )
+            raise ValueError(msg)
+
+        # Clients are created lazily in warm_up()
+        self.client = None  # type: ignore[assignment]
+        self.async_client = None  # type: ignore[assignment]
+        self._is_warmed_up = False
+
+    def warm_up(self) -> None:
+        """
+        Create the AnthropicFoundry clients.
+
+        This method is idempotent — it only creates clients once.
+        """
+        if self._is_warmed_up:
+            return
+
+        client_kwargs: dict[str, Any] = {}
+
+        if self.azure_ad_token_provider:
+            client_kwargs["azure_ad_token_provider"] = self.azure_ad_token_provider
+        else:
+            client_kwargs["api_key"] = self.api_key.resolve_value()  # type: ignore[union-attr]
+
+        if self.endpoint:
+            client_kwargs["base_url"] = self.endpoint
+        else:
+            client_kwargs["resource"] = self.resource
+
+        if self.timeout is not None:
+            client_kwargs["timeout"] = self.timeout
+
+        if self.max_retries is not None:
+            client_kwargs["max_retries"] = self.max_retries
+
+        self.client = AnthropicFoundry(**client_kwargs)  # type: ignore[assignment]
+        self.async_client = AsyncAnthropicFoundry(**client_kwargs)  # type: ignore[assignment]
+        self._is_warmed_up = True
+
+    @component.output_types(replies=list[ChatMessage])
+    def run(
+        self,
+        messages: list[ChatMessage],
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
+    ) -> dict[str, list[ChatMessage]]:
+        """
+        Invokes the AnthropicFoundry API with the given messages and generation kwargs.
+
+        :param messages: A list of ChatMessage instances representing the input messages.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
+            Each tool should have a unique name. If set, it will override the `tools` parameter set during component
+            initialization.
+        :returns: A dictionary with the following keys:
+            - `replies`: The responses from the model
+        """
+        if not self._is_warmed_up:
+            self.warm_up()
+        return super(AnthropicFoundryChatGenerator, self).run(
+            messages=messages, streaming_callback=streaming_callback,
+            generation_kwargs=generation_kwargs, tools=tools
+        )
+
+    @component.output_types(replies=list[ChatMessage])
+    async def run_async(
+        self,
+        messages: list[ChatMessage],
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
+    ) -> dict[str, list[ChatMessage]]:
+        """
+        Async version of the run method. Invokes the AnthropicFoundry API with the given messages and generation kwargs.
+
+        :param messages: A list of ChatMessage instances representing the input messages.
+        :param streaming_callback: A callback function that is called when a new token is received from the stream.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
+            Each tool should have a unique name. If set, it will override the `tools` parameter set during component
+            initialization.
+        :returns: A dictionary with the following keys:
+            - `replies`: The responses from the model
+        """
+        if not self._is_warmed_up:
+            self.warm_up()
+        return await super(AnthropicFoundryChatGenerator, self).run_async(
+            messages=messages, streaming_callback=streaming_callback,
+            generation_kwargs=generation_kwargs, tools=tools
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+
+        :returns:
+            The serialized component as a dictionary.
+        """
+        callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
+        azure_ad_token_provider_name = (
+            serialize_callable(self.azure_ad_token_provider) if self.azure_ad_token_provider else None
+        )
+        return default_to_dict(
+            self,
+            api_key=self.api_key.to_dict() if self.api_key else None,
+            resource=self.resource,
+            endpoint=self.endpoint,
+            model=self.model,
+            streaming_callback=callback_name,
+            generation_kwargs=self.generation_kwargs,
+            ignore_tools_thinking_messages=self.ignore_tools_thinking_messages,
+            tools=serialize_tools_or_toolset(self.tools),
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+            azure_ad_token_provider=azure_ad_token_provider_name,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AnthropicFoundryChatGenerator":
+        """
+        Deserialize this component from a dictionary.
+
+        :param data: The dictionary representation of this component.
+        :returns:
+            The deserialized component instance.
+        """
+        deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+
+        init_params = data.get("init_parameters", {})
+        if serialized_callback := init_params.get("streaming_callback"):
+            data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback)
+        if serialized_token_provider := init_params.get("azure_ad_token_provider"):
+            data["init_parameters"]["azure_ad_token_provider"] = deserialize_callable(serialized_token_provider)
+
+        return default_from_dict(cls, data)

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -1,0 +1,334 @@
+import inspect
+import os
+from unittest.mock import AsyncMock, patch
+
+import anthropic
+import pytest
+from anthropic.types import Message
+from haystack.components.generators.utils import print_streaming_chunk
+from haystack.dataclasses import ChatMessage, ChatRole
+
+from haystack_integrations.components.generators.anthropic import AnthropicFoundryChatGenerator
+
+
+@pytest.fixture
+def chat_messages():
+    return [
+        ChatMessage.from_system("\nYou are a helpful assistant, be super brief in your responses."),
+        ChatMessage.from_user("What's the capital of France?"),
+    ]
+
+
+class TestAnthropicFoundryChatGenerator:
+    def test_supported_models(self):
+        assert isinstance(AnthropicFoundryChatGenerator.SUPPORTED_MODELS, list)
+        assert len(AnthropicFoundryChatGenerator.SUPPORTED_MODELS) > 0
+        assert all(isinstance(m, str) for m in AnthropicFoundryChatGenerator.SUPPORTED_MODELS)
+        # No old claude-3 models
+        assert not any("claude-3" in m for m in AnthropicFoundryChatGenerator.SUPPORTED_MODELS)
+
+    def test_init_with_api_key_and_resource(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(resource="my-resource")
+        assert component.resource == "my-resource"
+        assert component.endpoint is None
+        assert component.model == "claude-sonnet-4-5"
+        assert component.streaming_callback is None
+        assert not component.generation_kwargs
+        assert component.ignore_tools_thinking_messages
+        assert component.timeout is None
+        assert component.max_retries is None
+        assert component.azure_ad_token_provider is None
+        # Clients are not created until warm_up
+        assert component.client is None
+        assert component.async_client is None
+
+    def test_init_with_endpoint(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(endpoint="https://my-resource.openai.azure.com/anthropic")
+        assert component.resource is None
+        assert component.endpoint == "https://my-resource.openai.azure.com/anthropic"
+
+    def test_init_resource_from_env(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_RESOURCE", "env-resource")
+        component = AnthropicFoundryChatGenerator()
+        assert component.resource == "env-resource"
+
+    def test_init_with_azure_ad_token_provider_no_api_key(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_API_KEY", raising=False)
+        token_provider = lambda: "my-token"  # noqa: E731
+        component = AnthropicFoundryChatGenerator(
+            resource="my-resource",
+            azure_ad_token_provider=token_provider,
+        )
+        assert component.azure_ad_token_provider is token_provider
+        assert component.api_key is None or component.api_key.resolve_value() is None
+
+    def test_init_no_auth_raises(self):
+        with pytest.raises(ValueError, match="Please provide an API key or an azure_ad_token_provider"):
+            AnthropicFoundryChatGenerator(api_key=None, resource="my-resource")
+
+    def test_init_missing_resource_and_endpoint_raises(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_RESOURCE", raising=False)
+        with pytest.raises(ValueError, match="Either 'resource' or 'endpoint' must be provided"):
+            AnthropicFoundryChatGenerator()
+
+    def test_init_all_params_are_keyword_only(self):
+        import inspect
+        sig = inspect.signature(AnthropicFoundryChatGenerator.__init__)
+        for name, param in sig.parameters.items():
+            if name == "self":
+                continue
+            assert param.kind == inspect.Parameter.KEYWORD_ONLY, f"Parameter '{name}' should be keyword-only"
+
+    def test_init_with_all_parameters(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(
+            resource="my-resource",
+            model="claude-opus-4-6",
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={"max_tokens": 10, "temperature": 0.5},
+            ignore_tools_thinking_messages=False,
+            timeout=30.0,
+            max_retries=3,
+        )
+        assert component.resource == "my-resource"
+        assert component.model == "claude-opus-4-6"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.generation_kwargs == {"max_tokens": 10, "temperature": 0.5}
+        assert component.ignore_tools_thinking_messages is False
+        assert component.timeout == 30.0
+        assert component.max_retries == 3
+
+    def test_warm_up_creates_clients(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(resource="my-resource")
+        assert component.client is None
+        assert component.async_client is None
+        component.warm_up()
+        assert component.client is not None
+        assert component.async_client is not None
+
+    def test_warm_up_is_idempotent(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(resource="my-resource")
+        component.warm_up()
+        client_before = component.client
+        component.warm_up()
+        assert component.client is client_before
+
+    def test_to_dict_default(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(resource="my-resource")
+        data = component.to_dict()
+        assert data == {
+            "type": (
+                "haystack_integrations.components.generators."
+                "anthropic.chat.foundry_chat_generator.AnthropicFoundryChatGenerator"
+            ),
+            "init_parameters": {
+                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": False, "type": "env_var"},
+                "resource": "my-resource",
+                "endpoint": None,
+                "model": "claude-sonnet-4-5",
+                "streaming_callback": None,
+                "generation_kwargs": {},
+                "ignore_tools_thinking_messages": True,
+                "tools": None,
+                "timeout": None,
+                "max_retries": None,
+                "azure_ad_token_provider": None,
+            },
+        }
+
+    def test_to_dict_with_parameters(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(
+            resource="my-resource",
+            model="claude-opus-4-6",
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+            ignore_tools_thinking_messages=False,
+            timeout=10.0,
+            max_retries=1,
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": (
+                "haystack_integrations.components.generators."
+                "anthropic.chat.foundry_chat_generator.AnthropicFoundryChatGenerator"
+            ),
+            "init_parameters": {
+                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": False, "type": "env_var"},
+                "resource": "my-resource",
+                "endpoint": None,
+                "model": "claude-opus-4-6",
+                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+                "ignore_tools_thinking_messages": False,
+                "tools": None,
+                "timeout": 10.0,
+                "max_retries": 1,
+                "azure_ad_token_provider": None,
+            },
+        }
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        data = {
+            "type": (
+                "haystack_integrations.components.generators."
+                "anthropic.chat.foundry_chat_generator.AnthropicFoundryChatGenerator"
+            ),
+            "init_parameters": {
+                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": False, "type": "env_var"},
+                "resource": "my-resource",
+                "endpoint": None,
+                "model": "claude-sonnet-4-5",
+                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
+                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+                "ignore_tools_thinking_messages": True,
+                "tools": None,
+                "timeout": None,
+                "max_retries": None,
+                "azure_ad_token_provider": None,
+            },
+        }
+        component = AnthropicFoundryChatGenerator.from_dict(data)
+        assert component.model == "claude-sonnet-4-5"
+        assert component.resource == "my-resource"
+        assert component.endpoint is None
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.ignore_tools_thinking_messages is True
+        assert component.timeout is None
+        assert component.max_retries is None
+        assert component.azure_ad_token_provider is None
+
+    def test_to_dict_from_dict_roundtrip(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        original = AnthropicFoundryChatGenerator(
+            resource="my-resource",
+            model="claude-sonnet-4-6",
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={"max_tokens": 500},
+            timeout=15.0,
+            max_retries=2,
+        )
+        restored = AnthropicFoundryChatGenerator.from_dict(original.to_dict())
+        assert restored.model == original.model
+        assert restored.resource == original.resource
+        assert restored.streaming_callback is original.streaming_callback
+        assert restored.generation_kwargs == original.generation_kwargs
+        assert restored.timeout == original.timeout
+        assert restored.max_retries == original.max_retries
+
+    def test_run_triggers_warm_up(self, chat_messages, mock_chat_completion, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(resource="my-resource")
+        assert not component._is_warmed_up
+        response = component.run(chat_messages)
+        assert component._is_warmed_up
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert all(isinstance(reply, ChatMessage) for reply in response["replies"])
+
+    def test_run_with_params(self, chat_messages, mock_chat_completion, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(
+            resource="my-resource",
+            generation_kwargs={"max_tokens": 10, "temperature": 0.5},
+        )
+        response = component.run(chat_messages)
+
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.5
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert all(isinstance(reply, ChatMessage) for reply in response["replies"])
+
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_FOUNDRY_API_KEY") or not os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
+        reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_wrong_model(self, chat_messages):
+        component = AnthropicFoundryChatGenerator(
+            model="something-obviously-wrong",
+            resource=os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
+        )
+        with pytest.raises(anthropic.NotFoundError):
+            component.run(chat_messages)
+
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_FOUNDRY_API_KEY") or not os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
+        reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
+    )
+    @pytest.mark.integration
+    def test_default_inference_params(self, chat_messages):
+        client = AnthropicFoundryChatGenerator(
+            resource=os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
+            model="claude-sonnet-4-5",
+        )
+        response = client.run(chat_messages)
+
+        assert "replies" in response
+        replies = response["replies"]
+        assert isinstance(replies, list)
+        assert len(replies) > 0
+
+        first_reply = replies[0]
+        assert isinstance(first_reply, ChatMessage)
+        assert first_reply.text
+        assert ChatMessage.is_from(first_reply, ChatRole.ASSISTANT)
+        assert "paris" in first_reply.text.lower()
+        assert first_reply.meta
+
+    # Anthropic messages API is similar for AnthropicFoundry and Anthropic endpoint;
+    # remaining tests are skipped as they are already tested in AnthropicChatGenerator.
+
+
+class TestAnthropicFoundryChatGeneratorAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_triggers_warm_up(self, mock_chat_completion, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(resource="my-resource")
+        assert not component._is_warmed_up
+        completion = Message(
+            id="foo",
+            content=[{"type": "text", "text": "Hello!"}],
+            model="claude-sonnet-4-5",
+            role="assistant",
+            type="message",
+            usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        with patch("anthropic.resources.messages.AsyncMessages.create", new_callable=AsyncMock, return_value=completion):
+            response = await component.run_async([ChatMessage.from_user("hi")])
+        assert component._is_warmed_up
+        assert "replies" in response
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_FOUNDRY_API_KEY") or not os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
+        reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_live_run_async(self):
+        component = AnthropicFoundryChatGenerator(
+            resource=os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
+            model="claude-sonnet-4-5",
+        )
+        results = await component.run_async(messages=[ChatMessage.from_user("What's the capital of France?")])
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert message.meta["finish_reason"] == "end_turn"
+
+    # Anthropic messages API is similar for AnthropicFoundry and Anthropic endpoint;
+    # remaining tests are skipped as they are already tested in AnthropicChatGenerator.

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 from unittest.mock import AsyncMock, patch
 

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -75,33 +75,7 @@ class TestAnthropicFoundryChatGenerator:
         with pytest.raises(ValueError, match="Either 'resource' or 'endpoint' must be provided"):
             AnthropicFoundryChatGenerator()
 
-    def test_init_all_params_are_keyword_only(self):
-        sig = inspect.signature(AnthropicFoundryChatGenerator.__init__)
-        for name, param in sig.parameters.items():
-            if name == "self":
-                continue
-            assert param.kind == inspect.Parameter.KEYWORD_ONLY, f"Parameter '{name}' should be keyword-only"
-
-    def test_init_with_all_parameters(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
-        component = AnthropicFoundryChatGenerator(
-            resource="my-resource",
-            model="claude-opus-4-6",
-            streaming_callback=print_streaming_chunk,
-            generation_kwargs={"max_tokens": 10, "temperature": 0.5},
-            ignore_tools_thinking_messages=False,
-            timeout=30.0,
-            max_retries=3,
-        )
-        assert component.resource == "my-resource"
-        assert component.model == "claude-opus-4-6"
-        assert component.streaming_callback is print_streaming_chunk
-        assert component.generation_kwargs == {"max_tokens": 10, "temperature": 0.5}
-        assert component.ignore_tools_thinking_messages is False
-        assert component.timeout == 30.0
-        assert component.max_retries == 3
-
-    def test_warm_up_creates_clients(self, monkeypatch):
+    def test_warm_up(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
         component = AnthropicFoundryChatGenerator(resource="my-resource")
         assert component.client is None
@@ -109,14 +83,6 @@ class TestAnthropicFoundryChatGenerator:
         component.warm_up()
         assert component.client is not None
         assert component.async_client is not None
-
-    def test_warm_up_is_idempotent(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
-        component = AnthropicFoundryChatGenerator(resource="my-resource")
-        component.warm_up()
-        client_before = component.client
-        component.warm_up()
-        assert component.client is client_before
 
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
@@ -270,10 +236,9 @@ class TestAnthropicFoundryChatGenerator:
         reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
     )
     @pytest.mark.integration
-    def test_default_inference_params(self, chat_messages):
+    def test_live_run(self, chat_messages):
         client = AnthropicFoundryChatGenerator(
-            resource=os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
-            model="claude-sonnet-4-5",
+            resource=os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"), model="claude-sonnet-4-5"
         )
         response = client.run(chat_messages)
 

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -62,7 +62,6 @@ class TestAnthropicFoundryChatGenerator:
             azure_ad_token_provider=token_provider,
         )
         assert component.azure_ad_token_provider is token_provider
-        assert component.api_key is None or component.api_key.resolve_value() is None
 
     def test_init_no_auth_raises(self):
         with pytest.raises(ValueError, match="Please provide an API key or an azure_ad_token_provider"):
@@ -93,7 +92,7 @@ class TestAnthropicFoundryChatGenerator:
                 "anthropic.chat.foundry_chat_generator.AnthropicFoundryChatGenerator"
             ),
             "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": False, "type": "env_var"},
+                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": True, "type": "env_var"},
                 "resource": "my-resource",
                 "endpoint": None,
                 "model": "claude-sonnet-4-5",
@@ -125,7 +124,7 @@ class TestAnthropicFoundryChatGenerator:
                 "anthropic.chat.foundry_chat_generator.AnthropicFoundryChatGenerator"
             ),
             "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": False, "type": "env_var"},
+                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": True, "type": "env_var"},
                 "resource": "my-resource",
                 "endpoint": None,
                 "model": "claude-opus-4-6",
@@ -147,7 +146,7 @@ class TestAnthropicFoundryChatGenerator:
                 "anthropic.chat.foundry_chat_generator.AnthropicFoundryChatGenerator"
             ),
             "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": False, "type": "env_var"},
+                "api_key": {"env_vars": ["ANTHROPIC_FOUNDRY_API_KEY"], "strict": True, "type": "env_var"},
                 "resource": "my-resource",
                 "endpoint": None,
                 "model": "claude-sonnet-4-5",

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -76,7 +76,6 @@ class TestAnthropicFoundryChatGenerator:
             AnthropicFoundryChatGenerator()
 
     def test_init_all_params_are_keyword_only(self):
-        import inspect
         sig = inspect.signature(AnthropicFoundryChatGenerator.__init__)
         for name, param in sig.parameters.items():
             if name == "self":
@@ -308,7 +307,9 @@ class TestAnthropicFoundryChatGeneratorAsync:
             type="message",
             usage={"input_tokens": 10, "output_tokens": 5},
         )
-        with patch("anthropic.resources.messages.AsyncMessages.create", new_callable=AsyncMock, return_value=completion):
+        with patch(
+            "anthropic.resources.messages.AsyncMessages.create", new_callable=AsyncMock, return_value=completion
+        ):
             response = await component.run_async([ChatMessage.from_user("hi")])
         assert component._is_warmed_up
         assert "replies" in response


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/254

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add `AnthropicFoundryChatGenerator` to support anthropic models hosted on Azure Foundry. Similar in spirit to the `AnthropicVertexChatGenerator`. Basically we need to support a different client initialization to all clients to connect to anthropic models hosted through Azure Foundry. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

- Added new unit tests
- I'm not sure if we should keep the integration tests b/c I don't think this is easy for us to test. @bglearning would it be possible if you can test if this component works as expected?

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
