### PR TITLE
fix: serialize OllamaChatGenerator think parameter

### DIFF
--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -341,6 +341,7 @@ class OllamaChatGenerator:
             streaming_callback=callback_name,
             tools=serialize_tools_or_toolset(self.tools),
             response_format=self.response_format,
+            think=self.think,
         )
 
     @classmethod

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -848,10 +848,23 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
                     "type": "object",
                     "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
                 },
+                "think": False,
             },
         }
 
         assert data == expected_dict
+
+    def test_to_dict_and_from_dict_preserves_think(self):
+        """`think` enables a model's reasoning output and must survive a
+        to_dict/from_dict round-trip; otherwise a reloaded generator silently
+        falls back to think=False (reasoning disabled)."""
+        component = OllamaChatGenerator(model="gpt-oss", think="high")
+
+        data = component.to_dict()
+        assert data["init_parameters"]["think"] == "high"
+
+        restored = OllamaChatGenerator.from_dict(data)
+        assert restored.think == "high"
 
     def test_from_dict(self):
         tool = Tool(


### PR DESCRIPTION
### Related Issues

None — found while reviewing `to_dict`/`from_dict` parity across the generators.

### Proposed Changes:

`OllamaChatGenerator.to_dict()` omitted `think`, so it was lost on a `to_dict`/`from_dict` round-trip. `think` is passed to the Ollama client on every run and enables a thinking model's reasoning; a generator configured with `think=True` (or `"low"`/`"medium"`/`"high"`) reverted to `False` after reload, disabling reasoning. Added it to `to_dict()`; `from_dict` already forwards it via `default_from_dict`.

### How did you test it?

Added a round-trip regression test with `think="high"` — fails before the change, passes after. Updated the existing `test_to_dict` assertion. Non-live chat-generator tests + `ruff` pass.

### Notes for the reviewer

One-line change in `to_dict`; no `from_dict` change needed.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`
