### PR TITLE
test: fix mongodb async connection teardown

### DIFF
--- a/integrations/mongodb_atlas/tests/test_document_store_async.py
+++ b/integrations/mongodb_atlas/tests/test_document_store_async.py
@@ -128,7 +128,7 @@ class TestDocumentStoreAsync(
             yield store
         finally:
             if store._connection_async:
-                await store.connection.close()
+                await store._connection_async.close()
 
     async def test_count_not_empty_async(self, document_store):
         # Override needed: base class uses @staticmethod which breaks fixture injection


### PR DESCRIPTION
### Related Issues

- failing tests (https://github.com/deepset-ai/haystack-core-integrations/actions/runs/25085301286) after https://github.com/deepset-ai/haystack-core-integrations/pull/3249

### Proposed Changes:
- make the async fixture close the async connection (not the sync one)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
