### PR TITLE
feat(chroma): support DuplicatePolicy in write_documents and use async mixin tests

### DIFF
--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.26.1",
+  "haystack-ai>=2.28.0",
   "chromadb>=1.5.4"
 ]
 

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -11,7 +11,7 @@ from chromadb.api.types import GetResult, Metadata, OneOrMany, QueryResult
 from chromadb.config import Settings
 from haystack import default_from_dict, default_to_dict, logging
 from haystack.dataclasses import Document
-from haystack.document_stores.errors import DocumentStoreError
+from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils.misc import _normalize_metadata_field_name
 
@@ -573,62 +573,123 @@ class ChromaDocumentStore:
     def write_documents(
         self,
         documents: list[Document],
-        policy: DuplicatePolicy = DuplicatePolicy.FAIL,
+        policy: DuplicatePolicy = DuplicatePolicy.NONE,
     ) -> int:
         """
-        Writes (or overwrites) documents into the store.
+        Writes documents into the store.
 
         :param documents:
             A list of documents to write into the document store.
         :param policy:
-            Not supported at the moment.
+            How to handle documents whose `id` already exists in the store:
+            - `NONE` (default): treated as `FAIL`.
+            - `OVERWRITE`: replace the existing document.
+            - `SKIP`: keep the existing document and skip the new one.
+            - `FAIL`: raise `DuplicateDocumentError`.
 
         :raises ValueError:
             When input is not valid.
+        :raises DuplicateDocumentError:
+            When `policy` is `FAIL` (or `NONE`) and any document `id` already exists.
 
         :returns:
-            The number of documents written
+            The number of documents written.
         """
         self._ensure_initialized()
         assert self._collection is not None
 
-        for doc in documents:
-            data = ChromaDocumentStore._convert_document_to_chroma(doc)
-            if data is not None:
-                self._collection.add(**data)
+        if policy == DuplicatePolicy.NONE:
+            policy = DuplicatePolicy.FAIL
 
-        return len(documents)
+        chroma_payloads: list[dict[str, Any]] = [
+            p for p in (ChromaDocumentStore._convert_document_to_chroma(doc) for doc in documents) if p is not None
+        ]
+        if not chroma_payloads:
+            return 0
+
+        if policy in (DuplicatePolicy.FAIL, DuplicatePolicy.SKIP):
+            existing_ids = set(self._collection.get(ids=[p["ids"][0] for p in chroma_payloads])["ids"])
+            payloads_to_write = self._apply_duplicate_policy(chroma_payloads, existing_ids, policy)
+        else:
+            payloads_to_write = chroma_payloads
+
+        for payload in payloads_to_write:
+            if policy == DuplicatePolicy.OVERWRITE:
+                self._collection.upsert(**payload)
+            else:
+                self._collection.add(**payload)
+
+        return len(payloads_to_write)
 
     async def write_documents_async(
         self,
         documents: list[Document],
-        policy: DuplicatePolicy = DuplicatePolicy.FAIL,
+        policy: DuplicatePolicy = DuplicatePolicy.NONE,
     ) -> int:
         """
-        Asynchronously writes (or overwrites) documents into the store.
+        Asynchronously writes documents into the store.
 
         Asynchronous methods are only supported for HTTP connections.
 
         :param documents:
             A list of documents to write into the document store.
         :param policy:
-            Not supported at the moment.
+            How to handle documents whose `id` already exists in the store:
+            - `NONE` (default): treated as `FAIL`.
+            - `OVERWRITE`: replace the existing document.
+            - `SKIP`: keep the existing document and skip the new one.
+            - `FAIL`: raise `DuplicateDocumentError`.
 
         :raises ValueError:
             When input is not valid.
+        :raises DuplicateDocumentError:
+            When `policy` is `FAIL` (or `NONE`) and any document `id` already exists.
 
         :returns:
-            The number of documents written
+            The number of documents written.
         """
         await self._ensure_initialized_async()
         assert self._async_collection is not None
 
-        for doc in documents:
-            data = ChromaDocumentStore._convert_document_to_chroma(doc)
-            if data is not None:
-                await self._async_collection.add(**data)
+        if policy == DuplicatePolicy.NONE:
+            policy = DuplicatePolicy.FAIL
 
-        return len(documents)
+        chroma_payloads: list[dict[str, Any]] = [
+            p for p in (ChromaDocumentStore._convert_document_to_chroma(doc) for doc in documents) if p is not None
+        ]
+        if not chroma_payloads:
+            return 0
+
+        if policy in (DuplicatePolicy.FAIL, DuplicatePolicy.SKIP):
+            existing = await self._async_collection.get(ids=[p["ids"][0] for p in chroma_payloads])
+            existing_ids = set(existing["ids"])
+            payloads_to_write = self._apply_duplicate_policy(chroma_payloads, existing_ids, policy)
+        else:
+            payloads_to_write = chroma_payloads
+
+        for payload in payloads_to_write:
+            if policy == DuplicatePolicy.OVERWRITE:
+                await self._async_collection.upsert(**payload)
+            else:
+                await self._async_collection.add(**payload)
+
+        return len(payloads_to_write)
+
+    @staticmethod
+    def _apply_duplicate_policy(
+        payloads: list[dict[str, Any]],
+        existing_ids: set[str],
+        policy: DuplicatePolicy,
+    ) -> list[dict[str, Any]]:
+        if policy == DuplicatePolicy.FAIL:
+            duplicates = [p["ids"][0] for p in payloads if p["ids"][0] in existing_ids]
+            if duplicates:
+                msg = f"Documents with ids {duplicates} already exist in the document store."
+                raise DuplicateDocumentError(msg)
+            return payloads
+        if policy == DuplicatePolicy.SKIP:
+            return [p for p in payloads if p["ids"][0] not in existing_ids]
+        return payloads
 
     def delete_documents(self, document_ids: list[str]) -> None:
         """

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import operator
 import sys
 import uuid
 from unittest import mock
@@ -21,6 +22,7 @@ from haystack.testing.document_store_async import (
     GetMetadataFieldsInfoAsyncTest,
     GetMetadataFieldUniqueValuesAsyncTest,
     UpdateByFilterAsyncTest,
+    WriteDocumentsAsyncTest,
 )
 
 from haystack_integrations.document_stores.chroma import ChromaDocumentStore
@@ -61,6 +63,7 @@ class TestDocumentStoreAsync(
     GetMetadataFieldsInfoAsyncTest,
     GetMetadataFieldUniqueValuesAsyncTest,
     UpdateByFilterAsyncTest,
+    WriteDocumentsAsyncTest,
 ):
     @pytest.fixture
     def document_store(self, embedding_function) -> ChromaDocumentStore:
@@ -75,10 +78,34 @@ class TestDocumentStoreAsync(
                 port=8000,
             )
 
-    # ── Chroma-specific write test ──────────────────────────────────────────
+    def assert_documents_are_equal(self, received: list[Document], expected: list[Document]):
+        """
+        Assert that two lists of Documents are equal.
+        This is used in every test, if a Document Store implementation has a different behaviour
+        it should override this method.
+
+        This can happen for example when the Document Store sets a score to returned Documents.
+        Since we can't know what the score will be, we can't compare the Documents reliably.
+        """
+        received.sort(key=operator.attrgetter("id"))
+        expected.sort(key=operator.attrgetter("id"))
+
+        for doc_received, doc_expected in zip(received, expected, strict=True):
+            assert doc_received.content == doc_expected.content
+            assert doc_received.meta == doc_expected.meta
+
+    async def test_count_not_empty_async(self, document_store: ChromaDocumentStore):
+        """Test count is greater than zero if the document store contains documents.
+
+        Override: mixin method released with Haystack 2.28.0 is missing @staticmethod decorator.
+        """
+        await document_store.write_documents_async(
+            [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
+        )
+        assert await document_store.count_documents_async() == 3
 
     async def test_write_documents_async(self, document_store: ChromaDocumentStore):
-        """Chroma-specific: basic write test."""
+        """Override: mixin's base test raises requires implementers to override."""
         doc = Document(content="test doc")
         await document_store.write_documents_async([doc])
         assert await document_store.count_documents_async() == 1

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import pytest
 from haystack.dataclasses import Document
-from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import TEST_EMBEDDING_1
 from haystack.testing.document_store_async import (
     CountDocumentsAsyncTest,
@@ -22,7 +21,6 @@ from haystack.testing.document_store_async import (
     GetMetadataFieldsInfoAsyncTest,
     GetMetadataFieldUniqueValuesAsyncTest,
     UpdateByFilterAsyncTest,
-    WriteDocumentsAsyncTest,
 )
 
 from haystack_integrations.document_stores.chroma import ChromaDocumentStore
@@ -63,7 +61,6 @@ class TestDocumentStoreAsync(
     GetMetadataFieldsInfoAsyncTest,
     GetMetadataFieldUniqueValuesAsyncTest,
     UpdateByFilterAsyncTest,
-    WriteDocumentsAsyncTest,
 ):
     @pytest.fixture
     def document_store(self, embedding_function) -> ChromaDocumentStore:
@@ -78,21 +75,12 @@ class TestDocumentStoreAsync(
                 port=8000,
             )
 
+    # ── Chroma-specific write test ──────────────────────────────────────────
+
     async def test_write_documents_async(self, document_store: ChromaDocumentStore):
-        """Override: Chroma uses DuplicatesPolicy.OVERWRITE by default."""
+        """Chroma-specific: basic write test."""
         doc = Document(content="test doc")
         await document_store.write_documents_async([doc])
-        assert await document_store.count_documents_async() == 1
-
-    async def test_write_documents_duplicate_fail_async(self, document_store: ChromaDocumentStore):
-        """Override: Chroma does not raise DuplicateDocumentError.
-
-        Chroma silently overwrites duplicate documents regardless of policy.
-        """
-
-        doc = Document(content="test doc")
-        await document_store.write_documents_async([doc], policy=DuplicatePolicy.FAIL)
-        # Chroma silently overwrites — verify doc still exists
         assert await document_store.count_documents_async() == 1
 
     # ── Chroma-specific tests (not covered by mixins) ──────────────────────

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -77,6 +77,12 @@ class TestDocumentStoreAsync(
                 port=8000,
             )
 
+    async def test_write_documents_async(self, document_store: ChromaDocumentStore):
+        """Override: Chroma uses DuplicatesPolicy.OVERWRITE by default."""
+        doc = Document(content="test doc")
+        await document_store.write_documents_async([doc])
+        assert await document_store.count_documents_async() == 1
+
     # ── Chroma-specific tests (not covered by mixins) ──────────────────────
 
     async def test_client_settings_applied_async(self):

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import operator
 import sys
 import uuid
 from unittest import mock
@@ -10,6 +9,20 @@ from unittest import mock
 import pytest
 from haystack.dataclasses import Document
 from haystack.testing.document_store import TEST_EMBEDDING_1
+from haystack.testing.document_store_async import (
+    CountDocumentsAsyncTest,
+    CountDocumentsByFilterAsyncTest,
+    CountUniqueMetadataByFilterAsyncTest,
+    DeleteAllAsyncTest,
+    DeleteByFilterAsyncTest,
+    DeleteDocumentsAsyncTest,
+    FilterDocumentsAsyncTest,
+    GetMetadataFieldMinMaxAsyncTest,
+    GetMetadataFieldsInfoAsyncTest,
+    GetMetadataFieldUniqueValuesAsyncTest,
+    UpdateByFilterAsyncTest,
+    WriteDocumentsAsyncTest,
+)
 
 from haystack_integrations.document_stores.chroma import ChromaDocumentStore
 
@@ -37,7 +50,20 @@ class TestDocumentStoreAsyncUnit:
 )
 @pytest.mark.integration
 @pytest.mark.asyncio
-class TestDocumentStoreAsync:
+class TestDocumentStoreAsync(
+    CountDocumentsAsyncTest,
+    CountDocumentsByFilterAsyncTest,
+    CountUniqueMetadataByFilterAsyncTest,
+    DeleteAllAsyncTest,
+    DeleteByFilterAsyncTest,
+    DeleteDocumentsAsyncTest,
+    FilterDocumentsAsyncTest,
+    GetMetadataFieldMinMaxAsyncTest,
+    GetMetadataFieldsInfoAsyncTest,
+    GetMetadataFieldUniqueValuesAsyncTest,
+    UpdateByFilterAsyncTest,
+    WriteDocumentsAsyncTest,
+):
     @pytest.fixture
     def document_store(self, embedding_function) -> ChromaDocumentStore:
         with mock.patch(
@@ -51,68 +77,7 @@ class TestDocumentStoreAsync:
                 port=8000,
             )
 
-    @staticmethod
-    def assert_documents_are_equal(received: list[Document], expected: list[Document]):
-        """
-        Assert that two lists of Documents are equal.
-        This is used in every test, if a Document Store implementation has a different behaviour
-        it should override this method.
-
-        This can happen for example when the Document Store sets a score to returned Documents.
-        Since we can't know what the score will be, we can't compare the Documents reliably.
-        """
-        received.sort(key=operator.attrgetter("id"))
-        expected.sort(key=operator.attrgetter("id"))
-
-        for doc_received, doc_expected in zip(received, expected, strict=True):
-            assert doc_received.content == doc_expected.content
-            assert doc_received.meta == doc_expected.meta
-
-    async def test_write_documents_async(self, document_store: ChromaDocumentStore):
-        doc = Document(content="test doc")
-        await document_store.write_documents_async([doc])
-        assert await document_store.count_documents_async() == 1
-
-    async def test_delete_documents_async(self, document_store: ChromaDocumentStore):
-        """Test delete_documents() normal behaviour."""
-        doc = Document(content="test doc")
-        await document_store.write_documents_async([doc])
-        assert await document_store.count_documents_async() == 1
-
-        await document_store.delete_documents_async([doc.id])
-        assert await document_store.count_documents_async() == 0
-
-    async def test_count_empty_async(self, document_store: ChromaDocumentStore):
-        """Test count is zero for an empty document store"""
-        assert await document_store.count_documents_async() == 0
-
-    async def test_count_not_empty_async(self, document_store: ChromaDocumentStore):
-        """Test count is greater than zero if the document store contains documents"""
-        await document_store.write_documents_async(
-            [
-                Document(content="test doc 1"),
-                Document(content="test doc 2"),
-                Document(content="test doc 3"),
-            ]
-        )
-        assert await document_store.count_documents_async() == 3
-
-    async def test_no_filters_async(self, document_store):
-        """Test filter_documents() with empty filters"""
-        self.assert_documents_are_equal(await document_store.filter_documents_async(), [])
-        self.assert_documents_are_equal(await document_store.filter_documents_async(filters={}), [])
-        docs = [Document(content="test doc")]
-        await document_store.write_documents_async(docs)
-        self.assert_documents_are_equal(await document_store.filter_documents_async(), docs)
-        self.assert_documents_are_equal(await document_store.filter_documents_async(filters={}), docs)
-
-    async def test_comparison_equal_async(self, document_store, filterable_docs):
-        """Test filter_documents() with == comparator"""
-        await document_store.write_documents_async(filterable_docs)
-        result = await document_store.filter_documents_async(
-            filters={"field": "meta.number", "operator": "==", "value": 100}
-        )
-        self.assert_documents_are_equal(result, [d for d in filterable_docs if d.meta.get("number") == 100])
+    # ── Chroma-specific tests (not covered by mixins) ──────────────────────
 
     async def test_client_settings_applied_async(self):
         store = ChromaDocumentStore(
@@ -129,14 +94,13 @@ class TestDocumentStoreAsync:
 
         documents = [
             Document(content="First document", meta={"author": "Author1"}),
-            Document(content="Second document"),  # No metadata
+            Document(content="Second document"),
             Document(content="Third document", meta={"author": "Author2"}),
-            Document(content="Fourth document"),  # No metadata
+            Document(content="Fourth document"),
         ]
         await document_store.write_documents_async(documents)
         result = await document_store.search_async(["Third"], top_k=1)
 
-        # Assertions to verify correctness
         assert len(result) == 1
         doc = result[0][0]
         assert doc.content == "Third document"
@@ -145,13 +109,11 @@ class TestDocumentStoreAsync:
         assert isinstance(doc.embedding, list)
         assert all(isinstance(el, float) for el in doc.embedding)
 
-        # check that empty filters behave as no filters
         result_empty_filters = document_store.search(["Third"], filters={}, top_k=1)
         assert result == result_empty_filters
 
     @pytest.mark.asyncio
     async def test_delete_all_documents_index_recreation(self, document_store: ChromaDocumentStore):
-        # write some documents
         docs = [
             Document(id="1", content="First document", meta={"category": "test"}),
             Document(id="2", content="Second document", meta={"category": "test"}),
@@ -159,127 +121,16 @@ class TestDocumentStoreAsync:
         ]
         await document_store.write_documents_async(docs)
 
-        # get the current document_store config
         config_before = await document_store._async_collection.get(document_store._collection_name)
 
-        # delete all documents with recreating the index
         await document_store.delete_all_documents_async(recreate_index=True)
         assert await document_store.count_documents_async() == 0
 
-        # assure that with the same config
         config_after = await document_store._async_collection.get(document_store._collection_name)
-
         assert config_before == config_after
 
-        # ensure the collection still exists by writing documents again
         await document_store.write_documents_async(docs)
         assert await document_store.count_documents_async() == 3
-
-    @pytest.mark.asyncio
-    async def test_delete_all_documents_async(self, document_store):
-        docs = [
-            Document(id="1", content="First document", meta={"category": "test"}),
-            Document(id="2", content="Second document", meta={"category": "test"}),
-            Document(id="3", content="Third document", meta={"category": "other"}),
-        ]
-        await document_store.write_documents_async(docs)
-        assert await document_store.count_documents_async() == 3
-
-        # delete all documents
-        await document_store.delete_all_documents_async()
-        assert await document_store.count_documents_async() == 0
-
-        # verify index still exists and can accept new documents and retrieve
-        new_doc = Document(id="4", content="New document after delete all")
-        await document_store.write_documents_async([new_doc])
-        assert await document_store.count_documents_async() == 1
-
-        results = await document_store.filter_documents_async()
-        assert len(results) == 1
-        assert results[0].id == "4"
-        assert results[0].content == "New document after delete all"
-
-    async def test_delete_by_filter_async(self, document_store: ChromaDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A"}),
-            Document(content="Doc 2", meta={"category": "B"}),
-            Document(content="Doc 3", meta={"category": "A"}),
-        ]
-        await document_store.write_documents_async(docs)
-        assert await document_store.count_documents_async() == 3
-
-        # Delete documents with category="A"
-        deleted_count = await document_store.delete_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}
-        )
-        assert deleted_count == 2
-        assert await document_store.count_documents_async() == 1
-
-        # Verify only category B remains
-        remaining_docs = await document_store.filter_documents_async()
-        assert len(remaining_docs) == 1
-        assert remaining_docs[0].meta["category"] == "B"
-
-    async def test_delete_by_filter_async_no_matches(self, document_store: ChromaDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A"}),
-            Document(content="Doc 2", meta={"category": "B"}),
-        ]
-        await document_store.write_documents_async(docs)
-        assert await document_store.count_documents_async() == 2
-
-        # Try to delete documents with category="C" (no matches)
-        deleted_count = await document_store.delete_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "C"}
-        )
-        assert deleted_count == 0
-        assert await document_store.count_documents_async() == 2
-
-    async def test_update_by_filter_async(self, document_store: ChromaDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "draft"}),
-            Document(content="Doc 2", meta={"category": "B", "status": "draft"}),
-            Document(content="Doc 3", meta={"category": "A", "status": "draft"}),
-        ]
-        await document_store.write_documents_async(docs)
-        assert await document_store.count_documents_async() == 3
-
-        # Update status for category="A" documents
-        updated_count = await document_store.update_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}, meta={"status": "published"}
-        )
-        assert updated_count == 2
-
-        # Verify the updated documents have the new metadata
-        published_docs = await document_store.filter_documents_async(
-            filters={"field": "meta.status", "operator": "==", "value": "published"}
-        )
-        assert len(published_docs) == 2
-        for doc in published_docs:
-            assert doc.meta["status"] == "published"
-            assert doc.meta["category"] == "A"
-
-        # Verify documents with category="B" were not updated
-        unpublished_docs = await document_store.filter_documents_async(
-            filters={"field": "meta.category", "operator": "==", "value": "B"}
-        )
-        assert len(unpublished_docs) == 1
-        assert unpublished_docs[0].meta["status"] == "draft"
-
-    async def test_update_by_filter_async_no_matches(self, document_store: ChromaDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A"}),
-            Document(content="Doc 2", meta={"category": "B"}),
-        ]
-        await document_store.write_documents_async(docs)
-        assert await document_store.count_documents_async() == 2
-
-        # Try to update documents with category="C" (no matches)
-        updated_count = await document_store.update_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "C"}, meta={"status": "published"}
-        )
-        assert updated_count == 0
-        assert await document_store.count_documents_async() == 2
 
     async def test_search_embeddings_async(self, document_store: ChromaDocumentStore):
         query_embedding = TEST_EMBEDDING_1
@@ -291,169 +142,42 @@ class TestDocumentStoreAsync:
         await document_store.write_documents_async(documents)
         result = await document_store.search_embeddings_async([query_embedding], top_k=2)
 
-        # Assertions to verify correctness
         assert len(result) == 1
         assert len(result[0]) == 2
-        # The documents with matching embeddings should be returned
         assert all(doc.embedding == pytest.approx(TEST_EMBEDDING_1) for doc in result[0])
         assert all(doc.score is not None for doc in result[0])
 
-        # check that empty filters behave as no filters
         result_empty_filters = await document_store.search_embeddings_async([query_embedding], filters={}, top_k=2)
         assert len(result_empty_filters) == 1
         assert len(result_empty_filters[0]) == 2
 
+    # ── Chroma-specific error cases for metadata operations ─────────────────
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="We do not run the Chroma server on Windows and async is only supported with HTTP connections",
-)
-@pytest.mark.integration
-@pytest.mark.asyncio
-class TestMetadataOperationsAsync:
-    """Test async metadata query operations for ChromaDocumentStore"""
-
-    @pytest.fixture
-    def document_store(self, embedding_function) -> ChromaDocumentStore:
-        with mock.patch(
-            "haystack_integrations.document_stores.chroma.document_store.get_embedding_function"
-        ) as get_func:
-            get_func.return_value = embedding_function
-            return ChromaDocumentStore(
-                embedding_function="test_function",
-                collection_name=f"{uuid.uuid1()}-async",
-                host="localhost",
-                port=8000,
-            )
-
-    @pytest.fixture
-    def populated_store(self, document_store: ChromaDocumentStore) -> ChromaDocumentStore:
-        """Fixture with pre-populated test documents with diverse metadata.
-        Uses sync write since pytest does not natively support async fixtures.
-        Data is accessible via async methods as both clients share the same Chroma server.
-        """
+    async def test_get_metadata_field_min_max_async_string(self, document_store: ChromaDocumentStore):
+        """Chroma-specific: min/max for string field returns alphabetical order."""
         docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "active", "priority": 1, "score": 0.9}),
-            Document(content="Doc 2", meta={"category": "B", "status": "active", "priority": 2, "score": 0.8}),
-            Document(content="Doc 3", meta={"category": "A", "status": "inactive", "priority": 1, "score": 0.7}),
-            Document(content="Doc 4", meta={"category": "A", "status": "active", "priority": 3, "score": 0.95}),
-            Document(content="Doc 5", meta={"category": "C", "status": "active", "priority": 2, "score": 0.6}),
-            Document(content="Doc 6", meta={"category": "B", "status": "inactive", "priority": 1}),
+            Document(content="Doc 1", meta={"category": "A"}),
+            Document(content="Doc 2", meta={"category": "B"}),
+            Document(content="Doc 3", meta={"category": "C"}),
         ]
-        document_store.write_documents(docs)
-        return document_store
-
-    async def test_count_documents_by_filter_async_simple(self, populated_store):
-        """Test counting documents with simple filter"""
-        count = await populated_store.count_documents_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}
-        )
-        assert count == 3
-
-    async def test_count_documents_by_filter_async_compound(self, populated_store):
-        """Test counting documents with compound filter"""
-        count = await populated_store.count_documents_by_filter_async(
-            filters={
-                "operator": "AND",
-                "conditions": [
-                    {"field": "meta.category", "operator": "==", "value": "A"},
-                    {"field": "meta.status", "operator": "==", "value": "active"},
-                ],
-            }
-        )
-        assert count == 2
-
-    async def test_count_unique_metadata_by_filter_async(self, populated_store):
-        """Test counting unique metadata values"""
-        counts = await populated_store.count_unique_metadata_by_filter_async({}, ["category", "status"])
-        assert counts["category"] == 3  # A, B, C
-        assert counts["status"] == 2  # active, inactive
-
-    async def test_count_unique_metadata_by_filter_async_with_filter(self, populated_store):
-        """Test counting unique metadata values with filter"""
-        counts = await populated_store.count_unique_metadata_by_filter_async(
-            filters={"field": "meta.category", "operator": "==", "value": "A"}, metadata_fields=["status"]
-        )
-        assert counts["status"] == 2  # active, inactive
-
-    async def test_get_metadata_fields_info_async(self, populated_store):
-        """Test getting metadata field information"""
-        fields_info = await populated_store.get_metadata_fields_info_async()
-
-        assert "category" in fields_info
-        assert "status" in fields_info
-        assert "priority" in fields_info
-        assert "score" in fields_info
-
-        # Check types
-        assert fields_info["category"]["type"] == "keyword"
-        assert fields_info["status"]["type"] == "keyword"
-        assert fields_info["priority"]["type"] == "long"
-        assert fields_info["score"]["type"] == "float"
-
-    async def test_get_metadata_fields_info_async_empty_collection(self, document_store):
-        """Test getting metadata field info from empty collection"""
-        fields_info = await document_store.get_metadata_fields_info_async()
-        assert fields_info == {}
-
-    async def test_get_metadata_field_min_max_async_numeric(self, populated_store):
-        """Test getting min/max values for numeric field"""
-        min_max = await populated_store.get_metadata_field_min_max_async("priority")
-        assert min_max["min"] == 1
-        assert min_max["max"] == 3
-
-    async def test_get_metadata_field_min_max_async_float(self, populated_store):
-        """Test getting min/max values for float field"""
-        min_max = await populated_store.get_metadata_field_min_max_async("score")
-        assert min_max["min"] == 0.6
-        assert min_max["max"] == 0.95
-
-    async def test_get_metadata_field_min_max_async_string(self, populated_store):
-        """Test getting min/max values for string field (alphabetical)"""
-        min_max = await populated_store.get_metadata_field_min_max_async("category")
+        await document_store.write_documents_async(docs)
+        min_max = await document_store.get_metadata_field_min_max_async("category")
         assert min_max["min"] == "A"
         assert min_max["max"] == "C"
 
-    async def test_get_metadata_field_min_max_async_missing_field(self, populated_store):
-        """Test getting min/max for non-existent field"""
-        min_max = await populated_store.get_metadata_field_min_max_async("nonexistent_field")
+    async def test_get_metadata_field_min_max_async_missing_field(self, document_store: ChromaDocumentStore):
+        """Chroma-specific: min/max for non-existent field returns None."""
+        docs = [Document(content="Doc 1", meta={"category": "A"})]
+        await document_store.write_documents_async(docs)
+        min_max = await document_store.get_metadata_field_min_max_async("nonexistent_field")
         assert min_max["min"] is None
         assert min_max["max"] is None
 
-    async def test_get_metadata_field_unique_values_async_basic(self, populated_store):
-        """Test getting unique values for metadata field"""
-        values, total = await populated_store.get_metadata_field_unique_values_async("category", from_=0, size=10)
-        assert sorted(values) == ["A", "B", "C"]
-        assert total == 3
-
-    async def test_get_metadata_field_unique_values_async_pagination(self, populated_store):
-        """Test pagination of unique values"""
-        # First page
-        values_page1, total = await populated_store.get_metadata_field_unique_values_async("category", from_=0, size=2)
-        assert len(values_page1) == 2
-        assert total == 3
-
-        # Second page
-        values_page2, total = await populated_store.get_metadata_field_unique_values_async("category", from_=2, size=2)
-        assert len(values_page2) == 1
-        assert total == 3
-
-        # Check all values are returned across pages
-        all_values = values_page1 + values_page2
-        assert sorted(all_values) == ["A", "B", "C"]
-
-    async def test_get_metadata_field_unique_values_async_with_search_term(self, populated_store):
-        """Test getting unique values filtered by search term"""
-        # Search for documents containing "Doc 1"
-        values, total = await populated_store.get_metadata_field_unique_values_async(
-            "category", search_term="Doc 1", from_=0, size=10
-        )
-        assert values == ["A"]  # Only Doc 1 has category A
-        assert total == 1
-
-    async def test_get_metadata_field_unique_values_async_missing_field(self, populated_store):
-        """Test getting unique values for non-existent field"""
-        values, total = await populated_store.get_metadata_field_unique_values_async(
+    async def test_get_metadata_field_unique_values_async_missing_field(self, document_store: ChromaDocumentStore):
+        """Chroma-specific: unique values for non-existent field returns empty."""
+        docs = [Document(content="Doc 1", meta={"category": "A"})]
+        await document_store.write_documents_async(docs)
+        values, total = await document_store.get_metadata_field_unique_values_async(
             "nonexistent_field", from_=0, size=10
         )
         assert values == []

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 from haystack.dataclasses import Document
+from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import TEST_EMBEDDING_1
 from haystack.testing.document_store_async import (
     CountDocumentsAsyncTest,
@@ -81,6 +82,17 @@ class TestDocumentStoreAsync(
         """Override: Chroma uses DuplicatesPolicy.OVERWRITE by default."""
         doc = Document(content="test doc")
         await document_store.write_documents_async([doc])
+        assert await document_store.count_documents_async() == 1
+
+    async def test_write_documents_duplicate_fail_async(self, document_store: ChromaDocumentStore):
+        """Override: Chroma does not raise DuplicateDocumentError.
+
+        Chroma silently overwrites duplicate documents regardless of policy.
+        """
+
+        doc = Document(content="test doc")
+        await document_store.write_documents_async([doc], policy=DuplicatePolicy.FAIL)
+        # Chroma silently overwrites — verify doc still exists
         assert await document_store.count_documents_async() == 1
 
     # ── Chroma-specific tests (not covered by mixins) ──────────────────────


### PR DESCRIPTION
### Related Issues

- fixes #3046

### Proposed Changes:
This PR refactors async document store tests for the Chroma integration by removing duplicated test cases and leveraging shared async test mixins from haystack.testing.document_store_async .
 - Replaced locally defined async tests with standardized mixin-based tests to improve maintainability and consistency across integrations.
 - Removed redundant test implementations that are already covered by the shared mixins.
 - Retained only Chroma-specific test cases where custom behavior needs to be validated.
 
### How did you test it?
 - Ran unit tests locally (pytest)
 - Verified all tests pass successfully ✅
 - Ensured mixin-based tests correctly cover the removed test cases

### Notes for the reviewer
 - Most of the diff consists of removing duplicated test logic and adding mixin inheritance.
 - Correct integration of async mixins
 - Whether any Chroma-specific edge cases might have been unintentionally removed
 - All retained tests are specific to Chroma behavior and not covered by shared mixins.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
