### PR TITLE
fix: add missing click dep for presidio

### DIFF
--- a/integrations/presidio/pyproject.toml
+++ b/integrations/presidio/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "haystack-ai>=2.9.0",
   "presidio-analyzer>=2.2.0",
   "presidio-anonymizer>=2.2.0",
+  "click>=8.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26547805380/job/78203382347#step:7:58

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Somehow the click dependency that spacy requires is no longer in the environment. It's unclear to me where the click dependency was originally being downloaded, since it's not declared in spacy's requirements https://github.com/explosion/spaCy/blob/master/pyproject.toml#L2

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
