### PR TITLE
feat: Cohere - accept str as ChatGenerator input; deprecate generator

### DIFF
--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "cohere>=5.17.0", "pydantic>=2.12.0"]
+dependencies = ["haystack-ai>=2.30.0", "cohere>=5.17.0", "pydantic>=2.12.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncIterator, Iterator
 from typing import Any, ClassVar, Literal, get_args
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message
+from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses import ChatMessage, ComponentInfo, ImageContent, TextContent, ToolCall
 from haystack.dataclasses.streaming_chunk import (
     AsyncStreamingCallbackT,
@@ -616,7 +616,7 @@ class CohereChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
         streaming_callback: StreamingCallbackT | None = None,
@@ -625,6 +625,7 @@ class CohereChatGenerator:
         Invoke the chat endpoint based on the provided messages and generation parameters.
 
         :param messages: list of `ChatMessage` instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs: additional keyword arguments for chat generation. These parameters will
             potentially override the parameters passed in the __init__ method.
             For more details on the parameters supported by the Cohere API, refer to the
@@ -637,6 +638,7 @@ class CohereChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: a list of `ChatMessage` instances representing the generated responses.
         """
+        messages = _normalize_messages(messages)
 
         # update generation kwargs by merging with the generation kwargs passed to the run method
         generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
@@ -682,7 +684,7 @@ class CohereChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
         streaming_callback: StreamingCallbackT | None = None,
@@ -691,6 +693,7 @@ class CohereChatGenerator:
         Asynchronously invoke the chat endpoint based on the provided messages and generation parameters.
 
         :param messages: list of `ChatMessage` instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs: additional keyword arguments for chat generation. These parameters will
             potentially override the parameters passed in the __init__ method.
             For more details on the parameters supported by the Cohere API, refer to the
@@ -701,6 +704,7 @@ class CohereChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: a list of `ChatMessage` instances representing the generated responses.
         """
+        messages = _normalize_messages(messages)
 
         # update generation kwargs by merging with the generation kwargs passed to the run method
         generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/generator.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+import warnings
 from collections.abc import Callable
 from typing import Any, ClassVar
 
@@ -70,6 +71,12 @@ class CohereGenerator(CohereChatGenerator):
             You can check them in model's documentation.
         """
 
+        warnings.warn(
+            "The `CohereGenerator` component is deprecated and will be removed in a future version. "
+            "Use `CohereChatGenerator` instead, which now also supports string inputs.",
+            FutureWarning,
+            stacklevel=2,
+        )
         # from_dict deserialization, where `generation_kwargs` is in **kwargs
         if "generation_kwargs" in kwargs:
             generation_kwargs = kwargs.pop("generation_kwargs")

--- a/integrations/cohere/tests/test_chat_generator.py
+++ b/integrations/cohere/tests/test_chat_generator.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from cohere.core import ApiError
@@ -497,6 +497,59 @@ class TestCohereChatGenerator:
         assert len(multimodal_msg["content"]) == 2
         assert multimodal_msg["content"][0]["type"] == "text"
         assert multimodal_msg["content"][1]["type"] == "image_url"
+
+    def test_run_with_string_input(self):
+        """Test that a string input is converted to a user ChatMessage before sending to the API."""
+        generator = CohereChatGenerator(api_key=Secret.from_token("test-api-key"))
+
+        mock_response = MagicMock()
+        mock_response.message.content = [MagicMock()]
+        mock_response.message.content[0].text = "Paris"
+        mock_response.message.content[0].type = "text"
+        mock_response.message.tool_calls = None
+        mock_response.finish_reason = "COMPLETE"
+        mock_response.usage = None
+
+        generator.client.chat = MagicMock(return_value=mock_response)
+
+        result = generator.run("What's the capital of France?")
+
+        generator.client.chat.assert_called_once()
+        call_args = generator.client.chat.call_args
+        sent_messages = call_args[1]["messages"]
+
+        assert len(sent_messages) == 1
+        assert sent_messages[0]["role"] == "user"
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_string_input(self):
+        """Test that a string input is converted to a user ChatMessage before sending to the async API."""
+        generator = CohereChatGenerator(api_key=Secret.from_token("test-api-key"))
+
+        mock_response = MagicMock()
+        mock_response.message.content = [MagicMock()]
+        mock_response.message.content[0].text = "Paris"
+        mock_response.message.content[0].type = "text"
+        mock_response.message.tool_calls = None
+        mock_response.finish_reason = "COMPLETE"
+        mock_response.usage = None
+
+        generator.async_client.chat = AsyncMock(return_value=mock_response)
+
+        result = await generator.run_async("What's the capital of France?")
+
+        generator.async_client.chat.assert_called_once()
+        call_args = generator.async_client.chat.call_args
+        sent_messages = call_args[1]["messages"]
+
+        assert len(sent_messages) == 1
+        assert sent_messages[0]["role"] == "user"
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- accept str as ChatGenerator input
- deprecate generator

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I have used one of the conventional commit types for my PR title.