### PR TITLE
fix(mistral): exclude compromised mistralai 2.4.6 from dependencies

### DIFF
--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "mistralai>=2.0.0"]
+# mistralai 2.4.6 is excluded because of security issue https://github.com/mistralai/client-python/security/advisories/GHSA-wx9m-wx4f-4cmg
+dependencies = ["haystack-ai>=2.22.0", "mistralai>=2.0.0,!=2.4.6"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mistral#readme"


### PR DESCRIPTION
### Related Issues
None

### Proposed Changes:
- Exclude `mistralai==2.4.6` from the mistral-haystack integration dependencies via `!=2.4.6` version constraint
- Added a comment referencing the GitHub security advisory (GHSA-wx9m-wx4f-4cmg)

### How did you test it?
No code changes. Only a version exclusion in `pyproject.toml`.

### Notes for the reviewer
`mistralai` 2.4.6 was a compromised PyPI release uploaded on 2026-05-12 at 00:05 UTC and removed at 03:05 UTC. See the security advisory: https://github.com/mistralai/client-python/security/advisories/GHSA-wx9m-wx4f-4cmg

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.