### PR TITLE
test: make vLLM wheel detection more robust

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -84,15 +84,19 @@ jobs:
         run: |
           # vLLM on PyPI is GPU-only and requires CUDA, so it won't run on CPU-only systems.
           # CPU wheels are not published to PyPI; they are only available as direct downloads from GitHub releases.
-          # We fetch the latest release and install the appropriate x86 CPU wheel.
+          # We query the latest release's assets and pick the x86_64 CPU wheel, since the manylinux/ABI
+          # tags in the filename can change between releases.
           # The --torch-backend cpu flag ensures uv installs PyTorch from the official CPU-only index,
           # since the required torch+cpu builds are also not available on PyPI.
-          VLLM_VERSION="$(curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest | jq -r .tag_name | sed 's/^v//')"
-          export VLLM_VERSION
-          echo "Installing vLLM ${VLLM_VERSION} (CPU)"
-          hatch run -- uv pip install \
-            "https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cpu-cp38-abi3-manylinux_2_35_x86_64.whl" \
-            --torch-backend cpu
+          VLLM_WHEEL_URL="$(curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest \
+            | jq -r '.assets[] | select(.name | test("\\+cpu.*x86_64\\.whl$")) | .browser_download_url' \
+            | head -n1)"
+          if [ -z "${VLLM_WHEEL_URL}" ]; then
+            echo "Could not find a CPU x86_64 wheel in the latest vLLM release" >&2
+            exit 1
+          fi
+          echo "Installing ${VLLM_WHEEL_URL}"
+          hatch run -- uv pip install "${VLLM_WHEEL_URL}" --torch-backend cpu
 
       - name: Start vLLM chat server
         run: |


### PR DESCRIPTION
### Related Issues

- vLLM fails to install on tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26007221959/job/76440807282
- for the CPU wheel name, we follow instructions in [their documentation](https://docs.vllm.ai/en/stable/getting_started/installation/cpu/#pre-built-wheels), but manylinux/ABI tags change unpredictably

### Proposed Changes:
- adopt a more robust mechanism to get the latest CPU wheel via GitHub API

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
