### PR TITLE
chore: deepeval - fix types

### DIFF
--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
@@ -234,8 +234,9 @@ class InputConverters:
             An iterable of `LLMTestCase` objects.
         """
         InputConverters._validate_input_elements(questions=questions, contexts=contexts, responses=responses)
-        for q, c, r in zip(questions, contexts, responses, strict=True):  # type: ignore
-            test_case = LLMTestCase(input=q, actual_output=r, retrieval_context=c)
+        for q, c, r in zip(questions, contexts, responses, strict=True):
+            # deepeval expects list[str | RetrievedContextData]; we pass list[str] but mypy complains
+            test_case = LLMTestCase(input=q, actual_output=r, retrieval_context=c)  # type: ignore[arg-type]
             yield test_case
 
     @staticmethod
@@ -257,8 +258,9 @@ class InputConverters:
             An iterable of `LLMTestCase` objects.
         """
         InputConverters._validate_input_elements(questions=questions, contexts=contexts, responses=responses)
-        for q, c, r, gt in zip(questions, contexts, responses, ground_truths, strict=True):  # type: ignore
-            test_case = LLMTestCase(input=q, actual_output=r, retrieval_context=c, expected_output=gt)
+        for q, c, r, gt in zip(questions, contexts, responses, ground_truths, strict=True):
+            # deepeval expects list[str | RetrievedContextData]; we pass list[str] but mypy complains
+            test_case = LLMTestCase(input=q, actual_output=r, retrieval_context=c, expected_output=gt)  # type: ignore[arg-type]
             yield test_case
 
 
@@ -297,31 +299,31 @@ METRIC_DESCRIPTORS = {
     DeepEvalMetric.ANSWER_RELEVANCY: MetricDescriptor.new(
         DeepEvalMetric.ANSWER_RELEVANCY,
         AnswerRelevancyMetric,
-        InputConverters.question_context_response,  # type: ignore
-        init_parameters={"model": str | None},  # type: ignore
+        InputConverters.question_context_response,  # type: ignore[arg-type]
+        init_parameters={"model": str | None},  # type: ignore[dict-item]
     ),
     DeepEvalMetric.FAITHFULNESS: MetricDescriptor.new(
         DeepEvalMetric.FAITHFULNESS,
         FaithfulnessMetric,
-        InputConverters.question_context_response,  # type: ignore
-        init_parameters={"model": str | None},  # type: ignore
+        InputConverters.question_context_response,  # type: ignore[arg-type]
+        init_parameters={"model": str | None},  # type: ignore[dict-item]
     ),
     DeepEvalMetric.CONTEXTUAL_PRECISION: MetricDescriptor.new(
         DeepEvalMetric.CONTEXTUAL_PRECISION,
         ContextualPrecisionMetric,
-        InputConverters.question_context_response_ground_truth,  # type: ignore
-        init_parameters={"model": str | None},  # type: ignore
+        InputConverters.question_context_response_ground_truth,  # type: ignore[arg-type]
+        init_parameters={"model": str | None},  # type: ignore[dict-item]
     ),
     DeepEvalMetric.CONTEXTUAL_RECALL: MetricDescriptor.new(
         DeepEvalMetric.CONTEXTUAL_RECALL,
         ContextualRecallMetric,
-        InputConverters.question_context_response_ground_truth,  # type: ignore
-        init_parameters={"model": str | None},  # type: ignore
+        InputConverters.question_context_response_ground_truth,  # type: ignore[arg-type]
+        init_parameters={"model": str | None},  # type: ignore[dict-item]
     ),
     DeepEvalMetric.CONTEXTUAL_RELEVANCE: MetricDescriptor.new(
         DeepEvalMetric.CONTEXTUAL_RELEVANCE,
         ContextualRelevancyMetric,
-        InputConverters.question_context_response,  # type: ignore
-        init_parameters={"model": str | None},  # type: ignore
+        InputConverters.question_context_response,  # type: ignore[arg-type]
+        init_parameters={"model": str | None},  # type: ignore[dict-item]
     ),
 }

--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
@@ -235,7 +235,7 @@ class InputConverters:
         """
         InputConverters._validate_input_elements(questions=questions, contexts=contexts, responses=responses)
         for q, c, r in zip(questions, contexts, responses, strict=True):
-            # deepeval expects list[str | RetrievedContextData]; we pass list[str] but mypy complains
+            # for retrieval_context, deepeval expects list[str | RetrievedContextData]; we pass list[str]
             test_case = LLMTestCase(input=q, actual_output=r, retrieval_context=c)  # type: ignore[arg-type]
             yield test_case
 
@@ -259,7 +259,7 @@ class InputConverters:
         """
         InputConverters._validate_input_elements(questions=questions, contexts=contexts, responses=responses)
         for q, c, r, gt in zip(questions, contexts, responses, ground_truths, strict=True):
-            # deepeval expects list[str | RetrievedContextData]; we pass list[str] but mypy complains
+            # for retrieval_context, deepeval expects list[str | RetrievedContextData]; we pass list[str]
             test_case = LLMTestCase(input=q, actual_output=r, retrieval_context=c, expected_output=gt)  # type: ignore[arg-type]
             yield test_case
 


### PR DESCRIPTION
### Related Issues

- a new version of Deepeval was released and now type checking fails: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26376860292/job/77638518509

### Proposed Changes:
- ignore the specific type error; my impression is that Deepeval type is not well specified
- specialize existing type ignore 

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
