### PR TITLE
revert: remove pip ecosystem from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,3 @@ updates:
       interval: 'daily'
     cooldown:
       default-days: 1
-
-  - package-ecosystem: 'pip'
-    directories:
-      - 'integrations/*'
-    schedule:
-      interval: 'daily'
-    cooldown:
-      default-days: 1


### PR DESCRIPTION
### Related Issues
None

### Proposed Changes:
- Remove the `pip` package-ecosystem block (with `cooldown: default-days: 1`) added in #3258

### How did you test it?
Config-only change.

### Notes for the reviewer
The `github-actions` cooldown added in #3258 is kept. Only the `pip` ecosystem entry is reverted here.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.