### PR TITLE
feat: add CLIENT SETNAME for connection identification

### DIFF
--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -224,6 +224,7 @@ class ValkeyDocumentStore(DocumentStore):
                     addresses=addresses,
                     use_tls=self._use_tls,
                     credentials=self._build_credentials(self._username, self._password),
+                    client_name="haystack_vector_store_client",
                     request_timeout=self._request_timeout,
                     reconnect_strategy=reconnect_strategy,
                 )
@@ -233,6 +234,7 @@ class ValkeyDocumentStore(DocumentStore):
                     addresses=addresses,
                     use_tls=self._use_tls,
                     credentials=self._build_credentials(self._username, self._password),
+                    client_name="haystack_vector_store_client",
                     request_timeout=self._request_timeout,
                     reconnect_strategy=reconnect_strategy,
                 )
@@ -261,6 +263,7 @@ class ValkeyDocumentStore(DocumentStore):
                     addresses=addresses,
                     use_tls=self._use_tls,
                     credentials=self._build_credentials(self._username, self._password),
+                    client_name="haystack_vector_store_client",
                     request_timeout=self._request_timeout,
                     reconnect_strategy=reconnect_strategy,
                 )
@@ -270,6 +273,7 @@ class ValkeyDocumentStore(DocumentStore):
                     addresses=addresses,
                     use_tls=self._use_tls,
                     credentials=self._build_credentials(self._username, self._password),
+                    client_name="haystack_vector_store_client",
                     request_timeout=self._request_timeout,
                     reconnect_strategy=reconnect_strategy,
                 )


### PR DESCRIPTION
### Related Issues

- fixes #3356

### Proposed Changes:

Adds `client_name="haystack_vector_store_client"` to all 4 Glide client configurations (sync/async, standalone/cluster) in `document_store.py`. This sends a `CLIENT SETNAME` command on connection, making Haystack connections identifiable in `CLIENT LIST`, monitoring dashboards, and CloudWatch metrics.

### How did you test it?

Manual verification — `client_name` is a metadata-only parameter passed to the Glide client configuration. It does not alter any behavior, only sets the connection name visible in `CLIENT LIST`.

### Notes for the reviewer

Zero-risk change — `client_name` is a standard parameter on `GlideClientConfiguration` (and all variants). It sends `CLIENT SETNAME` after connecting. No behavioral changes.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
