### PR TITLE
Fix: S3Downloader concurrency races in cache writing and eviction

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import time
+import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -207,7 +209,14 @@ class S3Downloader:
         else:
             s3_key = self.s3_key_generation_function(document) if self.s3_key_generation_function else file_name
             # we know that _storage is not None after warm_up() is called, but mypy does not know that
-            self._storage.download(key=s3_key, local_file_path=file_path)  # type: ignore[union-attr]
+            temp_file_path = file_path.with_name(f"{file_path.name}.tmp.{uuid.uuid4().hex}")
+            try:
+                self._storage.download(key=s3_key, local_file_path=temp_file_path)  # type: ignore[union-attr]
+                temp_file_path.replace(file_path)
+            except Exception:
+                if temp_file_path.exists():
+                    temp_file_path.unlink()
+                raise
 
         document.meta["file_path"] = str(file_path)
         return document
@@ -222,13 +231,28 @@ class S3Downloader:
             str(abs(hash(str(doc.meta.get("cache_id", ""))))) for doc in documents if doc.meta.get("cache_id")
         }
 
-        all_files = [p for p in self.file_root_path.iterdir() if p.is_file()]
+        now = time.time()
+
+        # Clean up stale temp files that might have been left over from crashes
+        for p in self.file_root_path.glob("*.tmp.*"):
+            try:
+                if now - p.stat().st_mtime > 300:  # noqa: PLR2004
+                    p.unlink()
+            except Exception as error:
+                logger.debug("Failed to remove stale temp file {path}: {error}", path=p, error=error)
+
+        all_files = [p for p in self.file_root_path.iterdir() if p.is_file() and ".tmp." not in p.name]
+
         misses = [p for p in all_files if p.stem not in requested_ids]
 
         overflow = len(misses) + len(requested_ids) - self.max_cache_size
         if overflow > 0:
             misses.sort(key=lambda p: p.stat().st_atime)
-            for p in misses[:overflow]:
+
+            # Protect recently accessed files (last 60 seconds) from being deleted by concurrent runs
+            evictable_misses = [p for p in misses if (now - p.stat().st_atime) > 60]  # noqa: PLR2004
+
+            for p in evictable_misses[:overflow]:
                 try:
                     p.unlink()
                 except Exception as error:


### PR DESCRIPTION
- fixes #3294 

### Proposed Changes:

This PR fixes two critical race conditions in the `S3Downloader` component that occur when multiple pipeline runs execute in parallel with a shared cache directory:

1.  **Partial Write Corruption**: `_download_file` previously wrote directly to the final cache path. Concurrent readers could observe a partially written file, leading to parsing errors (e.g., `PDFium: Data format error`). 
    *   **Solution**: Implemented atomic writes by downloading to a unique temporary file (`.tmp.<uuid>`) and using `pathlib.Path.replace()` only once the download is complete.
2.  **Premature Cache Eviction**: `_cleanup_cache` would identify files from other active runs as "misses" and delete them if the cache was full, leading to `KeyError` or missing files for downstream components.
    *   **Solution**: Updated the eviction logic to calculate overflow correctly but strictly protect any file accessed within the last **60 seconds**. It also now safely ignores and cleans up stale `.tmp.` files older than 5 minutes.

### How did you test it?

- **Unit Tests**: Ran the full suite using `hatch run test:unit`.
- **Regression Testing**: Updated `test_cleanup_cache_evicts_old_files` in `tests/test_s3_downloader.py` to verify that stale files are still evicted while recently accessed files (the new "fresh" file) are correctly protected.
- **Quality Checks**: Verified all checks pass with `hatch run fmt` and `hatch run test:types`.

### Notes for the reviewer

- The 60-second time-based heuristic for cache protection was chosen as a lightweight alternative to complex file locking, effectively preventing races in concurrent pipeline executions without adding new dependencies. This approach was refined using AI assistance to balance safety and performance.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`
