### PR TITLE
feat: Add serialization/deserialization to DoclingConverter 

### DIFF
--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -165,7 +165,16 @@ class DoclingConverter:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "DoclingConverter":
-        """Deserialize this component from a dictionary."""
+        """
+        Deserialize this component from a dictionary.
+
+        The `converter` and `chunker` parameters are not serializable and are always ignored during
+        deserialization; the restored instance will use the default `DocumentConverter` and `HybridChunker`
+        respectively.
+
+        :param data: Dictionary with keys `type` and `init_parameters`, as produced by `to_dict`.
+        :returns: A new `DoclingConverter` instance.
+        """
         init_params = data.get("init_parameters", {})
 
         meta_extractor_data = init_params.get("meta_extractor")

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -12,7 +12,14 @@ from typing import Any
 from docling_core.types.io import DocumentStream
 from haystack import Document, component
 from haystack.components.converters.utils import normalize_metadata
+from haystack.core.serialization import (
+    default_from_dict,
+    default_to_dict,
+    generate_qualified_class_name,
+    import_class_by_name,
+)
 from haystack.dataclasses import ByteStream
+from haystack.utils.base_serialization import deserialize_class_instance, serialize_class_instance
 
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
@@ -62,6 +69,15 @@ class BaseMetaExtractor(ABC):
     def extract_dl_doc_meta(self, dl_doc: DoclingDocument) -> dict[str, Any]:
         """Extract Docling document meta."""
         raise NotImplementedError()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dictionary."""
+        return {}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseMetaExtractor":
+        """Deserialize from a dictionary."""
+        return cls()
 
 
 class MetaExtractor(BaseMetaExtractor):
@@ -122,6 +138,53 @@ class DoclingConverter:
         if self.export_type == ExportType.DOC_CHUNKS:
             self._chunker_instance = chunker or HybridChunker()
         self._meta_extractor_instance = meta_extractor or MetaExtractor()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this component to a dictionary."""
+        chunker_data = None
+        if self.chunker is not None:
+            try:
+                pydantic_data = self.chunker.model_dump(mode="json")
+            except Exception:
+                # Fall back to primitive fields only when complex nested objects
+                # (e.g. non-Pydantic serializer providers) block full JSON serialization.
+                raw = self.chunker.model_dump()
+                pydantic_data = {
+                    k: v
+                    for k, v in raw.items()
+                    if not k.startswith("_") and isinstance(v, (str, int, float, bool, type(None)))
+                }
+            chunker_data = {"type": generate_qualified_class_name(type(self.chunker)), "data": pydantic_data}
+
+        meta_extractor_data = None
+        if self.meta_extractor is not None:
+            meta_extractor_data = serialize_class_instance(self.meta_extractor)
+
+        return default_to_dict(
+            self,
+            converter=None,
+            convert_kwargs=self.convert_kwargs,
+            export_type=self.export_type.value,
+            md_export_kwargs=self.md_export_kwargs,
+            chunker=chunker_data,
+            meta_extractor=meta_extractor_data,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DoclingConverter":
+        """Deserialize this component from a dictionary."""
+        init_params = data.get("init_parameters", {})
+
+        chunker_data = init_params.get("chunker")
+        if chunker_data is not None:
+            chunker_cls = import_class_by_name(chunker_data["type"])
+            init_params["chunker"] = chunker_cls.model_validate(chunker_data["data"])
+
+        meta_extractor_data = init_params.get("meta_extractor")
+        if meta_extractor_data is not None:
+            init_params["meta_extractor"] = deserialize_class_instance(meta_extractor_data)
+
+        return default_from_dict(cls, data)
 
     @component.output_types(documents=list[Document])
     def run(

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -10,11 +10,13 @@ from pathlib import Path
 from typing import Any
 
 from docling_core.types.io import DocumentStream
-from haystack import Document, component
+from haystack import Document, component, logging
 from haystack.components.converters.utils import normalize_metadata
 from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
 from haystack.utils.base_serialization import deserialize_class_instance, serialize_class_instance
+
+logger = logging.getLogger(__name__)
 
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
@@ -136,12 +138,15 @@ class DoclingConverter:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize this component to a dictionary."""
+        if self.converter is not None:
+            logger.warning(
+                "DoclingConverter.to_dict: the 'converter' parameter cannot be serialized and will be dropped. "
+                "The component will use the default DocumentConverter when restored from the serialized form."
+            )
         if self.chunker is not None:
-            warnings.warn(
+            logger.warning(
                 "DoclingConverter.to_dict: the 'chunker' parameter cannot be serialized and will be dropped. "
-                "The converter will use the default chunker when restored from the serialized form.",
-                UserWarning,
-                stacklevel=2,
+                "The component will use the default chunker when restored from the serialized form."
             )
 
         meta_extractor_data = None

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -12,12 +12,7 @@ from typing import Any
 from docling_core.types.io import DocumentStream
 from haystack import Document, component
 from haystack.components.converters.utils import normalize_metadata
-from haystack.core.serialization import (
-    default_from_dict,
-    default_to_dict,
-    generate_qualified_class_name,
-    import_class_by_name,
-)
+from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
 from haystack.utils.base_serialization import deserialize_class_instance, serialize_class_instance
 
@@ -141,20 +136,13 @@ class DoclingConverter:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize this component to a dictionary."""
-        chunker_data = None
         if self.chunker is not None:
-            try:
-                pydantic_data = self.chunker.model_dump(mode="json")
-            except Exception:
-                # Fall back to primitive fields only when complex nested objects
-                # (e.g. non-Pydantic serializer providers) block full JSON serialization.
-                raw = self.chunker.model_dump()
-                pydantic_data = {
-                    k: v
-                    for k, v in raw.items()
-                    if not k.startswith("_") and isinstance(v, (str, int, float, bool, type(None)))
-                }
-            chunker_data = {"type": generate_qualified_class_name(type(self.chunker)), "data": pydantic_data}
+            warnings.warn(
+                "DoclingConverter.to_dict: the 'chunker' parameter cannot be serialized and will be dropped. "
+                "The converter will use the default chunker when restored from the serialized form.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         meta_extractor_data = None
         if self.meta_extractor is not None:
@@ -166,7 +154,7 @@ class DoclingConverter:
             convert_kwargs=self.convert_kwargs,
             export_type=self.export_type.value,
             md_export_kwargs=self.md_export_kwargs,
-            chunker=chunker_data,
+            chunker=None,
             meta_extractor=meta_extractor_data,
         )
 
@@ -174,11 +162,6 @@ class DoclingConverter:
     def from_dict(cls, data: dict[str, Any]) -> "DoclingConverter":
         """Deserialize this component from a dictionary."""
         init_params = data.get("init_parameters", {})
-
-        chunker_data = init_params.get("chunker")
-        if chunker_data is not None:
-            chunker_cls = import_class_by_name(chunker_data["type"])
-            init_params["chunker"] = chunker_cls.model_validate(chunker_data["data"])
 
         meta_extractor_data = init_params.get("meta_extractor")
         if meta_extractor_data is not None:

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -16,11 +16,11 @@ from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
 from haystack.utils.base_serialization import deserialize_class_instance, serialize_class_instance
 
-logger = logging.getLogger(__name__)
-
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
 from docling.document_converter import DocumentConverter
+
+logger = logging.getLogger(__name__)
 
 
 def _bytestream_to_document_stream(source: ByteStream) -> DocumentStream:
@@ -72,7 +72,7 @@ class BaseMetaExtractor(ABC):
         return {}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "BaseMetaExtractor":
+    def from_dict(cls, data: dict[str, Any]) -> "BaseMetaExtractor":  # noqa: ARG003
         """Deserialize from a dictionary."""
         return cls()
 

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from docling.chunking import HybridChunker
 from docling_core.types.io import DocumentStream
 from haystack.core.serialization import component_from_dict, component_to_dict
 from haystack.dataclasses import ByteStream
@@ -223,6 +224,15 @@ def test_component_from_dict_custom_params() -> None:
     assert restored.export_type == ExportType.JSON
     assert restored.md_export_kwargs == {"image_placeholder": "[img]"}
     assert isinstance(restored.meta_extractor, MetaExtractor)
+
+
+def test_component_to_dict_chunker_warns_and_is_dropped() -> None:
+    converter = DoclingConverter(chunker=HybridChunker(merge_peers=False))
+
+    with pytest.warns(UserWarning, match="chunker"):
+        data = component_to_dict(converter, "docling_converter")
+
+    assert data["init_parameters"]["chunker"] is None
 
 
 def test_run_with_sources_parameter() -> None:

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 from docling.chunking import HybridChunker
 from docling_core.types.io import DocumentStream
-from haystack.core.serialization import component_from_dict, component_to_dict
+
 from haystack.dataclasses import ByteStream
 
 from haystack_integrations.components.converters.docling import (
@@ -135,8 +135,6 @@ def test_run_json_minimal() -> None:
 
 
 def test_legacy_import_path() -> None:
-    import warnings
-
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         from docling_haystack.converter import DoclingConverter as LegacyDoclingConverter
@@ -149,15 +147,16 @@ def test_legacy_import_path() -> None:
 
 def test_component_to_dict_defaults() -> None:
     converter = DoclingConverter()
-    data = component_to_dict(converter, "docling_converter")
-
-    assert data["init_parameters"] == {
-        "converter": None,
-        "convert_kwargs": {},
-        "export_type": "doc_chunks",
-        "md_export_kwargs": {"image_placeholder": ""},
-        "chunker": None,
-        "meta_extractor": None,
+    assert converter.to_dict() == {
+        "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",
+        "init_parameters": {
+            "converter": None,
+            "convert_kwargs": {},
+            "export_type": "doc_chunks",
+            "md_export_kwargs": {"image_placeholder": ""},
+            "chunker": None,
+            "meta_extractor": None,
+        },
     }
 
 
@@ -168,15 +167,19 @@ def test_component_to_dict_custom_params() -> None:
         md_export_kwargs={"image_placeholder": "[img]"},
         meta_extractor=MetaExtractor(),
     )
-    data = component_to_dict(converter, "docling_converter")
-
-    init_params = data["init_parameters"]
-    assert init_params["convert_kwargs"] == {"raises_on_error": False}
-    assert init_params["export_type"] == "markdown"
-    assert init_params["md_export_kwargs"] == {"image_placeholder": "[img]"}
-    assert init_params["meta_extractor"] == {
-        "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
-        "data": {},
+    assert converter.to_dict() == {
+        "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",
+        "init_parameters": {
+            "converter": None,
+            "convert_kwargs": {"raises_on_error": False},
+            "export_type": "markdown",
+            "md_export_kwargs": {"image_placeholder": "[img]"},
+            "chunker": None,
+            "meta_extractor": {
+                "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
+                "data": {},
+            },
+        },
     }
 
 
@@ -193,7 +196,7 @@ def test_component_from_dict_defaults() -> None:
             "meta_extractor": None,
         },
     }
-    restored = component_from_dict(DoclingConverter, data, "docling_converter")
+    restored = DoclingConverter.from_dict(data)
 
     assert restored.converter is None
     assert restored.convert_kwargs == {}
@@ -218,11 +221,13 @@ def test_component_from_dict_custom_params() -> None:
             },
         },
     }
-    restored = component_from_dict(DoclingConverter, data, "docling_converter")
+    restored = DoclingConverter.from_dict(data)
 
+    assert restored.converter is None
     assert restored.convert_kwargs == {"raises_on_error": False}
     assert restored.export_type == ExportType.JSON
     assert restored.md_export_kwargs == {"image_placeholder": "[img]"}
+    assert restored.chunker is None
     assert isinstance(restored.meta_extractor, MetaExtractor)
 
 
@@ -230,9 +235,19 @@ def test_component_to_dict_chunker_warns_and_is_dropped() -> None:
     converter = DoclingConverter(chunker=HybridChunker(merge_peers=False))
 
     with pytest.warns(UserWarning, match="chunker"):
-        data = component_to_dict(converter, "docling_converter")
+        data = converter.to_dict()
 
-    assert data["init_parameters"]["chunker"] is None
+    assert data == {
+        "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",
+        "init_parameters": {
+            "converter": None,
+            "convert_kwargs": {},
+            "export_type": "doc_chunks",
+            "md_export_kwargs": {"image_placeholder": ""},
+            "chunker": None,
+            "meta_extractor": None,
+        },
+    }
 
 
 def test_run_with_sources_parameter() -> None:

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -146,12 +146,42 @@ def test_legacy_import_path() -> None:
     )
 
 
-def test_component_from_dict_legacy_nulls() -> None:
-    # Before the public-attribute refactor, default serialization couldn't find
-    # the _-prefixed attributes and fell back to the init defaults, so
-    # convert_kwargs and md_export_kwargs were always serialized as null.
-    # Verify that such a serialized dict still deserializes correctly.
-    legacy_data = {
+def test_component_to_dict_defaults() -> None:
+    converter = DoclingConverter()
+    data = component_to_dict(converter, "docling_converter")
+
+    assert data["init_parameters"] == {
+        "converter": None,
+        "convert_kwargs": {},
+        "export_type": "doc_chunks",
+        "md_export_kwargs": {"image_placeholder": ""},
+        "chunker": None,
+        "meta_extractor": None,
+    }
+
+
+def test_component_to_dict_custom_params() -> None:
+    converter = DoclingConverter(
+        convert_kwargs={"raises_on_error": False},
+        export_type=ExportType.MARKDOWN,
+        md_export_kwargs={"image_placeholder": "[img]"},
+        meta_extractor=MetaExtractor(),
+    )
+    data = component_to_dict(converter, "docling_converter")
+
+    init_params = data["init_parameters"]
+    assert init_params["convert_kwargs"] == {"raises_on_error": False}
+    assert init_params["export_type"] == "markdown"
+    assert init_params["md_export_kwargs"] == {"image_placeholder": "[img]"}
+    assert init_params["meta_extractor"] == {
+        "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
+        "data": {},
+    }
+
+
+def test_component_from_dict_defaults() -> None:
+    # null kwargs mirror the pre-refactor serialization format and must still deserialize correctly
+    data = {
         "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",
         "init_parameters": {
             "converter": None,
@@ -162,46 +192,6 @@ def test_component_from_dict_legacy_nulls() -> None:
             "meta_extractor": None,
         },
     }
-    restored = component_from_dict(DoclingConverter, legacy_data, "docling_converter")
-
-    assert restored.convert_kwargs == {}
-    assert restored.md_export_kwargs == {"image_placeholder": ""}
-    assert restored.export_type == ExportType.DOC_CHUNKS
-    assert restored.converter is None
-    assert restored.chunker is None
-    assert restored.meta_extractor is None
-
-
-def test_component_to_dict_defaults() -> None:
-    converter = DoclingConverter()
-    data = component_to_dict(converter, "docling_converter")
-
-    init_params = data["init_parameters"]
-    assert init_params["converter"] is None
-    assert init_params["convert_kwargs"] == {}
-    assert init_params["export_type"] == ExportType.DOC_CHUNKS
-    assert init_params["md_export_kwargs"] == {"image_placeholder": ""}
-    assert init_params["chunker"] is None
-    assert init_params["meta_extractor"] is None
-
-
-def test_component_to_dict_custom_params() -> None:
-    converter = DoclingConverter(
-        convert_kwargs={"raises_on_error": False},
-        export_type=ExportType.MARKDOWN,
-        md_export_kwargs={"image_placeholder": "[img]"},
-    )
-    data = component_to_dict(converter, "docling_converter")
-
-    init_params = data["init_parameters"]
-    assert init_params["convert_kwargs"] == {"raises_on_error": False}
-    assert init_params["export_type"] == ExportType.MARKDOWN
-    assert init_params["md_export_kwargs"] == {"image_placeholder": "[img]"}
-
-
-def test_component_from_dict_defaults() -> None:
-    converter = DoclingConverter()
-    data = component_to_dict(converter, "docling_converter")
     restored = component_from_dict(DoclingConverter, data, "docling_converter")
 
     assert restored.converter is None
@@ -213,17 +203,26 @@ def test_component_from_dict_defaults() -> None:
 
 
 def test_component_from_dict_custom_params() -> None:
-    converter = DoclingConverter(
-        convert_kwargs={"raises_on_error": False},
-        export_type=ExportType.JSON,
-        md_export_kwargs={"image_placeholder": "[img]"},
-    )
-    data = component_to_dict(converter, "docling_converter")
+    data = {
+        "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",
+        "init_parameters": {
+            "converter": None,
+            "convert_kwargs": {"raises_on_error": False},
+            "export_type": "json",
+            "md_export_kwargs": {"image_placeholder": "[img]"},
+            "chunker": None,
+            "meta_extractor": {
+                "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
+                "data": {},
+            },
+        },
+    }
     restored = component_from_dict(DoclingConverter, data, "docling_converter")
 
     assert restored.convert_kwargs == {"raises_on_error": False}
     assert restored.export_type == ExportType.JSON
     assert restored.md_export_kwargs == {"image_placeholder": "[img]"}
+    assert isinstance(restored.meta_extractor, MetaExtractor)
 
 
 def test_run_with_sources_parameter() -> None:

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -10,7 +10,6 @@ import pytest
 from docling.chunking import HybridChunker
 from docling.document_converter import DocumentConverter
 from docling_core.types.io import DocumentStream
-
 from haystack.dataclasses import ByteStream
 
 from haystack_integrations.components.converters.docling import (

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from docling.chunking import HybridChunker
+from docling.document_converter import DocumentConverter
 from docling_core.types.io import DocumentStream
 
 from haystack.dataclasses import ByteStream
@@ -162,6 +163,7 @@ def test_component_to_dict_defaults() -> None:
 
 def test_component_to_dict_custom_params() -> None:
     converter = DoclingConverter(
+        converter=DocumentConverter(),
         convert_kwargs={"raises_on_error": False},
         export_type=ExportType.MARKDOWN,
         md_export_kwargs={"image_placeholder": "[img]"},
@@ -234,10 +236,7 @@ def test_component_from_dict_custom_params() -> None:
 def test_component_to_dict_chunker_warns_and_is_dropped() -> None:
     converter = DoclingConverter(chunker=HybridChunker(merge_peers=False))
 
-    with pytest.warns(UserWarning, match="chunker"):
-        data = converter.to_dict()
-
-    assert data == {
+    assert converter.to_dict() == {
         "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",
         "init_parameters": {
             "converter": None,


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/3255

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add a `to_dict` and `from_dict` methods to `DoclingConverter` to properly support serialization and deserialization. 

Add warnings at serialization time that we don't support serializing the `converter` or `chunker` fields since they are classes that are not easily serialized. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added and updated unit tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
