### PR TITLE
chore: NVIDIA - deprecate generator

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
@@ -75,6 +75,12 @@ class NvidiaGenerator:
             Timeout for request calls, if not set it is inferred from the `NVIDIA_TIMEOUT` environment variable
             or set to 60 by default.
         """
+        warnings.warn(
+            "The `NvidiaGenerator` component is deprecated and will be removed in a future version. "
+            "Use `NvidiaChatGenerator` instead, which now also supports string inputs.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self._model = model
         self.api_url = url_validation(api_url)
         self._api_key = api_key

--- a/integrations/nvidia/tests/test_base_url.py
+++ b/integrations/nvidia/tests/test_base_url.py
@@ -28,7 +28,8 @@ from haystack_integrations.components.rankers.nvidia import NvidiaRanker
 def test_base_url_invalid_not_hosted(base_url: str, component) -> None:
     with pytest.warns(UserWarning) as msg:
         component(api_url=base_url, model="x")
-    assert "you may have inference and listing issues" in str(msg[0].message)
+    user_warnings = [w for w in msg if issubclass(w.category, UserWarning)]
+    assert any("you may have inference and listing issues" in str(w.message) for w in user_warnings)
 
 
 @pytest.mark.parametrize(

--- a/integrations/nvidia/tests/test_generator.py
+++ b/integrations/nvidia/tests/test_generator.py
@@ -193,7 +193,7 @@ class TestNvidiaGenerator:
     @pytest.mark.integration
     def test_run_integration_with_api_catalog(self):
         generator = NvidiaGenerator(
-            model="meta/llama3-8b-instruct",
+            model="meta/llama-3.1-8b-instruct",
             api_url="https://integrate.api.nvidia.com/v1",
             api_key=Secret.from_env_var("NVIDIA_API_KEY"),
             model_arguments={
@@ -256,7 +256,7 @@ class TestNvidiaGenerator:
 
     def test_warm_up_is_idempotent(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
-        generator = NvidiaGenerator("meta/llama3-8b-instruct")
+        generator = NvidiaGenerator("meta/llama-3.1-8b-instruct")
         generator.warm_up()
         backend = generator.backend
         generator.warm_up()
@@ -264,7 +264,7 @@ class TestNvidiaGenerator:
 
     def test_available_models_without_backend(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
-        generator = NvidiaGenerator("meta/llama3-8b-instruct")
+        generator = NvidiaGenerator("meta/llama-3.1-8b-instruct")
         assert generator.available_models == []
 
     @pytest.mark.usefixtures("mock_local_models")
@@ -283,12 +283,12 @@ class TestNvidiaGenerator:
             "init_parameters": {
                 "api_key": {"env_vars": ["NVIDIA_API_KEY"], "strict": True, "type": "env_var"},
                 "api_url": "https://my.url.com/v1",
-                "model": "meta/llama3-8b-instruct",
+                "model": "meta/llama-3.1-8b-instruct",
                 "model_arguments": {"temperature": 0.5},
             },
         }
         generator = NvidiaGenerator.from_dict(data)
-        assert generator._model == "meta/llama3-8b-instruct"
+        assert generator._model == "meta/llama-3.1-8b-instruct"
         assert generator.api_url == "https://my.url.com/v1"
         assert generator._model_arguments == {"temperature": 0.5}
 


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- deprecate generator
- changed the model used in integration test for Generator (the previous one was retired)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I have used one of the conventional commit types for my PR title.