### PR TITLE
chore: fix scaffolding script to produce valid pydoc configs

### DIFF
--- a/scripts/create_new_integration.py
+++ b/scripts/create_new_integration.py
@@ -96,7 +96,11 @@ def prompt_component_type() -> str:
 def main():
     parser = argparse.ArgumentParser(description="Scaffold a new Haystack integration.")
     parser.add_argument("--name", type=str, help="The name of the integration (e.g. opensearch)")
-    parser.add_argument("--type", dest="component_type", help=f"Component type: {', '.join(COMPONENT_TYPES)}")
+    parser.add_argument(
+        "--type",
+        dest="component_type",
+        help=f"Component type: {', '.join(COMPONENT_TYPES)}",
+    )
     args = parser.parse_args()
 
     name = args.name
@@ -126,7 +130,11 @@ def main():
     print(f"  Module: {module_path}")
 
     created_files = create_integration_files(
-        name, component_type, repo_root=REPO_ROOT, integrations_dir=INTEGRATIONS_DIR, license_header=LICENSE_HEADER
+        name,
+        component_type,
+        repo_root=REPO_ROOT,
+        integrations_dir=INTEGRATIONS_DIR,
+        license_header=LICENSE_HEADER,
     )
     for file in created_files:
         print(f"  Created: {file.relative_to(REPO_ROOT)}")
@@ -143,13 +151,13 @@ def main():
     readme_path = update_root_readme(name, component_type, TYPE_LABELS, repo_root=REPO_ROOT)
     print(f"  Updated: {readme_path}")
 
-    print(f"\nDone! Next steps:")
+    print("\nDone! Next steps:")
     print(f"  1. Add your component code in integrations/{name}/src/")
-    print(f"  2. Export the component classes from the __init__.py in your module")
+    print("  2. Export the component classes from the __init__.py in your module")
     print(f"  3. Add integration-specific dependencies to integrations/{name}/pyproject.toml")
     print(f"  4. Add tests in integrations/{name}/tests/")
     print(f"  5. If your integration tests need API keys, update .github/workflows/{name}.yml accordingly")
-    print(f"     and ask a maintainer to add the secret to the GitHub repo.")
+    print("     and ask a maintainer to add the secret to the GitHub repo.")
     print(f"  6. Add relevant keywords to integrations/{name}/pyproject.toml")
     print(f"  7. Check that the correct module paths are used in integrations/{name}/pydoc/config_docusaurus.yml")
 

--- a/scripts/utils/templates/pydoc_config.yml
+++ b/scripts/utils/templates/pydoc_config.yml
@@ -8,6 +8,6 @@ processors:
     skip_empty_modules: true
 renderer:
   description: $title integration for Haystack
-  id: integrations-$name
-  filename: $name_hyphenated.md
+  id: integrations-$name_hyphenated
+  filename: $name.md
   title: $title


### PR DESCRIPTION
### Related Issues

When introducing the new sentence_transformers integration, the script produced an invalid pydoc config:

```yaml
  id: integrations-sentence_transformers # correct: integrations-sentence-transformers
  filename: sentence-transformers.md # correct: sentence_transformers
```

### Proposed Changes:
- fix the script to produce valid pydoc configs for integration names that include an underscore

### How did you test it?
Tested locally

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
