### PR TITLE
feat: LiteLLM - accept str as ChatGenerator input

### DIFF
--- a/integrations/litellm/pyproject.toml
+++ b/integrations/litellm/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 # litellm 1.82.7 and 1.82.8 were malicious releases and are excluded.
-dependencies = ["haystack-ai>=2.24.1", "litellm>=1.60.0,<2.0,!=1.82.7,!=1.82.8"]
+dependencies = ["haystack-ai>=2.30.0", "litellm>=1.60.0,<2.0,!=1.82.7,!=1.82.8"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/litellm#readme"

--- a/integrations/litellm/src/haystack_integrations/components/generators/litellm/chat/chat_generator.py
+++ b/integrations/litellm/src/haystack_integrations/components/generators/litellm/chat/chat_generator.py
@@ -6,7 +6,7 @@ import json
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message
+from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.dataclasses.streaming_chunk import (
     AsyncStreamingCallbackT,
@@ -138,7 +138,7 @@ class LiteLLMChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         *,
@@ -147,11 +147,13 @@ class LiteLLMChatGenerator:
         """Invoke chat completion via LiteLLM.
 
         :param messages: Input messages as ChatMessage instances.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: Override the streaming callback for this call.
         :param generation_kwargs: Override generation parameters for this call.
         :param tools: Override tools for this call.
         :returns: A dict with key ``replies`` containing ChatMessage instances.
         """
+        messages = _normalize_messages(messages)
         if not messages:
             return {"replies": []}
 
@@ -173,13 +175,22 @@ class LiteLLMChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         *,
         tools: ToolsType | None = None,
     ) -> dict[str, list[ChatMessage]]:
-        """Async version of run()."""
+        """Async version of run(). Invoke chat completion via LiteLLM.
+
+        :param messages: Input messages as ChatMessage instances.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
+        :param streaming_callback: Override the streaming callback for this call.
+        :param generation_kwargs: Override generation parameters for this call.
+        :param tools: Override tools for this call.
+        :returns: A dict with key ``replies`` containing ChatMessage instances.
+        """
+        messages = _normalize_messages(messages)
         if not messages:
             return {"replies": []}
 

--- a/integrations/litellm/tests/test_litellm_chat_generator.py
+++ b/integrations/litellm/tests/test_litellm_chat_generator.py
@@ -142,6 +142,21 @@ class TestRun:
             assert result["replies"][0].text == "The capital is Paris."
             fake_litellm.completion.assert_called_once()
 
+    def test_run_with_string_input(self):
+        gen = LiteLLMChatGenerator(model="openai/gpt-4o")
+        mock_resp = _make_mock_response("Paris")
+
+        fake_litellm = types.ModuleType("litellm")
+        fake_litellm.completion = MagicMock(return_value=mock_resp)
+
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            result = gen.run("What's the capital of France?")
+            call_kwargs = fake_litellm.completion.call_args
+            assert call_kwargs.kwargs["messages"] == [{"role": "user", "content": "What's the capital of France?"}]
+            assert isinstance(result["replies"], list)
+            assert len(result["replies"]) == 1
+            assert isinstance(result["replies"][0], ChatMessage)
+
     def test_drop_params_always_set(self):
         gen = LiteLLMChatGenerator(model="openai/gpt-4o")
         mock_resp = _make_mock_response()
@@ -406,6 +421,27 @@ class TestAsync:
             result = await gen.run_async(messages=[ChatMessage.from_user("hi")])
             assert len(result["replies"]) == 1
             assert result["replies"][0].text == "async reply"
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_string_input(self):
+        gen = LiteLLMChatGenerator(model="openai/gpt-4o")
+        mock_resp = _make_mock_response("Paris")
+
+        fake_litellm = types.ModuleType("litellm")
+        captured_kwargs = {}
+
+        async def _acompletion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_resp
+
+        fake_litellm.acompletion = _acompletion
+
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            result = await gen.run_async("What's the capital of France?")
+            assert captured_kwargs["messages"] == [{"role": "user", "content": "What's the capital of France?"}]
+            assert isinstance(result["replies"], list)
+            assert len(result["replies"]) == 1
+            assert isinstance(result["replies"][0], ChatMessage)
 
     @pytest.mark.asyncio
     async def test_run_async_empty_messages(self):


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- accept str as ChatGenerator input

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I have used one of the conventional commit types for my PR title.