### PR TITLE
test: improve del_hf_env_vars fixture

### DIFF
--- a/integrations/huggingface_api/tests/conftest.py
+++ b/integrations/huggingface_api/tests/conftest.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
 
 import pytest
@@ -13,9 +14,9 @@ def test_files_path():
 
 
 @pytest.fixture()
-def del_hf_env_vars(monkeypatch):
+def del_hf_env_vars_if_empty(monkeypatch):
     """
-    Delete Hugging Face environment variables for tests.
+    Delete Hugging Face environment variables for tests if empty.
 
     Prevents passing empty tokens to Hugging Face, which would cause API calls to fail.
     This is particularly relevant for PRs opened from forks, where secrets are not available
@@ -23,5 +24,6 @@ def del_hf_env_vars(monkeypatch):
 
     See https://github.com/deepset-ai/haystack/issues/8811 for more details.
     """
-    monkeypatch.delenv("HF_API_TOKEN", raising=False)
-    monkeypatch.delenv("HF_TOKEN", raising=False)
+    for var in ("HF_API_TOKEN", "HF_TOKEN"):
+        if not os.environ.get(var, "").strip():
+            monkeypatch.delenv(var, raising=False)

--- a/integrations/huggingface_api/tests/test_ranker.py
+++ b/integrations/huggingface_api/tests/test_ranker.py
@@ -13,7 +13,7 @@ from haystack_integrations.components.rankers.huggingface_api import HuggingFace
 
 
 class TestHuggingFaceTEIRanker:
-    def test_init(self, del_hf_env_vars):
+    def test_init(self, del_hf_env_vars_if_empty):
         """Test initialization with default and custom parameters"""
         # Default parameters
         ranker = HuggingFaceTEIRanker(url="https://api.my-tei-service.com")
@@ -41,7 +41,7 @@ class TestHuggingFaceTEIRanker:
         assert ranker.max_retries == 5
         assert ranker.retry_status_codes == [500, 502, 503]
 
-    def test_to_dict(self, del_hf_env_vars):
+    def test_to_dict(self, del_hf_env_vars_if_empty):
         """Test serialization to dict with Secret token"""
         component = HuggingFaceTEIRanker(
             url="https://api.my-tei-service.com", top_k=5, timeout=30, max_retries=4, retry_status_codes=[500, 502]
@@ -60,7 +60,7 @@ class TestHuggingFaceTEIRanker:
         assert data["init_parameters"]["max_retries"] == 4
         assert data["init_parameters"]["retry_status_codes"] == [500, 502]
 
-    def test_from_dict(self, del_hf_env_vars):
+    def test_from_dict(self, del_hf_env_vars_if_empty):
         """Test deserialization from dict with environment variable token"""
         data = {
             "type": "haystack_integrations.components.rankers.huggingface_api.ranker.HuggingFaceTEIRanker",
@@ -82,14 +82,14 @@ class TestHuggingFaceTEIRanker:
         assert component.max_retries == 4
         assert component.retry_status_codes == [500, 502]
 
-    def test_empty_documents(self, del_hf_env_vars):
+    def test_empty_documents(self, del_hf_env_vars_if_empty):
         """Test that empty documents list returns empty result"""
         ranker = HuggingFaceTEIRanker(url="https://api.my-tei-service.com")
         result = ranker.run(query="test query", documents=[])
         assert result == {"documents": []}
 
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.request_with_retry")
-    def test_run_with_mock(self, mock_request, del_hf_env_vars):
+    def test_run_with_mock(self, mock_request, del_hf_env_vars_if_empty):
         """Test run method with mocked API response"""
         # Setup mock response
         mock_response = MagicMock(spec=httpx.Response)
@@ -137,7 +137,7 @@ class TestHuggingFaceTEIRanker:
         assert result["documents"][2].score == 0.75
 
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.request_with_retry")
-    def test_run_with_truncation_direction(self, mock_request, del_hf_env_vars):
+    def test_run_with_truncation_direction(self, mock_request, del_hf_env_vars_if_empty):
         """Test run method with truncation direction parameter"""
         # Setup mock response
         mock_response = MagicMock(spec=httpx.Response)
@@ -170,7 +170,7 @@ class TestHuggingFaceTEIRanker:
         )
 
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.request_with_retry")
-    def test_run_with_custom_top_k(self, mock_request, del_hf_env_vars):
+    def test_run_with_custom_top_k(self, mock_request, del_hf_env_vars_if_empty):
         """Test run method with custom top_k parameter"""
         # Setup mock response with 5 documents
         mock_response = MagicMock(spec=httpx.Response)
@@ -207,7 +207,7 @@ class TestHuggingFaceTEIRanker:
         assert result["documents"][1].content == "Document 3"
 
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.request_with_retry")
-    def test_run_deduplicates_documents(self, mock_request, del_hf_env_vars):
+    def test_run_deduplicates_documents(self, mock_request, del_hf_env_vars_if_empty):
         """Test that duplicate documents are removed before sending to the API."""
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.json.return_value = [{"index": 1, "score": 0.9}, {"index": 0, "score": 0.2}]
@@ -237,7 +237,7 @@ class TestHuggingFaceTEIRanker:
         assert result["documents"][1].content == "keep me"
 
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.request_with_retry")
-    def test_error_handling(self, mock_request, del_hf_env_vars):
+    def test_error_handling(self, mock_request, del_hf_env_vars_if_empty):
         """Test error handling in the ranker"""
         # Setup mock response with error
         mock_response = MagicMock(spec=httpx.Response)
@@ -261,7 +261,7 @@ class TestHuggingFaceTEIRanker:
 
     @pytest.mark.asyncio
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.async_request_with_retry")
-    async def test_run_async_with_mock(self, mock_request, del_hf_env_vars):
+    async def test_run_async_with_mock(self, mock_request, del_hf_env_vars_if_empty):
         """Test run_async method with mocked API response"""
         # Setup mock response
         mock_response = MagicMock(spec=httpx.Response)
@@ -310,7 +310,7 @@ class TestHuggingFaceTEIRanker:
 
     @pytest.mark.asyncio
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.async_request_with_retry")
-    async def test_run_async_deduplicates_documents(self, mock_request, del_hf_env_vars):
+    async def test_run_async_deduplicates_documents(self, mock_request, del_hf_env_vars_if_empty):
         """Test that duplicate documents are removed before sending to the API."""
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.json.return_value = [{"index": 1, "score": 0.9}, {"index": 0, "score": 0.2}]
@@ -341,7 +341,7 @@ class TestHuggingFaceTEIRanker:
 
     @pytest.mark.asyncio
     @patch("haystack_integrations.components.rankers.huggingface_api.ranker.async_request_with_retry")
-    async def test_run_async_empty_documents(self, mock_request, del_hf_env_vars):
+    async def test_run_async_empty_documents(self, mock_request, del_hf_env_vars_if_empty):
         """Test run_async with empty documents list"""
         ranker = HuggingFaceTEIRanker(url="https://api.my-tei-service.com")
         result = await ranker.run_async(query="test query", documents=[])

--- a/integrations/huggingface_api/tests/test_ranker.py
+++ b/integrations/huggingface_api/tests/test_ranker.py
@@ -20,7 +20,7 @@ class TestHuggingFaceTEIRanker:
         assert ranker.url == "https://api.my-tei-service.com"
         assert ranker.top_k == 10
         assert ranker.timeout == 30
-        assert not ranker.token.resolve_value()
+        assert ranker.token == Secret.from_env_var(["HF_API_TOKEN", "HF_TOKEN"], strict=False)
         assert ranker.max_retries == 3
         assert ranker.retry_status_codes is None
 
@@ -228,7 +228,7 @@ class TestHuggingFaceTEIRanker:
             url="https://api.my-tei-service.com/rerank",
             json={"query": "test query", "texts": ["keep me", "unique"], "raw_scores": False},
             timeout=30,
-            headers={},
+            headers={"Authorization": f"Bearer {ranker.token.resolve_value()}"} if ranker.token.resolve_value() else {},
             attempts=3,
             status_codes_to_retry=None,
         )
@@ -331,7 +331,7 @@ class TestHuggingFaceTEIRanker:
             url="https://api.my-tei-service.com/rerank",
             json={"query": "test query", "texts": ["keep me", "unique"], "raw_scores": False},
             timeout=30,
-            headers={},
+            headers={"Authorization": f"Bearer {ranker.token.resolve_value()}"} if ranker.token.resolve_value() else {},
             attempts=3,
             status_codes_to_retry=None,
         )

--- a/integrations/transformers/tests/conftest.py
+++ b/integrations/transformers/tests/conftest.py
@@ -2,14 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 
 @pytest.fixture()
-def del_hf_env_vars(monkeypatch):
+def del_hf_env_vars_if_empty(monkeypatch):
     """
-    Delete Hugging Face environment variables for tests.
+    Delete Hugging Face environment variables for tests if empty.
 
     Prevents passing empty tokens to Hugging Face, which would cause API calls to fail.
     This is particularly relevant for PRs opened from forks, where secrets are not available
@@ -17,8 +19,9 @@ def del_hf_env_vars(monkeypatch):
 
     See https://github.com/deepset-ai/haystack/issues/8811 for more details.
     """
-    monkeypatch.delenv("HF_API_TOKEN", raising=False)
-    monkeypatch.delenv("HF_TOKEN", raising=False)
+    for var in ("HF_API_TOKEN", "HF_TOKEN"):
+        if not os.environ.get(var, "").strip():
+            monkeypatch.delenv(var, raising=False)
 
 
 @pytest.fixture()

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -266,7 +266,10 @@ class TestTransformersChatGenerator:
         generator.warm_up()
 
         pipeline_mock.assert_called_once_with(
-            model="mistralai/Mistral-7B-Instruct-v0.2", task="text-generation", token=None, device="cpu"
+            model="mistralai/Mistral-7B-Instruct-v0.2",
+            task="text-generation",
+            token=generator.token.resolve_value(),
+            device="cpu",
         )
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -256,7 +256,7 @@ class TestTransformersChatGenerator:
         }
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up(self, pipeline_mock, del_hf_env_vars):
+    def test_warm_up(self, pipeline_mock, del_hf_env_vars_if_empty):
         generator = TransformersChatGenerator(
             model="mistralai/Mistral-7B-Instruct-v0.2", task="text-generation", device=ComponentDevice.from_str("cpu")
         )
@@ -270,7 +270,7 @@ class TestTransformersChatGenerator:
         )
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up_with_tools(self, pipeline_mock, del_hf_env_vars):
+    def test_warm_up_with_tools(self, pipeline_mock, del_hf_env_vars_if_empty):
         """Test that warm_up() calls warm_up on tools and is idempotent."""
 
         # Create a mock tool that tracks if warm_up() was called
@@ -324,7 +324,7 @@ class TestTransformersChatGenerator:
         pipeline_mock.assert_called_once()
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up_with_no_tools(self, pipeline_mock, del_hf_env_vars):
+    def test_warm_up_with_no_tools(self, pipeline_mock, del_hf_env_vars_if_empty):
         """Test that warm_up() works when no tools are provided."""
 
         generator = TransformersChatGenerator(
@@ -349,7 +349,7 @@ class TestTransformersChatGenerator:
         pipeline_mock.assert_called_once()
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up_with_multiple_tools(self, pipeline_mock, del_hf_env_vars):
+    def test_warm_up_with_multiple_tools(self, pipeline_mock, del_hf_env_vars_if_empty):
         """Test that warm_up() works with multiple tools."""
 
         # Track warm_up calls
@@ -507,7 +507,7 @@ class TestTransformersChatGenerator:
 
     @pytest.mark.integration
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
-    def test_live_run(self, del_hf_env_vars):
+    def test_live_run(self, del_hf_env_vars_if_empty):
         """Test live run with default behavior (no thinking)."""
         messages = [ChatMessage.from_user("Please create a summary about the following topic: Climate change")]
 
@@ -521,7 +521,7 @@ class TestTransformersChatGenerator:
 
     @pytest.mark.integration
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
-    def test_live_run_thinking(self, del_hf_env_vars):
+    def test_live_run_thinking(self, del_hf_env_vars_if_empty):
         """Test live run with enable_thinking=True."""
         messages = [ChatMessage.from_user("What is 2+2?")]
 
@@ -865,7 +865,7 @@ class TestTransformersChatGeneratorAsync:
     @pytest.mark.integration
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
     @pytest.mark.asyncio
-    async def test_live_run_async_with_streaming(self, del_hf_env_vars):
+    async def test_live_run_async_with_streaming(self, del_hf_env_vars_if_empty):
         """Test async streaming with a live model."""
         streaming_chunks = []
 

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -651,7 +651,9 @@ def test_device_map_auto(mocked_automodel, _mocked_autotokenizer, del_hf_env_var
     mocked_automodel.return_value = MockedModel()
     reader.warm_up()
 
-    mocked_automodel.assert_called_once_with("deepset/roberta-base-squad2", token=None, device_map="auto")
+    mocked_automodel.assert_called_once_with(
+        "deepset/roberta-base-squad2", token=reader.token.resolve_value(), device_map="auto"
+    )
     assert reader.device == ComponentDevice.from_multiple(DeviceMap.from_hf({"": auto_device.to_hf()}))
 
 
@@ -670,7 +672,9 @@ def test_device_map_str(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars
     mocked_automodel.return_value = MockedModel()
     reader.warm_up()
 
-    mocked_automodel.assert_called_once_with("deepset/roberta-base-squad2", token=None, device_map="cpu:0")
+    mocked_automodel.assert_called_once_with(
+        "deepset/roberta-base-squad2", token=reader.token.resolve_value(), device_map="cpu:0"
+    )
     assert reader.device == ComponentDevice.from_multiple(DeviceMap.from_hf({"": "cpu:0"}))
 
 
@@ -692,7 +696,9 @@ def test_device_map_dict(mocked_automodel, _mocked_autotokenizer, del_hf_env_var
     reader.warm_up()
 
     mocked_automodel.assert_called_once_with(
-        "deepset/roberta-base-squad2", token=None, device_map={"layer_1": 1, "classifier": "cpu"}
+        "deepset/roberta-base-squad2",
+        token=reader.token.resolve_value(),
+        device_map={"layer_1": 1, "classifier": "cpu"},
     )
     assert reader.device == ComponentDevice.from_multiple(DeviceMap.from_hf({"layer_1": 1, "classifier": "cpu"}))
 

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -640,7 +640,7 @@ def test_warm_up_use_hf_token(mocked_automodel, mocked_autotokenizer, initialize
     "haystack_integrations.components.readers.transformers.extractive_reader."
     "AutoModelForQuestionAnswering.from_pretrained"
 )
-def test_device_map_auto(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars):
+def test_device_map_auto(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars_if_empty):
     reader = TransformersExtractiveReader("deepset/roberta-base-squad2", model_kwargs={"device_map": "auto"})
     auto_device = ComponentDevice.resolve_device(None)
 
@@ -660,7 +660,7 @@ def test_device_map_auto(mocked_automodel, _mocked_autotokenizer, del_hf_env_var
     "haystack_integrations.components.readers.transformers.extractive_reader."
     "AutoModelForQuestionAnswering.from_pretrained"
 )
-def test_device_map_str(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars):
+def test_device_map_str(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars_if_empty):
     reader = TransformersExtractiveReader("deepset/roberta-base-squad2", model_kwargs={"device_map": "cpu:0"})
 
     class MockedModel:
@@ -679,7 +679,7 @@ def test_device_map_str(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars
     "haystack_integrations.components.readers.transformers.extractive_reader."
     "AutoModelForQuestionAnswering.from_pretrained"
 )
-def test_device_map_dict(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars):
+def test_device_map_dict(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars_if_empty):
     reader = TransformersExtractiveReader(
         "deepset/roberta-base-squad2", model_kwargs={"device_map": {"layer_1": 1, "classifier": "cpu"}}
     )
@@ -907,7 +907,7 @@ class TestDeduplication:
 
 
 @pytest.mark.integration
-def test_t5(del_hf_env_vars):
+def test_t5(del_hf_env_vars_if_empty):
     reader = TransformersExtractiveReader("sjrhuschlee/flan-t5-base-squad2")
     answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
         "answers"
@@ -930,7 +930,7 @@ def test_t5(del_hf_env_vars):
 
 
 @pytest.mark.integration
-def test_roberta(del_hf_env_vars):
+def test_roberta(del_hf_env_vars_if_empty):
     reader = TransformersExtractiveReader("deepset/tinyroberta-squad2")
     answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
         "answers"

--- a/integrations/transformers/tests/test_named_entity_extractor.py
+++ b/integrations/transformers/tests/test_named_entity_extractor.py
@@ -101,7 +101,7 @@ def test_named_entity_extractor_serde():
         _ = TransformersNamedEntityExtractor.from_dict(serde_data)
 
 
-def test_to_dict_default(del_hf_env_vars):
+def test_to_dict_default(del_hf_env_vars_if_empty):
     component = TransformersNamedEntityExtractor(
         model="dslim/bert-base-NER",
         device=ComponentDevice.from_str("mps"),
@@ -144,7 +144,7 @@ def test_to_dict_with_parameters():
     }
 
 
-def test_named_entity_extractor_from_dict_no_default_parameters(del_hf_env_vars):
+def test_named_entity_extractor_from_dict_no_default_parameters(del_hf_env_vars_if_empty):
     data = {
         "type": COMPONENT_TYPE,
         "init_parameters": {"model": "dslim/bert-base-NER"},
@@ -226,7 +226,7 @@ def test_named_entity_extractor_run_fails_with_wrong_number_of_annotations():
 
 
 @pytest.mark.integration
-def test_ner_extractor_init(del_hf_env_vars):
+def test_ner_extractor_init(del_hf_env_vars_if_empty):
     extractor = TransformersNamedEntityExtractor(model="dslim/bert-base-NER")
     extractor.warm_up()
     assert extractor.initialized
@@ -234,7 +234,7 @@ def test_ner_extractor_init(del_hf_env_vars):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("batch_size", [1, 3])
-def test_ner_extractor(raw_texts, hf_annotations, batch_size, del_hf_env_vars):
+def test_ner_extractor(raw_texts, hf_annotations, batch_size, del_hf_env_vars_if_empty):
     extractor = TransformersNamedEntityExtractor(model="dslim/bert-base-NER")
     extractor.warm_up()
 
@@ -256,7 +256,7 @@ def test_ner_extractor_private_models(raw_texts, hf_annotations, batch_size):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("batch_size", [1, 3])
-def test_ner_extractor_in_pipeline(raw_texts, hf_annotations, batch_size, del_hf_env_vars):
+def test_ner_extractor_in_pipeline(raw_texts, hf_annotations, batch_size, del_hf_env_vars_if_empty):
     pipeline = Pipeline()
     pipeline.add_component(
         name="ner_extractor",

--- a/integrations/transformers/tests/test_text_router.py
+++ b/integrations/transformers/tests/test_text_router.py
@@ -54,7 +54,7 @@ class TestTransformersTextRouter:
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
-    def test_from_dict(self, mock_auto_config_from_pretrained, del_hf_env_vars):
+    def test_from_dict(self, mock_auto_config_from_pretrained, del_hf_env_vars_if_empty):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         data = {
             "type": COMPONENT_TYPE,
@@ -83,7 +83,7 @@ class TestTransformersTextRouter:
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
-    def test_from_dict_no_default_parameters(self, mock_auto_config_from_pretrained, del_hf_env_vars):
+    def test_from_dict_no_default_parameters(self, mock_auto_config_from_pretrained, del_hf_env_vars_if_empty):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         data = {
             "type": COMPONENT_TYPE,
@@ -103,7 +103,7 @@ class TestTransformersTextRouter:
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
-    def test_from_dict_with_cpu_device(self, mock_auto_config_from_pretrained, del_hf_env_vars):
+    def test_from_dict_with_cpu_device(self, mock_auto_config_from_pretrained, del_hf_env_vars_if_empty):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         data = {
             "type": COMPONENT_TYPE,
@@ -172,7 +172,7 @@ class TestTransformersTextRouter:
         assert out == {"en": "What is the color of the sky?"}
 
     @pytest.mark.integration
-    def test_run(self, del_hf_env_vars):
+    def test_run(self, del_hf_env_vars_if_empty):
         router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection")
         out = router.run("What is the color of the sky?")
         assert set(router.labels) == {
@@ -201,7 +201,7 @@ class TestTransformersTextRouter:
         assert out == {"en": "What is the color of the sky?"}
 
     @pytest.mark.integration
-    def test_wrong_labels(self, del_hf_env_vars):
+    def test_wrong_labels(self, del_hf_env_vars_if_empty):
         router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection", labels=["en", "de"])
         with pytest.raises(ValueError):
             router.warm_up()

--- a/integrations/transformers/tests/test_text_router.py
+++ b/integrations/transformers/tests/test_text_router.py
@@ -79,7 +79,7 @@ class TestTransformersTextRouter:
             "model": "papluca/xlm-roberta-base-language-detection",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "text-classification",
-            "token": None,
+            "token": component.token.resolve_value(),
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
@@ -99,7 +99,7 @@ class TestTransformersTextRouter:
             "model": "papluca/xlm-roberta-base-language-detection",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "text-classification",
-            "token": None,
+            "token": component.token.resolve_value(),
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
@@ -128,7 +128,7 @@ class TestTransformersTextRouter:
             "model": "papluca/xlm-roberta-base-language-detection",
             "device": ComponentDevice.from_str("cpu").to_hf(),
             "task": "text-classification",
-            "token": None,
+            "token": component.token.resolve_value(),
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")

--- a/integrations/transformers/tests/test_zero_shot_document_classifier.py
+++ b/integrations/transformers/tests/test_zero_shot_document_classifier.py
@@ -80,7 +80,7 @@ class TestTransformersZeroShotDocumentClassifier:
             "model": "cross-encoder/nli-deberta-v3-xsmall",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": None,
+            "token": component.token.resolve_value(),
         }
 
     def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
@@ -98,7 +98,7 @@ class TestTransformersZeroShotDocumentClassifier:
             "model": "cross-encoder/nli-deberta-v3-xsmall",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": None,
+            "token": component.token.resolve_value(),
         }
 
     @patch("haystack_integrations.components.classifiers.transformers.zero_shot_document_classifier.pipeline")

--- a/integrations/transformers/tests/test_zero_shot_document_classifier.py
+++ b/integrations/transformers/tests/test_zero_shot_document_classifier.py
@@ -52,7 +52,7 @@ class TestTransformersZeroShotDocumentClassifier:
             },
         }
 
-    def test_from_dict(self, del_hf_env_vars):
+    def test_from_dict(self, del_hf_env_vars_if_empty):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {
@@ -83,7 +83,7 @@ class TestTransformersZeroShotDocumentClassifier:
             "token": None,
         }
 
-    def test_from_dict_no_default_parameters(self, del_hf_env_vars):
+    def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {"model": "cross-encoder/nli-deberta-v3-xsmall", "labels": ["positive", "negative"]},
@@ -165,7 +165,7 @@ class TestTransformersZeroShotDocumentClassifier:
             component.run(documents=documents)
 
     @pytest.mark.integration
-    def test_run(self, del_hf_env_vars):
+    def test_run(self, del_hf_env_vars_if_empty):
         component = TransformersZeroShotDocumentClassifier(
             model="cross-encoder/nli-deberta-v3-xsmall", labels=["positive", "negative"]
         )

--- a/integrations/transformers/tests/test_zero_shot_text_router.py
+++ b/integrations/transformers/tests/test_zero_shot_text_router.py
@@ -31,7 +31,7 @@ class TestTransformersZeroShotTextRouter:
             },
         }
 
-    def test_from_dict(self, del_hf_env_vars):
+    def test_from_dict(self, del_hf_env_vars_if_empty):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {
@@ -58,7 +58,7 @@ class TestTransformersZeroShotTextRouter:
             "token": None,
         }
 
-    def test_from_dict_no_default_parameters(self, del_hf_env_vars):
+    def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {"labels": ["query", "passage"]},
@@ -110,7 +110,7 @@ class TestTransformersZeroShotTextRouter:
         assert out == {"query": "What is the color of the sky?"}
 
     @pytest.mark.integration
-    def test_run(self, del_hf_env_vars):
+    def test_run(self, del_hf_env_vars_if_empty):
         router = TransformersZeroShotTextRouter(labels=["query", "passage"])
         out = router.run("What is the color of the sky?")
         assert router.pipeline is not None

--- a/integrations/transformers/tests/test_zero_shot_text_router.py
+++ b/integrations/transformers/tests/test_zero_shot_text_router.py
@@ -55,7 +55,7 @@ class TestTransformersZeroShotTextRouter:
             "model": "MoritzLaurer/deberta-v3-base-zeroshot-v1.1-all-33",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": None,
+            "token": component.token.resolve_value(),
         }
 
     def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
@@ -73,7 +73,7 @@ class TestTransformersZeroShotTextRouter:
             "model": "MoritzLaurer/deberta-v3-base-zeroshot-v1.1-all-33",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": None,
+            "token": component.token.resolve_value(),
         }
 
     @patch("haystack_integrations.components.routers.transformers.zero_shot_text_router.pipeline")


### PR DESCRIPTION
### Related Issues

- the existing `del_hf_env_vars` fixture might lead to making HF requests without token, leading to rate limiting

### Proposed Changes:
- modify the fixture to only unset HF env vars if they are empty (like in PRs from forks) - I have verified that https://github.com/deepset-ai/haystack/issues/8811 is still a problem to work around

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
