### PR TITLE
fix: make ArcadeDB include null records in NOT IN operation

### DIFF
--- a/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/filters.py
+++ b/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/filters.py
@@ -65,7 +65,6 @@ def _parse_condition(condition: dict[str, Any]) -> str:
 
 
 def _comparison_to_sql(field: str, operator: str, value: Any) -> str:
-
     if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_.\[\]"]*$', field):
         msg = (
             f"Invalid field name: {field}. Field names must start with a letter or underscore and can contain "
@@ -106,7 +105,8 @@ def _comparison_to_sql(field: str, operator: str, value: Any) -> str:
             msg = "Operator 'not in' requires value to be a list"
             raise ValueError(msg)
         values = ", ".join(_sql_value(v) for v in value)
-        return f"{field} NOT IN [{values}]"
+        # ArcadeDB's NOT IN excludes records where the property is null/missing
+        return f"({field} NOT IN [{values}] OR {field} IS NULL)"
 
     msg = f"Unsupported filter operator: {operator}"
     raise ValueError(msg)

--- a/integrations/arcadedb/tests/test_filters.py
+++ b/integrations/arcadedb/tests/test_filters.py
@@ -41,7 +41,7 @@ class TestFilterConversion:
 
     def test_not_in_operator(self):
         result = _convert_filters({"field": "meta.tag", "operator": "not in", "value": ["x"]})
-        assert result == "meta.tag NOT IN ['x']"
+        assert result == "(meta.tag NOT IN ['x'] OR meta.tag IS NULL)"
 
     def test_and(self):
         result = _convert_filters(


### PR DESCRIPTION
### Related Issues

- failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/27585653669/job/81555297916
- ArcadeDB semantics seem to have changed: previously, `number NOT IN [9,10]` also included records where `number` is NULL or missing (aligned with Haystack); now it's the opposite.

### Proposed Changes:
- Handle this behavior on the Haystack side

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
