### PR TITLE
test: (docling) update unit test to not download model

### DIFF
--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 from docling.chunking import HybridChunker
 from docling.document_converter import DocumentConverter
+from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
 from docling_core.types.io import DocumentStream
 from haystack.dataclasses import ByteStream
 
@@ -233,7 +234,10 @@ def test_component_from_dict_custom_params() -> None:
 
 
 def test_component_to_dict_chunker_warns_and_is_dropped() -> None:
-    converter = DoclingConverter(export_type=ExportType.DOC_CHUNKS, chunker=HybridChunker(merge_peers=False))
+    # Pass an explicit tokenizer so HybridChunker doesn't invoke its default factory
+    # (get_default_tokenizer), which would download a tokenizer from HuggingFace.
+    chunker = HybridChunker(merge_peers=False, tokenizer=MagicMock(spec=BaseTokenizer))
+    converter = DoclingConverter(export_type=ExportType.DOC_CHUNKS, chunker=chunker)
 
     assert converter.to_dict() == {
         "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/27730045604/job/82034904173

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Pass in a base tokenizer that doesn't trigger a HF model download

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
