### PR TITLE
build: apply pip supply-chain hardening to new-integration workflow template

### DIFF
--- a/scripts/utils/templates/workflow.yml
+++ b/scripts/utils/templates/workflow.yml
@@ -74,7 +74,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch --uploaded-prior-to=P1D
       - name: Lint
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types


### PR DESCRIPTION
### Related Issues

- Follow-up to #3258

### Proposed Changes:

- Update `scripts/utils/templates/workflow.yml` so newly scaffolded integration workflows upgrade pip and pass `--uploaded-prior-to=P1D` when installing Hatch, matching the pattern applied across all existing per-integration workflows in #3258. Without this, any new integration created via `scripts/create_new_integration.py` would ship without the supply-chain guardrail.

### How did you test it?

- Verified the diff matches the pattern used in #3258 for existing per-integration workflows.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.