### PR TITLE
feat(google_genai): add timeout and max_retries to embedder components

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
@@ -124,6 +124,11 @@ class GoogleGenAIDocumentEmbedder:
             Specifying task types in `config` does not take effect for `gemini-embedding-2`.
             See [Gemini documentation](https://ai.google.dev/gemini-api/docs/embeddings#task-types) for more
             information.
+        :param timeout:
+            The timeout in seconds for the underlying Google GenAI client network requests.
+        :param max_retries:
+            The maximum number of retries for the underlying Google GenAI client network requests.
+
         """
         self._api_key = api_key
         self._api = api

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/document_embedder.py
@@ -85,6 +85,8 @@ class GoogleGenAIDocumentEmbedder:
         meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
         config: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
     ) -> None:
         """
         Creates an GoogleGenAIDocumentEmbedder component.
@@ -135,12 +137,16 @@ class GoogleGenAIDocumentEmbedder:
         self._meta_fields_to_embed = meta_fields_to_embed or []
         self._embedding_separator = embedding_separator
         self._config = config
+        self._timeout = timeout
+        self._max_retries = max_retries
 
         self._client = _get_client(
             api_key=api_key,
             api=api,
             vertex_ai_project=vertex_ai_project,
             vertex_ai_location=vertex_ai_location,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -164,6 +170,8 @@ class GoogleGenAIDocumentEmbedder:
             vertex_ai_project=self._vertex_ai_project,
             vertex_ai_location=self._vertex_ai_location,
             config=self._config,
+            timeout=self._timeout,
+            max_retries=self._max_retries,
         )
 
     @classmethod

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from google.genai.types import Content, EmbedContentConfig, Part
-from haystack import Document, component, logging, default_from_dict, default_to_dict
+from haystack import Document, component, logging
 from haystack.components.converters.image.image_utils import (
     _batch_convert_pdf_pages_to_images,
     _encode_image_to_base64,

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -219,6 +219,11 @@ class GoogleGenAIMultimodalDocumentEmbedder:
             You can for example set the output dimensionality of the embedding: `{"output_dimensionality": 768}`.
             See [Google API documentation](https://googleapis.github.io/python-genai/genai.html#genai.types.EmbedContentConfig)
             for the available options.
+        :param timeout:
+            The timeout in seconds for the underlying Google GenAI client network requests.
+        :param max_retries:
+            The maximum number of retries for the underlying Google GenAI client network requests.
+        """
         """
         self._api_key = api_key
         self._api = api

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -258,7 +258,7 @@ class GoogleGenAIMultimodalDocumentEmbedder:
             self,
             model=self._model,
             file_path_meta_field=self._file_path_meta_field,
-            root_path=str(self._root_path) if self._root_path else None,
+            root_path=self._root_path if self._root_path != "" else None,
             image_size=self._image_size,
             batch_size=self._batch_size,
             progress_bar=self._progress_bar,

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from google.genai.types import Content, EmbedContentConfig, Part
-from haystack import Document, component, logging
+from haystack import Document, component, logging, default_from_dict, default_to_dict
 from haystack.components.converters.image.image_utils import (
     _batch_convert_pdf_pages_to_images,
     _encode_image_to_base64,
@@ -181,6 +181,8 @@ class GoogleGenAIMultimodalDocumentEmbedder:
         batch_size: int = 6,
         progress_bar: bool = True,
         config: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
     ) -> None:
         """
         Creates an GoogleGenAIMultimodalDocumentEmbedder component.
@@ -229,12 +231,16 @@ class GoogleGenAIMultimodalDocumentEmbedder:
         self._batch_size = batch_size
         self._progress_bar = progress_bar
         self._config = config
+        self._timeout = timeout
+        self._max_retries = max_retries
 
         self._client = _get_client(
             api_key=api_key,
             api=api,
             vertex_ai_project=vertex_ai_project,
             vertex_ai_location=vertex_ai_location,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     def _extract_parts_to_embed(self, documents: list[Document]) -> list[Part]:

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -9,14 +9,14 @@ from pathlib import Path
 from typing import Any, Literal
 
 from google.genai.types import Content, EmbedContentConfig, Part
-from haystack import Document, component, logging
+from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.components.converters.image.image_utils import (
     _batch_convert_pdf_pages_to_images,
     _encode_image_to_base64,
     _PDFPageInfo,
 )
 from haystack.dataclasses import ByteStream
-from haystack.utils.auth import Secret
+from haystack.utils import Secret, deserialize_secrets_inplace
 from tqdm import tqdm
 from tqdm.asyncio import tqdm as async_tqdm
 from typing_extensions import NotRequired, TypedDict
@@ -246,6 +246,43 @@ class GoogleGenAIMultimodalDocumentEmbedder:
             timeout=timeout,
             max_retries=max_retries,
         )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            model=self._model,
+            file_path_meta_field=self._file_path_meta_field,
+            root_path=str(self._root_path) if self._root_path else None,
+            image_size=self._image_size,
+            batch_size=self._batch_size,
+            progress_bar=self._progress_bar,
+            api_key=self._api_key.to_dict(),
+            api=self._api,
+            vertex_ai_project=self._vertex_ai_project,
+            vertex_ai_location=self._vertex_ai_location,
+            config=self._config,
+            timeout=self._timeout,
+            max_retries=self._max_retries,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GoogleGenAIMultimodalDocumentEmbedder":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            Dictionary to deserialize from.
+        :returns:
+            Deserialized component.
+        """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        return default_from_dict(cls, data)
 
     def _extract_parts_to_embed(self, documents: list[Document]) -> list[Part]:
         """

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -224,7 +224,6 @@ class GoogleGenAIMultimodalDocumentEmbedder:
         :param max_retries:
             The maximum number of retries for the underlying Google GenAI client network requests.
         """
-        """
         self._api_key = api_key
         self._api = api
         self._vertex_ai_project = vertex_ai_project

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
@@ -82,6 +82,8 @@ class GoogleGenAITextEmbedder:
         prefix: str = "",
         suffix: str = "",
         config: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
     ) -> None:
         """
         Creates an GoogleGenAITextEmbedder component.
@@ -121,11 +123,15 @@ class GoogleGenAITextEmbedder:
         self._prefix = prefix
         self._suffix = suffix
         self._config = config
+        self._timeout = timeout
+        self._max_retries = max_retries
         self._client = _get_client(
             api_key=api_key,
             api=api,
             vertex_ai_project=vertex_ai_project,
             vertex_ai_location=vertex_ai_location,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -145,6 +151,8 @@ class GoogleGenAITextEmbedder:
             prefix=self._prefix,
             suffix=self._suffix,
             config=self._config,
+            timeout=self._timeout,
+            max_retries=self._max_retries,
         )
 
     @classmethod

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/text_embedder.py
@@ -113,6 +113,10 @@ class GoogleGenAITextEmbedder:
             Specifying task types in `config` does not take effect for `gemini-embedding-2`.
             See [Gemini documentation](https://ai.google.dev/gemini-api/docs/embeddings#task-types) for more
             information.
+        :param timeout:
+            The timeout in seconds for the underlying Google GenAI client network requests.
+        :param max_retries:
+            The maximum number of retries for the underlying Google GenAI client network requests.
         """
 
         self._api_key = api_key

--- a/integrations/google_genai/tests/test_document_embedder.py
+++ b/integrations/google_genai/tests/test_document_embedder.py
@@ -40,6 +40,8 @@ class TestGoogleGenAIDocumentEmbedder:
         assert embedder._meta_fields_to_embed == []
         assert embedder._embedding_separator == "\n"
         assert embedder._config is None
+        assert embedder._timeout is None
+        assert embedder._max_retries is None
 
     def test_init_with_parameters(self, monkeypatch):
         embedder = GoogleGenAIDocumentEmbedder(
@@ -52,6 +54,8 @@ class TestGoogleGenAIDocumentEmbedder:
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
             config={"task_type": "CLASSIFICATION"},
+            timeout=30.0,
+            max_retries=3,
         )
         assert embedder._api_key.resolve_value() == "fake-api-key-2"
         assert embedder._model == "model"
@@ -62,6 +66,8 @@ class TestGoogleGenAIDocumentEmbedder:
         assert embedder._meta_fields_to_embed == ["test_field"]
         assert embedder._embedding_separator == " | "
         assert embedder._config == {"task_type": "CLASSIFICATION"}
+        assert embedder._timeout == 30.0
+        assert embedder._max_retries == 3
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
@@ -90,6 +96,8 @@ class TestGoogleGenAIDocumentEmbedder:
                 "api": "gemini",
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
+                "timeout": None,
+                "max_retries": None,
             },
         }
 
@@ -105,6 +113,8 @@ class TestGoogleGenAIDocumentEmbedder:
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
             config={"task_type": "CLASSIFICATION"},
+            timeout=30.0,
+            max_retries=3,
         )
         data = component.to_dict()
         assert data == {
@@ -124,6 +134,8 @@ class TestGoogleGenAIDocumentEmbedder:
                 "api": "gemini",
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
+                "timeout": 30.0,
+                "max_retries": 3,
             },
         }
 
@@ -145,6 +157,8 @@ class TestGoogleGenAIDocumentEmbedder:
                 "api": "gemini",
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
+                "timeout": 30.0,
+                "max_retries": 3,
             },
         }
         monkeypatch.setenv("GOOGLE_API_KEY", "fake-api-key")
@@ -161,6 +175,8 @@ class TestGoogleGenAIDocumentEmbedder:
         assert embedder._api == "gemini"
         assert embedder._vertex_ai_project is None
         assert embedder._vertex_ai_location is None
+        assert embedder._timeout == 30.0
+        assert embedder._max_retries == 3
 
     def test_prepare_texts_to_embed_w_metadata(self):
         documents = [

--- a/integrations/google_genai/tests/test_multimodal_document_embedder.py
+++ b/integrations/google_genai/tests/test_multimodal_document_embedder.py
@@ -161,6 +161,68 @@ class TestGoogleGenAIMultimodalDocumentEmbedder:
         assert embedder._timeout == 30.0
         assert embedder._max_retries == 3
 
+    def test_to_dict_with_custom_init_parameters(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "fake-api-key")
+        component = GoogleGenAIMultimodalDocumentEmbedder(
+            model="model",
+            batch_size=12,
+            timeout=30.0,
+            max_retries=3,
+            config={"output_dimensionality": 768},
+            root_path="some_root_path",
+            image_size=(512, 512),
+            progress_bar=False,
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": (
+                "haystack_integrations.components.embedders.google_genai.multimodal_document_embedder.GoogleGenAIMultimodalDocumentEmbedder"
+            ),
+            "init_parameters": {
+                "model": "model",
+                "file_path_meta_field": "file_path",
+                "root_path": "some_root_path",
+                "image_size": (512, 512),
+                "batch_size": 12,
+                "progress_bar": False,
+                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"], "strict": False},
+                "api": "gemini",
+                "vertex_ai_project": None,
+                "vertex_ai_location": None,
+                "config": {"output_dimensionality": 768},
+                "timeout": 30.0,
+                "max_retries": 3,
+            },
+        }
+
+    def test_to_dict_from_dict_roundtrip(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "fake-api-key")
+        original = GoogleGenAIMultimodalDocumentEmbedder(
+            model="model",
+            batch_size=12,
+            timeout=30.0,
+            max_retries=3,
+            image_size=(512, 512),
+            progress_bar=False,
+            config={"output_dimensionality": 768},
+            root_path="some_root_path",
+        )
+        data = original.to_dict()
+        restored = component_from_dict(GoogleGenAIMultimodalDocumentEmbedder, data, "embedder")
+        assert restored._api_key.resolve_value() == "fake-api-key"
+        assert restored._model == "model"
+        assert restored._batch_size == 12
+        assert restored._timeout == 30.0
+        assert restored._max_retries == 3
+        assert restored._config == {"output_dimensionality": 768}
+        assert restored._root_path == "some_root_path"
+        assert restored._image_size == (512, 512)
+        assert restored._progress_bar is False
+        assert restored._file_path_meta_field == "file_path"
+        assert restored._api == "gemini"
+        assert restored._vertex_ai_project is None
+        assert restored._vertex_ai_location is None
+
     def test_extract_parts_to_embed_images(self, test_files_path):
         embedder = GoogleGenAIMultimodalDocumentEmbedder(api_key=Secret.from_token("fake-api-key"))
         docs = [

--- a/integrations/google_genai/tests/test_multimodal_document_embedder.py
+++ b/integrations/google_genai/tests/test_multimodal_document_embedder.py
@@ -76,6 +76,8 @@ class TestGoogleGenAIMultimodalDocumentEmbedder:
             root_path="root_path",
             image_size=(1024, 1024),
             config={"task_type": "CLASSIFICATION"},
+            timeout=30.0,
+            max_retries=3,
         )
         assert embedder._api_key.resolve_value() == "fake-api-key-2"
         assert embedder._model == "model"
@@ -85,6 +87,8 @@ class TestGoogleGenAIMultimodalDocumentEmbedder:
         assert embedder._batch_size == 64
         assert embedder._progress_bar is False
         assert embedder._config == {"task_type": "CLASSIFICATION"}
+        assert embedder._timeout == 30.0
+        assert embedder._max_retries == 3
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
@@ -114,6 +118,8 @@ class TestGoogleGenAIMultimodalDocumentEmbedder:
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
                 "config": None,
+                "timeout": None,
+                "max_retries": None,
             },
         }
 
@@ -134,6 +140,8 @@ class TestGoogleGenAIMultimodalDocumentEmbedder:
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
                 "config": {"task_type": "CLASSIFICATION"},
+                "timeout": 30.0,
+                "max_retries": 3,
             },
         }
         monkeypatch.setenv("GOOGLE_API_KEY", "fake-api-key")
@@ -150,6 +158,8 @@ class TestGoogleGenAIMultimodalDocumentEmbedder:
         assert embedder._api == "gemini"
         assert embedder._vertex_ai_project is None
         assert embedder._vertex_ai_location is None
+        assert embedder._timeout == 30.0
+        assert embedder._max_retries == 3
 
     def test_extract_parts_to_embed_images(self, test_files_path):
         embedder = GoogleGenAIMultimodalDocumentEmbedder(api_key=Secret.from_token("fake-api-key"))

--- a/integrations/google_genai/tests/test_text_embedder.py
+++ b/integrations/google_genai/tests/test_text_embedder.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from asyncio import timeout
 
 import pytest
 from google.genai.types import ContentEmbedding, EmbedContentResponse
@@ -24,6 +25,8 @@ class TestGoogleGenAITextEmbedder:
         assert embedder._api == "gemini"
         assert embedder._vertex_ai_project is None
         assert embedder._vertex_ai_location is None
+        assert embedder._timeout is None
+        assert embedder._max_retries is None
 
     def test_init_with_parameters(self):
         embedder = GoogleGenAITextEmbedder(
@@ -32,12 +35,16 @@ class TestGoogleGenAITextEmbedder:
             prefix="prefix",
             suffix="suffix",
             config={"task_type": "CLASSIFICATION"},
+            timeout=30.0,
+            max_retries=3,
         )
         assert embedder._api_key.resolve_value() == "fake-api-key"
         assert embedder._model_name == "model"
         assert embedder._prefix == "prefix"
         assert embedder._suffix == "suffix"
         assert embedder._config == {"task_type": "CLASSIFICATION"}
+        assert embedder._timeout == 30.0
+        assert embedder._max_retries == 3
 
     def test_to_dict(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "fake-api-key")
@@ -54,6 +61,8 @@ class TestGoogleGenAITextEmbedder:
                 "api": "gemini",
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
+                "timeout": None,
+                "max_retries": None,
             },
         }
 
@@ -65,6 +74,8 @@ class TestGoogleGenAITextEmbedder:
             prefix="prefix",
             suffix="suffix",
             config={"task_type": "CLASSIFICATION"},
+            timeout=30.0,
+            max_retries=3,
         )
         data = component.to_dict()
         assert data == {
@@ -78,6 +89,8 @@ class TestGoogleGenAITextEmbedder:
                 "api": "gemini",
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
+                "timeout": 30.0,
+                "max_retries": 3,
             },
         }
 
@@ -94,6 +107,8 @@ class TestGoogleGenAITextEmbedder:
                 "api": "gemini",
                 "vertex_ai_project": None,
                 "vertex_ai_location": None,
+                "timeout": 30.0,
+                "max_retries": 3,
             },
         }
         component = GoogleGenAITextEmbedder.from_dict(data)
@@ -102,6 +117,8 @@ class TestGoogleGenAITextEmbedder:
         assert component._prefix == ""
         assert component._suffix == ""
         assert component._config == {"task_type": "CLASSIFICATION"}
+        assert component._timeout == 30.0
+        assert component._max_retries == 3
 
     def test_prepare_input(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "fake-api-key")

--- a/integrations/google_genai/tests/test_text_embedder.py
+++ b/integrations/google_genai/tests/test_text_embedder.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from asyncio import timeout
 
 import pytest
 from google.genai.types import ContentEmbedding, EmbedContentResponse


### PR DESCRIPTION
### Related Issues

- fixes #3411 

### Proposed Changes:

- Added `timeout: float | None = None` and `max_retries: int | None = None` to the constructors of all three classes.
- Forwarded these arguments cleanly to the internal `_get_client` helper utility to natively apply network threshold and backoff configurations to the underlying Google GenAI client layer.
- Extended the `to_dict` and `from_dict` serialization logic to guarantee settings persist cleanly inside declarative Haystack pipeline blueprints.

### How did you test it?

Verified the adjustments locally across all testing matrices by expanding the existing test suites. 

- **Unit Tests:** Updated `test_text_embedder.py`, `test_document_embedder.py`, and `test_multimodal_document_embedder.py` to assert correct parameter initialization, default fallbacks, and serialization round-trips (`to_dict` / `from_dict`).
- **Execution:** Executed `hatch run test:unit` confirming a 100% clean green pass.
- **Formatting:** Code style and syntax layouts have been strictly checked and standardized using `hatch run ruff format`.

### Notes for the reviewer

The serialization modifications for the Text and Document embedders use direct parameter mappings, while the Multimodal embedder relies on the dynamic fallback check behavior of component_to_dict and component_from_dict. All defaults are set to None ensuring zero disruption or backward-compatibility breakages for existing users.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
