### PR TITLE
ci: let Dependabot update the scaffold workflow template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: 'github-actions'
-    directory: '/'
+    directories:
+      - '/'
+      - '/scripts/utils/templates'
     schedule:
       interval: 'daily'
     cooldown:


### PR DESCRIPTION
### Related Issues

Dependabot's `github-actions` ecosystem only scanned `.github/workflows`, so the GitHub Action versions pinned in the scaffolding workflow template (`scripts/utils/templates/workflow.yml`) were never updated. As a result the template drifted out of date and every newly scaffolded integration was generated with stale pins.

### Proposed Changes:

This PR switches the `github-actions` entry in `.github/dependabot.yml` from the singular `directory: '/'` to a
`directories` list that adds `/scripts/utils/templates`. Dependabot now also scans `workflow.yml` there and keeps its pinned actions current. 

### How did you test it?
 
The template should be updated automatically by dependabot once this PR is merged.

### Notes for the reviewer
