### PR TITLE
chore: arcadedb - use arcadedata/arcadedb:26.5.1

### DIFF
--- a/.github/workflows/arcadedb.yml
+++ b/.github/workflows/arcadedb.yml
@@ -64,7 +64,8 @@ jobs:
         python-version: ${{ fromJSON(needs.compute-test-matrix.outputs.python-version) }}
     services:
       arcadedb:
-        image: arcadedata/arcadedb:latest
+        # temporarily pinned due to https://github.com/ArcadeData/arcadedb/issues/4359
+        image: arcadedata/arcadedb:26.5.1
         env:
           # Default password so container starts in forks; main repo uses secret
           JAVA_OPTS: "-Darcadedb.server.rootPassword=${{ secrets.ARCADEDB_PASSWORD || 'arcadedb' }}"

--- a/integrations/arcadedb/README.md
+++ b/integrations/arcadedb/README.md
@@ -9,7 +9,17 @@
 
 ---
 
-## Contributing
-
 Refer to the general [Contribution Guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md).
 
+To run integration tests locally, you need to have an ArcadeDB server running.
+You can start it using Docker:
+
+```console
+docker run -d -p 2480:2480 -e JAVA_OPTS="-Darcadedb.server.rootPassword=arcadedb" arcadedata/arcadedb:latest
+```
+
+Then run the integration tests, providing the credentials via environment variables:
+
+```console
+ARCADEDB_USERNAME=root ARCADEDB_PASSWORD=arcadedb hatch run test:integration
+```


### PR DESCRIPTION
### Related Issues

- failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26482865693/job/78028436258
- https://github.com/ArcadeData/arcadedb/issues/4359

### Proposed Changes:
- temporarily use the latest stable Docker image instead of the latest (it's a bug on their side)
- add information on README on how to run integration tests locally

### How did you test it?
CI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
