### PR TITLE
fix(amazon-bedrock): use dataclasses.replace instead of mutating StreamingChunk

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -1,4 +1,5 @@
 import base64
+import dataclasses
 import json
 import os
 import re
@@ -627,7 +628,7 @@ def _convert_event_to_streaming_chunk(
         if len(chunk_meta) > len(base_meta):
             streaming_chunk = StreamingChunk(content="", meta=chunk_meta)
 
-    streaming_chunk.component_info = component_info
+    streaming_chunk = dataclasses.replace(streaming_chunk, component_info=component_info)
 
     return streaming_chunk
 


### PR DESCRIPTION
## Summary

Replace direct attribute mutation of `StreamingChunk.component_info` with `dataclasses.replace()` to avoid unexpected side effects on shared dataclass instances.

## Warning triggered

```
/home/haystackd/.local/lib/python3.12/site-packages/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py:630: Warning: Mutating attribute 'component_info' on an instance of 'StreamingChunk' can lead to unexpected behavior by affecting other parts of the pipeline that use the same dataclass instance. Use `dataclasses.replace(instance, component_info=new_value)` instead. See https://docs.haystack.deepset.ai/docs/custom-components#requirements for details.
```
