### PR TITLE
fix: serialize MongoDBAtlasDocumentStore embedding_field and content_field

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -245,6 +245,8 @@ class MongoDBAtlasDocumentStore:
             collection_name=self.collection_name,
             vector_search_index=self.vector_search_index,
             full_text_search_index=self.full_text_search_index,
+            embedding_field=self.embedding_field,
+            content_field=self.content_field,
         )
 
     @classmethod

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -248,6 +248,8 @@ class TestDocumentStore(
                 "database_name": "haystack_integration_test",
                 "vector_search_index": "cosine_index",
                 "full_text_search_index": "full_text_index",
+                "embedding_field": "embedding",
+                "content_field": "content",
             },
         }
 

--- a/integrations/mongodb_atlas/tests/test_retriever.py
+++ b/integrations/mongodb_atlas/tests/test_retriever.py
@@ -97,6 +97,8 @@ class TestRetriever:
                         "collection_name": case["collection_name"],
                         "vector_search_index": "cosine_index",
                         "full_text_search_index": "full_text_index",
+                        "embedding_field": "embedding",
+                        "content_field": "content",
                     },
                 },
                 "filters": {"field": "value"},


### PR DESCRIPTION
### Related Issues

None — found while reviewing `to_dict`/`from_dict` parity across the document-store integrations (same class of bug as the Chroma `metadata` omission).

### Proposed Changes:

`MongoDBAtlasDocumentStore.to_dict()` serialized the connection string, database/collection names and the two index names, but **omitted `embedding_field` and `content_field`**. Both were therefore silently dropped on a `to_dict`/`from_dict` round-trip (e.g. a pipeline serialized to YAML with `Pipeline.dumps()` and reloaded with `Pipeline.loads()`). `from_dict` already accepts both via `default_from_dict`, so the omission was one-directional — you could deserialize them, but never serialize them.

These fields are material:
- `embedding_field` is used as the `path` in the `$vectorSearch` stage and as the key under which embeddings are written.
- `content_field` is the key under which document content is stored/read.

A reloaded store reverted to the default `"embedding"` / `"content"` names, so a store configured with custom field names would query and write the **wrong fields** after a round-trip.

The fix adds both to the `default_to_dict(...)` payload. No `from_dict` change is needed.

### How did you test it?

- Added an offline round-trip regression test (`test_to_dict_preserves_custom_field_names`) asserting custom `embedding_field`/`content_field` survive `to_dict`→`from_dict`. It fails before the fix (store reverts to defaults) and passes after.
- Updated the existing exact-dict assertions: `test_document_store.py::test_to_dict` and the retriever `test_to_dict` (which embeds the store dict, parametrized over the embedding & full-text retrievers).
- mongodb_atlas non-integration unit tests: `37 passed`; `ruff check` clean.

### Notes for the reviewer

`to_dict` output now includes `embedding_field` and `content_field`; the affected exact-dict assertions are updated accordingly. No `from_dict` change required (it already forwarded these via `default_from_dict`).

### Checklist

- [x] I have read the contributors guidelines and the code of conduct
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the conventional commit types for my PR title: `fix:`