### PR TITLE
feat: (docling) move construction of default hybrid chunker to `DoclingConverter.warm_up`

### DIFF
--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -135,8 +135,8 @@ class DoclingConverter:
         self.chunker = chunker
         self.meta_extractor = meta_extractor
 
-        # Resolved instances used internally at runtime. The default HybridChunker is built in
-        # warm_up() instead of here because its construction downloads a Hugging Face tokenizer.
+        # Resolved instances used internally at runtime. The default HybridChunker is built in warm_up() instead of
+        # here because its construction downloads a Hugging Face tokenizer.
         self._converter_instance = converter or DocumentConverter()
         self._chunker_instance = chunker
         self._meta_extractor_instance = meta_extractor or MetaExtractor()
@@ -144,11 +144,9 @@ class DoclingConverter:
 
     def warm_up(self) -> None:
         """
-        Build the default `HybridChunker` for `ExportType.DOC_CHUNKS` if no `chunker` was passed at
-        init time.
+        Build the default `HybridChunker` for `ExportType.DOC_CHUNKS` if no `chunker` was passed at init time.
 
-        Deferred to warm-up time because constructing the default chunker downloads a Hugging Face
-        tokenizer.
+        Deferred to warm-up time because constructing the default chunker downloads a Hugging Face tokenizer.
         """
         if self._is_warmed_up:
             return

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -135,11 +135,26 @@ class DoclingConverter:
         self.chunker = chunker
         self.meta_extractor = meta_extractor
 
-        # Resolved instances used internally at runtime.
+        # Resolved instances used internally at runtime. The default HybridChunker is built in
+        # warm_up() instead of here because its construction downloads a Hugging Face tokenizer.
         self._converter_instance = converter or DocumentConverter()
-        if self.export_type == ExportType.DOC_CHUNKS:
-            self._chunker_instance = chunker or HybridChunker()
+        self._chunker_instance = chunker
         self._meta_extractor_instance = meta_extractor or MetaExtractor()
+        self._is_warmed_up = False
+
+    def warm_up(self) -> None:
+        """
+        Build the default `HybridChunker` for `ExportType.DOC_CHUNKS` if no `chunker` was passed at
+        init time.
+
+        Deferred to warm-up time because constructing the default chunker downloads a Hugging Face
+        tokenizer.
+        """
+        if self._is_warmed_up:
+            return
+        if self.export_type == ExportType.DOC_CHUNKS and self._chunker_instance is None:
+            self._chunker_instance = HybridChunker()
+        self._is_warmed_up = True
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize this component to a dictionary."""
@@ -224,6 +239,9 @@ class DoclingConverter:
         if sources is None:
             msg = "Either 'sources' or the deprecated 'paths' parameter must be provided."
             raise ValueError(msg)
+
+        if not self._is_warmed_up:
+            self.warm_up()
 
         meta_list = normalize_metadata(meta=meta, sources_count=len(sources))
 

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -256,8 +256,8 @@ class DoclingConverter:
 
             if self.export_type == ExportType.DOC_CHUNKS:
                 split_idx_start = 0
-                for split_id, chunk in enumerate(self._chunker_instance.chunk(dl_doc=dl_doc)):
-                    content = self._chunker_instance.contextualize(chunk=chunk)
+                for split_id, chunk in enumerate(self._chunker_instance.chunk(dl_doc=dl_doc)):  # type: ignore[union-attr]
+                    content = self._chunker_instance.contextualize(chunk=chunk)  # type: ignore[union-attr]
                     meta = {
                         **self._meta_extractor_instance.extract_chunk_meta(chunk=chunk),
                         "split_id": split_id,


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/27587363227/job/81560614114

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

DoclingConverter was downloading a huggingface model in its unit tests because the default doc chunker `HybridChunker` downloads a HF model when initialized. 

So we move its construction to warm_up time to be consistent with our other components. We also auto warm up the component at run time so from a users perspective usage should not be affected. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
