### PR TITLE
fix(ollama): preserve tool call IDs to fix repeated same-tool calls

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -165,10 +165,10 @@ def _convert_ollama_response_to_chatmessage(ollama_response: ChatResponse) -> Ch
     tool_calls: list[ToolCall] = []
 
     if ollama_tool_calls := ollama_message.get("tool_calls"):
-        for idx, ollama_tc in enumerate(ollama_tool_calls):
+        for ollama_tc in ollama_tool_calls:
             tool_calls.append(
                 ToolCall(
-                    id=ollama_tc.get("id") or f"call_{idx}",
+                    id=ollama_tc.get("id"),
                     tool_name=ollama_tc["function"]["name"],
                     arguments=ollama_tc["function"]["arguments"],
                 )
@@ -209,7 +209,7 @@ def _build_chunk(
             tool_calls_list.append(
                 ToolCallDelta(
                     index=tool_call_index,
-                    id=tool_call.get("id") or f"call_{tool_call_index}",
+                    id=tool_call.get("id"),
                     tool_name=tool_call["function"]["name"],
                     arguments=json.dumps(tool_call["function"]["arguments"])
                     if tool_call["function"]["arguments"]
@@ -372,10 +372,11 @@ class OllamaChatGenerator:
         component_info = ComponentInfo.from_component(self)
         chunks: list[StreamingChunk] = []
 
-        # Accumulators
-        arg_by_id: dict[str, str] = {}
-        name_by_id: dict[str, str] = {}
-        id_order: list[str] = []
+        # Accumulators keyed by tool_call.index (always unique per call, even for repeated tool names)
+        arg_by_index: dict[str, str] = {}
+        name_by_index: dict[str, str] = {}
+        id_by_index: dict[str, str | None] = {}
+        index_order: list[str] = []
         tool_call_index: int = 0
 
         # track reasoning and content blocks to correctly set start=True on the first chunk of each block
@@ -402,15 +403,14 @@ class OllamaChatGenerator:
 
             if chunk.tool_calls:
                 for tool_call in chunk.tool_calls:
-                    # id is always set by _build_chunk (either from the server or synthetic "call_N").
-                    # Fall back to tool_name only as a last resort for callers that bypass _build_chunk.
-                    tool_call_id = tool_call.id or tool_call.tool_name or ""
+                    key = str(tool_call.index)
                     args = tool_call.arguments or ""
 
-                    if tool_call_id not in id_order:
-                        id_order.append(tool_call_id)
-                        name_by_id[tool_call_id] = tool_call.tool_name or ""
-                    arg_by_id[tool_call_id] = args
+                    if key not in index_order:
+                        index_order.append(key)
+                        name_by_index[key] = tool_call.tool_name or ""
+                        id_by_index[key] = tool_call.id
+                    arg_by_index[key] = args
 
             if callback:
                 callback(chunk)
@@ -423,10 +423,10 @@ class OllamaChatGenerator:
             reasoning += c.reasoning.reasoning_text if c.reasoning else ""
 
         tool_calls = []
-        for tool_call_id in id_order:
-            arguments: str = arg_by_id.get(tool_call_id, "")
+        for key in index_order:
+            arguments: str = arg_by_index.get(key, "")
             tool_calls.append(
-                ToolCall(id=tool_call_id, tool_name=name_by_id[tool_call_id], arguments=json.loads(arguments))
+                ToolCall(id=id_by_index[key], tool_name=name_by_index[key], arguments=json.loads(arguments))
             )
 
         # We can't use _convert_streaming_chunks_to_chat_message because
@@ -453,10 +453,11 @@ class OllamaChatGenerator:
         component_info = ComponentInfo.from_component(self)
         chunks: list[StreamingChunk] = []
 
-        # Accumulators
-        arg_by_id: dict[str, str] = {}
-        name_by_id: dict[str, str] = {}
-        id_order: list[str] = []
+        # Accumulators keyed by tool_call.index (always unique per call, even for repeated tool names)
+        arg_by_index: dict[str, str] = {}
+        name_by_index: dict[str, str] = {}
+        id_by_index: dict[str, str | None] = {}
+        index_order: list[str] = []
         tool_call_index: int = 0
 
         # track reasoning and content blocks to correctly set start=True on the first chunk of each block
@@ -484,13 +485,14 @@ class OllamaChatGenerator:
 
             if chunk.tool_calls:
                 for tool_call in chunk.tool_calls:
-                    tool_call_id = tool_call.id or tool_call.tool_name or ""
+                    key = str(tool_call.index)
                     args = tool_call.arguments or ""
 
-                    if tool_call_id not in id_order:
-                        id_order.append(tool_call_id)
-                        name_by_id[tool_call_id] = tool_call.tool_name or ""
-                    arg_by_id[tool_call_id] = args
+                    if key not in index_order:
+                        index_order.append(key)
+                        name_by_index[key] = tool_call.tool_name or ""
+                        id_by_index[key] = tool_call.id
+                    arg_by_index[key] = args
 
             if callback is not None:
                 await callback(chunk)
@@ -505,10 +507,10 @@ class OllamaChatGenerator:
             reasoning += c.reasoning.reasoning_text if c.reasoning else ""
 
         tool_calls = []
-        for tool_call_id in id_order:
-            arguments: str = arg_by_id.get(tool_call_id, "")
+        for key in index_order:
+            arguments: str = arg_by_index.get(key, "")
             tool_calls.append(
-                ToolCall(id=tool_call_id, tool_name=name_by_id[tool_call_id], arguments=json.loads(arguments))
+                ToolCall(id=id_by_index[key], tool_name=name_by_index[key], arguments=json.loads(arguments))
             )
 
         # We can't use _convert_streaming_chunks_to_chat_message because

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -165,9 +165,10 @@ def _convert_ollama_response_to_chatmessage(ollama_response: ChatResponse) -> Ch
     tool_calls: list[ToolCall] = []
 
     if ollama_tool_calls := ollama_message.get("tool_calls"):
-        for ollama_tc in ollama_tool_calls:
+        for idx, ollama_tc in enumerate(ollama_tool_calls):
             tool_calls.append(
                 ToolCall(
+                    id=ollama_tc.get("id") or f"call_{idx}",
                     tool_name=ollama_tc["function"]["name"],
                     arguments=ollama_tc["function"]["arguments"],
                 )
@@ -208,6 +209,7 @@ def _build_chunk(
             tool_calls_list.append(
                 ToolCallDelta(
                     index=tool_call_index,
+                    id=tool_call.get("id") or f"call_{tool_call_index}",
                     tool_name=tool_call["function"]["name"],
                     arguments=json.dumps(tool_call["function"]["arguments"])
                     if tool_call["function"]["arguments"]
@@ -400,28 +402,14 @@ class OllamaChatGenerator:
 
             if chunk.tool_calls:
                 for tool_call in chunk.tool_calls:
-                    # the Ollama server doesn't guarantee an id field in every tool_calls entry.
-                    # OpenAI-compatible endpoint (/v1/chat/completions) - recent releases do add an auto-generated id
-                    # when the model produces multiple tool calls, so that clients can map results back.
-                    # Native Ollama endpoint (/api/chat) and older builds
-                    # - the JSON often contains only function.name + arguments;
-                    # many users have reported that id is missing even with several calls,
-                    # making client-side resolution harder:
-                    # https://github.com/ollama/ollama/issues/6708
-                    # https://github.com/ollama/ollama/issues/7510
-                    # - If id is provided → we can distinguish multiple calls to the same tool.
-
-                    # - If id is missing → fallback to function.name works only when there's one call.
-                    # - That's why the deduplication logic is cautious and assumes one logical
-                    #   call per name when id is absent.
+                    # id is always set by _build_chunk (either from the server or synthetic "call_N").
+                    # Fall back to tool_name only as a last resort for callers that bypass _build_chunk.
                     tool_call_id = tool_call.id or tool_call.tool_name or ""
                     args = tool_call.arguments or ""
 
-                    # Remember first-seen order and tool name
                     if tool_call_id not in id_order:
                         id_order.append(tool_call_id)
                         name_by_id[tool_call_id] = tool_call.tool_name or ""
-                    # Update the argument accumulator for this tool_call_id.
                     arg_by_id[tool_call_id] = args
 
             if callback:
@@ -437,7 +425,9 @@ class OllamaChatGenerator:
         tool_calls = []
         for tool_call_id in id_order:
             arguments: str = arg_by_id.get(tool_call_id, "")
-            tool_calls.append(ToolCall(tool_name=name_by_id[tool_call_id], arguments=json.loads(arguments)))
+            tool_calls.append(
+                ToolCall(id=tool_call_id, tool_name=name_by_id[tool_call_id], arguments=json.loads(arguments))
+            )
 
         # We can't use _convert_streaming_chunks_to_chat_message because
         # we need to map tool_call name and args by order.
@@ -497,11 +487,9 @@ class OllamaChatGenerator:
                     tool_call_id = tool_call.id or tool_call.tool_name or ""
                     args = tool_call.arguments or ""
 
-                    # Remember first-seen order and tool name
                     if tool_call_id not in id_order:
                         id_order.append(tool_call_id)
                         name_by_id[tool_call_id] = tool_call.tool_name or ""
-                    # Update the argument accumulator for this tool_call_id
                     arg_by_id[tool_call_id] = args
 
             if callback is not None:
@@ -519,7 +507,9 @@ class OllamaChatGenerator:
         tool_calls = []
         for tool_call_id in id_order:
             arguments: str = arg_by_id.get(tool_call_id, "")
-            tool_calls.append(ToolCall(tool_name=name_by_id[tool_call_id], arguments=json.loads(arguments)))
+            tool_calls.append(
+                ToolCall(id=tool_call_id, tool_name=name_by_id[tool_call_id], arguments=json.loads(arguments))
+            )
 
         # We can't use _convert_streaming_chunks_to_chat_message because
         # we need to map tool_call name and args by order.

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -507,6 +507,67 @@ class TestUtils:
         assert result["replies"][0].tool_calls[1].arguments == {"city": "London"}
         assert result["replies"][0].tool_calls[1].id is None
 
+    @pytest.mark.asyncio
+    async def test_handle_streaming_response_async_repeated_tool_calls(self):
+        ollama_chunks = [
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T14:48:03.471292Z",
+                done=False,
+                message=Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        Message.ToolCall(
+                            function=Message.ToolCall.Function(name="weather", arguments={"city": "Paris"})
+                        )
+                    ],
+                ),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T14:48:03.660179Z",
+                done=False,
+                message=Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        Message.ToolCall(
+                            function=Message.ToolCall.Function(name="weather", arguments={"city": "London"})
+                        )
+                    ],
+                ),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T14:48:03.678729Z",
+                done=True,
+                done_reason="stop",
+                total_duration=774786292,
+                load_duration=43608375,
+                prompt_eval_count=217,
+                prompt_eval_duration=312974541,
+                eval_count=46,
+                eval_duration=417069750,
+                message=Message(role="assistant", content=""),
+            ),
+        ]
+
+        async def async_chunks():
+            for chunk in ollama_chunks:
+                yield chunk
+
+        generator = OllamaChatGenerator()
+        result = await generator._handle_streaming_response_async(async_chunks(), None)
+
+        assert len(result["replies"][0].tool_calls) == 2
+        assert result["replies"][0].tool_calls[0].tool_name == "weather"
+        assert result["replies"][0].tool_calls[0].arguments == {"city": "Paris"}
+        assert result["replies"][0].tool_calls[0].id is None
+        assert result["replies"][0].tool_calls[1].tool_name == "weather"
+        assert result["replies"][0].tool_calls[1].arguments == {"city": "London"}
+        assert result["replies"][0].tool_calls[1].id is None
+
     def test_handle_streaming_response_tool_calls_with_thinking(self):
         ollama_chunks = [
             ChatResponse(

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -1392,6 +1392,33 @@ class TestOllamaChatGeneratorLiveInference:
         assert new_response.tool_calls[0].tool_name == "multiply"
         assert new_response.tool_calls[0].arguments == {"a": 5, "b": 10}
 
+    @pytest.mark.parametrize("streaming_callback", [None, print_streaming_chunk])
+    def test_live_run_with_repeated_tool_calls(self, tools, streaming_callback):
+        component = OllamaChatGenerator(model="qwen3:0.6b", tools=tools, streaming_callback=streaming_callback)
+        tool_invoker = ToolInvoker(tools=tools)
+
+        messages = [ChatMessage.from_user("What is the weather in Paris and London?")]
+        response = component.run(messages)
+
+        assert len(response["replies"]) == 1
+        assistant_msg = response["replies"][0]
+
+        assert assistant_msg.tool_calls
+        assert len(assistant_msg.tool_calls) == 2
+        for tc in assistant_msg.tool_calls:
+            assert isinstance(tc, ToolCall)
+            assert tc.tool_name == "weather"
+            assert "city" in tc.arguments
+
+        cities = {tc.arguments["city"].lower() for tc in assistant_msg.tool_calls}
+        assert any("paris" in c for c in cities)
+        assert any("london" in c for c in cities)
+
+        tool_messages = tool_invoker.run(messages=[assistant_msg])["tool_messages"]
+        final_response = component.run(messages + [assistant_msg] + tool_messages)
+        assert len(final_response["replies"]) == 1
+        assert final_response["replies"][0].text
+
     def test_live_run_with_tools_and_format(self, tools):
         response_format = {
             "type": "object",

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -1415,7 +1415,7 @@ class TestOllamaChatGeneratorLiveInference:
         assert any("london" in c for c in cities)
 
         tool_messages = tool_invoker.run(messages=[assistant_msg])["tool_messages"]
-        final_response = component.run(messages + [assistant_msg] + tool_messages)
+        final_response = component.run([*messages, assistant_msg, *tool_messages])
         assert len(final_response["replies"]) == 1
         assert final_response["replies"][0].text
 

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -190,7 +190,6 @@ class TestUtils:
         assert observed.role == "assistant"
         assert observed.text is None
         assert observed.tool_call == ToolCall(
-            id="call_0",
             tool_name="get_current_weather",
             arguments={"format": "celsius", "location": "Paris, FR"},
         )
@@ -219,8 +218,8 @@ class TestUtils:
         observed = _convert_ollama_response_to_chatmessage(ollama_response)
 
         assert len(observed.tool_calls) == 2
-        assert observed.tool_calls[0] == ToolCall(id="call_0", tool_name="weather", arguments={"city": "Paris"})
-        assert observed.tool_calls[1] == ToolCall(id="call_1", tool_name="weather", arguments={"city": "London"})
+        assert observed.tool_calls[0] == ToolCall(tool_name="weather", arguments={"city": "Paris"})
+        assert observed.tool_calls[1] == ToolCall(tool_name="weather", arguments={"city": "London"})
 
     def test_build_chunk(self):
         generator = OllamaChatGenerator()
@@ -414,10 +413,10 @@ class TestUtils:
         assert result["replies"][0].text is None
         assert result["replies"][0].tool_calls[0].tool_name == "calculator"
         assert result["replies"][0].tool_calls[0].arguments == {"expression": "7 * (4 + 2)"}
-        assert result["replies"][0].tool_calls[0].id == "call_1"
+        assert result["replies"][0].tool_calls[0].id is None
         assert result["replies"][0].tool_calls[1].tool_name == "factorial"
         assert result["replies"][0].tool_calls[1].arguments == {"n": 5}
-        assert result["replies"][0].tool_calls[1].id == "call_2"
+        assert result["replies"][0].tool_calls[1].id is None
         assert result["replies"][0].meta["finish_reason"] == "stop"
         assert result["replies"][0].meta["model"] == "qwen3:0.6b"
 
@@ -430,7 +429,7 @@ class TestUtils:
         expected = {
             "index": 1,
             "arguments": '{"expression": "7 * (4 + 2)"}',
-            "id": "call_1",
+            "id": None,
             "tool_name": "calculator",
         }
         # We add extra to the expected dict if it exists in the result for comparison
@@ -443,7 +442,7 @@ class TestUtils:
             "index": 2,
             "tool_name": "factorial",
             "arguments": '{"n": 5}',
-            "id": "call_2",
+            "id": None,
         }
         # We add extra to the expected dict if it exists in the result for comparison
         # This was added in PR https://github.com/deepset-ai/haystack/pull/10018 and released in Haystack 2.20.0
@@ -503,10 +502,10 @@ class TestUtils:
         assert len(result["replies"][0].tool_calls) == 2
         assert result["replies"][0].tool_calls[0].tool_name == "weather"
         assert result["replies"][0].tool_calls[0].arguments == {"city": "Paris"}
-        assert result["replies"][0].tool_calls[0].id == "call_1"
+        assert result["replies"][0].tool_calls[0].id is None
         assert result["replies"][0].tool_calls[1].tool_name == "weather"
         assert result["replies"][0].tool_calls[1].arguments == {"city": "London"}
-        assert result["replies"][0].tool_calls[1].id == "call_2"
+        assert result["replies"][0].tool_calls[1].id is None
 
     def test_handle_streaming_response_tool_calls_with_thinking(self):
         ollama_chunks = [
@@ -622,7 +621,7 @@ class TestUtils:
         assert result["replies"][0].text is None
         assert result["replies"][0].tool_calls[0].tool_name == "add_two_numbers"
         assert result["replies"][0].tool_calls[0].arguments == {"a": 2, "b": 2}
-        assert result["replies"][0].tool_calls[0].id == "call_1"
+        assert result["replies"][0].tool_calls[0].id is None
         assert result["replies"][0].reasoning.reasoning_text == "Okay, the user is asking 2 plus 2."
         assert result["replies"][0].meta["finish_reason"] == "stop"
         assert result["replies"][0].meta["model"] == "qwen3:0.6b"
@@ -651,7 +650,7 @@ class TestUtils:
         expected = {
             "index": 1,
             "arguments": '{"a": 2, "b": 2}',
-            "id": "call_1",
+            "id": None,
             "tool_name": "add_two_numbers",
         }
         serialized_dict = streaming_chunks[12].tool_calls[0].to_dict()

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -190,9 +190,37 @@ class TestUtils:
         assert observed.role == "assistant"
         assert observed.text is None
         assert observed.tool_call == ToolCall(
+            id="call_0",
             tool_name="get_current_weather",
             arguments={"format": "celsius", "location": "Paris, FR"},
         )
+
+    def test_convert_ollama_response_to_chatmessage_with_repeated_tool(self):
+        ollama_response = ChatResponse(
+            model="some_model",
+            created_at="2023-12-12T14:13:43.416799Z",
+            message={
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "weather", "arguments": {"city": "Paris"}}},
+                    {"function": {"name": "weather", "arguments": {"city": "London"}}},
+                ],
+            },
+            done=True,
+            total_duration=5191566416,
+            load_duration=2154458,
+            prompt_eval_count=26,
+            prompt_eval_duration=383809000,
+            eval_count=298,
+            eval_duration=4799921000,
+        )
+
+        observed = _convert_ollama_response_to_chatmessage(ollama_response)
+
+        assert len(observed.tool_calls) == 2
+        assert observed.tool_calls[0] == ToolCall(id="call_0", tool_name="weather", arguments={"city": "Paris"})
+        assert observed.tool_calls[1] == ToolCall(id="call_1", tool_name="weather", arguments={"city": "London"})
 
     def test_build_chunk(self):
         generator = OllamaChatGenerator()
@@ -386,8 +414,10 @@ class TestUtils:
         assert result["replies"][0].text is None
         assert result["replies"][0].tool_calls[0].tool_name == "calculator"
         assert result["replies"][0].tool_calls[0].arguments == {"expression": "7 * (4 + 2)"}
+        assert result["replies"][0].tool_calls[0].id == "call_1"
         assert result["replies"][0].tool_calls[1].tool_name == "factorial"
         assert result["replies"][0].tool_calls[1].arguments == {"n": 5}
+        assert result["replies"][0].tool_calls[1].id == "call_2"
         assert result["replies"][0].meta["finish_reason"] == "stop"
         assert result["replies"][0].meta["model"] == "qwen3:0.6b"
 
@@ -400,7 +430,7 @@ class TestUtils:
         expected = {
             "index": 1,
             "arguments": '{"expression": "7 * (4 + 2)"}',
-            "id": None,
+            "id": "call_1",
             "tool_name": "calculator",
         }
         # We add extra to the expected dict if it exists in the result for comparison
@@ -413,7 +443,7 @@ class TestUtils:
             "index": 2,
             "tool_name": "factorial",
             "arguments": '{"n": 5}',
-            "id": None,
+            "id": "call_2",
         }
         # We add extra to the expected dict if it exists in the result for comparison
         # This was added in PR https://github.com/deepset-ai/haystack/pull/10018 and released in Haystack 2.20.0
@@ -421,6 +451,62 @@ class TestUtils:
             expected["extra"] = streaming_chunks[1].tool_calls[0].to_dict()["extra"]
         assert streaming_chunks[1].tool_calls[0].to_dict() == expected
         assert len(streaming_chunks[2].tool_calls) == 0
+
+    def test_handle_streaming_response_repeated_tool_calls(self):
+        ollama_chunks = [
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T14:48:03.471292Z",
+                done=False,
+                message=Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        Message.ToolCall(
+                            function=Message.ToolCall.Function(name="weather", arguments={"city": "Paris"})
+                        )
+                    ],
+                ),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T14:48:03.660179Z",
+                done=False,
+                message=Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        Message.ToolCall(
+                            function=Message.ToolCall.Function(name="weather", arguments={"city": "London"})
+                        )
+                    ],
+                ),
+            ),
+            ChatResponse(
+                model="qwen3:0.6b",
+                created_at="2025-07-31T14:48:03.678729Z",
+                done=True,
+                done_reason="stop",
+                total_duration=774786292,
+                load_duration=43608375,
+                prompt_eval_count=217,
+                prompt_eval_duration=312974541,
+                eval_count=46,
+                eval_duration=417069750,
+                message=Message(role="assistant", content=""),
+            ),
+        ]
+
+        generator = OllamaChatGenerator()
+        result = generator._handle_streaming_response(ollama_chunks, None)
+
+        assert len(result["replies"][0].tool_calls) == 2
+        assert result["replies"][0].tool_calls[0].tool_name == "weather"
+        assert result["replies"][0].tool_calls[0].arguments == {"city": "Paris"}
+        assert result["replies"][0].tool_calls[0].id == "call_1"
+        assert result["replies"][0].tool_calls[1].tool_name == "weather"
+        assert result["replies"][0].tool_calls[1].arguments == {"city": "London"}
+        assert result["replies"][0].tool_calls[1].id == "call_2"
 
     def test_handle_streaming_response_tool_calls_with_thinking(self):
         ollama_chunks = [
@@ -536,6 +622,7 @@ class TestUtils:
         assert result["replies"][0].text is None
         assert result["replies"][0].tool_calls[0].tool_name == "add_two_numbers"
         assert result["replies"][0].tool_calls[0].arguments == {"a": 2, "b": 2}
+        assert result["replies"][0].tool_calls[0].id == "call_1"
         assert result["replies"][0].reasoning.reasoning_text == "Okay, the user is asking 2 plus 2."
         assert result["replies"][0].meta["finish_reason"] == "stop"
         assert result["replies"][0].meta["model"] == "qwen3:0.6b"
@@ -564,7 +651,7 @@ class TestUtils:
         expected = {
             "index": 1,
             "arguments": '{"a": 2, "b": 2}',
-            "id": None,
+            "id": "call_1",
             "tool_name": "add_two_numbers",
         }
         serialized_dict = streaming_chunks[12].tool_calls[0].to_dict()


### PR DESCRIPTION
### Related Issues

- fixes #3303

### Proposed Changes:

`OllamaChatGenerator` was silently dropping tool call IDs, which broke any scenario where the same tool is called more than once in a single assistant turn. In the streaming accumulator, both calls mapped to the same key (the tool name since ID was `None`), so the second call overwrote the first and it was lost.

Fix: generate a synthetic ID (`call_N`) for each tool call in both the streaming and non-streaming paths, and propagate it to the final `ToolCall` objects. `ollama_tc.get("id")` is checked first so the code will use server-assigned IDs automatically if a future Ollama SDK version exposes them.

Affected locations:
- `_convert_ollama_response_to_chatmessage`  non-streaming path
- `_build_chunk` streaming chunk builder
- `_handle_streaming_response` + `_handle_streaming_response_async`  streaming reconstruction

### How did you test it?

- Reproduced the bug: two streaming chunks calling `weather` with different cities  only the second call survived before the fix
- After the fix both calls are returned with distinct IDs
- Added `test_convert_ollama_response_to_chatmessage_with_repeated_tool`
- Added `test_handle_streaming_response_repeated_tool_calls`
- Updated existing tests that previously asserted `id=None` on `ToolCallDelta` and `ToolCall` objects
- All 41 unit tests pass, ruff clean

### Notes for the reviewer

The Ollama Python SDK (0.6.1) drops the `id` field from the server JSON response during Pydantic parsing `Message.ToolCall` has no `id` field defined. Synthetic IDs (`call_0`, `call_1`, …) are the only option today. The `get("id")` fallback is a forward-compatible hook for when the SDK adds the field.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`