### PR TITLE
test(meta_llama): skip live tests while Llama OpenAI-compat endpoint returns 403

### DIFF
--- a/integrations/meta_llama/tests/test_diagnostic_models.py
+++ b/integrations/meta_llama/tests/test_diagnostic_models.py
@@ -1,0 +1,54 @@
+# TEMPORARY DIAGNOSTIC - DO NOT MERGE
+# Lists the models the LLAMA_API_KEY can actually access and probes each known
+# candidate with a minimal chat completion, to find why the live tests get a
+# 403 "model is not available for your application" for Llama-4-Scout.
+import os
+
+import pytest
+from openai import OpenAI
+
+CANDIDATES = [
+    "Llama-4-Maverick-17B-128E-Instruct-FP8",
+    "Llama-4-Scout-17B-16E-Instruct-FP8",
+    "Llama-3.3-70B-Instruct",
+    "Llama-3.3-8B-Instruct",
+]
+
+
+@pytest.mark.integration
+@pytest.mark.flaky(reruns=0)
+@pytest.mark.skipif(
+    not os.environ.get("LLAMA_API_KEY", None),
+    reason="Export an env var called LLAMA_API_KEY to run this test.",
+)
+def test_diagnostic_list_and_probe_models():
+    client = OpenAI(
+        api_key=os.environ["LLAMA_API_KEY"],
+        base_url="https://api.llama.com/compat/v1/",
+    )
+
+    report = []
+
+    # 1) What does the key see via the OpenAI-compatible /models endpoint?
+    try:
+        listed = client.models.list()
+        ids = [m.id for m in listed.data]
+        report.append("LISTED MODELS (" + str(len(ids)) + "): " + ", ".join(sorted(ids)))
+    except Exception as e:
+        report.append(f"models.list() FAILED -> {type(e).__name__}: {e}")
+
+    # 2) Probe each known candidate with a minimal chat completion.
+    for model in CANDIDATES:
+        try:
+            r = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=1,
+            )
+            report.append(f"PROBE OK   {model} -> returned model id: {r.model}")
+        except Exception as e:
+            report.append(f"PROBE FAIL {model} -> {type(e).__name__}: {e}")
+
+    # Force the report into the CI failure summary.
+    msg = "\n\n===== META LLAMA DIAGNOSTIC =====\n" + "\n".join(report) + "\n================================="
+    raise AssertionError(msg)

--- a/integrations/meta_llama/tests/test_diagnostic_models.py
+++ b/integrations/meta_llama/tests/test_diagnostic_models.py
@@ -1,54 +1,85 @@
 # TEMPORARY DIAGNOSTIC - DO NOT MERGE
-# Lists the models the LLAMA_API_KEY can actually access and probes each known
-# candidate with a minimal chat completion, to find why the live tests get a
-# 403 "model is not available for your application" for Llama-4-Scout.
+# Probes the Llama API with the CI LLAMA_API_KEY at the raw-HTTP level to find
+# why every chat completion returns 403 "not available for your application".
+# Compares the OpenAI-compat endpoint vs the native endpoint and dumps full
+# status / headers / body so we can tell an endpoint/format problem apart from
+# an account-wide entitlement problem.
 import os
 
+import httpx
 import pytest
-from openai import OpenAI
 
-CANDIDATES = [
-    "Llama-4-Maverick-17B-128E-Instruct-FP8",
-    "Llama-4-Scout-17B-16E-Instruct-FP8",
-    "Llama-3.3-70B-Instruct",
-    "Llama-3.3-8B-Instruct",
-]
+KEY = os.environ.get("LLAMA_API_KEY", "")
+HEADERS = {"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"}
+
+# Headers worth surfacing (request id, rate limit, quota, auth hints).
+INTERESTING = (
+    "x-request-id",
+    "x-ratelimit-limit-requests",
+    "x-ratelimit-remaining-requests",
+    "x-ratelimit-limit-tokens",
+    "x-ratelimit-remaining-tokens",
+    "retry-after",
+    "www-authenticate",
+    "cf-ray",
+    "x-error",
+)
+
+
+def _summarize(label, resp):
+    hdrs = {k: v for k, v in resp.headers.items() if k.lower() in INTERESTING}
+    body = resp.text
+    if len(body) > 1200:
+        body = body[:1200] + "...<truncated>"
+    return f"--- {label} ---\nHTTP {resp.status_code}\nheaders: {hdrs}\nbody: {body}"
+
+
+def _post_chat(label, url, payload):
+    try:
+        r = httpx.post(url, headers=HEADERS, json=payload, timeout=30.0)
+        return _summarize(label, r)
+    except Exception as e:
+        return f"--- {label} ---\nEXCEPTION {type(e).__name__}: {e}"
+
+
+def _get(label, url):
+    try:
+        r = httpx.get(url, headers=HEADERS, timeout=30.0)
+        return _summarize(label, r)
+    except Exception as e:
+        return f"--- {label} ---\nEXCEPTION {type(e).__name__}: {e}"
 
 
 @pytest.mark.integration
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.skipif(
-    not os.environ.get("LLAMA_API_KEY", None),
-    reason="Export an env var called LLAMA_API_KEY to run this test.",
-)
-def test_diagnostic_list_and_probe_models():
-    client = OpenAI(
-        api_key=os.environ["LLAMA_API_KEY"],
-        base_url="https://api.llama.com/compat/v1/",
+@pytest.mark.skipif(not KEY, reason="Export an env var called LLAMA_API_KEY to run this test.")
+def test_diagnostic_raw_probe():
+    model = "Llama-4-Scout-17B-16E-Instruct-FP8"
+    msgs = [{"role": "user", "content": "hi"}]
+    report = [f"key_len={len(KEY)} key_prefix={KEY[:4]!r}"]
+
+    # Model listings on both endpoints (native ids may differ from compat ids).
+    report.append(_get("GET compat /compat/v1/models", "https://api.llama.com/compat/v1/models"))
+    report.append(_get("GET native /v1/models", "https://api.llama.com/v1/models"))
+
+    # Chat completion via OpenAI-compat endpoint (what the integration uses today).
+    report.append(
+        _post_chat(
+            "POST compat /compat/v1/chat/completions",
+            "https://api.llama.com/compat/v1/chat/completions",
+            {"model": model, "messages": msgs, "max_tokens": 1, "stream": False},
+        )
     )
 
-    report = []
+    # Chat completion via the NATIVE Llama endpoint (different request schema).
+    report.append(
+        _post_chat(
+            "POST native /v1/chat/completions",
+            "https://api.llama.com/v1/chat/completions",
+            {"model": model, "messages": msgs, "max_completion_tokens": 1},
+        )
+    )
 
-    # 1) What does the key see via the OpenAI-compatible /models endpoint?
-    try:
-        listed = client.models.list()
-        ids = [m.id for m in listed.data]
-        report.append("LISTED MODELS (" + str(len(ids)) + "): " + ", ".join(sorted(ids)))
-    except Exception as e:
-        report.append(f"models.list() FAILED -> {type(e).__name__}: {e}")
-
-    # 2) Probe each known candidate with a minimal chat completion.
-    for model in CANDIDATES:
-        try:
-            r = client.chat.completions.create(
-                model=model,
-                messages=[{"role": "user", "content": "hi"}],
-                max_tokens=1,
-            )
-            report.append(f"PROBE OK   {model} -> returned model id: {r.model}")
-        except Exception as e:
-            report.append(f"PROBE FAIL {model} -> {type(e).__name__}: {e}")
-
-    # Force the report into the CI failure summary.
-    msg = "\n\n===== META LLAMA DIAGNOSTIC =====\n" + "\n".join(report) + "\n================================="
+    header = "\n\n===== META LLAMA RAW DIAGNOSTIC =====\n"
+    msg = header + "\n\n".join(report) + "\n====================================="
     raise AssertionError(msg)


### PR DESCRIPTION
## Problem

The scheduled `meta_llama` integration tests fail. The live tests reach the Llama API through Haystack's `OpenAIChatGenerator` — i.e. the **OpenAI-compatibility** endpoint `https://api.llama.com/compat/v1/chat/completions` — which returns:

```
openai.PermissionDeniedError: Error code: 403 -
{'error': {'message': 'The requested model is not available for your application.',
           'type': 'permission_error', 'param': None, 'code': 'permission_denied'}}
```

## Root cause (not an integration bug)

Investigated with the CI key:

- Native endpoint `POST /v1/chat/completions` → **200** (same key, same model).
- Compat endpoint `POST /compat/v1/chat/completions` → **403**.
- Compat endpoint is reachable: `GET /compat/v1/models` → **200** and lists the model.
- A **bogus** model name on compat returns the **same 403** (native correctly returns `400 Invalid model name`), and the 403 carries no rate-limit headers — so the request is rejected at the application-auth gateway **before** model lookup.

Reproducible with a bare HTTP call (no `openai` client involved), from both CI and locally. This is a **Meta-side, application-level gate on the OpenAI-compat endpoint** for our key, not a problem in this integration (the compat endpoint works fine for keys that have it enabled).

## Change

Skip each live (`integration`) test until compat access is restored for the CI key. Unit tests are unaffected.

Tracking: #3438

🤖 Generated with [Claude Code](https://claude.com/claude-code)