### PR TITLE
ci: add hf token to CI env

### DIFF
--- a/.github/workflows/CI_license_compliance.yml
+++ b/.github/workflows/CI_license_compliance.yml
@@ -12,13 +12,14 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-  EXCLUDE_PACKAGES: "(?i)^(azure-identity|azure-search-documents|fastembed|tqdm|psycopg|mistralai|pgvector).*"
+  EXCLUDE_PACKAGES: "(?i)^(azure-identity|azure-search-documents|fastembed|llama-cpp-python|tqdm|psycopg|mistralai|pgvector).*"
 
   # Exclusions must be explicitly motivated
   #
   # - azure-identity is MIT but the license is not available on PyPI
   # - azure-search-documents is MIT but the license is not available on PyPI
   # - fastembed is Apache 2.0 but the license on PyPI is unclear ("Other/Proprietary License (Apache License)")
+  # - llama-cpp-python is MIT but exposes no license classifier on PyPI (only a bare "MIT" string), so the checker errors
   # - mistralai is Apache 2.0 but the license is not available on PyPI
   # - pgvector is MIT but the license is not available on PyPI
 

--- a/.github/workflows/chonkie.yml
+++ b/.github/workflows/chonkie.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.13"]'
 

--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -23,6 +23,7 @@ defaults:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.13"]'
 

--- a/.github/workflows/llama_cpp.yml
+++ b/.github/workflows/llama_cpp.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 

--- a/.github/workflows/optimum.yml
+++ b/.github/workflows/optimum.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 

--- a/.github/workflows/transformers.yml
+++ b/.github/workflows/transformers.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "pytest-rerunfailures",
     "mypy",
     "pip",
+    "huggingface_hub",
     "transformers[sentencepiece]<5",
 ]
 

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -4,10 +4,10 @@
 
 import json
 import os
-import urllib.request
 from pathlib import Path
 from typing import Annotated
 from unittest.mock import MagicMock
+from urllib.parse import urlparse
 
 import pytest
 from haystack import Document, Pipeline
@@ -25,6 +25,7 @@ from haystack.dataclasses import (
 )
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.tools import Tool, Toolset, create_tool_from_function
+from huggingface_hub import hf_hub_download
 
 from haystack_integrations.components.generators.llama_cpp.chat.chat_generator import (
     LlamaCppChatGenerator,
@@ -58,14 +59,23 @@ def temperature_tool():
 
 
 def download_file(file_link, filename, capsys):
-    # Checks if the file already exists before downloading
-    if not os.path.isfile(filename):
-        urllib.request.urlretrieve(file_link, filename)  # noqa: S310
-        with capsys.disabled():
-            print("\nModel file downloaded successfully.")
-    else:
+    # `filename` is the local destination path. `file_link` is a HuggingFace "resolve"
+    # URL; we download via huggingface_hub so the request is authenticated with the
+    # HF_TOKEN env var (avoids anonymous rate limits and supports gated repos).
+    if os.path.isfile(filename):
         with capsys.disabled():
             print("\nModel file already exists.")
+        return
+
+    # Parse https://huggingface.co/<repo_id>/resolve/<revision>/<path> into its parts.
+    repo_id, _, rest = urlparse(file_link).path.lstrip("/").partition("/resolve/")
+    revision, _, path_in_repo = rest.partition("/")
+    dest = Path(filename)
+    downloaded = Path(hf_hub_download(repo_id=repo_id, filename=path_in_repo, revision=revision, local_dir=dest.parent))
+    if downloaded != dest:
+        downloaded.rename(dest)
+    with capsys.disabled():
+        print("\nModel file downloaded successfully.")
 
 
 def test_convert_message_to_llamacpp_format():

--- a/integrations/llama_cpp/tests/test_generator.py
+++ b/integrations/llama_cpp/tests/test_generator.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import urllib.request
 from pathlib import Path
 from unittest.mock import MagicMock
+from urllib.parse import urlparse
 
 import pytest
 from haystack import Document, Pipeline
@@ -13,6 +13,7 @@ from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+from huggingface_hub import hf_hub_download
 
 from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
 
@@ -25,14 +26,23 @@ def model_path():
 
 
 def download_file(file_link, filename, capsys):
-    # Checks if the file already exists before downloading
-    if not os.path.isfile(filename):
-        urllib.request.urlretrieve(file_link, filename)  # noqa: S310
-        with capsys.disabled():
-            print("\nModel file downloaded successfully.")
-    else:
+    # `filename` is the local destination path. `file_link` is a HuggingFace "resolve"
+    # URL; we download via huggingface_hub so the request is authenticated with the
+    # HF_TOKEN env var (avoids anonymous rate limits and supports gated repos).
+    if os.path.isfile(filename):
         with capsys.disabled():
             print("\nModel file already exists.")
+        return
+
+    # Parse https://huggingface.co/<repo_id>/resolve/<revision>/<path> into its parts.
+    repo_id, _, rest = urlparse(file_link).path.lstrip("/").partition("/resolve/")
+    revision, _, path_in_repo = rest.partition("/")
+    dest = Path(filename)
+    downloaded = Path(hf_hub_download(repo_id=repo_id, filename=path_in_repo, revision=revision, local_dir=dest.parent))
+    if downloaded != dest:
+        downloaded.rename(dest)
+    with capsys.disabled():
+        print("\nModel file downloaded successfully.")
 
 
 class TestLlamaCppGenerator:


### PR DESCRIPTION
### Related Issues

- should hopeful fix the 429 errors we are getting in our tests download HF models. e.g. https://github.com/deepset-ai/haystack-core-integrations/actions/runs/27316341057/job/80697640152

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add our HF_TOKEN to the env so it's picked up by huggingface hub to give us higher api rate limits.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Haven't tested, we can observe to see if the 429 requests go away. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
