### PR TITLE
test: add more unit tests for Vespa

### DIFF
--- a/integrations/vespa/tests/test_document_store.py
+++ b/integrations/vespa/tests/test_document_store.py
@@ -239,6 +239,14 @@ class TestVespaDocumentStoreUnit:
         assert kwargs["body"]["ranking"] == "semantic"
         assert "targetHits:10" in kwargs["body"]["yql"]
 
+    def test_bm25_retrieval_requires_non_empty_query(self, mock_store):
+        with pytest.raises(ValueError, match="must be a non-empty"):
+            mock_store._bm25_retrieval(query="")
+
+    def test_embedding_retrieval_requires_non_empty_embedding(self, mock_store):
+        with pytest.raises(ValueError, match="must be a non-empty"):
+            mock_store._embedding_retrieval(query_embedding=[])
+
     def test_get_documents_by_id(self, mock_store):
         mock_store._app.get_data.return_value = DummyResponse(
             {"fields": {"id": "1", "content": "hello", "author": "sam"}}

--- a/integrations/vespa/tests/test_filters.py
+++ b/integrations/vespa/tests/test_filters.py
@@ -8,6 +8,7 @@ import pytest
 from haystack import Document
 from haystack.errors import FilterError
 
+from haystack_integrations.document_stores.vespa.errors import VespaDocumentStoreFilterError
 from haystack_integrations.document_stores.vespa.filters import _normalize_filters
 
 from .conftest import DummyResponse
@@ -27,6 +28,103 @@ class TestNormalizeFilters:
     def test_string_relational_filters_require_iso_dates(self):
         with pytest.raises(FilterError):
             _normalize_filters({"field": "meta.number", "operator": ">", "value": "1"}, content_field="content")
+
+    @pytest.mark.parametrize(
+        "leaf_filter, content_field, expected_yql",
+        [
+            ({"field": "meta.number", "operator": "==", "value": 100}, "content", "number = 100"),
+            ({"field": "page", "operator": "==", "value": "100"}, "content", 'page contains "100"'),
+            ({"field": "content", "operator": "==", "value": "hello"}, "body", 'body contains "hello"'),
+            ({"field": "meta.featured", "operator": ">", "value": True}, "content", "featured > true"),
+            ({"field": "meta.featured", "operator": "==", "value": True}, "content", "featured = true"),
+            ({"field": "meta.featured", "operator": "==", "value": False}, "content", "featured = false"),
+            ({"field": "meta.number", "operator": "==", "value": None}, "content", "number = null"),
+            (
+                {"field": "meta.category", "operator": "!=", "value": "news"},
+                "content",
+                '!( category contains "news" )',
+            ),
+            ({"field": "meta.number", "operator": "!=", "value": 2}, "content", "!( number = 2 )"),
+            ({"field": "meta.number", "operator": ">", "value": 5}, "content", "number > 5"),
+            ({"field": "meta.rating", "operator": ">", "value": 1.5}, "content", "rating > 1.5"),
+            ({"field": "meta.number", "operator": ">=", "value": 5}, "content", "number >= 5"),
+            ({"field": "meta.number", "operator": "<", "value": 5}, "content", "number < 5"),
+            ({"field": "meta.number", "operator": "<=", "value": 5}, "content", "number <= 5"),
+            ({"field": "meta.number", "operator": ">", "value": None}, "content", "false"),
+            (
+                {"field": "meta.date", "operator": ">", "value": "1972-12-11T19:54:58"},
+                "content",
+                'date > "1972-12-11T19:54:58"',
+            ),
+            ({"field": "meta.page", "operator": "in", "value": ["1", "2"]}, "content", 'page in ("1", "2")'),
+            ({"field": "meta.page", "operator": "not in", "value": ["1"]}, "content", '!( page in ("1") )'),
+            ({"field": "meta.name", "operator": "contains", "value": "foo"}, "content", 'name contains "foo"'),
+            (
+                {"field": "meta.name", "operator": "not contains", "value": "foo"},
+                "content",
+                '!( name contains "foo" )',
+            ),
+        ],
+    )
+    def test_leaf_filters_translate_to_yql(self, leaf_filter, content_field, expected_yql):
+        assert _normalize_filters(leaf_filter, content_field=content_field) == expected_yql
+
+    @pytest.mark.parametrize("empty_filters", [None, {}])
+    def test_empty_filters_match_everything(self, empty_filters):
+        assert _normalize_filters(empty_filters, content_field="content") == "true"
+
+    @pytest.mark.parametrize(
+        "logical_filter, expected_yql",
+        [
+            (
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"field": "meta.number", "operator": "==", "value": 100},
+                        {"field": "meta.name", "operator": "==", "value": "name_0"},
+                    ],
+                },
+                '( number = 100 and name contains "name_0" )',
+            ),
+            (
+                {
+                    "operator": "OR",
+                    "conditions": [
+                        {"field": "meta.number", "operator": "==", "value": 100},
+                        {"field": "meta.name", "operator": "==", "value": "name_0"},
+                    ],
+                },
+                '( number = 100 or name contains "name_0" )',
+            ),
+            (
+                {"operator": "NOT", "conditions": [{"field": "meta.number", "operator": "==", "value": 100}]},
+                "!( ( number = 100 ) )",
+            ),
+        ],
+    )
+    def test_logical_filters_translate_to_yql(self, logical_filter, expected_yql):
+        assert _normalize_filters(logical_filter, content_field="content") == expected_yql
+
+    @pytest.mark.parametrize(
+        "invalid_filter, expected_error",
+        [
+            ({"field": "meta.x", "operator": "like", "value": "y"}, VespaDocumentStoreFilterError),
+            ({"field": "meta.x", "operator": "in", "value": "not-a-list"}, VespaDocumentStoreFilterError),
+            ({"field": "meta.x", "operator": "not in", "value": "not-a-list"}, VespaDocumentStoreFilterError),
+            ({"operator": "AND", "conditions": []}, VespaDocumentStoreFilterError),
+            ({"operator": "OR"}, VespaDocumentStoreFilterError),
+            ({"operator": "NOT", "conditions": []}, VespaDocumentStoreFilterError),
+            ({"operator": "==", "value": "y"}, VespaDocumentStoreFilterError),
+            ({"field": "meta.x", "value": "y"}, VespaDocumentStoreFilterError),
+            ({"field": "meta.x", "operator": "=="}, VespaDocumentStoreFilterError),
+            ({"field": "meta.x", "operator": ">", "value": {"a": 1}}, FilterError),
+            ({"field": "meta.x", "operator": ">", "value": [1, 2]}, FilterError),
+            ({"field": "meta.x", "operator": ">", "value": "not-a-date"}, FilterError),
+        ],
+    )
+    def test_invalid_filters_raise(self, invalid_filter, expected_error):
+        with pytest.raises(expected_error):
+            _normalize_filters(invalid_filter, content_field="content")
 
     def test_multi_condition_not_clause(self):
         yql_filter = _normalize_filters(


### PR DESCRIPTION
### Related Issues

- Vespa combined integration is below our 90% coverage standard

### Proposed Changes:
- add new unit tests focusing on uncovered code paths (with AI help) -> increase unit tests coverage -> hopefully combined coverage is above 90%

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
