### PR TITLE
test: make TestOptimumDocumentEmbedder test_run_on_empty_list not contact HF Hub

### DIFF
--- a/integrations/optimum/tests/test_optimum_document_embedder.py
+++ b/integrations/optimum/tests/test_optimum_document_embedder.py
@@ -326,7 +326,7 @@ class TestOptimumDocumentEmbedder:
         with pytest.raises(TypeError, match="OptimumDocumentEmbedder expects a list of Documents as input"):
             embedder.run(documents=list_integers_input)
 
-    def test_run_on_empty_list(self, mock_check_valid_model):  # noqa: ARG002
+    def test_run_on_empty_list(self, mock_check_valid_model, mock_get_pooling_mode):  # noqa: ARG002
         embedder = OptimumDocumentEmbedder(
             model="sentence-transformers/paraphrase-albert-small-v2",
         )


### PR DESCRIPTION
### Related Issues

- Failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/27729562084/job/82033375518
- this is a unit test and should not contact HF Hub to run

### Proposed Changes:
- use the `mock_get_pooling_mode` fixture to prevent contacting the Hub

### How did you test it?
CI, also run locally with `HF_HUB_OFFLINE=1`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
