### PR TITLE
fix: adaptations for changes in Weave settings

### DIFF
--- a/integrations/weave/src/haystack_integrations/components/connectors/weave/weave_connector.py
+++ b/integrations/weave/src/haystack_integrations/components/connectors/weave/weave_connector.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import asdict, is_dataclass
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
+from pydantic import BaseModel
 
 from haystack_integrations.tracing.weave import WeaveTracer
 from weave.trace.settings import UserSettings
@@ -110,7 +112,10 @@ class WeaveConnector:
         weave_init_kwargs = self.weave_init_kwargs.copy()
         settings = weave_init_kwargs.get("settings", None)
         if isinstance(settings, UserSettings):
-            weave_init_kwargs["settings"] = settings.model_dump(mode="json", exclude_defaults=True)
+            if isinstance(settings, BaseModel):
+                weave_init_kwargs["settings"] = settings.model_dump(mode="json", exclude_defaults=True)
+            elif is_dataclass(settings):
+                weave_init_kwargs["settings"] = asdict(settings)
 
         return default_to_dict(self, pipeline_name=self.pipeline_name, weave_init_kwargs=weave_init_kwargs)
 

--- a/integrations/weave/tests/test_weave_connector.py
+++ b/integrations/weave/tests/test_weave_connector.py
@@ -97,9 +97,7 @@ class TestWeaveConnector:
         serialized: dict[str, Any] = connector.to_dict()
 
         assert serialized["init_parameters"]["pipeline_name"] == "test_pipeline"
-        assert serialized["init_parameters"]["weave_init_kwargs"] == {
-            "settings": {"implicitly_patch_integrations": False}
-        }
+        assert serialized["init_parameters"]["weave_init_kwargs"]["settings"]["implicitly_patch_integrations"] is False
         assert "type" in serialized
         assert serialized["type"] == "haystack_integrations.components.connectors.weave.weave_connector.WeaveConnector"
 
@@ -108,7 +106,7 @@ class TestWeaveConnector:
         assert isinstance(deserialized, WeaveConnector)
         assert deserialized.pipeline_name == "test_pipeline"
         assert deserialized.tracer is None  # tracer is only initialized with warm_up
-        assert deserialized.weave_init_kwargs == {"settings": {"implicitly_patch_integrations": False}}
+        assert deserialized.weave_init_kwargs["settings"]["implicitly_patch_integrations"] is False
 
     def test_pipeline_tracing(self, mock_weave_client: Mock, sample_pipeline: Pipeline) -> None:
         """Test that pipeline operations are correctly traced"""


### PR DESCRIPTION
### Related Issues

- failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/25893639434/job/76102036829
- this happend because `UserSettings` was a Pydantic BaseModel and now is a plain dataclass: https://github.com/wandb/weave/pull/6814

### Proposed Changes:
- if `UserSettings` is a dataclass, use `asdict` to serialize it. Keep backward compatibility

### How did you test it?
CI, adapted a test


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
