### PR TITLE
test: TogetherAI - replace gpt-oss-20b with 120b

### DIFF
--- a/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
@@ -176,7 +176,7 @@ class TestTogetherAIChatGeneratorAsync:
     @pytest.mark.asyncio
     async def test_live_run_with_tools_and_response_async(self, tools):
         initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = TogetherAIChatGenerator(model="openai/gpt-oss-20b", tools=tools)
+        component = TogetherAIChatGenerator(model="openai/gpt-oss-120b", tools=tools)
         results = await component.run_async(messages=initial_messages, generation_kwargs={"tool_choice": "auto"})
 
         assert len(results["replies"]) > 0, "No replies received"


### PR DESCRIPTION
### Related Issues

- gpt-oss-20b got unreliable: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/26989272673/job/79696328966

### Proposed Changes:
- use gpt-oss-120b instead, widely used in this test suite

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
