### PR TITLE
fix: change default model in `AnthropicGenerator` to Sonnet 4.5

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/generator.py
@@ -62,7 +62,7 @@ class AnthropicGenerator:
     def __init__(
         self,
         api_key: Secret = Secret.from_env_var("ANTHROPIC_API_KEY"),  # noqa: B008
-        model: str = "claude-sonnet-4-20250514",
+        model: str = "claude-sonnet-4-5",
         streaming_callback: Callable[[StreamingChunk], None] | None = None,
         system_prompt: str | None = None,
         generation_kwargs: dict[str, Any] | None = None,

--- a/integrations/anthropic/tests/test_generator.py
+++ b/integrations/anthropic/tests/test_generator.py
@@ -14,7 +14,7 @@ class TestAnthropicGenerator:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
         component = AnthropicGenerator()
         assert component.client.api_key == "test-api-key"
-        assert component.model == "claude-sonnet-4-20250514"
+        assert component.model == "claude-sonnet-4-5"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
 
@@ -43,7 +43,7 @@ class TestAnthropicGenerator:
             "type": "haystack_integrations.components.generators.anthropic.generator.AnthropicGenerator",
             "init_parameters": {
                 "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "claude-sonnet-4-20250514",
+                "model": "claude-sonnet-4-5",
                 "streaming_callback": None,
                 "system_prompt": None,
                 "generation_kwargs": {},
@@ -67,7 +67,7 @@ class TestAnthropicGenerator:
             "type": "haystack_integrations.components.generators.anthropic.generator.AnthropicGenerator",
             "init_parameters": {
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
-                "model": "claude-sonnet-4-20250514",
+                "model": "claude-sonnet-4-5",
                 "system_prompt": "test-prompt",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
@@ -242,7 +242,7 @@ class TestAnthropicGenerator:
     @pytest.mark.integration
     def test_extended_thinking_mode(self):
         client = AnthropicGenerator(
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-5",
             generation_kwargs={"thinking": {"type": "enabled", "budget_tokens": 1024}, "max_tokens": 1536},
         )
         response = client.run("What is the capital of France?")
@@ -290,7 +290,7 @@ class TestAnthropicGenerator:
                 thinking_end_tag_found = "</thinking>" in chunk.content
 
         client = AnthropicGenerator(
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-5",
             generation_kwargs={"thinking": {"type": "enabled", "budget_tokens": 1024}, "max_tokens": 1536},
             streaming_callback=streaming_callback,
         )
@@ -336,7 +336,7 @@ class TestAnthropicGenerator:
                 thinking_end_tag_found = "</thinking>" in chunk.content
 
         client = AnthropicGenerator(
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-5",
             generation_kwargs={
                 "thinking": {"type": "enabled", "budget_tokens": 1024},
                 "max_tokens": 1536,


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/27585745803/job/81555567491

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Claude Sonnet 4 was deprecated https://platform.claude.com/docs/en/about-claude/model-deprecations so update the default model to Sonnet 4.5

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Updated existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
