### PR TITLE
chore: Cohere - set lower bound pin for Pydantic

### DIFF
--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.8.0"]
+dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.10.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -44,7 +44,6 @@ git_describe_command = 'git describe --tags --match="integrations/cohere-v[0-9]*
 [tool.hatch.envs.default]
 installer = "uv"
 dependencies = ["haystack-pydoc-tools", "ruff"]
-python = "3.10"
 
 [tool.hatch.envs.default.scripts]
 docs = ["haystack-pydoc pydoc/config_docusaurus.yml"]

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.10.0"]
+dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.11.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0"]
+dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"
@@ -44,6 +44,7 @@ git_describe_command = 'git describe --tags --match="integrations/cohere-v[0-9]*
 [tool.hatch.envs.default]
 installer = "uv"
 dependencies = ["haystack-pydoc-tools", "ruff"]
+python = "3.10"
 
 [tool.hatch.envs.default.scripts]
 docs = ["haystack-pydoc pydoc/config_docusaurus.yml"]

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.0"]
+dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.8.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.11.0"]
+dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.12.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"


### PR DESCRIPTION
### Related Issues

- mypy 2.0.0 was released and some tests fail: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/25469352923/job/74729659046

### Proposed Changes:
- explicitly pin pydantic>=2.12.0 (goal was >=2.0, but running tests with lowest dependencies keep failing)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
