### PR TITLE
docs: document raised exceptions in HF API components

### DIFF
--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
@@ -147,6 +147,9 @@ class HuggingFaceAPIDocumentEmbedder:
         :param concurrency_limit:
             The maximum number of requests that should be allowed to run concurrently.
             This parameter is only used in the `run_async` method.
+        :raises ValueError:
+            If the required `model` or `url` is missing from `api_params`, the `url` is invalid,
+            or the `api_type` is unknown.
         """
         if isinstance(api_type, str):
             api_type = HFEmbeddingAPIType.from_str(api_type)
@@ -331,6 +334,10 @@ class HuggingFaceAPIDocumentEmbedder:
         :param documents:
             Documents to embed.
 
+        :raises TypeError:
+            If `documents` is not a list of Documents.
+        :raises ValueError:
+            If the embeddings returned by the API have an unexpected shape.
         :returns:
             A dictionary with the following keys:
             - `documents`: A list of documents with embeddings.
@@ -360,6 +367,10 @@ class HuggingFaceAPIDocumentEmbedder:
         :param documents:
             Documents to embed.
 
+        :raises TypeError:
+            If `documents` is not a list of Documents.
+        :raises ValueError:
+            If the embeddings returned by the API have an unexpected shape.
         :returns:
             A dictionary with the following keys:
             - `documents`: A list of documents with embeddings.

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
@@ -113,6 +113,9 @@ class HuggingFaceAPITextEmbedder:
             Applicable when `api_type` is `TEXT_EMBEDDINGS_INFERENCE`, or `INFERENCE_ENDPOINTS`
             if the backend uses Text Embeddings Inference.
             If `api_type` is `SERVERLESS_INFERENCE_API`, this parameter is ignored.
+        :raises ValueError:
+            If the required `model` or `url` is missing from `api_params`, the `url` is invalid,
+            or the `api_type` is unknown.
         """
         if isinstance(api_type, str):
             api_type = HFEmbeddingAPIType.from_str(api_type)
@@ -213,6 +216,10 @@ class HuggingFaceAPITextEmbedder:
         :param text:
             Text to embed.
 
+        :raises TypeError:
+            If `text` is not a string.
+        :raises ValueError:
+            If the embedding returned by the API has an unexpected shape.
         :returns:
             A dictionary with the following keys:
             - `embedding`: The embedding of the input text.
@@ -241,6 +248,10 @@ class HuggingFaceAPITextEmbedder:
         :param text:
             Text to embed.
 
+        :raises TypeError:
+            If `text` is not a string.
+        :raises ValueError:
+            If the embedding returned by the API has an unexpected shape.
         :returns:
             A dictionary with the following keys:
             - `embedding`: The embedding of the input text.

--- a/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
@@ -392,6 +392,9 @@ class HuggingFaceAPIChatGenerator:
             The chosen model should support tool/function calling, according to the model card.
             Support for tools in the Hugging Face API and TGI is not yet fully refined and you may experience
             unexpected behavior.
+        :raises ValueError:
+            If the required `model` or `url` is missing from `api_params`, the `url` is invalid, the `api_type`
+            is unknown, `tools` and `streaming_callback` are used together, or duplicate tool names are provided.
         """
         if isinstance(api_type, str):
             api_type = HFGenerationAPIType.from_str(api_type)
@@ -510,6 +513,8 @@ class HuggingFaceAPIChatGenerator:
         :param streaming_callback:
             An optional callable for handling streaming responses. If set, it will override the `streaming_callback`
             parameter set during component initialization.
+        :raises ValueError:
+            If `tools` and a streaming callback are used together, or if duplicate tool names are provided.
         :returns: A dictionary with the following keys:
             - `replies`: A list containing the generated responses as ChatMessage objects.
         """
@@ -568,6 +573,8 @@ class HuggingFaceAPIChatGenerator:
         :param streaming_callback:
             An optional callable for handling streaming responses. If set, it will override the `streaming_callback`
             parameter set during component initialization.
+        :raises ValueError:
+            If `tools` and a streaming callback are used together, or if duplicate tool names are provided.
         :returns: A dictionary with the following keys:
             - `replies`: A list containing the generated responses as ChatMessage objects.
         """


### PR DESCRIPTION
### Related Issues

Follow-up to the PR #3403 that moved HF API components to core integrations. I found some opportunities for improvement when reviewing the PR but I wanted to apply improvements in a separate PR.

### Proposed Changes:

- Add `:raises:` entries to the `__init__`, `run`, and `run_async` docstrings of the HF API components, which previously documented parameters and return values but not the exceptions they raise:
  - `HuggingFaceAPITextEmbedder`: `ValueError` in `__init__` (invalid `api_params`/`api_type`); `TypeError`/`ValueError` in `run`/`run_async`.
  - `HuggingFaceAPIDocumentEmbedder`: `ValueError` in `__init__`; `TypeError`/`ValueError` in `run`/`run_async`.
  - `HuggingFaceAPIChatGenerator`: `ValueError` in `__init__`, `run`, and `run_async` (e.g. tools + streaming used together, duplicate tool names).

### How did you test it?

### Notes for the reviewer

Failing tests can be ignored. Docs change only. No code change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)