### PR TITLE
chore: exclude azure-search-documents from license worfklow

### DIFF
--- a/.github/workflows/CI_license_compliance.yml
+++ b/.github/workflows/CI_license_compliance.yml
@@ -3,8 +3,8 @@ name: Core / License Compliance
 on:
   pull_request:
     paths:
-    - "integrations/**/pyproject.toml"
-    - ".github/workflows/CI_license_compliance.yml"
+      - "integrations/**/pyproject.toml"
+      - ".github/workflows/CI_license_compliance.yml"
   # Since we test PRs, there is no need to run the workflow at each
   # merge on `main`. Let's use a cron job instead.
   schedule:
@@ -12,13 +12,13 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-  EXCLUDE_PACKAGES: "(?i)^(azure-identity|fastembed|ragas|tqdm|psycopg|mistralai|pgvector).*"
+  EXCLUDE_PACKAGES: "(?i)^(azure-identity|azure-search-documents|fastembed|tqdm|psycopg|mistralai|pgvector).*"
 
   # Exclusions must be explicitly motivated
   #
   # - azure-identity is MIT but the license is not available on PyPI
+  # - azure-search-documents is MIT but the license is not available on PyPI
   # - fastembed is Apache 2.0 but the license on PyPI is unclear ("Other/Proprietary License (Apache License)")
-  # - ragas is Apache 2.0 but the license is not available on PyPI
   # - mistralai is Apache 2.0 but the license is not available on PyPI
   # - pgvector is MIT but the license is not available on PyPI
 


### PR DESCRIPTION
### Related Issues

- failing license workflow: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/25295184612/job/74152732418
- new azure-search-documents library does not ship license details on PyPI: https://pypi.org/project/azure-search-documents/12.0.0/

### Proposed Changes:
- exclude azure-search-documents from the check (it's MIT)
- re-add ragas (they now ship the licens)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
