### PR TITLE
feat: support str in addition to Secret for aws_region_name

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -37,7 +37,7 @@ class S3Downloader:
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
         aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
         aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
         boto3_config: dict[str, Any] | None = None,
         file_root_path: str | None = None,
@@ -115,8 +115,8 @@ class S3Downloader:
 
         self._storage: S3Storage | None = None
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         self._session = get_aws_session(
             aws_access_key_id=resolve_secret(aws_access_key_id),

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -29,7 +29,9 @@ class AmazonBedrockDocumentEmbedder:
     ```python
     import os
     from haystack.dataclasses import Document
-    from haystack_integrations.components.embedders.amazon_bedrock import AmazonBedrockDocumentEmbedder
+    from haystack_integrations.components.embedders.amazon_bedrock import (
+        AmazonBedrockDocumentEmbedder,
+    )
 
     os.environ["AWS_ACCESS_KEY_ID"] = "..."
     os.environ["AWS_SECRET_ACCESS_KEY_ID"] = "..."
@@ -43,7 +45,7 @@ class AmazonBedrockDocumentEmbedder:
     doc = Document(content="I love Paris in the winter.", meta={"name": "doc1"})
 
     result = embedder.run([doc])
-    print(result['documents'][0].embedding)
+    print(result["documents"][0].embedding)
 
     # [0.002, 0.032, 0.504, ...]
     ```
@@ -57,7 +59,7 @@ class AmazonBedrockDocumentEmbedder:
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
         aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
         aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
         batch_size: int = 32,
         progress_bar: bool = True,
@@ -120,8 +122,8 @@ class AmazonBedrockDocumentEmbedder:
         self.boto3_config = boto3_config
         self.kwargs = kwargs
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         try:
             session = get_aws_session(

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_image_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_image_embedder.py
@@ -73,7 +73,7 @@ class AmazonBedrockDocumentImageEmbedder:
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
         aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
         aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
         file_path_meta_field: str = "file_path",
         root_path: str | None = None,
@@ -146,8 +146,8 @@ class AmazonBedrockDocumentImageEmbedder:
                 raise ValueError(msg)
             self.embedding_types = embedding_types
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         try:
             session = get_aws_session(

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
@@ -23,7 +23,9 @@ class AmazonBedrockTextEmbedder:
     Usage example:
     ```python
     import os
-    from haystack_integrations.components.embedders.amazon_bedrock import AmazonBedrockTextEmbedder
+    from haystack_integrations.components.embedders.amazon_bedrock import (
+        AmazonBedrockTextEmbedder,
+    )
 
     os.environ["AWS_ACCESS_KEY_ID"] = "..."
     os.environ["AWS_SECRET_ACCESS_KEY_ID"] = "..."
@@ -48,7 +50,7 @@ class AmazonBedrockTextEmbedder:
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
         aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
         aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
         boto3_config: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -97,8 +99,8 @@ class AmazonBedrockTextEmbedder:
         self.boto3_config = boto3_config
         self.kwargs = kwargs
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         try:
             session = get_aws_session(

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -301,8 +301,8 @@ class AmazonBedrockChatGenerator:
             _validate_and_format_cache_point(tools_cachepoint_config) if tools_cachepoint_config else None
         )
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         config = Config(
             user_agent_extra="x-client-framework:haystack",
@@ -648,7 +648,11 @@ class AmazonBedrockChatGenerator:
                     self.aws_secret_access_key.resolve_value() if self.aws_secret_access_key else None
                 ),
                 aws_session_token=(self.aws_session_token.resolve_value() if self.aws_session_token else None),
-                region_name=(self.aws_region_name.resolve_value() if self.aws_region_name else None),
+                region_name=(
+                    self.aws_region_name.resolve_value()
+                    if isinstance(self.aws_region_name, Secret)
+                    else self.aws_region_name
+                ),
                 config=config,
             ) as async_client:
                 if callback:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -387,6 +387,10 @@ class AmazonBedrockChatGenerator:
         if stop_words:
             logger.warning(msg)
 
+        region_name = init_params.get("aws_region_name", None)
+        if isinstance(region_name, str):
+            init_params["aws_region_name"] = Secret.from_token(region_name)
+
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
             data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -55,16 +55,24 @@ class AmazonBedrockChatGenerator:
     **Usage example**
 
     ```python
-    from haystack_integrations.components.generators.amazon_bedrock import AmazonBedrockChatGenerator
+    from haystack_integrations.components.generators.amazon_bedrock import (
+        AmazonBedrockChatGenerator,
+    )
     from haystack.dataclasses import ChatMessage
     from haystack.components.generators.utils import print_streaming_chunk
 
-    messages = [ChatMessage.from_system("\\nYou are a helpful, respectful and honest assistant, answer in German only"),
-                ChatMessage.from_user("What's Natural Language Processing?")]
+    messages = [
+        ChatMessage.from_system(
+            "\\nYou are a helpful, respectful and honest assistant, answer in German only"
+        ),
+        ChatMessage.from_user("What's Natural Language Processing?"),
+    ]
 
 
-    client = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6",
-                                        streaming_callback=print_streaming_chunk)
+    client = AmazonBedrockChatGenerator(
+        model="global.anthropic.claude-sonnet-4-6",
+        streaming_callback=print_streaming_chunk,
+    )
     client.run(messages, generation_kwargs={"max_tokens": 512})
     ```
 
@@ -152,7 +160,9 @@ class AmazonBedrockChatGenerator:
     To cache messages, you can use the `cachePoint` key in `ChatMessage.meta` attribute.
 
     ```python
-    ChatMessage.from_user("Long message...", meta={"cachePoint": {"type": "default"}})
+    ChatMessage.from_user(
+        "Long message...", meta={"cachePoint": {"type": "default"}}
+    )
     ```
 
     For more information, see the [Amazon Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html).
@@ -179,7 +189,7 @@ class AmazonBedrockChatGenerator:
             ["AWS_SECRET_ACCESS_KEY"], strict=False
         ),
         aws_session_token: Secret | None = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
-        aws_region_name: Secret | None = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
         aws_profile_name: Secret | None = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
         generation_kwargs: dict[str, Any] | None = None,
         streaming_callback: StreamingCallbackT | None = None,
@@ -219,12 +229,15 @@ class AmazonBedrockChatGenerator:
 
                 Example::
 
-                    generation_kwargs={
+                    generation_kwargs = {
                         "response_format": {
                             "name": "person",
                             "schema": {
                                 "type": "object",
-                                "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "age": {"type": "integer"},
+                                },
                                 "required": ["name", "age"],
                                 "additionalProperties": False,
                             },
@@ -387,10 +400,6 @@ class AmazonBedrockChatGenerator:
         if stop_words:
             logger.warning(msg)
 
-        region_name = init_params.get("aws_region_name", None)
-        if isinstance(region_name, str):
-            init_params["aws_region_name"] = Secret.from_token(region_name)
-
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
             data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
@@ -405,7 +414,6 @@ class AmazonBedrockChatGenerator:
         tools: ToolsType | None = None,
         requires_async: bool = False,
     ) -> tuple[dict[str, Any], StreamingCallbackT | None]:
-
         generation_kwargs = generation_kwargs or {}
 
         # Merge generation_kwargs with defaults

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/generator.py
@@ -44,12 +44,11 @@ class AmazonBedrockGenerator:
     ### Usage example
 
     ```python
-    from haystack_integrations.components.generators.amazon_bedrock import AmazonBedrockGenerator
-
-    generator = AmazonBedrockGenerator(
-            model="anthropic.claude-v2",
-            max_length=99
+    from haystack_integrations.components.generators.amazon_bedrock import (
+        AmazonBedrockGenerator,
     )
+
+    generator = AmazonBedrockGenerator(model="anthropic.claude-v2", max_length=99)
 
     print(generator.run("Who is the best American actor?"))
     ```
@@ -106,7 +105,7 @@ class AmazonBedrockGenerator:
             "AWS_SECRET_ACCESS_KEY", strict=False
         ),
         aws_session_token: Secret | None = Secret.from_env_var("AWS_SESSION_TOKEN", strict=False),  # noqa: B008
-        aws_region_name: Secret | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var("AWS_DEFAULT_REGION", strict=False),  # noqa: B008
         aws_profile_name: Secret | None = Secret.from_env_var("AWS_PROFILE", strict=False),  # noqa: B008
         max_length: int | None = None,
         truncate: bool | None = None,
@@ -170,8 +169,8 @@ class AmazonBedrockGenerator:
         self.kwargs = kwargs
         self.model_family = model_family
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         try:
             session = get_aws_session(

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -31,12 +31,14 @@ class AmazonBedrockRanker:
     ```python
     from haystack import Document
     from haystack.utils import Secret
-    from haystack_integrations.components.rankers.amazon_bedrock import AmazonBedrockRanker
+    from haystack_integrations.components.rankers.amazon_bedrock import (
+        AmazonBedrockRanker,
+    )
 
     ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",
         top_k=2,
-        aws_region_name=Secret.from_token("eu-central-1")
+        aws_region_name=Secret.from_token("eu-central-1"),
     )
 
     docs = [Document(content="Paris"), Document(content="Berlin")]
@@ -66,7 +68,7 @@ class AmazonBedrockRanker:
             ["AWS_SECRET_ACCESS_KEY"], strict=False
         ),
         aws_session_token: Secret | None = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
-        aws_region_name: Secret | None = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
         aws_profile_name: Secret | None = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
         max_chunks_per_doc: int | None = None,
         meta_fields_to_embed: list[str] | None = None,
@@ -104,8 +106,8 @@ class AmazonBedrockRanker:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.meta_data_separator = meta_data_separator
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         try:
             session = get_aws_session(

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -201,8 +201,8 @@ class AmazonBedrockRanker:
         if not documents:
             return {"documents": []}
 
-        def resolve_secret(secret: Secret | None) -> str | None:
-            return secret.resolve_value() if secret else None
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
 
         region = resolve_secret(self.aws_region_name)
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -307,7 +307,6 @@ class TestAmazonBedrockChatGenerator:
         assert generator.model == "global.anthropic.claude-sonnet-4-6"
         assert generator.aws_region_name.resolve_value() == "my-fake-region"
 
-
     def test_default_constructor(self, mock_boto3_session, mock_aioboto3_session, set_env_variables):
         """
         Test that the default constructor sets the correct values

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -293,7 +293,7 @@ class TestAmazonBedrockChatGenerator:
 
     def test_from_dict_aws_region_name(self, mock_boto3_session: Any):
         """
-        Test that the from_dict method returns the correct object
+        Test that aws_region_name as str value is correctly parsed
         """
         generator = AmazonBedrockChatGenerator.from_dict(
             {

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -291,6 +291,23 @@ class TestAmazonBedrockChatGenerator:
         assert generator.streaming_callback == print_streaming_chunk
         assert generator.boto3_config == boto3_config
 
+    def test_from_dict_aws_region_name(self, mock_boto3_session: Any):
+        """
+        Test that the from_dict method returns the correct object
+        """
+        generator = AmazonBedrockChatGenerator.from_dict(
+            {
+                "type": CLASS_TYPE,
+                "init_parameters": {
+                    "aws_region_name": "my-fake-region",
+                    "model": "global.anthropic.claude-sonnet-4-6",
+                },
+            }
+        )
+        assert generator.model == "global.anthropic.claude-sonnet-4-6"
+        assert generator.aws_region_name.resolve_value() == "my-fake-region"
+
+
     def test_default_constructor(self, mock_boto3_session, mock_aioboto3_session, set_env_variables):
         """
         Test that the default constructor sets the correct values

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -305,7 +305,10 @@ class TestAmazonBedrockChatGenerator:
             }
         )
         assert generator.model == "global.anthropic.claude-sonnet-4-6"
-        assert generator.aws_region_name.resolve_value() == "my-fake-region"
+        assert generator.aws_region_name == "my-fake-region"
+
+        serialized = generator.to_dict()
+        assert serialized["init_parameters"]["aws_region_name"] == "my-fake-region"
 
     def test_default_constructor(self, mock_boto3_session, mock_aioboto3_session, set_env_variables):
         """
@@ -464,7 +467,6 @@ class TestAmazonBedrockChatGenerator:
         }
 
     def test_prepare_request_params_response_format(self, mock_boto3_session, set_env_variables):
-
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
         schema = {
             "type": "object",
@@ -740,7 +742,6 @@ class TestAmazonBedrockChatGenerator:
         assert result["replies"][0].text == "Paris"
 
     def test_run_client_error(self, mock_boto3_session, set_env_variables):
-
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
         generator.client = MagicMock()
         generator.client.converse.side_effect = ClientError(

--- a/integrations/amazon_bedrock/tests/test_document_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_document_embedder.py
@@ -165,6 +165,25 @@ class TestAmazonBedrockDocumentEmbedder:
         assert embedder.embedding_separator == "\n"
         assert embedder.boto3_config == boto3_config
 
+    def test_from_dict_aws_region_name(self, mock_boto3_session):
+        """
+        Test that aws_region_name as str value is correctly parsed
+        """
+        embedder = AmazonBedrockDocumentEmbedder.from_dict(
+            {
+                "type": TYPE,
+                "init_parameters": {
+                    "aws_region_name": "my-fake-region",
+                    "model": "cohere.embed-english-v3",
+                },
+            }
+        )
+        assert embedder.model == "cohere.embed-english-v3"
+        assert embedder.aws_region_name == "my-fake-region"
+
+        serialized = embedder.to_dict()
+        assert serialized["init_parameters"]["aws_region_name"] == "my-fake-region"
+
     def test_init_invalid_model(self):
         with pytest.raises(ValueError):
             AmazonBedrockDocumentEmbedder(model="")

--- a/integrations/amazon_bedrock/tests/test_document_image_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_document_image_embedder.py
@@ -165,6 +165,25 @@ class TestAmazonBedrockDocumentImageEmbedder:
         assert embedder.progress_bar
         assert embedder.boto3_config == boto3_config
 
+    def test_from_dict_aws_region_name(self, mock_boto3_session):
+        """
+        Test that aws_region_name as str value is correctly parsed
+        """
+        embedder = AmazonBedrockDocumentImageEmbedder.from_dict(
+            {
+                "type": TYPE,
+                "init_parameters": {
+                    "aws_region_name": "my-fake-region",
+                    "model": "cohere.embed-english-v3",
+                },
+            }
+        )
+        assert embedder.model == "cohere.embed-english-v3"
+        assert embedder.aws_region_name == "my-fake-region"
+
+        serialized = embedder.to_dict()
+        assert serialized["init_parameters"]["aws_region_name"] == "my-fake-region"
+
     def test_init_invalid_model(self):
         with pytest.raises(ValueError):
             AmazonBedrockDocumentImageEmbedder(model="")

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -126,6 +126,26 @@ def test_from_dict(mock_boto3_session: Any, boto3_config: dict[str, Any] | None)
     assert generator.model_family == "anthropic.claude"
 
 
+def test_from_dict_aws_region_name(self, mock_boto3_session: Any):
+    """
+    Test that aws_region_name as str value is correctly parsed
+    """
+    generator = AmazonBedrockGenerator.from_dict(
+        {
+            "type": "haystack_integrations.components.generators.amazon_bedrock.generator.AmazonBedrockGenerator",
+            "init_parameters": {
+                "aws_region_name": "my-fake-region",
+                "model": "global.anthropic.claude-sonnet-4-6",
+            },
+        }
+    )
+    assert generator.model == "global.anthropic.claude-sonnet-4-6"
+    assert generator.aws_region_name == "my-fake-region"
+
+    serialized = generator.to_dict()
+    assert serialized["init_parameters"]["aws_region_name"] == "my-fake-region"
+
+
 def test_default_constructor(mock_boto3_session, set_env_variables):
     """
     Test that the default constructor sets the correct values

--- a/integrations/amazon_bedrock/tests/test_generator.py
+++ b/integrations/amazon_bedrock/tests/test_generator.py
@@ -126,7 +126,7 @@ def test_from_dict(mock_boto3_session: Any, boto3_config: dict[str, Any] | None)
     assert generator.model_family == "anthropic.claude"
 
 
-def test_from_dict_aws_region_name(self, mock_boto3_session: Any):
+def test_from_dict_aws_region_name(mock_boto3_session: Any):
     """
     Test that aws_region_name as str value is correctly parsed
     """

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -102,6 +102,26 @@ def test_amazon_bedrock_ranker_serialization(mock_aws_session):
     assert deserialized.top_k == 2
 
 
+def test_from_dict_aws_region_name(mock_aws_session):
+    """
+    Test that aws_region_name as str value is correctly parsed
+    """
+    ranker = AmazonBedrockRanker.from_dict(
+        {
+            "type": "haystack_integrations.components.rankers.amazon_bedrock.ranker.AmazonBedrockRanker",
+            "init_parameters": {
+                "aws_region_name": "my-fake-region",
+                "model": "cohere.rerank-v3-5:0",
+            },
+        }
+    )
+    assert ranker.model_name == "cohere.rerank-v3-5:0"
+    assert ranker.aws_region_name == "my-fake-region"
+
+    serialized = ranker.to_dict()
+    assert serialized["init_parameters"]["aws_region_name"] == "my-fake-region"
+
+
 def test_amazon_bedrock_ranker_empty_documents(mock_aws_session):
     ranker = AmazonBedrockRanker(
         model="cohere.rerank-v3-5:0",

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -343,6 +343,24 @@ class TestS3Downloader:
 
         assert not stale.exists()
 
+    def test_from_dict_aws_region_name(self, mock_boto3_session, tmp_path):
+        """
+        Test that aws_region_name as str value is correctly parsed
+        """
+        d = S3Downloader.from_dict(
+            {
+                "type": TYPE,
+                "init_parameters": {
+                    "aws_region_name": "my-fake-region",
+                    "file_root_path": str(tmp_path),
+                },
+            }
+        )
+        assert d.aws_region_name == "my-fake-region"
+
+        serialized = d.to_dict()
+        assert serialized["init_parameters"]["aws_region_name"] == "my-fake-region"
+
     def test_from_dict_with_serialized_callable(self, mock_boto3_session, tmp_path):
         data = {
             "type": TYPE,

--- a/integrations/amazon_bedrock/tests/test_text_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_text_embedder.py
@@ -130,6 +130,25 @@ class TestAmazonBedrockTextEmbedder:
         assert embedder.kwargs == {"input_type": "search_query"}
         assert embedder.boto3_config == {"read_timeout": 1000}
 
+    def test_from_dict_aws_region_name(self, mock_boto3_session):
+        """
+        Test that aws_region_name as str value is correctly parsed
+        """
+        embedder = AmazonBedrockTextEmbedder.from_dict(
+            {
+                "type": "haystack_integrations.components.embedders.amazon_bedrock.text_embedder.AmazonBedrockTextEmbedder",  # noqa: E501
+                "init_parameters": {
+                    "aws_region_name": "my-fake-region",
+                    "model": "cohere.embed-english-v3",
+                },
+            }
+        )
+        assert embedder.model == "cohere.embed-english-v3"
+        assert embedder.aws_region_name == "my-fake-region"
+
+        serialized = embedder.to_dict()
+        assert serialized["init_parameters"]["aws_region_name"] == "my-fake-region"
+
     def test_init_invalid_model(self):
         with pytest.raises(ValueError):
             AmazonBedrockTextEmbedder(model="")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:
When not using secrets for region, it will be as easy as setting:
```yaml
...
init_parameters:
  aws_region_name: MY_REGION
```

instead of

```yaml
...
init_parameters:
  boto3_config:
    region_name: MY_REGION
```

Using flattened settings is especially easier when dealing with UI-driven configs.

Changes applied across all six Bedrock components (chat generator, generator, text/document/document-image embedders, ranker, S3 downloader)

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
