### PR TITLE
fix: type error during streaming of AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -569,9 +569,9 @@ def _convert_event_to_streaming_chunk(
         # This only occurs when accumulating the arguments for a toolUse
         # The content_block for this tool should already exist at this point
         elif "toolUse" in delta:
-            input = delta["toolUse"].get("input", "")
+            tool_use_input = delta["toolUse"].get("input", "")
             # boto3 might return int for input
-            arguments = str(input) if input is not None else None
+            arguments = str(tool_use_input) if tool_use_input is not None else None
             streaming_chunk = StreamingChunk(
                 content="",
                 index=block_idx,

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -569,13 +569,16 @@ def _convert_event_to_streaming_chunk(
         # This only occurs when accumulating the arguments for a toolUse
         # The content_block for this tool should already exist at this point
         elif "toolUse" in delta:
+            input = delta["toolUse"].get("input", "")
+            # boto3 might return int for input
+            arguments = str(input) if input is not None else None
             streaming_chunk = StreamingChunk(
                 content="",
                 index=block_idx,
                 tool_calls=[
                     ToolCallDelta(
                         index=block_idx,
-                        arguments=delta["toolUse"].get("input", ""),
+                        arguments=arguments,
                     )
                 ],
                 meta=base_meta,

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -17,6 +17,7 @@ from haystack.dataclasses import (
 from haystack.tools import Tool
 
 from haystack_integrations.components.generators.amazon_bedrock.chat.utils import (
+    _convert_event_to_streaming_chunk,
     _convert_file_content_to_bedrock_format,
     _convert_streaming_chunks_to_chat_message,
     _format_messages,
@@ -2099,3 +2100,42 @@ class TestAmazonBedrockChatGeneratorUtils:
 
         with pytest.raises(ValueError, match=r"Cache point can only contain 'type' and 'ttl' keys."):
             _validate_and_format_cache_point({"type": "default", "invalid": "config"})
+
+    def test_convert_event_to_streaming_chunk_tool_use_input_int(self):
+        model = "global.anthropic.claude-sonnet-4-6"
+        component_info = ComponentInfo(
+            type="haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator.AmazonBedrockChatGenerator"
+        )
+
+        # boto3 may return an int for toolUse input — must be cast to str
+        event_int = {
+            "contentBlockDelta": {
+                "delta": {"toolUse": {"input": 42}},
+                "contentBlockIndex": 1,
+            }
+        }
+        chunk = _convert_event_to_streaming_chunk(event_int, model, component_info)
+        assert chunk.tool_calls is not None
+        assert chunk.tool_calls[0].arguments == "42"
+
+        # None input should stay None
+        event_none = {
+            "contentBlockDelta": {
+                "delta": {"toolUse": {"input": None}},
+                "contentBlockIndex": 1,
+            }
+        }
+        chunk = _convert_event_to_streaming_chunk(event_none, model, component_info)
+        assert chunk.tool_calls is not None
+        assert chunk.tool_calls[0].arguments is None
+
+        # Normal string input should pass through unchanged
+        event_str = {
+            "contentBlockDelta": {
+                "delta": {"toolUse": {"input": '{"city": "Berlin"}'}},
+                "contentBlockIndex": 1,
+            }
+        }
+        chunk = _convert_event_to_streaming_chunk(event_str, model, component_info)
+        assert chunk.tool_calls is not None
+        assert chunk.tool_calls[0].arguments == '{"city": "Berlin"}'


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/3333

### Proposed Changes:
- ensure ToolCallDelta's argument is str: convert input if necessary

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
