### PR TITLE
feat: vLLM - accept str as ChatGenerator input

### DIFF
--- a/integrations/vllm/pyproject.toml
+++ b/integrations/vllm/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0"]
+dependencies = ["haystack-ai>=2.30.0", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/vllm#readme"

--- a/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
+++ b/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
@@ -8,7 +8,11 @@ from haystack.components.generators.chat.openai import (
     _check_finish_reason,
     _convert_chat_completion_chunk_to_streaming_chunk,
 )
-from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _serialize_object
+from haystack.components.generators.utils import (
+    _convert_streaming_chunks_to_chat_message,
+    _normalize_messages,
+    _serialize_object,
+)
 from haystack.core.component import component
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.dataclasses.chat_message import ReasoningContent
@@ -429,7 +433,7 @@ class VLLMChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         *,
@@ -440,6 +444,7 @@ class VLLMChatGenerator:
 
         :param messages:
             A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param generation_kwargs:
@@ -455,6 +460,7 @@ class VLLMChatGenerator:
             A dictionary with the following key:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
+        messages = _normalize_messages(messages)
         if not self._is_warmed_up:
             self.warm_up()
 
@@ -484,7 +490,7 @@ class VLLMChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         *,
@@ -495,6 +501,7 @@ class VLLMChatGenerator:
 
         :param messages:
             A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
             Must be a coroutine.
@@ -511,6 +518,7 @@ class VLLMChatGenerator:
             A dictionary with the following key:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
+        messages = _normalize_messages(messages)
         if not self._is_warmed_up:
             self.warm_up()
 

--- a/integrations/vllm/tests/test_chat_generator.py
+++ b/integrations/vllm/tests/test_chat_generator.py
@@ -380,6 +380,16 @@ class TestVLLMChatGeneratorRun:
         assert kwargs["max_tokens"] == 100
         assert kwargs["temperature"] == 0.5
 
+    def test_run_with_string_input(self, mock_chat_completion):
+        component = VLLMChatGenerator(model=MODEL)
+        result = component.run("What's the capital of France?")
+
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["messages"] == [{"role": "user", "content": "What's the capital of France?"}]
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
+
     def test_run_empty_messages(self):
         component = VLLMChatGenerator(model=MODEL)
         assert component.run([]) == {"replies": []}
@@ -445,6 +455,16 @@ class TestVLLMChatGeneratorRunAsync:
     async def test_run_async_empty_messages(self):
         component = VLLMChatGenerator(model=MODEL)
         assert await component.run_async([]) == {"replies": []}
+
+    async def test_run_async_with_string_input(self, mock_async_chat_completion):
+        component = VLLMChatGenerator(model=MODEL)
+        result = await component.run_async("What's the capital of France?")
+
+        _, kwargs = mock_async_chat_completion.call_args
+        assert kwargs["messages"] == [{"role": "user", "content": "What's the capital of France?"}]
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
 
     async def test_run_async(self, mock_async_chat_completion):  # noqa: ARG002
         component = VLLMChatGenerator(model=MODEL)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- accept str as ChatGenerator input

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I have used one of the conventional commit types for my PR title.