### PR TITLE
test: Pinecone - remove namespaces when tests ends

### DIFF
--- a/integrations/pinecone/tests/conftest.py
+++ b/integrations/pinecone/tests/conftest.py
@@ -57,7 +57,7 @@ def document_store(request):
     yield store
     try:
         if store._index is not None:
-            store._index.delete(delete_all=True, namespace=namespace)
+            store._index.delete_namespace(namespace=namespace)
     except NotFoundException:
         pass
 
@@ -107,7 +107,7 @@ async def document_store_async(request):
     yield store
     try:
         if store._async_index is not None:
-            await store._async_index.delete(delete_all=True, namespace=namespace)
+            await store._async_index.delete_namespace(namespace=namespace)
             await store.close_async()
     except NotFoundException:
         pass


### PR DESCRIPTION
### Related Issues

Over time, our Pinecone test instance (limited to 100 namespaces) hits the limit.

I initially thought the problem was that some tests do not clean up namespaces properly.

I recently realized that we were simply deleting all records in a namespace ([docs](https://docs.pinecone.io/guides/manage-data/delete-data#delete-all-records-in-a-namespace)) instead of deleting the namespace.

### Proposed Changes:
- delete each namespaces when the test ends

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
