### PR TITLE
feat: Amazon Bedrock - accept str as ChatGenerator input; deprecate generator; migrate generator example to chat generator

### DIFF
--- a/integrations/amazon_bedrock/examples/embedders_generator_with_rag_example.py
+++ b/integrations/amazon_bedrock/examples/embedders_generator_with_rag_example.py
@@ -4,20 +4,23 @@
 # Note: if you change the model, update the model-specific inference parameters.
 
 from haystack import Document, Pipeline
-from haystack.components.builders import PromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 from haystack_integrations.components.embedders.amazon_bedrock import (
     AmazonBedrockDocumentEmbedder,
     AmazonBedrockTextEmbedder,
 )
-from haystack_integrations.components.generators.amazon_bedrock import AmazonBedrockGenerator
+from haystack_integrations.components.generators.amazon_bedrock import AmazonBedrockChatGenerator
 
-generator_model_name = "amazon.titan-text-lite-v1"
+generator_model_name = "amazon.nova-lite-v1:0"
 embedder_model_name = "amazon.titan-embed-text-v1"
 
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
 Context:
 {% for document in documents %}
     {{ document.content }}
@@ -30,6 +33,8 @@ If you cannot answer the question, output "I do not know".
 
 Question: {{ question }}?
 """
+    )
+]
 
 docs = [
     Document(content="User ABC is using Amazon SageMaker to train ML models."),
@@ -47,21 +52,21 @@ doc_store.write_documents(docs_with_embeddings)
 pipe = Pipeline()
 pipe.add_component("text_embedder", AmazonBedrockTextEmbedder(embedder_model_name))
 pipe.add_component("retriever", InMemoryEmbeddingRetriever(doc_store, top_k=1))
-pipe.add_component("prompt_builder", PromptBuilder(prompt_template))
+pipe.add_component("prompt_builder", ChatPromptBuilder(prompt_template))
 pipe.add_component(
-    "generator",
-    AmazonBedrockGenerator(
+    "llm",
+    AmazonBedrockChatGenerator(
         model=generator_model_name,
         # model-specific inference parameters
         generation_kwargs={
-            "maxTokenCount": 1024,
+            "maxTokens": 1024,
             "temperature": 0.0,
         },
     ),
 )
 pipe.connect("text_embedder", "retriever")
 pipe.connect("retriever", "prompt_builder")
-pipe.connect("prompt_builder", "generator")
+pipe.connect("prompt_builder.prompt", "llm.messages")
 
 
 question = "Which user is using IaaS services for Machine Learning?"
@@ -71,4 +76,4 @@ results = pipe.run(
         "prompt_builder": {"question": question},
     }
 )
-results["generator"]["replies"]
+print(results["llm"]["replies"][0].text)  # noqa: T201

--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "boto3>=1.42.84,<2", "aiobotocore>=3.4.0,<4"]
+dependencies = ["haystack-ai>=2.30.0", "boto3>=1.42.84,<2", "aiobotocore>=3.4.0,<4"]
 
 
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -6,6 +6,7 @@ from botocore.config import Config
 from botocore.eventstream import EventStream
 from botocore.exceptions import ClientError
 from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.components.generators.utils import _normalize_messages
 from haystack.dataclasses import (
     ChatMessage,
     ComponentInfo,
@@ -520,7 +521,7 @@ class AmazonBedrockChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
@@ -531,6 +532,7 @@ class AmazonBedrockChatGenerator:
         Supports both standard and streaming responses depending on whether a streaming callback is provided.
 
         :param messages: A list of `ChatMessage` objects forming the chat history.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: Optional callback for handling streaming outputs.
         :param generation_kwargs: Optional dictionary of generation parameters. Some common parameters are:
             - `maxTokens`: Maximum number of tokens to generate.
@@ -546,6 +548,7 @@ class AmazonBedrockChatGenerator:
         :raises AmazonBedrockInferenceError:
             If the Bedrock inference API call fails.
         """
+        messages = _normalize_messages(messages)
         component_info = ComponentInfo.from_component(self)
 
         params, callback = self._prepare_request_params(
@@ -582,7 +585,7 @@ class AmazonBedrockChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
@@ -593,6 +596,7 @@ class AmazonBedrockChatGenerator:
         Designed for use cases where non-blocking or concurrent execution is desired.
 
         :param messages: A list of `ChatMessage` objects forming the chat history.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: Optional async-compatible callback for handling streaming outputs.
         :param generation_kwargs: Optional dictionary of generation parameters. Some common parameters are:
             - `maxTokens`: Maximum number of tokens to generate.
@@ -608,6 +612,7 @@ class AmazonBedrockChatGenerator:
         :raises AmazonBedrockInferenceError:
             If the Bedrock inference API call fails.
         """
+        messages = _normalize_messages(messages)
         component_info = ComponentInfo.from_component(self)
 
         params, callback = self._prepare_request_params(

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -142,6 +142,12 @@ class AmazonBedrockGenerator:
         :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly or the model is
             not supported.
         """
+        warnings.warn(
+            "The `AmazonBedrockGenerator` component is deprecated and will be removed in a future version. "
+            "Use `AmazonBedrockChatGenerator` instead, which now also supports string inputs.",
+            FutureWarning,
+            stacklevel=2,
+        )
         if not model:
             msg = "'model' cannot be None or empty string"
             raise ValueError(msg)

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -779,6 +779,49 @@ class TestAmazonBedrockChatGenerator:
         assert len(result["replies"]) == 1
         assert result["replies"][0].text == "Paris"
 
+    def test_run_with_string_input(self, mock_boto3_session, set_env_variables):
+        generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
+        generator.client = MagicMock()
+        generator.client.converse.return_value = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Paris"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5},
+            "metrics": {"latencyMs": 100},
+        }
+        result = generator.run("What's the capital of France?")
+        _, kwargs = generator.client.converse.call_args
+        assert kwargs["messages"] == [{"content": [{"text": "What's the capital of France?"}], "role": "user"}]
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_string_input(self, mock_boto3_session, set_env_variables):
+        generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
+        mock_response = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Paris"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5},
+            "metrics": {"latencyMs": 100},
+        }
+        mock_async_client = AsyncMock()
+        mock_async_client.converse.return_value = mock_response
+
+        mock_session = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_session.create_client.return_value = mock_cm
+
+        generator.async_session = mock_session
+
+        result = await generator.run_async("What's the capital of France?")
+        _, kwargs = mock_async_client.converse.call_args
+        assert kwargs["messages"] == [{"content": [{"text": "What's the capital of France?"}], "role": "user"}]
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
+
 
 # In the CI, those tests are skipped if AWS Authentication fails
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- accept str as ChatGenerator input
- deprecate generator
- migrate generator example to chat generator

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I have used one of the conventional commit types for my PR title.