### PR TITLE
Fix: Use Async pipeline with ElasticsearchHybridRetriever

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/elasticsearch_hybrid_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/elasticsearch_hybrid_retriever.py
@@ -4,7 +4,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-from haystack import Document, Pipeline, default_from_dict, default_to_dict, logging, super_component
+from haystack import AsyncPipeline, Document, default_from_dict, default_to_dict, logging, super_component
 from haystack.components.embedders.types import TextEmbedder
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.joiners.document_joiner import JoinMode
@@ -246,7 +246,7 @@ class ElasticsearchHybridRetriever:
             """Run the hybrid retrieval pipeline and return retrieved documents."""
             ...
 
-    def _create_pipeline(self, data: dict[str, Any]) -> Pipeline:
+    def _create_pipeline(self, data: dict[str, Any]) -> AsyncPipeline:
         """
         Create the pipeline for the ElasticsearchHybridRetriever.
 
@@ -257,7 +257,7 @@ class ElasticsearchHybridRetriever:
         bm25_retriever = ElasticsearchBM25Retriever(**data["bm25_retriever"])
         document_joiner = DocumentJoiner(**data["document_joiner"])
 
-        hybrid_retrieval = Pipeline()
+        hybrid_retrieval = AsyncPipeline()
         hybrid_retrieval.add_component("text_embedder", self.embedder)
         hybrid_retrieval.add_component("embedding_retriever", embedding_retriever)
         hybrid_retrieval.add_component("bm25_retriever", bm25_retriever)

--- a/integrations/elasticsearch/tests/test_hybrid_retriever.py
+++ b/integrations/elasticsearch/tests/test_hybrid_retriever.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
-from haystack import Document, Pipeline
+from haystack import AsyncPipeline, Document, Pipeline
 from haystack.components.embedders import SentenceTransformersTextEmbedder
 from haystack.components.joiners.document_joiner import JoinMode
 from haystack.core.component import component
@@ -21,6 +21,10 @@ from haystack_integrations.document_stores.elasticsearch import ElasticsearchDoc
 class MockedTextEmbedder:
     @component.output_types(embedding=list[float])
     def run(self, text: str, param_a: str = "default", param_b: str = "another_default") -> dict[str, Any]:
+        return {"embedding": [0.1, 0.2, 0.3], "metadata": {"text": text, "param_a": param_a, "param_b": param_b}}
+
+    @component.output_types(embedding=list[float])
+    async def run_async(self, text: str, param_a: str = "default", param_b: str = "another_default") -> dict[str, Any]:
         return {"embedding": [0.1, 0.2, 0.3], "metadata": {"text": text, "param_a": param_a, "param_b": param_b}}
 
 
@@ -182,8 +186,8 @@ class TestElasticsearchHybridRetriever:
     def test_run(self, mock_embedder):
         # mocked document store
         mock_store = Mock(spec=ElasticsearchDocumentStore)
-        mock_store._bm25_retrieval.return_value = [Document(content="Test doc BM25")]
-        mock_store._embedding_retrieval.return_value = [Document(content="Test doc Embedding")]
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
 
         # use the mocked embedder
         retriever = ElasticsearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
@@ -197,8 +201,8 @@ class TestElasticsearchHybridRetriever:
     def test_run_with_extra_arg(self, mock_embedder):
         # mocked document store
         mock_store = Mock(spec=ElasticsearchDocumentStore)
-        mock_store._bm25_retrieval.return_value = [Document(content="Test doc BM25")]
-        mock_store._embedding_retrieval.return_value = [Document(content="Test doc Embedding")]
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
 
         # use the mocked embedder
         retriever = ElasticsearchHybridRetriever(
@@ -210,14 +214,14 @@ class TestElasticsearchHybridRetriever:
         result = retriever.run(query="test query")
 
         # Verify the retrievers were called with propagated init-time extra args
-        mock_store._bm25_retrieval.assert_called_once_with(
+        mock_store._bm25_retrieval_async.assert_called_once_with(
             query="test query",
             filters={"source": "bm25_init"},
             top_k=10,
             fuzziness="AUTO",
             scale_score=False,
         )
-        mock_store._embedding_retrieval.assert_called_once_with(
+        mock_store._embedding_retrieval_async.assert_called_once_with(
             query_embedding=[0.1, 0.2, 0.3],
             filters={"source": "embedding_init"},
             top_k=10,
@@ -233,8 +237,8 @@ class TestElasticsearchHybridRetriever:
     def test_run_with_extra_arg_invalid_param(self, mock_embedder):
         # mocked document store
         mock_store = Mock(spec=ElasticsearchDocumentStore)
-        mock_store._bm25_retrieval.return_value = [Document(content="Test doc BM25")]
-        mock_store._embedding_retrieval.return_value = [Document(content="Test doc Embedding")]
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
 
         with pytest.raises(
             ValueError, match=r"valid extra args are only: 'bm25_retriever' and 'embedding_retriever'\."
@@ -249,8 +253,8 @@ class TestElasticsearchHybridRetriever:
     def test_run_with_extra_runtime_params(self, mock_embedder):
         # mocked document store
         mock_store = Mock(spec=ElasticsearchDocumentStore)
-        mock_store._bm25_retrieval.return_value = [Document(content="Test doc BM25")]
-        mock_store._embedding_retrieval.return_value = [Document(content="Test doc Embedding")]
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
 
         # use the mocked embedder
         retriever = ElasticsearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
@@ -262,14 +266,14 @@ class TestElasticsearchHybridRetriever:
             top_k_embedding=1,
         )
 
-        mock_store._bm25_retrieval.assert_called_once_with(
+        mock_store._bm25_retrieval_async.assert_called_once_with(
             query="test query",
             filters={"key": "value"},
             top_k=1,
             fuzziness="AUTO",
             scale_score=False,
         )
-        mock_store._embedding_retrieval.assert_called_once_with(
+        mock_store._embedding_retrieval_async.assert_called_once_with(
             query_embedding=[0.1, 0.2, 0.3],
             filters={"key": "value"},
             top_k=1,
@@ -280,8 +284,8 @@ class TestElasticsearchHybridRetriever:
         # mocked document store
         pipeline = Pipeline()
         mock_store = Mock(spec=ElasticsearchDocumentStore)
-        mock_store._bm25_retrieval.return_value = [Document(content="Test doc BM25")]
-        mock_store._embedding_retrieval.return_value = [Document(content="Test doc Embedding")]
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
 
         # use the mocked embedder
         retriever = ElasticsearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
@@ -290,14 +294,116 @@ class TestElasticsearchHybridRetriever:
         # Should not fail
         _ = pipeline.run(data={"retriever": {"query": "test query", "filters_bm25": {"param_a": "default"}}})
 
-        mock_store._bm25_retrieval.assert_called_once_with(
+        mock_store._bm25_retrieval_async.assert_called_once_with(
             query="test query",
             filters={"param_a": "default"},
             top_k=10,
             fuzziness="AUTO",
             scale_score=False,
         )
-        mock_store._embedding_retrieval.assert_called_once_with(
+        mock_store._embedding_retrieval_async.assert_called_once_with(
+            query_embedding=[0.1, 0.2, 0.3],
+            filters={},
+            top_k=10,
+            num_candidates=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_async(self, mock_embedder):
+        mock_store = Mock(spec=ElasticsearchDocumentStore)
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
+
+        retriever = ElasticsearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
+        result = await retriever.run_async(query="test query")
+
+        assert len(result) == 1
+        assert len(result["documents"]) == 2
+        assert any(doc.content == "Test doc BM25" for doc in result["documents"])
+        assert any(doc.content == "Test doc Embedding" for doc in result["documents"])
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_extra_arg(self, mock_embedder):
+        mock_store = Mock(spec=ElasticsearchDocumentStore)
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
+
+        retriever = ElasticsearchHybridRetriever(
+            document_store=mock_store,
+            embedder=mock_embedder,
+            bm25_retriever={"filters": {"source": "bm25_init"}},
+            embedding_retriever={"num_candidates": 42, "filters": {"source": "embedding_init"}},
+        )
+        result = await retriever.run_async(query="test query")
+
+        mock_store._bm25_retrieval_async.assert_called_once_with(
+            query="test query",
+            filters={"source": "bm25_init"},
+            top_k=10,
+            fuzziness="AUTO",
+            scale_score=False,
+        )
+        mock_store._embedding_retrieval_async.assert_called_once_with(
+            query_embedding=[0.1, 0.2, 0.3],
+            filters={"source": "embedding_init"},
+            top_k=10,
+            num_candidates=42,
+        )
+
+        assert len(result) == 1
+        assert len(result["documents"]) == 2
+        assert any(doc.content == "Test doc BM25" for doc in result["documents"])
+        assert any(doc.content == "Test doc Embedding" for doc in result["documents"])
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_extra_runtime_params(self, mock_embedder):
+        mock_store = Mock(spec=ElasticsearchDocumentStore)
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
+
+        retriever = ElasticsearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
+        await retriever.run_async(
+            query="test query",
+            filters_bm25={"key": "value"},
+            filters_embedding={"key": "value"},
+            top_k_bm25=1,
+            top_k_embedding=1,
+        )
+
+        mock_store._bm25_retrieval_async.assert_called_once_with(
+            query="test query",
+            filters={"key": "value"},
+            top_k=1,
+            fuzziness="AUTO",
+            scale_score=False,
+        )
+        mock_store._embedding_retrieval_async.assert_called_once_with(
+            query_embedding=[0.1, 0.2, 0.3],
+            filters={"key": "value"},
+            top_k=1,
+            num_candidates=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_async_in_pipeline(self, mock_embedder):
+        pipeline = AsyncPipeline()
+        mock_store = Mock(spec=ElasticsearchDocumentStore)
+        mock_store._bm25_retrieval_async.return_value = [Document(content="Test doc BM25")]
+        mock_store._embedding_retrieval_async.return_value = [Document(content="Test doc Embedding")]
+
+        retriever = ElasticsearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
+        pipeline.add_component("retriever", retriever)
+
+        await pipeline.run_async(data={"retriever": {"query": "test query", "filters_bm25": {"param_a": "default"}}})
+
+        mock_store._bm25_retrieval_async.assert_called_once_with(
+            query="test query",
+            filters={"param_a": "default"},
+            top_k=10,
+            fuzziness="AUTO",
+            scale_score=False,
+        )
+        mock_store._embedding_retrieval_async.assert_called_once_with(
             query_embedding=[0.1, 0.2, 0.3],
             filters={},
             top_k=10,


### PR DESCRIPTION
### Proposed Changes:

 Use AsyncPipeline so that ElasticsearchHybridRetriever component work within sync and async pipelines

### How did you test it?

Created Unit tests for usage within async pipelines