### PR TITLE
test: remove old integration tests using deprecated model

### DIFF
--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -807,25 +807,6 @@ class TestGoogleGenAIChatGeneratorInference:
         # The model should maintain context from previous turns
         assert "22" in second_response.text or "sunny" in second_response.text.lower()
 
-    def test_live_run_with_thinking_unsupported_model_fails_fast(self):
-        """
-        Integration test to verify that thinking configuration fails fast with unsupported models.
-        """
-        # gemini-2.0-flash does not support thinking
-        chat_messages = [ChatMessage.from_user("Why is the sky blue?")]
-        component = GoogleGenAIChatGenerator(model="gemini-2.0-flash", generation_kwargs={"thinking_budget": 1024})
-
-        # The call should raise a RuntimeError with a helpful message
-        with pytest.raises(RuntimeError) as exc_info:
-            component.run(chat_messages)
-
-        # Verify the error message is helpful and mentions thinking configuration
-        error_message = str(exc_info.value)
-        assert "Thinking configuration error" in error_message
-        assert "gemini-2.0" in error_message
-        assert "thinking_budget" in error_message or "thinking features" in error_message
-        assert "Try removing" in error_message or "use a different model" in error_message
-
     def test_live_run_with_structured_output_pydantic(self):
         """Test that response_format with a Pydantic model returns valid structured JSON output."""
 
@@ -978,26 +959,6 @@ class TestAsyncGoogleGenAIChatGeneratorInference:
         assert "thoughts_token_count" in message.meta["usage"]
         assert message.meta["usage"]["thoughts_token_count"] is not None
         assert message.meta["usage"]["thoughts_token_count"] > 0
-
-    async def test_live_run_async_with_thinking_unsupported_model_fails_fast(self):
-        """
-        Async integration test to verify that thinking configuration fails fast with unsupported models.
-        This tests the fail-fast principle - no silent fallbacks.
-        """
-        # Use a model that does NOT support thinking features (gemini-2.0-flash)
-        chat_messages = [ChatMessage.from_user("Why is the sky blue?")]
-        component = GoogleGenAIChatGenerator(model="gemini-2.0-flash", generation_kwargs={"thinking_budget": 1024})
-
-        # The call should raise a RuntimeError with a helpful message
-        with pytest.raises(RuntimeError) as exc_info:
-            await component.run_async(chat_messages)
-
-        # Verify the error message is helpful and mentions thinking configuration
-        error_message = str(exc_info.value)
-        assert "Thinking configuration error" in error_message
-        assert "gemini-2.0" in error_message
-        assert "thinking_budget" in error_message or "thinking features" in error_message
-        assert "Try removing" in error_message or "use a different model" in error_message
 
     async def test_live_run_async_with_structured_output(self):
         """Async integration test for structured output with a Pydantic model."""


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26791322477/job/78978192995#step:10:61

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Remove old integrations tests for testing what happens when asking for thinking support on a model that doesn't support it. All of google's non-deprecated models supports thinking so there is no good replacement. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
