### PR TITLE
fix: `Supabase` integration tests

### DIFF
--- a/integrations/supabase/tests/test_document_store.py
+++ b/integrations/supabase/tests/test_document_store.py
@@ -39,13 +39,6 @@ class TestDocumentStore(
     GetMetadataFieldMinMaxTest,
     GetMetadataFieldUniqueValuesTest,
 ):
-    def test_get_metadata_field_min_max_empty_collection(self, document_store: SupabasePgvectorDocumentStore):
-        """SupabasePgvectorDocumentStore raises ValueError when the field doesn't exist in the store."""
-        assert document_store.count_documents() == 0
-
-        with pytest.raises(ValueError, match="not found in document store"):
-            document_store.get_metadata_field_min_max("priority")
-
     def test_write_documents(self, document_store: SupabasePgvectorDocumentStore):
         docs = [Document(id="1")]
         assert document_store.write_documents(docs) == 1

--- a/integrations/supabase/tests/test_document_store.py
+++ b/integrations/supabase/tests/test_document_store.py
@@ -39,13 +39,6 @@ class TestDocumentStore(
     GetMetadataFieldMinMaxTest,
     GetMetadataFieldUniqueValuesTest,
 ):
-    def test_get_metadata_fields_info_empty_collection(self, document_store: SupabasePgvectorDocumentStore):
-        """SupabasePgvectorDocumentStore always includes 'content' in fields info, even for empty stores."""
-        assert document_store.count_documents() == 0
-
-        fields_info = document_store.get_metadata_fields_info()
-        assert fields_info == {"content": {"type": "text"}}
-
     def test_get_metadata_field_min_max_empty_collection(self, document_store: SupabasePgvectorDocumentStore):
         """SupabasePgvectorDocumentStore raises ValueError when the field doesn't exist in the store."""
         assert document_store.count_documents() == 0


### PR DESCRIPTION
### Proposed Changes:

- 2 overrides tests were written for `pgvector-haystack==6.3.0` behaviour that changed in 6.3.1 — removing them lets the base class tests run, which match the current implementation

### How did you test it?

- unit tests, integration tests, manual verification, instructions for manual tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
