### PR TITLE
feat: Anthropic - accept str as ChatGenerator input; deprecate generator

### DIFF
--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "anthropic>=0.74.0"]
+dependencies = ["haystack-ai>=2.30.0", "anthropic>=0.74.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/anthropic#readme"

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Any, ClassVar
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message
+from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.dataclasses.streaming_chunk import (
     AsyncStreamingCallbackT,
@@ -472,7 +472,7 @@ class AnthropicChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
@@ -481,6 +481,7 @@ class AnthropicChatGenerator:
         Invokes the Anthropic API with the given messages and generation kwargs.
 
         :param messages: A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
         :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
@@ -489,6 +490,7 @@ class AnthropicChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: The responses from the model
         """
+        messages = _normalize_messages(messages)
         system_messages, non_system_messages, generation_kwargs, anthropic_tools = self._prepare_request_params(
             messages, generation_kwargs, tools
         )
@@ -514,7 +516,7 @@ class AnthropicChatGenerator:
     @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
@@ -523,6 +525,7 @@ class AnthropicChatGenerator:
         Async version of the run method. Invokes the Anthropic API with the given messages and generation kwargs.
 
         :param messages: A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
         :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
@@ -531,6 +534,7 @@ class AnthropicChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: The responses from the model
         """
+        messages = _normalize_messages(messages)
         system_messages, non_system_messages, generation_kwargs, anthropic_tools = self._prepare_request_params(
             messages, generation_kwargs, tools
         )

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from typing import Any, ClassVar
 
 from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.components.generators.utils import _normalize_messages
 from haystack.dataclasses import ChatMessage, StreamingChunk
 from haystack.dataclasses.streaming_chunk import StreamingCallbackT
 from haystack.tools import (
@@ -210,7 +211,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
     @component.output_types(replies=list[ChatMessage])
     def run(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
@@ -219,6 +220,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         Invokes the AnthropicFoundry API with the given messages and generation kwargs.
 
         :param messages: A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
         :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
@@ -227,6 +229,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         :returns: A dictionary with the following keys:
             - `replies`: The responses from the model
         """
+        messages = _normalize_messages(messages)
         if not self._is_warmed_up:
             self.warm_up()
         return super(AnthropicFoundryChatGenerator, self).run(  # noqa: UP008
@@ -236,7 +239,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
     @component.output_types(replies=list[ChatMessage])
     async def run_async(
         self,
-        messages: list[ChatMessage],
+        messages: list[ChatMessage] | str,
         streaming_callback: StreamingCallbackT | None = None,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | None = None,
@@ -245,6 +248,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         Async version of the run method. Invokes the AnthropicFoundry API with the given messages and generation kwargs.
 
         :param messages: A list of ChatMessage instances representing the input messages.
+            If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
         :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
@@ -253,6 +257,7 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         :returns: A dictionary with the following keys:
             - `replies`: The responses from the model
         """
+        messages = _normalize_messages(messages)
         if not self._is_warmed_up:
             self.warm_up()
         return await super(AnthropicFoundryChatGenerator, self).run_async(  # noqa: UP008

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable
 from typing import Any, ClassVar
 
@@ -78,6 +79,12 @@ class AnthropicGenerator:
         :param system_prompt: An optional system prompt to use for generation.
         :param generation_kwargs: Additional keyword arguments for generation.
         """
+        warnings.warn(
+            "The `AnthropicGenerator` component is deprecated and will be removed in a future version. "
+            "Use `AnthropicChatGenerator` instead, which now also supports string inputs.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.api_key = api_key
         self.model = model
         self.generation_kwargs = generation_kwargs or {}

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -312,6 +312,22 @@ class TestAnthropicChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    def test_run_with_string_input(self, mock_anthropic_completion):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        result = component.run("What's the capital of France?")
+
+        # Check that the backend received exactly one user message
+        _, kwargs = mock_anthropic_completion.call_args
+        assert len(kwargs["messages"]) == 1
+        assert kwargs["messages"][0]["role"] == "user"
+        assert kwargs["messages"][0]["content"][0]["type"] == "text"
+        assert kwargs["messages"][0]["content"][0]["text"] == "What's the capital of France?"
+
+        # Check that the result contains exactly one ChatMessage
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
+
     def test_run_with_params(self, chat_messages, mock_anthropic_completion):
         """
         Test that the AnthropicChatGenerator component can run with parameters.
@@ -1456,6 +1472,26 @@ class TestAnthropicChatGeneratorAsync:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_string_input(self, mock_anthropic_completion_async):
+        """
+        Test that the async run method of AnthropicChatGenerator works with string input.
+        """
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        result = await component.run_async("What's the capital of France?")
+
+        # Check that the backend received exactly one user message
+        _, kwargs = mock_anthropic_completion_async.call_args
+        assert len(kwargs["messages"]) == 1
+        assert kwargs["messages"][0]["role"] == "user"
+        assert kwargs["messages"][0]["content"][0]["type"] == "text"
+        assert kwargs["messages"][0]["content"][0]["text"] == "What's the capital of France?"
+
+        # Check that the result contains exactly one ChatMessage
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
 
     @pytest.mark.asyncio
     async def test_run_async_with_params(self, chat_messages, mock_anthropic_completion_async):


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- accept str as ChatGenerator input
- deprecate generator

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I have used one of the conventional commit types for my PR title.