### PR TITLE
fix(valkey): add client_name to Valkey connection configuration

### DIFF
--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -235,6 +235,7 @@ class ValkeyDocumentStore(DocumentStore):
                     credentials=self._build_credentials(self._username, self._password),
                     request_timeout=self._request_timeout,
                     reconnect_strategy=reconnect_strategy,
+                    client_name="haystack_vector_store_client",
                 )
                 self._client = SyncGlideClient.create(client_config)
             return self._client
@@ -272,6 +273,7 @@ class ValkeyDocumentStore(DocumentStore):
                     credentials=self._build_credentials(self._username, self._password),
                     request_timeout=self._request_timeout,
                     reconnect_strategy=reconnect_strategy,
+                    client_name="haystack_vector_store_client",
                 )
                 self._async_client = await GlideClient.create(client_config)
             return self._async_client


### PR DESCRIPTION
## Related Issues

Closes #3356

## Proposed Changes

Add `client_name=haystack_vector_store_client` to `SyncGlideClientConfiguration` and `GlideClientConfiguration` when creating standalone (non-cluster) Valkey connections.

This makes Haystack connections identifiable in monitoring tools like `CLIENT LIST`, Valkey Admin, and CloudWatch metrics (ElastiCache).

## How did you test it

The change adds a known parameter to an existing configuration object. No logic is affected.

## Notes for the reviewer

Applied to both sync and async paths for consistency.

## Checklist

- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md)
- [ ] I have updated the related component(s) documentation if needed
- [ ] I have added tests for the changes I made (if applicable)
- [ ] I have updated the `CHANGELOG.md` file in the relevant integration folder