### PR TITLE
fix: Fix langfuse tracer when input messages is `None`

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -90,7 +90,7 @@ class LangfuseSpan(Span):
             return
         if key.endswith(".input"):
             if "messages" in value:
-                messages = [m.to_openai_dict_format(require_tool_call_ids=False) for m in value["messages"]]
+                messages = [m.to_openai_dict_format(require_tool_call_ids=False) for m in (value.get("messages") or [])]
                 if isinstance(gen_kwargs := value.get("generation_kwargs"), dict):
                     self._span.update(input={"messages": messages, "generation_kwargs": gen_kwargs})
                 else:

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -100,10 +100,11 @@ class LangfuseSpan(Span):
                 self._span.update(input=coerced_value)
         elif key.endswith(".output"):
             if "replies" in value:
-                if all(isinstance(r, ChatMessage) for r in value["replies"]):
-                    replies = [m.to_openai_dict_format(require_tool_call_ids=False) for m in value["replies"]]
+                replies_list = value.get("replies") or []
+                if all(isinstance(r, ChatMessage) for r in replies_list):
+                    replies = [m.to_openai_dict_format(require_tool_call_ids=False) for m in replies_list]
                 else:
-                    replies = value["replies"]
+                    replies = replies_list
                 self._span.update(output=replies)
             else:
                 coerced_value = tracing_utils.coerce_tag_value(value)

--- a/integrations/langfuse/tests/test_tracer.py
+++ b/integrations/langfuse/tests/test_tracer.py
@@ -180,6 +180,16 @@ class TestLangfuseSpan:
             # check we handle properly string list replies
             assert mock_context_manager._span.update.call_args_list[0][1] == {"output": ["reply1", "reply2"]}
 
+    def test_set_content_tag_messages_none_does_not_raise(self):
+        # Regression test: value["messages"] key present but value is None must not raise TypeError
+        mock_context_manager = MockContextManager()
+        span = LangfuseSpan(mock_context_manager)
+
+        with patch("haystack_integrations.tracing.langfuse.tracer.proxy_tracer.is_content_tracing_enabled", True):
+            span.set_content_tag("key.input", {"messages": None})
+            assert mock_context_manager._span.update.call_count == 1
+            assert mock_context_manager._span.update.call_args_list[0][1] == {"input": []}
+
 
 class TestSpanContext:
     def test_post_init(self):

--- a/integrations/langfuse/tests/test_tracer.py
+++ b/integrations/langfuse/tests/test_tracer.py
@@ -181,7 +181,6 @@ class TestLangfuseSpan:
             assert mock_context_manager._span.update.call_args_list[0][1] == {"output": ["reply1", "reply2"]}
 
     def test_set_content_tag_messages_none_does_not_raise(self):
-        # Regression test: value["messages"] key present but value is None must not raise TypeError
         mock_context_manager = MockContextManager()
         span = LangfuseSpan(mock_context_manager)
 
@@ -189,6 +188,15 @@ class TestLangfuseSpan:
             span.set_content_tag("key.input", {"messages": None})
             assert mock_context_manager._span.update.call_count == 1
             assert mock_context_manager._span.update.call_args_list[0][1] == {"input": []}
+
+    def test_set_content_tag_replies_none_does_not_raise(self):
+        mock_context_manager = MockContextManager()
+        span = LangfuseSpan(mock_context_manager)
+
+        with patch("haystack_integrations.tracing.langfuse.tracer.proxy_tracer.is_content_tracing_enabled", True):
+            span.set_content_tag("key.output", {"replies": None})
+            assert mock_context_manager._span.update.call_count == 1
+            assert mock_context_manager._span.update.call_args_list[0][1] == {"output": []}
 
 
 class TestSpanContext:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/358

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

The LLM component accepts `messages=None` as valid input which can break the Langfuse Tracer since it always assumes that if `messages` is present that it's always a `list[ChatMessage]`. This PR updates to handle the `None` case. 

We also add the same guard for `replies` returning as `None`. This is not a known case but done for safety. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
