### PR TITLE
ci: update integration version regex to allow numeric characters in folder names

### DIFF
--- a/.github/utils/validate_version.py
+++ b/.github/utils/validate_version.py
@@ -3,7 +3,7 @@ import requests
 
 # * integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0
 # * integrations/<INTEGRATION_FOLDER_NAME>-v1.0.0.post0 (for post-releases)
-INTEGRATION_VERSION_REGEX = r"integrations/([a-zA-Z_]+)-v([0-9]+\.[0-9]+\.[0-9]+(?:\.post[0-9]+)?)"
+INTEGRATION_VERSION_REGEX = r"integrations/([a-zA-Z0-9_]+)-v([0-9]+\.[0-9]+\.[0-9]+(?:\.post[0-9]+)?)"
 
 
 def validate_version_number(tag: str):


### PR DESCRIPTION
### Related Issues

- Failing release of E2B integration (https://github.com/deepset-ai/haystack-core-integrations/actions/runs/25160150073/job/73752153012)

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR updates the validation regex to allow numbers in integration names.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
