### PR TITLE
ci: use MEM0_API_KEY to mem0 integration tests

### DIFF
--- a/.github/workflows/mem0.yml
+++ b/.github/workflows/mem0.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  MEM0_API_KEY: ${{ secrets.MEM0_API_KEY }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 


### PR DESCRIPTION
### Related Issues
None

Some tests, for example https://github.com/deepset-ai/haystack-core-integrations/blob/ce8956700903217ebc1813968e19592ffb749a11/integrations/mem0/tests/test_memory_store.py#L266 integration test requires a MEM0_API_KEY and the GitHub action secret is already set but the key is not available in the workflow file.

### Proposed Changes:
- Use `MEM0_API_KEY` from repository secrets in `.github/workflows/mem0.yml` so integration tests that require it (e.g. `integrations/mem0/tests/test_memory_store.py::test_*` gated by `MEM0_API_KEY`) actually run in CI instead of being silently skipped.

### How did you test it?

### Notes for the reviewer

Integration tests were skipped before indeed: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26167519430/job/76975741734#step:11:24
Now they run: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26456146611/job/77890597455?pr=3351#step:10:24


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.