### PR TITLE
test: together ai - replace Kimi K2.5 retired model with K2.6

### DIFF
--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -685,7 +685,7 @@ class TestTogetherAIChatGenerator:
         initial_messages = [
             ChatMessage.from_user("What's the weather like in Paris and what is the population of Berlin?")
         ]
-        component = TogetherAIChatGenerator(model="deepseek/deepseek-v4-flash", tools=mixed_tools)
+        component = TogetherAIChatGenerator(model="MiniMaxAI/MiniMax-M2.7", tools=mixed_tools)
         results = component.run(messages=initial_messages)
 
         assert len(results["replies"]) > 0, "No replies received"

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -685,7 +685,7 @@ class TestTogetherAIChatGenerator:
         initial_messages = [
             ChatMessage.from_user("What's the weather like in Paris and what is the population of Berlin?")
         ]
-        component = TogetherAIChatGenerator(model="moonshotai/Kimi-K2.5", tools=mixed_tools)
+        component = TogetherAIChatGenerator(model="deepseek/deepseek-v4-flash", tools=mixed_tools)
         results = component.run(messages=initial_messages)
 
         assert len(results["replies"]) > 0, "No replies received"

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -685,7 +685,7 @@ class TestTogetherAIChatGenerator:
         initial_messages = [
             ChatMessage.from_user("What's the weather like in Paris and what is the population of Berlin?")
         ]
-        component = TogetherAIChatGenerator(model="MiniMaxAI/MiniMax-M2.7", tools=mixed_tools)
+        component = TogetherAIChatGenerator(model="moonshotai/Kimi-K2.6", tools=mixed_tools)
         results = component.run(messages=initial_messages)
 
         assert len(results["replies"]) > 0, "No replies received"


### PR DESCRIPTION
### Related Issues

- Kimi K2.5 model was retired: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26262414002/job/77298573800

### Proposed Changes:
- use the newer K2.6

### How did you test it?
CI
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
