### PR TITLE
fix: ragas - pin langchain-community to avoid ModuleNotFoundError

### DIFF
--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "ragas>=0.4.3"]
+
+# langchain-community pinned due to https://github.com/vibrantlabsai/ragas/issues/2741
+dependencies = ["haystack-ai>=2.22.0", "ragas>=0.4.3", "langchain-community<0.4.2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ragas"

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 # langchain-community pinned due to https://github.com/vibrantlabsai/ragas/issues/2741
-dependencies = ["haystack-ai>=2.22.0", "ragas>=0.4.3", "langchain-community>=0.2.0,<0.4.2"]
+dependencies = ["haystack-ai>=2.22.0", "ragas>=0.4.3", "langchain-community>=0.3.9,<0.4.2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ragas"

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 # langchain-community pinned due to https://github.com/vibrantlabsai/ragas/issues/2741
-dependencies = ["haystack-ai>=2.22.0", "ragas>=0.4.3", "langchain-community<0.4.2"]
+dependencies = ["haystack-ai>=2.22.0", "ragas>=0.4.3", "langchain-community>=0.2.0,<0.4.2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ragas"


### PR DESCRIPTION
### Related Issues

- https://github.com/vibrantlabsai/ragas/issues/2741 (ragas seems to be not very actively maintained at this point)
- failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26377641552/job/77640709997

### Proposed Changes:
- pin langchain-community to a version that includes `langchain_community.chat_models.vertexai` (imported in ragas)

### How did you test it?
CI
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
