### PR TITLE
test: test arcadedb with latest docker image

### DIFF
--- a/.github/workflows/arcadedb.yml
+++ b/.github/workflows/arcadedb.yml
@@ -64,8 +64,7 @@ jobs:
         python-version: ${{ fromJSON(needs.compute-test-matrix.outputs.python-version) }}
     services:
       arcadedb:
-        # temporarily pinned due to https://github.com/ArcadeData/arcadedb/issues/4359
-        image: arcadedata/arcadedb:26.5.1
+        image: arcadedata/arcadedb:latest
         env:
           # Default password so container starts in forks; main repo uses secret
           JAVA_OPTS: "-Darcadedb.server.rootPassword=${{ secrets.ARCADEDB_PASSWORD || 'arcadedb' }}"


### PR DESCRIPTION
### Related Issues

- this reverts https://github.com/deepset-ai/haystack-core-integrations/pull/3357 since https://github.com/ArcadeData/arcadedb/issues/4359 has been fixed

### Proposed Changes:
- use the latest docker image to test this integration

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
