### PR TITLE
fix: `ArcadeDB` does not support in-place updates, changing to: fetch, update write back docs

### DIFF
--- a/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
+++ b/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
@@ -456,11 +456,16 @@ class ArcadeDBDocumentStore:
             msg = "update_by_filter requires a non-empty filter."
             raise FilterError(msg)
 
-        sql_set = ",".join(f"meta[{_sql_str(key)}] = {_map_literal_base(value)}" for key, value in meta.items())
-        sql = f"UPDATE `{self._type_name}` SET {sql_set} WHERE {where}"
-        count_result = self._command(sql)
-
-        return count_result[0]["count"]
+        # ArcadeDB does not support in-place MAP key updates via SET or MERGE.
+        # Read-modify-write: fetch matching docs, merge meta in Python, write back.
+        rows = self._command(f"SELECT id, meta FROM `{self._type_name}` WHERE {where}")
+        for row in rows:
+            merged = {**(row.get("meta") or {}), **meta}
+            meta_str = _map_literal(merged)
+            self._command(
+                f"UPDATE `{self._type_name}` SET meta = {meta_str} WHERE id = {_sql_str(row['id'])}"
+            )
+        return len(rows)
 
     def count_documents_by_filter(self, filters: dict[str, Any]) -> int:
         """

--- a/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
+++ b/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
@@ -462,9 +462,7 @@ class ArcadeDBDocumentStore:
         for row in rows:
             merged = {**(row.get("meta") or {}), **meta}
             meta_str = _map_literal(merged)
-            self._command(
-                f"UPDATE `{self._type_name}` SET meta = {meta_str} WHERE id = {_sql_str(row['id'])}"
-            )
+            self._command(f"UPDATE `{self._type_name}` SET meta = {meta_str} WHERE id = {_sql_str(row['id'])}")
         return len(rows)
 
     def count_documents_by_filter(self, filters: dict[str, Any]) -> int:

--- a/integrations/arcadedb/tests/test_converters.py
+++ b/integrations/arcadedb/tests/test_converters.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack import Document
+
+from haystack_integrations.document_stores.arcadedb.converters import (
+    _from_arcadedb_to_haystack,
+    _from_haystack_to_arcadedb,
+)
+
+
+def test_from_haystack_to_arcadedb():
+    docs = [Document(content="hello", meta={"key": "val"}, embedding=[0.1, 0.2])]
+    records = _from_haystack_to_arcadedb(docs)
+    assert len(records) == 1
+    assert records[0]["id"] == docs[0].id
+    assert records[0]["content"] == "hello"
+    assert records[0]["embedding"] == [0.1, 0.2]
+    assert records[0]["meta"] == {"key": "val"}
+
+
+def test_from_arcadedb_to_haystack_full():
+    records = [{"id": "abc", "content": "world", "embedding": [0.3], "meta": {"x": 1}, "score": 0.9}]
+    docs = _from_arcadedb_to_haystack(records)
+    assert len(docs) == 1
+    assert docs[0].id == "abc"
+    assert docs[0].content == "world"
+    assert docs[0].embedding == [0.3]
+    assert docs[0].meta == {"x": 1}
+    assert docs[0].score == 0.9
+
+
+def test_from_arcadedb_to_haystack_missing_optional_fields():
+    records = [{"id": "xyz"}]
+    docs = _from_arcadedb_to_haystack(records)
+    assert len(docs) == 1
+    assert docs[0].id == "xyz"
+    assert docs[0].content is None
+    assert docs[0].embedding is None
+    assert docs[0].meta == {}
+    assert docs[0].score is None
+
+
+def test_from_arcadedb_to_haystack_null_meta_becomes_empty_dict():
+    records = [{"id": "m", "meta": None}]
+    docs = _from_arcadedb_to_haystack(records)
+    assert docs[0].meta == {}

--- a/integrations/arcadedb/tests/test_document_store.py
+++ b/integrations/arcadedb/tests/test_document_store.py
@@ -578,6 +578,33 @@ class TestArcadeDBDocumentStore(
         assert "tags" in info
         assert info["tags"] == {"type": "keyword"}
 
+    def test_get_metadata_fields_info_list_valued_bool(self, document_store: ArcadeDBDocumentStore):
+        """Boolean items inside list-valued metadata fields are inferred as boolean type."""
+        docs = [Document(id="lvb-1", content="doc", meta={"flags": [True, False]})]
+        document_store.write_documents(docs)
+
+        info = document_store.get_metadata_fields_info()
+
+        assert info.get("flags") == {"type": "boolean"}
+
+    def test_get_metadata_fields_info_list_valued_float(self, document_store: ArcadeDBDocumentStore):
+        """Float items inside list-valued metadata fields are inferred as double type."""
+        docs = [Document(id="lvf-1", content="doc", meta={"scores": [1.5, 2.5]})]
+        document_store.write_documents(docs)
+
+        info = document_store.get_metadata_fields_info()
+
+        assert info.get("scores") == {"type": "double"}
+
+    def test_get_metadata_fields_info_list_valued_int(self, document_store: ArcadeDBDocumentStore):
+        """Integer items inside list-valued metadata fields are inferred as long type."""
+        docs = [Document(id="lvi-1", content="doc", meta={"counts": [1, 2, 3]})]
+        document_store.write_documents(docs)
+
+        info = document_store.get_metadata_fields_info()
+
+        assert info.get("counts") == {"type": "long"}
+
     def test_count_unique_metadata_by_filter_list_valued_field(self, document_store: ArcadeDBDocumentStore):
         """count_unique_metadata_by_filter handles metadata fields whose values are lists."""
         docs = [

--- a/integrations/arcadedb/tests/test_document_store.py
+++ b/integrations/arcadedb/tests/test_document_store.py
@@ -539,3 +539,53 @@ class TestArcadeDBDocumentStore(
         assert document_store.count_documents() == 1
         results = document_store.filter_documents({"field": "id", "operator": "==", "value": "ow-hit"})
         assert results[0].content == "updated"
+
+    def test_get_metadata_fields_info_mixed_types_defaults_to_keyword(self, document_store: ArcadeDBDocumentStore):
+        """When the same metadata field has different types across documents, type defaults to 'keyword'."""
+        docs = [
+            Document(id="mt-1", content="doc 1", meta={"x": 1}),
+            Document(id="mt-2", content="doc 2", meta={"x": "one"}),
+        ]
+        document_store.write_documents(docs)
+
+        info = document_store.get_metadata_fields_info()
+
+        assert info["x"] == {"type": "keyword"}
+
+    def test_get_metadata_fields_info_no_content_documents(self, document_store: ArcadeDBDocumentStore):
+        """Documents with no content do not produce a 'content' entry in metadata fields info."""
+        docs = [
+            Document(id="nc-1", meta={"tag": "a"}),
+            Document(id="nc-2", meta={"tag": "b"}),
+        ]
+        document_store.write_documents(docs)
+
+        info = document_store.get_metadata_fields_info()
+
+        assert "content" not in info
+        assert "tag" in info
+
+    def test_get_metadata_fields_info_list_valued_metadata(self, document_store: ArcadeDBDocumentStore):
+        """List-valued metadata fields are recognised and their item types are inferred."""
+        docs = [
+            Document(id="lv-1", content="doc 1", meta={"tags": ["python", "haystack"]}),
+            Document(id="lv-2", content="doc 2", meta={"tags": ["arcadedb"]}),
+        ]
+        document_store.write_documents(docs)
+
+        info = document_store.get_metadata_fields_info()
+
+        assert "tags" in info
+        assert info["tags"] == {"type": "keyword"}
+
+    def test_count_unique_metadata_by_filter_list_valued_field(self, document_store: ArcadeDBDocumentStore):
+        """count_unique_metadata_by_filter handles metadata fields whose values are lists."""
+        docs = [
+            Document(id="cu-1", content="doc 1", meta={"tags": ["a", "b"]}),
+            Document(id="cu-2", content="doc 2", meta={"tags": ["b", "c"]}),
+        ]
+        document_store.write_documents(docs)
+
+        counts = document_store.count_unique_metadata_by_filter({}, ["meta.tags"])
+
+        assert counts["tags"] >= 1

--- a/integrations/arcadedb/tests/test_document_store.py
+++ b/integrations/arcadedb/tests/test_document_store.py
@@ -498,3 +498,44 @@ class TestArcadeDBDocumentStore(
 
         assert values == []
         assert total == 0
+
+    def test_write_documents_none_embedding_is_zero_padded(self, document_store: ArcadeDBDocumentStore):
+        """Documents written without an embedding get a zero vector of the correct dimension."""
+        dim = document_store._embedding_dimension
+        doc = Document(id="no-emb", content="no embedding")
+        document_store.write_documents([doc])
+
+        results = document_store.filter_documents({"field": "id", "operator": "==", "value": "no-emb"})
+        assert len(results) == 1
+        assert results[0].embedding == [0.0] * dim
+
+    def test_write_documents_skip_policy_inserts_new_document(self, document_store: ArcadeDBDocumentStore):
+        """SKIP policy writes a document that does not already exist."""
+        doc = Document(id="new-skip", content="new doc")
+        written = document_store.write_documents([doc], policy=DuplicatePolicy.SKIP)
+
+        assert written == 1
+        results = document_store.filter_documents({"field": "id", "operator": "==", "value": "new-skip"})
+        assert len(results) == 1
+
+    def test_write_documents_none_policy_success(self, document_store: ArcadeDBDocumentStore):
+        """NONE policy successfully inserts a document when no duplicate exists."""
+        doc = Document(id="none-policy", content="inserted with NONE")
+        written = document_store.write_documents([doc], policy=DuplicatePolicy.NONE)
+
+        assert written == 1
+        results = document_store.filter_documents({"field": "id", "operator": "==", "value": "none-policy"})
+        assert len(results) == 1
+
+    def test_write_documents_overwrite_updates_existing(self, document_store: ArcadeDBDocumentStore):
+        """OVERWRITE updates an existing document without creating a duplicate."""
+        doc = Document(id="ow-hit", content="original")
+        document_store.write_documents([doc], policy=DuplicatePolicy.OVERWRITE)
+
+        updated = Document(id="ow-hit", content="updated")
+        written = document_store.write_documents([updated], policy=DuplicatePolicy.OVERWRITE)
+
+        assert written == 1
+        assert document_store.count_documents() == 1
+        results = document_store.filter_documents({"field": "id", "operator": "==", "value": "ow-hit"})
+        assert results[0].content == "updated"


### PR DESCRIPTION
### Proposed Changes:

ArcadeDB does not support in-place updates.

### How did you test it?

- unit tests, integration tests, manual verification, instructions for manual tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
