### PR TITLE
fix: serialize WeaviateDocumentStore grpc_port and grpc_secure

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -325,6 +325,8 @@ class WeaviateDocumentStore:
         return default_to_dict(
             self,
             url=self._url,
+            grpc_port=self._grpc_port,
+            grpc_secure=self._grpc_secure,
             collection_settings=self._collection_settings,
             auth_client_secret=self._auth_client_secret.to_dict() if self._auth_client_secret else None,
             additional_headers=self._additional_headers,

--- a/integrations/weaviate/tests/test_bm25_retriever.py
+++ b/integrations/weaviate/tests/test_bm25_retriever.py
@@ -40,6 +40,8 @@ def test_to_dict(_mock_weaviate):
                 "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                 "init_parameters": {
                     "url": None,
+                    "grpc_port": 50051,
+                    "grpc_secure": False,
                     "collection_settings": {
                         "class": "Default",
                         "invertedIndexConfig": {"indexNullState": True},
@@ -74,6 +76,8 @@ def test_from_dict(_mock_weaviate):
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {
                         "url": None,
+                        "grpc_port": 50051,
+                        "grpc_secure": False,
                         "collection_settings": {
                             "class": "Default",
                             "invertedIndexConfig": {"indexNullState": True},
@@ -111,6 +115,8 @@ def test_from_dict_no_filter_policy(_mock_weaviate):
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {
                         "url": None,
+                        "grpc_port": 50051,
+                        "grpc_secure": False,
                         "collection_settings": {
                             "class": "Default",
                             "invertedIndexConfig": {"indexNullState": True},

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -355,6 +355,8 @@ class TestWeaviateDocumentStore(
             "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
             "init_parameters": {
                 "url": "http://localhost:8080",
+                "grpc_port": 50051,
+                "grpc_secure": False,
                 "collection_settings": {
                     "class": "Default",
                     "invertedIndexConfig": {"indexNullState": True},
@@ -396,6 +398,25 @@ class TestWeaviateDocumentStore(
                 },
             },
         }
+
+    @patch("haystack_integrations.document_stores.weaviate.document_store.weaviate")
+    def test_to_dict_and_from_dict_preserves_grpc_settings(self, _mock_weaviate):
+        """`grpc_port`/`grpc_secure` configure the gRPC connection and must
+        survive a to_dict/from_dict round-trip; otherwise a reloaded store
+        silently falls back to the default gRPC port/security."""
+        document_store = WeaviateDocumentStore(
+            url="http://localhost:8080",
+            grpc_port=50052,
+            grpc_secure=True,
+        )
+
+        serialized = document_store.to_dict()
+        assert serialized["init_parameters"]["grpc_port"] == 50052
+        assert serialized["init_parameters"]["grpc_secure"] is True
+
+        restored = WeaviateDocumentStore.from_dict(serialized)
+        assert restored._grpc_port == 50052
+        assert restored._grpc_secure is True
 
     @patch("haystack_integrations.document_stores.weaviate.document_store.weaviate")
     def test_from_dict(self, _mock_weaviate, monkeypatch):

--- a/integrations/weaviate/tests/test_embedding_retriever.py
+++ b/integrations/weaviate/tests/test_embedding_retriever.py
@@ -50,6 +50,8 @@ def test_to_dict(_mock_weaviate):
                 "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                 "init_parameters": {
                     "url": None,
+                    "grpc_port": 50051,
+                    "grpc_secure": False,
                     "collection_settings": {
                         "class": "Default",
                         "invertedIndexConfig": {"indexNullState": True},
@@ -86,6 +88,8 @@ def test_from_dict(_mock_weaviate):
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {
                         "url": None,
+                        "grpc_port": 50051,
+                        "grpc_secure": False,
                         "collection_settings": {
                             "class": "Default",
                             "invertedIndexConfig": {"indexNullState": True},
@@ -127,6 +131,8 @@ def test_from_dict_no_filter_policy(_mock_weaviate):
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {
                         "url": None,
+                        "grpc_port": 50051,
+                        "grpc_secure": False,
                         "collection_settings": {
                             "class": "Default",
                             "invertedIndexConfig": {"indexNullState": True},

--- a/integrations/weaviate/tests/test_hybrid_retriever.py
+++ b/integrations/weaviate/tests/test_hybrid_retriever.py
@@ -63,6 +63,8 @@ def test_to_dict(_mock_weaviate):
                 "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                 "init_parameters": {
                     "url": None,
+                    "grpc_port": 50051,
+                    "grpc_secure": False,
                     "collection_settings": {
                         "class": "Default",
                         "invertedIndexConfig": {"indexNullState": True},
@@ -119,6 +121,8 @@ def test_from_dict(_mock_weaviate):
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {
                         "url": None,
+                        "grpc_port": 50051,
+                        "grpc_secure": False,
                         "collection_settings": {
                             "class": "Default",
                             "invertedIndexConfig": {"indexNullState": True},
@@ -162,6 +166,8 @@ def test_from_dict_with_parameters(_mock_weaviate):
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {
                         "url": None,
+                        "grpc_port": 50051,
+                        "grpc_secure": False,
                         "collection_settings": {
                             "class": "Default",
                             "invertedIndexConfig": {"indexNullState": True},
@@ -300,6 +306,8 @@ def test_from_dict_no_filter_policy(_mock_weaviate):
                     "type": "haystack_integrations.document_stores.weaviate.document_store.WeaviateDocumentStore",
                     "init_parameters": {
                         "url": None,
+                        "grpc_port": 50051,
+                        "grpc_secure": False,
                         "collection_settings": {
                             "class": "Default",
                             "invertedIndexConfig": {"indexNullState": True},


### PR DESCRIPTION
### Related Issues

None — found while reviewing `to_dict`/`from_dict` parity across the document stores.

### Proposed Changes:

`WeaviateDocumentStore.to_dict()` omitted `grpc_port` and `grpc_secure`, so they were lost on a `to_dict`/`from_dict` round-trip and a reloaded store fell back to the defaults (`50051` / `False`). Added both to `to_dict()`; `from_dict` already forwards them via `default_from_dict`.

### How did you test it?

Added a round-trip regression test with non-default values (`grpc_port=50052`, `grpc_secure=True`) — fails before the change, passes after. Updated the existing `test_to_dict` assertion. Non-integration tests + `ruff` pass.

### Notes for the reviewer

One-line change in `to_dict`; no `from_dict` change needed.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`
