### PR TITLE
chore: weaviate - lower-bound pin for python-dateutil

### DIFF
--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
   "haystack-ai>=2.28.0",
   "weaviate-client>=4.20",
-  "python-dateutil",
+  "python-dateutil>=2.7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- failing unit tests with lowest direct dependencies: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/25295161615/job/74237013270 (I am not sure why this did not fail before)

### Proposed Changes:
- set a lower-bound pin for python-dateutil (to the first version that introduced `parser.isoparse`)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
