### PR TITLE
fix: skip valkey-glide version 2.4.0

### DIFF
--- a/integrations/valkey/pyproject.toml
+++ b/integrations/valkey/pyproject.toml
@@ -26,7 +26,13 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.28.0", "valkey-glide>=2.2.0", "valkey-glide-sync>=2.2.0"]
+dependencies = [
+    "haystack-ai>=2.28.0",
+    # 2.4.0 wheels are missing the glide_shared._fast_response extension, which
+    # breaks `import glide_sync`. See https://github.com/valkey-io/valkey-glide/pull/6020.
+    "valkey-glide>=2.2.0,!=2.4.0",
+    "valkey-glide-sync>=2.2.0,!=2.4.0",
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/valkey#readme"


### PR DESCRIPTION
### Related Issues

2.4.0 wheels are missing the glide_shared._fast_response extension, which breaks `import glide_sync`. See https://github.com/valkey-io/valkey-glide/pull/6020.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Skip version 2.4.0 in pyproject.toml

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
