### PR TITLE
fix: Update langfuse deserialization to not require `span_handler` key

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -228,7 +228,6 @@ class LangfuseConnector:
         """
         init_params = data["init_parameters"]
         deserialize_secrets_inplace(init_params, keys=["secret_key", "public_key"])
-        init_params["span_handler"] = (
-            deserialize_class_instance(init_params["span_handler"]) if init_params["span_handler"] else None
-        )
+        if init_params.get("span_handler") is not None:
+            init_params["span_handler"] = deserialize_class_instance(init_params["span_handler"])
         return default_from_dict(cls, data)

--- a/integrations/langfuse/tests/test_langfuse_connector.py
+++ b/integrations/langfuse/tests/test_langfuse_connector.py
@@ -147,6 +147,37 @@ class TestLangfuseConnector:
         assert langfuse_connector.host is None
         assert langfuse_connector.langfuse_client_kwargs is None
 
+    def test_from_dict_without_span_handler(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
+
+        # All keys that would point to None (span_handler, host, langfuse_client_kwargs) are intentionally absent
+        data = {
+            "type": "haystack_integrations.components.connectors.langfuse.langfuse_connector.LangfuseConnector",
+            "init_parameters": {
+                "name": "Chat example - OpenAI",
+                "public": False,
+                "secret_key": {
+                    "type": "env_var",
+                    "env_vars": ["LANGFUSE_SECRET_KEY"],
+                    "strict": True,
+                },
+                "public_key": {
+                    "type": "env_var",
+                    "env_vars": ["LANGFUSE_PUBLIC_KEY"],
+                    "strict": True,
+                },
+            },
+        }
+        langfuse_connector = LangfuseConnector.from_dict(data)
+        assert langfuse_connector.name == "Chat example - OpenAI"
+        assert langfuse_connector.public is False
+        assert langfuse_connector.secret_key == Secret.from_env_var("LANGFUSE_SECRET_KEY")
+        assert langfuse_connector.public_key == Secret.from_env_var("LANGFUSE_PUBLIC_KEY")
+        assert langfuse_connector.span_handler is None
+        assert langfuse_connector.host is None
+        assert langfuse_connector.langfuse_client_kwargs is None
+
     def test_from_dict_with_params(self, monkeypatch):
         monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
         monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update the `LangfuseConnector.from_dict` to not require the presence of the `span_handler` key since it's default value is `None` in the init. This allows users to deserialize dicts for LangfuseConnector that might be missing the `span_handler` key which is relevant for the Haystack Enterprise Platform. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added a new unit test. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
