### PR TITLE
feat: Google GenAI - accept str as ChatGenerator input

### DIFF
--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "google-genai[aiohttp]>=1.56.0", "jsonref>=1.0.0"]
+dependencies = ["haystack-ai>=2.30.0", "google-genai[aiohttp]>=1.56.0", "jsonref>=1.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_genai#readme"

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Literal
 
 from google.genai import types
 from haystack import logging
+from haystack.components.generators.utils import _normalize_messages
 from haystack.core.component import component
 from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import AsyncStreamingCallbackT, ComponentInfo, StreamingCallbackT, select_streaming_callback
@@ -381,7 +382,7 @@ class GoogleGenAIChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         generation_kwargs: dict[str, Any] | None = None,
         safety_settings: list[dict[str, Any]] | None = None,
         streaming_callback: StreamingCallbackT | None = None,
@@ -391,6 +392,7 @@ class GoogleGenAIChatGenerator:
         Run the Google Gen AI chat generator on the given input data.
 
         :param messages: A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs: Configuration for generation. If provided, it will override
         the default config. Supports `thinking_budget` for Gemini 2.5 series thinking configuration.
         :param safety_settings: Safety settings for content filtering. If provided, it will override the
@@ -406,6 +408,7 @@ class GoogleGenAIChatGenerator:
         :raises ValueError: If a ChatMessage does not contain at least one of TextContent, ToolCall, or
         ToolCallResult or if the role in ChatMessage is different from User, System, Assistant.
         """
+        messages = _normalize_messages(messages)
         # Use provided configs or fall back to instance defaults
         generation_kwargs = generation_kwargs or self._generation_kwargs
         safety_settings = safety_settings or self._safety_settings
@@ -491,7 +494,7 @@ class GoogleGenAIChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         generation_kwargs: dict[str, Any] | None = None,
         safety_settings: list[dict[str, Any]] | None = None,
         streaming_callback: StreamingCallbackT | None = None,
@@ -501,6 +504,7 @@ class GoogleGenAIChatGenerator:
         Async version of the run method. Run the Google Gen AI chat generator on the given input data.
 
         :param messages: A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs: Configuration for generation. If provided, it will override
         the default config. Supports `thinking_budget` for Gemini 2.5 series thinking configuration.
         See https://ai.google.dev/gemini-api/docs/thinking for possible values.
@@ -517,6 +521,7 @@ class GoogleGenAIChatGenerator:
         :raises ValueError: If a ChatMessage does not contain at least one of TextContent, ToolCall, or
         ToolCallResult or if the role in ChatMessage is different from User, System, Assistant.
         """
+        messages = _normalize_messages(messages)
         # Use provided configs or fall back to instance defaults
         generation_kwargs = generation_kwargs or self._generation_kwargs
         safety_settings = safety_settings or self._safety_settings

--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -422,6 +422,22 @@ class TestGoogleGenAIChatGeneratorRun:
                 streaming_callback=lambda chunk: None,
             )
 
+    def test_run_with_string_input(self, monkeypatch, mock_response):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        component = GoogleGenAIChatGenerator()
+        component._client.models.generate_content = Mock(return_value=mock_response)
+
+        result = component.run("What's the capital of France?")
+
+        call_kwargs = component._client.models.generate_content.call_args
+        contents = call_kwargs.kwargs.get("contents") or call_kwargs[1].get("contents")
+        assert len(contents) == 1
+        assert contents[0].role == "user"
+        assert contents[0].parts[0].text == "What's the capital of France?"
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
+
     def test_from_dict_with_streaming_callback(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
         component = GoogleGenAIChatGenerator(streaming_callback=print_streaming_chunk)
@@ -441,6 +457,23 @@ class TestGoogleGenAIChatGeneratorRun:
         assert len(results["replies"]) == 1
         assert results["replies"][0].text == "Hello"
         assert results["replies"][0].meta["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_string_input(self, monkeypatch, mock_response):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        component = GoogleGenAIChatGenerator()
+        component._client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+
+        result = await component.run_async("What's the capital of France?")
+
+        call_kwargs = component._client.aio.models.generate_content.call_args
+        contents = call_kwargs.kwargs.get("contents") or call_kwargs[1].get("contents")
+        assert len(contents) == 1
+        assert contents[0].role == "user"
+        assert contents[0].parts[0].text == "What's the capital of France?"
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
 
     @pytest.mark.asyncio
     async def test_run_async_streaming(self, monkeypatch, mock_streaming_chunk):


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- accept str as ChatGenerator input

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I have used one of the conventional commit types for my PR title.