### PR TITLE
feat!: migrate to official PaddleOCRClient, drop paddlex dependency

### DIFF
--- a/.github/workflows/paddleocr.yml
+++ b/.github/workflows/paddleocr.yml
@@ -29,8 +29,8 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
-  AISTUDIO_ACCESS_TOKEN: ${{ secrets.AISTUDIO_ACCESS_TOKEN }}
-  PADDLEOCR_VL_API_URL: ${{ secrets.PADDLEOCR_VL_API_URL }}
+  PADDLEOCR_ACCESS_TOKEN: ${{ secrets.PADDLEOCR_ACCESS_TOKEN }}
+  PADDLEOCR_VL_BASE_URL: ${{ secrets.PADDLEOCR_VL_BASE_URL }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.12"]'
 

--- a/.github/workflows/paddleocr.yml
+++ b/.github/workflows/paddleocr.yml
@@ -30,7 +30,7 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   PADDLEOCR_ACCESS_TOKEN: ${{ secrets.PADDLEOCR_ACCESS_TOKEN }}
-  PADDLEOCR_VL_BASE_URL: ${{ secrets.PADDLEOCR_VL_BASE_URL }}
+  PADDLEOCR_BASE_URL: ${{ secrets.PADDLEOCR_BASE_URL }}
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
   TEST_MATRIX_PYTHON: '["3.10", "3.12"]'
 

--- a/integrations/paddleocr/README.md
+++ b/integrations/paddleocr/README.md
@@ -12,4 +12,4 @@
 
 Refer to the general [Contribution Guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md).
 
-To run integration tests locally, you need to export the `PADDLEOCR_VL_BASE_URL` and `PADDLEOCR_ACCESS_TOKEN` environment variables.
+To run integration tests locally, you need to export the `PADDLEOCR_BASE_URL` and `PADDLEOCR_ACCESS_TOKEN` environment variables.

--- a/integrations/paddleocr/README.md
+++ b/integrations/paddleocr/README.md
@@ -12,4 +12,4 @@
 
 Refer to the general [Contribution Guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md).
 
-To run integration tests locally, you need to export the `PADDLEOCR_VL_API_URL` and `AISTUDIO_ACCESS_TOKEN` environment variables.
+To run integration tests locally, you need to export the `PADDLEOCR_VL_BASE_URL` and `PADDLEOCR_ACCESS_TOKEN` environment variables.

--- a/integrations/paddleocr/pyproject.toml
+++ b/integrations/paddleocr/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.22.0",
-  "paddleocr>=3.4.0",
-  "paddlex[serving]>=3.4.0",
-  "requests>=2.25.0",
+  "paddleocr>=3.7.0",
 ]
 
 [project.urls]

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -112,11 +112,11 @@ class PaddleOCRVLDocumentConverter:
         self,
         *,
         base_url: str | None = None,
-        access_token: Secret = Secret.from_env_var("PADDLEOCR_ACCESS_TOKEN"),
+        access_token: Secret = Secret.from_env_var(["PADDLEOCR_ACCESS_TOKEN", "AISTUDIO_ACCESS_TOKEN"]),
         model: Model | str = Model.PADDLE_OCR_VL_16,
         file_type: FileTypeInput = None,
-        use_doc_orientation_classify: bool | None = None,
-        use_doc_unwarping: bool | None = None,
+        use_doc_orientation_classify: bool | None = False,
+        use_doc_unwarping: bool | None = False,
         use_layout_detection: bool | None = None,
         use_chart_recognition: bool | None = None,
         use_seal_recognition: bool | None = None,
@@ -305,6 +305,12 @@ class PaddleOCRVLDocumentConverter:
             Deserialized component.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["access_token"])
+        init_params = data["init_parameters"]
+        if "model" in init_params and isinstance(init_params["model"], str):
+            try:
+                init_params["model"] = Model(init_params["model"])
+            except ValueError:
+                pass
         return default_from_dict(cls, data)
 
     def _build_options(self) -> PaddleOCRVLOptions:
@@ -396,7 +402,7 @@ class PaddleOCRVLDocumentConverter:
                 try:
                     bytestream = get_bytestream_from_source(source)
                 except Exception as e:
-                    logger.warning(f"Could not read {source}. Skipping it. Error: {e}")
+                    logger.warning("Could not read {source}. Skipping it. Error: {error}", source=source, error=e)
                     continue
 
                 if self.file_type is not None:
@@ -406,13 +412,13 @@ class PaddleOCRVLDocumentConverter:
                     file_type = _infer_file_type_from_source(source, mime_type)
 
                 if file_type is None:
-                    logger.warning(f"Could not determine file type for {source}. Skipping it.")
+                    logger.warning("Could not determine file type for {source}. Skipping it.", source=source)
                     continue
 
                 try:
                     text, raw_resp = self._parse(bytestream.data, file_type, client)
                 except Exception as e:
-                    logger.warning(f"Could not convert {source} to Document, skipping. Error: {e}")
+                    logger.warning("Could not convert {source} to Document, skipping. Error: {error}", source=source, error=e)
                     continue
 
                 if not text:

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -427,7 +427,9 @@ class PaddleOCRVLDocumentConverter:
 
                 if not text:
                     logger.warning(
-                        f"{self.__class__.__name__} could not extract text from {source}. Returning an empty document."
+                        f"{cls} could not extract text from {source}. Returning an empty document.",
+                        cls=self.__class__.__name__,
+                        source=source,
                     )
 
                 merged_metadata = {**bytestream.meta, **metadata}

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import base64
+import asyncio
+import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
-import requests
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.components.converters.utils import (
     get_bytestream_from_source,
@@ -13,37 +13,23 @@ from haystack.components.converters.utils import (
 )
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret, deserialize_secrets_inplace
-from paddlex.inference.serving.schemas.paddleocr_vl import (  # type: ignore[import-untyped]
-    InferRequest as PaddleOCRVLInferRequest,
-)
-from paddlex.inference.serving.schemas.paddleocr_vl import (  # type: ignore[import-untyped]
-    InferResult as PaddleOCRVLInferResult,
-)
-from paddlex.inference.serving.schemas.shared.ocr import FileType  # type: ignore[import-untyped]
+from paddleocr import AsyncPaddleOCRClient, Model, PaddleOCRVLOptions  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
 
 
 FileTypeInput = Literal["pdf", "image"] | None
 
-# Supported image file extensions
-_IMAGE_EXTENSIONS = {
-    ".jpg",
-    ".jpeg",
-    ".png",
-    ".bmp",
-    ".tiff",
-    ".tif",
-    ".webp",
-}
-# Supported PDF file extensions
+_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".webp"}
 _PDF_EXTENSIONS = {".pdf"}
+_FILE_TYPE_TO_STR = {0: "pdf", 1: "image"}
+_EXTENSION_FOR_FILE_TYPE = {0: ".pdf", 1: ".jpg"}
 
 
 def _infer_file_type_from_source(
     source: str | Path | ByteStream,
     mime_type: str | None = None,
-) -> FileType | None:
+) -> int | None:
     """
     Infer file type from file extension or MIME type.
 
@@ -52,58 +38,49 @@ def _infer_file_type_from_source(
     :param mime_type:
         MIME type of the source.
     :returns:
-        Inferred file type: 0 for PDF, 1 for image, or None if cannot be
-        determined.
+        Inferred file type: 0 for PDF, 1 for image, or None if cannot be determined.
     """
-    # Try to get extension from file path
     file_path: str | None = None
 
-    # Check if source is a file path
     if isinstance(source, (str, Path)):
         file_path = str(source)
-    # Check if source is `ByteStream` and has `file_path` in metadata
     elif isinstance(source, ByteStream) and source.meta:
         file_path = source.meta.get("file_path")
 
-    # Try to infer from file extension
     if file_path:
-        path_obj = Path(file_path)
-        extension = path_obj.suffix.lower()
-
+        extension = Path(file_path).suffix.lower()
         if extension in _PDF_EXTENSIONS:
             return 0
         if extension in _IMAGE_EXTENSIONS:
             return 1
 
-    # Try to infer from MIME type if available
     if mime_type:
-        mime_type_lower = mime_type.lower()
-        if mime_type_lower == "application/pdf":
+        mime_lower = mime_type.lower()
+        if mime_lower == "application/pdf":
             return 0
-        if mime_type_lower.startswith("image/"):
+        if mime_lower.startswith("image/"):
             return 1
 
     return None
 
 
-def _normalize_file_type(file_type: FileTypeInput) -> FileType | None:
+def _normalize_file_type(file_type: FileTypeInput) -> int | None:
     """
-    Normalize file type input to the numeric format expected by the API.
+    Normalize file type input to the numeric format expected by the SDK.
 
     :param file_type:
-        File type input. Can be "pdf" for PDF, "image" for image,
-        or `None` for auto-detection.
+        File type input. Can be "pdf", "image", or None for auto-detection.
+        Integers 0 (PDF) and 1 (image) are also accepted for deserialization.
     :returns:
-        Normalized file type: 0 for PDF, 1 for image, or `None` for
-        auto-detection.
+        Normalized file type: 0 for PDF, 1 for image, or None for auto-detection.
     """
     if file_type is None:
         return None
+    if file_type in ("pdf", 0):
+        return 0
+    if file_type in ("image", 1):
+        return 1
     if isinstance(file_type, str):
-        if file_type.lower() == "pdf":
-            return 0
-        if file_type.lower() == "image":
-            return 1
         msg = f"Invalid `file_type` string: {file_type}. Must be 'pdf' or 'image'."
         raise ValueError(msg)
     msg = f"Invalid `file_type` value: {file_type}. Must be 'pdf', 'image', or `None`."
@@ -128,8 +105,8 @@ class PaddleOCRVLDocumentConverter:
     )
 
     converter = PaddleOCRVLDocumentConverter(
-        api_url="http://xxxxx.aistudio-app.com/layout-parsing",
-        access_token=Secret.from_env_var("AISTUDIO_ACCESS_TOKEN"),
+        base_url="http://xxxxx.aistudio-app.com",
+        access_token=Secret.from_env_var("PADDLEOCR_ACCESS_TOKEN"),
     )
 
     result = converter.run(sources=["sample.pdf"])
@@ -142,8 +119,9 @@ class PaddleOCRVLDocumentConverter:
     def __init__(
         self,
         *,
-        api_url: str,
-        access_token: Secret = Secret.from_env_var("AISTUDIO_ACCESS_TOKEN"),
+        base_url: str | None = None,
+        access_token: Secret = Secret.from_env_var("PADDLEOCR_ACCESS_TOKEN"),
+        model: Model | str = Model.PADDLE_OCR_VL_16,
         file_type: FileTypeInput = None,
         use_doc_orientation_classify: bool | None = False,
         use_doc_unwarping: bool | None = False,
@@ -151,10 +129,10 @@ class PaddleOCRVLDocumentConverter:
         use_chart_recognition: bool | None = None,
         use_seal_recognition: bool | None = None,
         use_ocr_for_image_block: bool | None = None,
-        layout_threshold: float | dict | None = None,
+        layout_threshold: float | dict[str, object] | None = None,
         layout_nms: bool | None = None,
-        layout_unclip_ratio: float | tuple[float, float] | dict | None = None,
-        layout_merge_bboxes_mode: str | dict | None = None,
+        layout_unclip_ratio: float | list[float] | dict[str, object] | None = None,
+        layout_merge_bboxes_mode: str | dict[str, object] | None = None,
         layout_shape_mode: str | None = None,
         prompt_label: str | None = None,
         format_block_content: bool | None = None,
@@ -178,25 +156,21 @@ class PaddleOCRVLDocumentConverter:
         """
         Create a `PaddleOCRVLDocumentConverter` component.
 
-        :param api_url:
-            API URL. To obtain the API URL, visit the [PaddleOCR official
-            website](https://aistudio.baidu.com/paddleocr), click the
-            **API** button, choose the example code for PaddleOCR-VL, and copy
-            the `API_URL`.
+        :param base_url:
+            Base URL for the PaddleOCR API. Falls back to the `PADDLEOCR_BASE_URL`
+            environment variable, then the SDK default.
         :param access_token:
-            AI Studio access token. You can obtain it from [this
-            page](https://aistudio.baidu.com/account/accessToken).
+            PaddleOCR access token. You can obtain it from the AI Studio account page.
+            Falls back to the `PADDLEOCR_ACCESS_TOKEN` environment variable.
+        :param model:
+            Document parsing model to use. Defaults to `Model.PADDLE_OCR_VL_16`.
         :param file_type:
-            File type. Can be "pdf" for PDF files, "image" for
-            image files, or `None` for auto-detection. If not specified, the
-            file type will be inferred from the file extension.
+            File type. Can be "pdf" for PDF files, "image" for image files, or
+            `None` for auto-detection from the file extension or MIME type.
         :param use_doc_orientation_classify:
-            Whether to enable the document orientation classification
-            function. Enabling this feature allows the input image to be
-            automatically rotated to the correct orientation.
+            Whether to enable the document orientation classification function.
         :param use_doc_unwarping:
-            Whether to enable the text image unwarping function. Enabling
-            this feature allows automatic correction of distorted text images.
+            Whether to enable the text image unwarping function.
         :param use_layout_detection:
             Whether to enable the layout detection function.
         :param use_chart_recognition:
@@ -206,21 +180,17 @@ class PaddleOCRVLDocumentConverter:
         :param use_ocr_for_image_block:
             Whether to recognize text in image blocks.
         :param layout_threshold:
-            Layout detection threshold. Can be a float or a dict with
-            page-specific thresholds.
+            Layout detection threshold.
         :param layout_nms:
-            Whether to perform NMS (Non-Maximum Suppression) on layout
-            detection results.
+            Whether to perform NMS on layout detection results.
         :param layout_unclip_ratio:
-            Layout unclip ratio. Can be a float, a tuple of (min, max), or a
-            dict with page-specific values.
+            Layout unclip ratio.
         :param layout_merge_bboxes_mode:
-            Layout merge bounding boxes mode. Can be a string or a dict.
+            Layout merge bounding boxes mode.
         :param layout_shape_mode:
             Layout shape mode.
         :param prompt_label:
-            Prompt type for the VLM. Possible values are "ocr", "formula",
-            "table", "chart", "seal", and "spotting".
+            Prompt type for the VLM.
         :param format_block_content:
             Whether to format block content.
         :param repetition_penalty:
@@ -236,16 +206,15 @@ class PaddleOCRVLDocumentConverter:
         :param max_new_tokens:
             Maximum number of tokens generated by the VLM.
         :param merge_layout_blocks:
-            Whether to merge the layout detection boxes for cross-column or
-            staggered top and bottom columns.
+            Whether to merge layout detection boxes for cross-column content.
         :param markdown_ignore_labels:
-            Layout labels that need to be ignored in Markdown.
+            Layout labels to ignore in Markdown.
         :param vlm_extra_args:
             Additional configuration parameters for the VLM.
         :param prettify_markdown:
             Whether to prettify the output Markdown text.
         :param show_formula_number:
-            Whether to include formula numbers in the output markdown text.
+            Whether to include formula numbers in the output markdown.
         :param restructure_pages:
             Whether to restructure results across multiple pages.
         :param merge_tables:
@@ -255,10 +224,11 @@ class PaddleOCRVLDocumentConverter:
         :param visualize:
             Whether to return visualization results.
         :param additional_params:
-            Additional parameters for calling the PaddleOCR API.
+            Additional parameters passed as `extra_options` to `PaddleOCRVLOptions`.
         """
-        self.api_url = api_url
+        self.base_url = base_url
         self.access_token = access_token
+        self.model = model
         self.file_type = _normalize_file_type(file_type)
         self.use_doc_orientation_classify = use_doc_orientation_classify
         self.use_doc_unwarping = use_doc_unwarping
@@ -299,8 +269,9 @@ class PaddleOCRVLDocumentConverter:
         """
         return default_to_dict(
             self,
-            api_url=self.api_url,
+            base_url=self.base_url,
             access_token=self.access_token.to_dict(),
+            model=self.model if isinstance(self.model, str) else self.model.value,
             file_type=self.file_type,
             use_doc_orientation_classify=self.use_doc_orientation_classify,
             use_doc_unwarping=self.use_doc_unwarping,
@@ -346,146 +317,80 @@ class PaddleOCRVLDocumentConverter:
         deserialize_secrets_inplace(data["init_parameters"], keys=["access_token"])
         return default_from_dict(cls, data)
 
-    def _parse(self, data: bytes, file_type: FileType) -> tuple[str, dict[str, Any]]:
-        """
-        Parse document using PaddleOCR API.
+    def _build_options(self) -> PaddleOCRVLOptions:
+        return PaddleOCRVLOptions(
+            use_doc_orientation_classify=self.use_doc_orientation_classify,
+            use_doc_unwarping=self.use_doc_unwarping,
+            use_layout_detection=self.use_layout_detection,
+            use_chart_recognition=self.use_chart_recognition,
+            use_seal_recognition=self.use_seal_recognition,
+            use_ocr_for_image_block=self.use_ocr_for_image_block,
+            layout_threshold=self.layout_threshold,
+            layout_nms=self.layout_nms,
+            layout_unclip_ratio=self.layout_unclip_ratio,
+            layout_merge_bboxes_mode=self.layout_merge_bboxes_mode,
+            layout_shape_mode=self.layout_shape_mode,
+            prompt_label=self.prompt_label,
+            format_block_content=self.format_block_content,
+            repetition_penalty=self.repetition_penalty,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            min_pixels=self.min_pixels,
+            max_pixels=self.max_pixels,
+            max_new_tokens=self.max_new_tokens,
+            merge_layout_blocks=self.merge_layout_blocks,
+            markdown_ignore_labels=self.markdown_ignore_labels,
+            vlm_extra_args=self.vlm_extra_args,
+            prettify_markdown=self.prettify_markdown,
+            show_formula_number=self.show_formula_number,
+            restructure_pages=self.restructure_pages,
+            merge_tables=self.merge_tables,
+            relevel_titles=self.relevel_titles,
+            visualize=self.visualize,
+            extra_options=self.additional_params,
+        )
 
-        :param data:
-            Raw file data as bytes.
-        :param file_type:
-            File type (0 for PDF, 1 for image).
-        :returns:
-            A tuple containing the extracted text (separated by form feed
-            characters for multiple pages) and the raw response dictionary.
-        :raises requests.RequestException:
-            If the API request fails.
-        :raises ValueError:
-            If the API response is invalid or missing required fields.
-        """
-        # Encode file data to base64
-        encoded_data = base64.b64encode(data).decode("ascii")
-
-        # Build request payload
-        request_data = {
-            "file": encoded_data,
-            "fileType": file_type,
-        }
-
-        # Add optional parameters if they are set
-        if self.use_doc_orientation_classify is not None:
-            request_data["useDocOrientationClassify"] = self.use_doc_orientation_classify
-        if self.use_doc_unwarping is not None:
-            request_data["useDocUnwarping"] = self.use_doc_unwarping
-        if self.use_layout_detection is not None:
-            request_data["useLayoutDetection"] = self.use_layout_detection
-        if self.use_chart_recognition is not None:
-            request_data["useChartRecognition"] = self.use_chart_recognition
-        if self.use_seal_recognition is not None:
-            request_data["useSealRecognition"] = self.use_seal_recognition
-        if self.use_ocr_for_image_block is not None:
-            request_data["useOcrForImageBlock"] = self.use_ocr_for_image_block
-        if self.layout_threshold is not None:
-            request_data["layoutThreshold"] = self.layout_threshold
-        if self.layout_nms is not None:
-            request_data["layoutNms"] = self.layout_nms
-        if self.layout_unclip_ratio is not None:
-            request_data["layoutUnclipRatio"] = self.layout_unclip_ratio
-        if self.layout_merge_bboxes_mode is not None:
-            request_data["layoutMergeBboxesMode"] = self.layout_merge_bboxes_mode
-        if self.layout_shape_mode is not None:
-            request_data["layoutShapeMode"] = self.layout_shape_mode
-        if self.prompt_label is not None:
-            request_data["promptLabel"] = self.prompt_label
-        if self.format_block_content is not None:
-            request_data["formatBlockContent"] = self.format_block_content
-        if self.repetition_penalty is not None:
-            request_data["repetitionPenalty"] = self.repetition_penalty
-        if self.temperature is not None:
-            request_data["temperature"] = self.temperature
-        if self.top_p is not None:
-            request_data["topP"] = self.top_p
-        if self.min_pixels is not None:
-            request_data["minPixels"] = self.min_pixels
-        if self.max_pixels is not None:
-            request_data["maxPixels"] = self.max_pixels
-        if self.max_new_tokens is not None:
-            request_data["maxNewTokens"] = self.max_new_tokens
-        if self.merge_layout_blocks is not None:
-            request_data["mergeLayoutBlocks"] = self.merge_layout_blocks
-        if self.markdown_ignore_labels is not None:
-            request_data["markdownIgnoreLabels"] = self.markdown_ignore_labels
-        if self.vlm_extra_args is not None:
-            request_data["vlmExtraArgs"] = self.vlm_extra_args
-        if self.prettify_markdown is not None:
-            request_data["prettifyMarkdown"] = self.prettify_markdown
-        if self.show_formula_number is not None:
-            request_data["showFormulaNumber"] = self.show_formula_number
-        if self.restructure_pages is not None:
-            request_data["restructurePages"] = self.restructure_pages
-        if self.merge_tables is not None:
-            request_data["mergeTables"] = self.merge_tables
-        if self.relevel_titles is not None:
-            request_data["relevelTitles"] = self.relevel_titles
-        if self.visualize is not None:
-            request_data["visualize"] = self.visualize
-        if self.additional_params is not None:
-            request_data.update(self.additional_params)
-
-        # Validate input parameters
+    async def _parse_one(
+        self,
+        data: bytes,
+        file_type: int,
+        client: AsyncPaddleOCRClient,
+    ) -> tuple[str, dict[str, Any]]:
+        extension = _EXTENSION_FOR_FILE_TYPE[file_type]
+        tmp_path: str | None = None
         try:
-            request = PaddleOCRVLInferRequest(**request_data)
-            request_dict = request.model_dump(exclude_none=True)
-        except Exception as e:
-            msg = f"Invalid request parameters: {e}"
-            raise ValueError(msg) from e
-
-        # Prepare headers with authentication
-        access_token_value = self.access_token.resolve_value() if self.access_token else None
-        headers = {"Content-Type": "application/json", "Client-Platform": "haystack"}
-        if access_token_value:
-            headers["Authorization"] = f"token {access_token_value}"
-
-        # Make API request
-        try:
-            response = requests.post(
-                self.api_url,
-                json=request_dict,
-                headers=headers,
-                timeout=300,
+            with tempfile.NamedTemporaryFile(suffix=extension, delete=False) as tmp:
+                tmp_path = tmp.name
+                _ = tmp.write(data)
+            result = await client.parse_document(
+                model=self.model,
+                file_path=tmp_path,
+                options=self._build_options(),
             )
-            response.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(f"Failed to call PaddleOCR API: {e}")
-            raise
+        finally:
+            if tmp_path is not None:
+                Path(tmp_path).unlink(missing_ok=True)
 
-        # Parse and validate response
-        try:
-            response_data = response.json()
-        except ValueError as e:
-            msg = f"Invalid JSON response from API: {e}"
-            raise ValueError(msg) from e
+        text = "\f".join(page.markdown_text for page in result.pages)
+        raw = {
+            "job_id": result.job_id,
+            "pages": [page.raw for page in result.pages],
+            "data_info": result.data_info,
+        }
+        return text, raw
 
-        if "result" not in response_data:
-            msg = "Response missing 'result' field"
-            raise ValueError(msg)
-
-        try:
-            result = PaddleOCRVLInferResult(**response_data["result"])
-        except Exception as e:
-            msg = f"Invalid response format: {e}"
-            raise ValueError(msg) from e
-
-        # Extract text from markdown in layout parsing results
-        # Pages are separated by form feed character (\f) for compatibility
-        # with Haystack's `DocumentSplitter`
-        text_parts = []
-        for layout_result in result.layoutParsingResults:
-            if layout_result.markdown and layout_result.markdown.text:
-                text_parts.append(layout_result.markdown.text)
-
-        text = "\f".join(text_parts) if text_parts else ""
-
-        return text, response_data
+    async def _parse_all(
+        self,
+        items: list[tuple[bytes, int]],
+        token: str | None,
+    ) -> list[tuple[str, dict[str, Any]] | BaseException]:
+        async with AsyncPaddleOCRClient(
+            token=token,
+            base_url=self.base_url,
+            client_platform="haystack",
+        ) as client:
+            tasks = [self._parse_one(data, ft, client) for data, ft in items]
+            return await asyncio.gather(*tasks, return_exceptions=True)
 
     @component.output_types(documents=list[Document], raw_paddleocr_responses=list[dict[str, Any]])
     def run(
@@ -499,65 +404,70 @@ class PaddleOCRVLDocumentConverter:
         :param sources:
             List of image or PDF file paths or ByteStream objects.
         :param meta:
-            Optional metadata to attach to the Documents.
-            This value can be either a list of dictionaries or a single
-            dictionary. If it's a single dictionary, its content is added to
-            the metadata of all produced Documents. If it's a list, the length
-            of the list must match the number of sources, because the two
-            lists will be zipped. If `sources` contains ByteStream objects,
-            their `meta` will be added to the output Documents.
+            Optional metadata to attach to the Documents. A single dict is applied
+            to all documents; a list must match the number of sources.
 
         :returns:
-            A dictionary with the following keys:
-            - `documents`: A list of created Documents.
-            - `raw_paddleocr_responses`: A list of raw PaddleOCR API responses.
+            A dictionary with:
+            - `documents`: List of created Documents.
+            - `raw_paddleocr_responses`: List of raw PaddleOCR API responses.
         """
         documents = []
         raw_responses = []
 
         meta_list = normalize_metadata(meta, sources_count=len(sources))
 
+        # Resolve token once — AsyncPaddleOCRClient raises AuthError if empty
+        token = self.access_token.resolve_value() if self.access_token else None
+
+        valid_items: list[tuple[bytes, int, dict[str, Any]]] = []
         for source, metadata in zip(sources, meta_list, strict=True):
             try:
                 bytestream = get_bytestream_from_source(source)
             except Exception as e:
-                logger.warning(
-                    f"Could not read {source}. Skipping it. Error: {e}",
-                )
+                logger.warning(f"Could not read {source}. Skipping it. Error: {e}")
                 continue
 
-            # Determine file type (either from config or inferred from extension)
             if self.file_type is not None:
                 file_type = self.file_type
             else:
                 mime_type = bytestream.mime_type if hasattr(bytestream, "mime_type") and bytestream.mime_type else None
                 file_type = _infer_file_type_from_source(source, mime_type)
+
             if file_type is None:
-                logger.warning(
-                    f"Could not determine file type for {source}. Skipping it.",
-                )
+                logger.warning(f"Could not determine file type for {source}. Skipping it.")
                 continue
-
-            try:
-                text, raw_resp = self._parse(bytestream.data, file_type)
-            except Exception as e:
-                logger.warning(
-                    f"Could not read {source} and convert it to Document, skipping. Error: {e}",
-                )
-                continue
-
-            if not text:
-                msg = (
-                    f"{self.__class__.__name__} could not extract text"
-                    " from the file {source}. Returning an empty document."
-                )
-                logger.warning(msg)
 
             merged_metadata = {**bytestream.meta, **metadata}
+            valid_items.append((bytestream.data, file_type, merged_metadata))
 
-            document = Document(content=text, meta=merged_metadata)
-            documents.append(document)
+        if not valid_items:
+            return {"documents": [], "raw_paddleocr_responses": []}
 
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        coro = self._parse_all([(data, ft) for data, ft, _ in valid_items], token=token)
+        if loop is not None and loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                results = pool.submit(asyncio.run, coro).result()
+        else:
+            results = asyncio.run(coro)
+
+        for (_, _, merged_metadata), result in zip(valid_items, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(f"Could not convert a source to Document, skipping. Error: {result}")
+                continue
+            text, raw_resp = result
+            if not text:
+                logger.warning(
+                    f"{self.__class__.__name__} could not extract text from a file. Returning an empty document."
+                )
+            documents.append(Document(content=text, meta=merged_metadata))
             raw_responses.append(raw_resp)
 
         return {"documents": documents, "raw_paddleocr_responses": raw_responses}

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -13,7 +13,7 @@ from haystack.components.converters.utils import (
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret, deserialize_secrets_inplace
 
-from paddleocr import Model, PaddleOCRClient, PaddleOCRVLOptions
+from paddleocr import Model, PaddleOCRClient, PaddleOCRVLOptions  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import asyncio
-import concurrent.futures
 import tempfile
 from pathlib import Path
 from typing import Any, Literal
@@ -15,16 +13,14 @@ from haystack.components.converters.utils import (
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret, deserialize_secrets_inplace
 
-from paddleocr import AsyncPaddleOCRClient, Model, PaddleOCRVLOptions  # type: ignore[import-untyped]
+from paddleocr import Model, PaddleOCRClient, PaddleOCRVLOptions
 
 logger = logging.getLogger(__name__)
-
 
 FileTypeInput = Literal["pdf", "image"] | None
 
 _IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".webp"}
 _PDF_EXTENSIONS = {".pdf"}
-_FILE_TYPE_TO_STR = {0: "pdf", 1: "image"}
 _EXTENSION_FOR_FILE_TYPE = {0: ".pdf", 1: ".jpg"}
 
 
@@ -68,13 +64,13 @@ def _infer_file_type_from_source(
 
 def _normalize_file_type(file_type: FileTypeInput) -> int | None:
     """
-    Normalize file type input to the numeric format expected by the SDK.
+    Normalize file type input to the numeric format used internally.
 
     :param file_type:
-        File type input. Can be "pdf", "image", or None for auto-detection.
-        Integers 0 (PDF) and 1 (image) are also accepted for deserialization.
+        "pdf", "image", or None for auto-detection.
+        Integers 0 and 1 are also accepted for deserialization round-trips.
     :returns:
-        Normalized file type: 0 for PDF, 1 for image, or None for auto-detection.
+        0 for PDF, 1 for image, or None for auto-detection.
     """
     if file_type is None:
         return None
@@ -92,27 +88,21 @@ def _normalize_file_type(file_type: FileTypeInput) -> int | None:
 @component
 class PaddleOCRVLDocumentConverter:
     """
-    Extracts text from documents using PaddleOCR's large model document parsing API.
+    Extracts text from documents using PaddleOCR's official document parsing API.
 
-    PaddleOCR-VL is used behind the scenes. For more information, please
-    refer to:
+    Uses `PaddleOCRClient` to parse documents via the PaddleOCR serving API.
+    For more information, please refer to:
     https://www.paddleocr.ai/latest/en/version3.x/algorithm/PaddleOCR-VL/PaddleOCR-VL.html
 
     **Usage Example:**
 
     ```python
-    from haystack.utils import Secret
-    from haystack_integrations.components.converters.paddleocr import (
-        PaddleOCRVLDocumentConverter,
-    )
+    from haystack_integrations.components.converters.paddleocr import PaddleOCRVLDocumentConverter
 
     converter = PaddleOCRVLDocumentConverter(
         base_url="http://xxxxx.aistudio-app.com",
-        access_token=Secret.from_env_var("PADDLEOCR_ACCESS_TOKEN"),
     )
-
     result = converter.run(sources=["sample.pdf"])
-
     documents = result["documents"]
     raw_responses = result["raw_paddleocr_responses"]
     ```
@@ -125,16 +115,16 @@ class PaddleOCRVLDocumentConverter:
         access_token: Secret = Secret.from_env_var("PADDLEOCR_ACCESS_TOKEN"),
         model: Model | str = Model.PADDLE_OCR_VL_16,
         file_type: FileTypeInput = None,
-        use_doc_orientation_classify: bool | None = False,
-        use_doc_unwarping: bool | None = False,
+        use_doc_orientation_classify: bool | None = None,
+        use_doc_unwarping: bool | None = None,
         use_layout_detection: bool | None = None,
         use_chart_recognition: bool | None = None,
         use_seal_recognition: bool | None = None,
         use_ocr_for_image_block: bool | None = None,
-        layout_threshold: float | dict[str, object] | None = None,
+        layout_threshold: float | dict | None = None,
         layout_nms: bool | None = None,
-        layout_unclip_ratio: float | list[float] | dict[str, object] | None = None,
-        layout_merge_bboxes_mode: str | dict[str, object] | None = None,
+        layout_unclip_ratio: float | list | dict | None = None,
+        layout_merge_bboxes_mode: str | dict | None = None,
         layout_shape_mode: str | None = None,
         prompt_label: str | None = None,
         format_block_content: bool | None = None,
@@ -159,32 +149,30 @@ class PaddleOCRVLDocumentConverter:
         Create a `PaddleOCRVLDocumentConverter` component.
 
         :param base_url:
-            Base URL for the PaddleOCR API. Falls back to the `PADDLEOCR_BASE_URL`
-            environment variable, then the SDK default.
+            Base URL for the PaddleOCR API. Falls back to `PADDLEOCR_BASE_URL`
+            env var, then the SDK default.
         :param access_token:
-            PaddleOCR access token. You can obtain it from the AI Studio account page.
-            Falls back to the `PADDLEOCR_ACCESS_TOKEN` environment variable.
+            PaddleOCR access token. Falls back to `PADDLEOCR_ACCESS_TOKEN` env var.
         :param model:
-            Document parsing model to use. Defaults to `Model.PADDLE_OCR_VL_16`.
+            Document parsing model. Defaults to `Model.PADDLE_OCR_VL_16`.
         :param file_type:
-            File type. Can be "pdf" for PDF files, "image" for image files, or
-            `None` for auto-detection from the file extension or MIME type.
+            "pdf", "image", or None for auto-detection.
         :param use_doc_orientation_classify:
-            Whether to enable the document orientation classification function.
+            Enable document orientation classification.
         :param use_doc_unwarping:
-            Whether to enable the text image unwarping function.
+            Enable text image unwarping.
         :param use_layout_detection:
-            Whether to enable the layout detection function.
+            Enable layout detection.
         :param use_chart_recognition:
-            Whether to enable the chart recognition function.
+            Enable chart recognition.
         :param use_seal_recognition:
-            Whether to enable the seal recognition function.
+            Enable seal recognition.
         :param use_ocr_for_image_block:
-            Whether to recognize text in image blocks.
+            Recognize text in image blocks.
         :param layout_threshold:
             Layout detection threshold.
         :param layout_nms:
-            Whether to perform NMS on layout detection results.
+            Perform NMS on layout detection results.
         :param layout_unclip_ratio:
             Layout unclip ratio.
         :param layout_merge_bboxes_mode:
@@ -192,41 +180,41 @@ class PaddleOCRVLDocumentConverter:
         :param layout_shape_mode:
             Layout shape mode.
         :param prompt_label:
-            Prompt type for the VLM.
+            Prompt type for the VLM ("ocr", "formula", "table", "chart", "seal", "spotting").
         :param format_block_content:
-            Whether to format block content.
+            Format block content.
         :param repetition_penalty:
-            Repetition penalty parameter used in VLM sampling.
+            Repetition penalty for VLM sampling.
         :param temperature:
-            Temperature parameter used in VLM sampling.
+            Temperature for VLM sampling.
         :param top_p:
-            Top-p parameter used in VLM sampling.
+            Top-p for VLM sampling.
         :param min_pixels:
-            Minimum number of pixels allowed during VLM preprocessing.
+            Minimum pixels for VLM preprocessing.
         :param max_pixels:
-            Maximum number of pixels allowed during VLM preprocessing.
+            Maximum pixels for VLM preprocessing.
         :param max_new_tokens:
-            Maximum number of tokens generated by the VLM.
+            Maximum tokens generated by the VLM.
         :param merge_layout_blocks:
-            Whether to merge layout detection boxes for cross-column content.
+            Merge layout detection boxes for cross-column content.
         :param markdown_ignore_labels:
-            Layout labels to ignore in Markdown.
+            Layout labels to ignore in Markdown output.
         :param vlm_extra_args:
-            Additional configuration parameters for the VLM.
+            Extra configuration for the VLM.
         :param prettify_markdown:
-            Whether to prettify the output Markdown text.
+            Prettify output Markdown.
         :param show_formula_number:
-            Whether to include formula numbers in the output markdown.
+            Include formula numbers in Markdown output.
         :param restructure_pages:
-            Whether to restructure results across multiple pages.
+            Restructure results across multiple pages.
         :param merge_tables:
-            Whether to merge tables across pages.
+            Merge tables across pages.
         :param relevel_titles:
-            Whether to relevel titles.
+            Relevel titles.
         :param visualize:
-            Whether to return visualization results.
+            Return visualization results.
         :param additional_params:
-            Additional parameters passed as `extra_options` to `PaddleOCRVLOptions`.
+            Extra options passed to `PaddleOCRVLOptions.extra_options`.
         """
         self.base_url = base_url
         self.access_token = access_token
@@ -352,18 +340,13 @@ class PaddleOCRVLDocumentConverter:
             extra_options=self.additional_params,
         )
 
-    async def _parse_one(
-        self,
-        data: bytes,
-        file_type: int,
-        client: AsyncPaddleOCRClient,
-    ) -> tuple[str, dict[str, Any]]:
+    def _parse(self, data: bytes, file_type: int, client: PaddleOCRClient) -> tuple[str, dict[str, Any]]:
         extension = _EXTENSION_FOR_FILE_TYPE[file_type]
         with tempfile.NamedTemporaryFile(suffix=extension, delete=False) as tmp:
             tmp_path = tmp.name
-            _ = tmp.write(data)
+            tmp.write(data)
         try:
-            result = await client.parse_document(
+            result = client.parse_document(
                 model=self.model,
                 file_path=tmp_path,
                 options=self._build_options(),
@@ -372,25 +355,12 @@ class PaddleOCRVLDocumentConverter:
             Path(tmp_path).unlink(missing_ok=True)
 
         text = "\f".join(page.markdown_text for page in result.pages)
-        raw = {
+        raw: dict[str, Any] = {
             "job_id": result.job_id,
             "pages": [page.raw for page in result.pages],
             "data_info": result.data_info,
         }
         return text, raw
-
-    async def _parse_all(
-        self,
-        items: list[tuple[bytes, int]],
-        token: str | None,
-    ) -> list[tuple[str, dict[str, Any]] | BaseException]:
-        async with AsyncPaddleOCRClient(
-            token=token,
-            base_url=self.base_url,
-            client_platform="haystack",
-        ) as client:
-            tasks = [self._parse_one(data, ft, client) for data, ft in items]
-            return await asyncio.gather(*tasks, return_exceptions=True)
 
     @component.output_types(documents=list[Document], raw_paddleocr_responses=list[dict[str, Any]])
     def run(
@@ -406,66 +376,52 @@ class PaddleOCRVLDocumentConverter:
         :param meta:
             Optional metadata to attach to the Documents. A single dict is applied
             to all documents; a list must match the number of sources.
-
         :returns:
             A dictionary with:
             - `documents`: List of created Documents.
             - `raw_paddleocr_responses`: List of raw PaddleOCR API responses.
         """
-        documents = []
-        raw_responses = []
+        documents: list[Document] = []
+        raw_responses: list[dict[str, Any]] = []
 
         meta_list = normalize_metadata(meta, sources_count=len(sources))
-
-        # Resolve token once — AsyncPaddleOCRClient raises AuthError if empty
         token = self.access_token.resolve_value() if self.access_token else None
 
-        valid_items: list[tuple[bytes, int, dict[str, Any]]] = []
-        for source, metadata in zip(sources, meta_list, strict=True):
-            try:
-                bytestream = get_bytestream_from_source(source)
-            except Exception as e:
-                logger.warning(f"Could not read {source}. Skipping it. Error: {e}")
-                continue
+        kwargs: dict[str, Any] = {"client_platform": "haystack", "token": token}
+        if self.base_url is not None:
+            kwargs["base_url"] = self.base_url
 
-            if self.file_type is not None:
-                file_type: int | None = self.file_type
-            else:
-                mime_type = bytestream.mime_type if hasattr(bytestream, "mime_type") and bytestream.mime_type else None
-                file_type = _infer_file_type_from_source(source, mime_type)
+        with PaddleOCRClient(**kwargs) as client:
+            for source, metadata in zip(sources, meta_list, strict=True):
+                try:
+                    bytestream = get_bytestream_from_source(source)
+                except Exception as e:
+                    logger.warning(f"Could not read {source}. Skipping it. Error: {e}")
+                    continue
 
-            if file_type is None:
-                logger.warning(f"Could not determine file type for {source}. Skipping it.")
-                continue
+                if self.file_type is not None:
+                    file_type: int | None = self.file_type
+                else:
+                    mime_type = bytestream.mime_type if bytestream.mime_type else None
+                    file_type = _infer_file_type_from_source(source, mime_type)
 
-            merged_metadata = {**bytestream.meta, **metadata}
-            valid_items.append((bytestream.data, file_type, merged_metadata))
+                if file_type is None:
+                    logger.warning(f"Could not determine file type for {source}. Skipping it.")
+                    continue
 
-        if not valid_items:
-            return {"documents": [], "raw_paddleocr_responses": []}
+                try:
+                    text, raw_resp = self._parse(bytestream.data, file_type, client)
+                except Exception as e:
+                    logger.warning(f"Could not convert {source} to Document, skipping. Error: {e}")
+                    continue
 
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
+                if not text:
+                    logger.warning(
+                        f"{self.__class__.__name__} could not extract text from {source}. Returning an empty document."
+                    )
 
-        coro = self._parse_all([(data, ft) for data, ft, _ in valid_items], token=token)
-        if loop is not None and loop.is_running():
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                results = pool.submit(asyncio.run, coro).result()
-        else:
-            results = asyncio.run(coro)
-
-        for (_, _, merged_metadata), result in zip(valid_items, results, strict=True):
-            if isinstance(result, BaseException):
-                logger.warning(f"Could not convert a source to Document, skipping. Error: {result}")
-                continue
-            text, raw_resp = result
-            if not text:
-                logger.warning(
-                    f"{self.__class__.__name__} could not extract text from a file. Returning an empty document."
-                )
-            documents.append(Document(content=text, meta=merged_metadata))
-            raw_responses.append(raw_resp)
+                merged_metadata = {**bytestream.meta, **metadata}
+                documents.append(Document(content=text, meta=merged_metadata))
+                raw_responses.append(raw_resp)
 
         return {"documents": documents, "raw_paddleocr_responses": raw_responses}

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -359,19 +359,17 @@ class PaddleOCRVLDocumentConverter:
         client: AsyncPaddleOCRClient,
     ) -> tuple[str, dict[str, Any]]:
         extension = _EXTENSION_FOR_FILE_TYPE[file_type]
-        tmp_path: str | None = None
+        with tempfile.NamedTemporaryFile(suffix=extension, delete=False) as tmp:
+            tmp_path = tmp.name
+            _ = tmp.write(data)
         try:
-            with tempfile.NamedTemporaryFile(suffix=extension, delete=False) as tmp:
-                tmp_path = tmp.name
-                _ = tmp.write(data)
             result = await client.parse_document(
                 model=self.model,
                 file_path=tmp_path,
                 options=self._build_options(),
             )
         finally:
-            if tmp_path is not None:
-                Path(tmp_path).unlink(missing_ok=True)
+            Path(tmp_path).unlink(missing_ok=True)
 
         text = "\f".join(page.markdown_text for page in result.pages)
         raw = {

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -14,6 +14,7 @@ from haystack.components.converters.utils import (
 )
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret, deserialize_secrets_inplace
+
 from paddleocr import AsyncPaddleOCRClient, Model, PaddleOCRVLOptions  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
@@ -430,7 +431,7 @@ class PaddleOCRVLDocumentConverter:
                 continue
 
             if self.file_type is not None:
-                file_type = self.file_type
+                file_type: int | None = self.file_type
             else:
                 mime_type = bytestream.mime_type if hasattr(bytestream, "mime_type") and bytestream.mime_type else None
                 file_type = _infer_file_type_from_source(source, mime_type)

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -427,7 +427,7 @@ class PaddleOCRVLDocumentConverter:
 
                 if not text:
                     logger.warning(
-                        f"{cls} could not extract text from {source}. Returning an empty document.",
+                        "{cls} could not extract text from {source}. Returning an empty document.",
                         cls=self.__class__.__name__,
                         source=source,
                     )

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -346,8 +346,10 @@ class PaddleOCRVLDocumentConverter:
             extra_options=self.additional_params,
         )
 
-    def _parse(self, data: bytes, file_type: int, client: PaddleOCRClient) -> tuple[str, dict[str, Any]]:
-        extension = _EXTENSION_FOR_FILE_TYPE[file_type]
+    def _parse(
+        self, data: bytes, file_type: int, client: PaddleOCRClient, source_extension: str | None = None
+    ) -> tuple[str, dict[str, Any]]:
+        extension = source_extension if source_extension else _EXTENSION_FOR_FILE_TYPE[file_type]
         with tempfile.NamedTemporaryFile(suffix=extension, delete=False) as tmp:
             tmp_path = tmp.name
             tmp.write(data)
@@ -415,8 +417,15 @@ class PaddleOCRVLDocumentConverter:
                     logger.warning("Could not determine file type for {source}. Skipping it.", source=source)
                     continue
 
+                source_ext: str | None = None
+                if self.file_type is None:
+                    if isinstance(source, (str, Path)):
+                        source_ext = Path(source).suffix.lower() or None
+                    elif isinstance(source, ByteStream) and source.meta.get("file_path"):
+                        source_ext = Path(str(source.meta["file_path"])).suffix.lower() or None
+
                 try:
-                    text, raw_resp = self._parse(bytestream.data, file_type, client)
+                    text, raw_resp = self._parse(bytestream.data, file_type, client, source_extension=source_ext)
                 except Exception as e:
                     logger.warning(
                         "Could not convert {source} to Document, skipping. Error: {error}",

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
+import concurrent.futures
 import tempfile
 from pathlib import Path
 from typing import Any, Literal
@@ -451,8 +452,6 @@ class PaddleOCRVLDocumentConverter:
 
         coro = self._parse_all([(data, ft) for data, ft, _ in valid_items], token=token)
         if loop is not None and loop.is_running():
-            import concurrent.futures
-
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 results = pool.submit(asyncio.run, coro).result()
         else:

--- a/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/src/haystack_integrations/components/converters/paddleocr/paddleocr_vl_document_converter.py
@@ -418,7 +418,11 @@ class PaddleOCRVLDocumentConverter:
                 try:
                     text, raw_resp = self._parse(bytestream.data, file_type, client)
                 except Exception as e:
-                    logger.warning("Could not convert {source} to Document, skipping. Error: {error}", source=source, error=e)
+                    logger.warning(
+                        "Could not convert {source} to Document, skipping. Error: {error}",
+                        source=source,
+                        error=e,
+                    )
                     continue
 
                 if not text:

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -393,7 +393,7 @@ class TestRun:
 
         converter.run(sources=[str(f)])
 
-        assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".jpg")
+        assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".png")
 
     def test_file_type_manual_override(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"), file_type="pdf")

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -2,11 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
-import pypdfium2 as pdfium
 import pytest
-import requests
 from haystack import Document
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret
@@ -20,652 +19,87 @@ from haystack_integrations.components.converters.paddleocr.paddleocr_vl_document
 )
 
 
-def create_empty_pdf(tmp_path, filename="test.pdf"):
-    """Create an empty PDF file using pypdfium2."""
-    pdf = pdfium.PdfDocument.new()
-    pdf.new_page(595, 842)  # A4 size in points
-    pdf.save(tmp_path / filename)
-    return tmp_path / filename
-
-
-def create_empty_image(tmp_path, filename="test.png"):
-    """Create an empty image file using PIL."""
+def create_empty_image(tmp_path: Path, filename: str = "test.png") -> Path:
     img = Image.new("RGB", (800, 600), color="white")
     img.save(tmp_path / filename)
     return tmp_path / filename
 
 
-class TestPaddleOCRVLDocumentConverter:
-    CLASS_TYPE = "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.PaddleOCRVLDocumentConverter"  # noqa: E501
+def make_parse_result(pages_text: list[str]) -> MagicMock:
+    """Build a mock DocParsingResult with given per-page markdown texts."""
+    pages = []
+    for text in pages_text:
+        page = MagicMock()
+        page.markdown_text = text
+        page.raw = {"markdown": {"text": text}}
+        pages.append(page)
+    result = MagicMock()
+    result.job_id = "job-123"
+    result.pages = pages
+    result.data_info = {}
+    return result
 
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("AISTUDIO_ACCESS_TOKEN", "test-access-token")
-        converter = PaddleOCRVLDocumentConverter(api_url="http://test-api-url.com")
 
-        assert converter.access_token == Secret.from_env_var("AISTUDIO_ACCESS_TOKEN")
-        assert converter.api_url == "http://test-api-url.com"
+CLASS_TYPE = "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.PaddleOCRVLDocumentConverter"
+
+
+@pytest.fixture
+def mock_client_ctx(monkeypatch: pytest.MonkeyPatch):
+    """Patch AsyncPaddleOCRClient so parse_document can be controlled per-test."""
+    client_instance = MagicMock()
+    client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+    client_instance.__aexit__ = AsyncMock(return_value=False)
+    client_instance.parse_document = AsyncMock(
+        return_value=make_parse_result(["# Sample Document\n\nThis is page 1."])
+    )
+    with patch(
+        "haystack_integrations.components.converters.paddleocr."
+        "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
+        return_value=client_instance,
+    ):
+        yield client_instance
+
+
+class TestInit:
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
+        from paddleocr import Model
+
+        converter = PaddleOCRVLDocumentConverter()
+
+        assert converter.base_url is None
+        assert converter.model == Model.PADDLE_OCR_VL_16
         assert converter.file_type is None
         assert converter.use_doc_orientation_classify is False
         assert converter.use_doc_unwarping is False
         assert converter.use_layout_detection is None
-        assert converter.use_chart_recognition is None
         assert converter.layout_threshold is None
-        assert converter.layout_nms is None
-        assert converter.layout_unclip_ratio is None
-        assert converter.layout_merge_bboxes_mode is None
-        assert converter.prompt_label is None
-        assert converter.format_block_content is None
-        assert converter.repetition_penalty is None
-        assert converter.temperature is None
-        assert converter.top_p is None
-        assert converter.min_pixels is None
-        assert converter.max_pixels is None
-        assert converter.prettify_markdown is None
-        assert converter.show_formula_number is None
-        assert converter.visualize is None
         assert converter.additional_params is None
 
-    def test_init_with_all_optional_parameters(self):
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://custom-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
-            file_type="pdf",
-            use_doc_orientation_classify=True,
-            use_doc_unwarping=True,
-            use_layout_detection=True,
-            use_chart_recognition=True,
-            layout_threshold=0.5,
-            layout_nms=True,
-            layout_unclip_ratio=1.5,
-            layout_merge_bboxes_mode="merge",
-            prompt_label="ocr",
-            format_block_content=True,
-            repetition_penalty=1.1,
-            temperature=0.7,
-            top_p=0.9,
-            min_pixels=100,
-            max_pixels=1000,
-            prettify_markdown=False,
-            show_formula_number=True,
-            visualize=True,
-            additional_params={},
-        )
+    def test_custom_model_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
+        converter = PaddleOCRVLDocumentConverter(model="PaddleOCR-VL-1.5")
+        assert converter.model == "PaddleOCR-VL-1.5"
 
-        assert converter.api_url == "http://custom-api-url.com"
-        assert converter.access_token == Secret.from_token("test-access-token")
-        assert converter.file_type == 0  # "pdf" normalized to 0
-        assert converter.use_doc_orientation_classify is True
-        assert converter.use_doc_unwarping is True
-        assert converter.use_layout_detection is True
-        assert converter.use_chart_recognition is True
-        assert converter.layout_threshold == 0.5
-        assert converter.layout_nms is True
-        assert converter.layout_unclip_ratio == 1.5
-        assert converter.layout_merge_bboxes_mode == "merge"
-        assert converter.prompt_label == "ocr"
-        assert converter.format_block_content is True
-        assert converter.repetition_penalty == 1.1
-        assert converter.temperature == 0.7
-        assert converter.top_p == 0.9
-        assert converter.min_pixels == 100
-        assert converter.max_pixels == 1000
-        assert converter.prettify_markdown is False
-        assert converter.show_formula_number is True
-        assert converter.visualize is True
-        assert converter.additional_params == {}
-
-    @pytest.mark.parametrize(
-        "file_type, error_match",
-        [
-            ("invalid_string", "Invalid `file_type` string"),
-            (123, "Invalid `file_type` value"),
-        ],
-    )
-    def test_init_invalid_file_type_raises(self, file_type, error_match):
-        with pytest.raises(ValueError, match=error_match):
+    def test_invalid_file_type_string(self) -> None:
+        with pytest.raises(ValueError, match="Invalid `file_type` string"):
             PaddleOCRVLDocumentConverter(
-                api_url="http://test-api-url.com",
-                access_token=Secret.from_token("test-access-token"),
-                file_type=file_type,
+                access_token=Secret.from_token("t"),
+                file_type="invalid",  # type: ignore[arg-type]
             )
 
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("AISTUDIO_ACCESS_TOKEN", "test-access-token")
-        converter = PaddleOCRVLDocumentConverter(api_url="http://test-api-url.com")
-        converter_dict = converter.to_dict()
-
-        assert converter_dict == {
-            "type": self.CLASS_TYPE,
-            "init_parameters": {
-                "api_url": "http://test-api-url.com",
-                "access_token": {
-                    "env_vars": ["AISTUDIO_ACCESS_TOKEN"],
-                    "strict": True,
-                    "type": "env_var",
-                },
-                "file_type": None,
-                "use_doc_orientation_classify": False,
-                "use_doc_unwarping": False,
-                "use_layout_detection": None,
-                "use_chart_recognition": None,
-                "use_seal_recognition": None,
-                "use_ocr_for_image_block": None,
-                "layout_threshold": None,
-                "layout_nms": None,
-                "layout_unclip_ratio": None,
-                "layout_merge_bboxes_mode": None,
-                "layout_shape_mode": None,
-                "prompt_label": None,
-                "format_block_content": None,
-                "repetition_penalty": None,
-                "temperature": None,
-                "top_p": None,
-                "min_pixels": None,
-                "max_pixels": None,
-                "max_new_tokens": None,
-                "merge_layout_blocks": None,
-                "markdown_ignore_labels": None,
-                "vlm_extra_args": None,
-                "prettify_markdown": None,
-                "show_formula_number": None,
-                "restructure_pages": None,
-                "merge_tables": None,
-                "relevel_titles": None,
-                "visualize": None,
-                "additional_params": None,
-            },
-        }
-
-    def test_to_dict_with_custom_parameters(self, monkeypatch):
-        monkeypatch.setenv("CUSTOM_ACCESS_TOKEN", "test-access-token")
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://custom-api-url.com",
-            access_token=Secret.from_env_var("CUSTOM_ACCESS_TOKEN", strict=False),
-            file_type="image",
-            use_doc_orientation_classify=True,
-            use_doc_unwarping=False,
-            use_layout_detection=True,
-            use_chart_recognition=False,
-            use_seal_recognition=None,
-            use_ocr_for_image_block=None,
-            layout_threshold=0.7,
-            layout_nms=False,
-            layout_unclip_ratio=2.0,
-            layout_merge_bboxes_mode="separate",
-            layout_shape_mode=None,
-            prompt_label="formula",
-            format_block_content=False,
-            repetition_penalty=1.2,
-            temperature=0.8,
-            top_p=0.95,
-            min_pixels=200,
-            max_pixels=2000,
-            max_new_tokens=None,
-            merge_layout_blocks=None,
-            markdown_ignore_labels=None,
-            vlm_extra_args=None,
-            prettify_markdown=True,
-            show_formula_number=True,
-            restructure_pages=None,
-            merge_tables=None,
-            relevel_titles=None,
-            visualize=False,
-            additional_params={},
-        )
-        converter_dict = converter.to_dict()
-
-        assert converter_dict == {
-            "type": self.CLASS_TYPE,
-            "init_parameters": {
-                "api_url": "http://custom-api-url.com",
-                "access_token": {
-                    "type": "env_var",
-                    "env_vars": ["CUSTOM_ACCESS_TOKEN"],
-                    "strict": False,
-                },
-                "file_type": 1,  # "image" normalized to 1
-                "use_doc_orientation_classify": True,
-                "use_doc_unwarping": False,
-                "use_layout_detection": True,
-                "use_chart_recognition": False,
-                "use_seal_recognition": None,
-                "use_ocr_for_image_block": None,
-                "layout_threshold": 0.7,
-                "layout_nms": False,
-                "layout_unclip_ratio": 2.0,
-                "layout_merge_bboxes_mode": "separate",
-                "layout_shape_mode": None,
-                "prompt_label": "formula",
-                "format_block_content": False,
-                "repetition_penalty": 1.2,
-                "temperature": 0.8,
-                "top_p": 0.95,
-                "min_pixels": 200,
-                "max_pixels": 2000,
-                "max_new_tokens": None,
-                "merge_layout_blocks": None,
-                "markdown_ignore_labels": None,
-                "vlm_extra_args": None,
-                "prettify_markdown": True,
-                "show_formula_number": True,
-                "restructure_pages": None,
-                "merge_tables": None,
-                "relevel_titles": None,
-                "visualize": False,
-                "additional_params": {},
-            },
-        }
-
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("AISTUDIO_ACCESS_TOKEN", "test-access-token")
-        converter_dict = {
-            "type": self.CLASS_TYPE,
-            "init_parameters": {
-                "api_url": "http://test-api-url.com",
-                "access_token": {
-                    "env_vars": ["AISTUDIO_ACCESS_TOKEN"],
-                    "strict": True,
-                    "type": "env_var",
-                },
-                "file_type": None,
-                "use_doc_orientation_classify": None,
-                "use_doc_unwarping": None,
-                "use_layout_detection": None,
-                "use_chart_recognition": None,
-                "layout_threshold": None,
-                "layout_nms": None,
-                "layout_unclip_ratio": None,
-                "layout_merge_bboxes_mode": None,
-                "prompt_label": None,
-                "format_block_content": None,
-                "repetition_penalty": None,
-                "temperature": None,
-                "top_p": None,
-                "min_pixels": None,
-                "max_pixels": None,
-                "prettify_markdown": None,
-                "show_formula_number": None,
-                "visualize": None,
-                "additional_params": None,
-            },
-        }
-
-        converter = PaddleOCRVLDocumentConverter.from_dict(converter_dict)
-
-        assert converter.api_url == "http://test-api-url.com"
-        assert converter.file_type is None
-        assert converter.use_doc_orientation_classify is None
-        assert converter.use_doc_unwarping is None
-        assert converter.use_layout_detection is None
-        assert converter.use_chart_recognition is None
-        assert converter.layout_threshold is None
-        assert converter.layout_nms is None
-        assert converter.layout_unclip_ratio is None
-        assert converter.layout_merge_bboxes_mode is None
-        assert converter.prompt_label is None
-        assert converter.format_block_content is None
-        assert converter.repetition_penalty is None
-        assert converter.temperature is None
-        assert converter.top_p is None
-        assert converter.min_pixels is None
-        assert converter.max_pixels is None
-        assert converter.prettify_markdown is None
-        assert converter.show_formula_number is None
-        assert converter.visualize is None
-        assert converter.additional_params is None
-
-    def test_from_dict_with_custom_parameters(self, monkeypatch):
-        monkeypatch.setenv("AISTUDIO_ACCESS_TOKEN", "test-access-token")
-        converter_dict = {
-            "type": self.CLASS_TYPE,
-            "init_parameters": {
-                "api_url": "http://custom-api-url.com",
-                "access_token": {
-                    "env_vars": ["AISTUDIO_ACCESS_TOKEN"],
-                    "strict": True,
-                    "type": "env_var",
-                },
-                "file_type": "pdf",
-                "use_doc_orientation_classify": True,
-                "use_doc_unwarping": False,
-                "use_layout_detection": True,
-                "use_chart_recognition": False,
-                "layout_threshold": 0.6,
-                "layout_nms": True,
-                "layout_unclip_ratio": 1.8,
-                "layout_merge_bboxes_mode": "merge",
-                "prompt_label": "table",
-                "format_block_content": True,
-                "repetition_penalty": 1.1,
-                "temperature": 0.9,
-                "top_p": 0.8,
-                "min_pixels": 150,
-                "max_pixels": 1500,
-                "prettify_markdown": False,
-                "show_formula_number": True,
-                "visualize": True,
-                "additional_params": {},
-            },
-        }
-
-        converter = PaddleOCRVLDocumentConverter.from_dict(converter_dict)
-
-        assert converter.api_url == "http://custom-api-url.com"
-        assert converter.file_type == 0
-        assert converter.use_doc_orientation_classify is True
-        assert converter.use_doc_unwarping is False
-        assert converter.use_layout_detection is True
-        assert converter.use_chart_recognition is False
-        assert converter.layout_threshold == 0.6
-        assert converter.layout_nms is True
-        assert converter.layout_unclip_ratio == 1.8
-        assert converter.layout_merge_bboxes_mode == "merge"
-        assert converter.prompt_label == "table"
-        assert converter.format_block_content is True
-        assert converter.repetition_penalty == 1.1
-        assert converter.temperature == 0.9
-        assert converter.top_p == 0.8
-        assert converter.min_pixels == 150
-        assert converter.max_pixels == 1500
-        assert converter.prettify_markdown is False
-        assert converter.show_formula_number is True
-        assert converter.visualize is True
-        assert converter.additional_params == {}
-
-    @pytest.fixture
-    def mock_ocr_response(self):
-        """Create a mock PaddleOCR response"""
-        mock_response = {
-            "logId": "123",
-            "errorCode": "0",
-            "errorMsg": "Success",
-            "result": {
-                "layoutParsingResults": [
-                    {
-                        "markdown": {"text": "# Sample Document\n\nThis is page 1."},
-                        "prunedResult": {},
-                    }
-                ],
-                "dataInfo": {
-                    "width": 1024,
-                    "height": 1024,
-                    "type": "image",
-                },
-            },
-        }
-        return mock_response
-
-    @pytest.fixture
-    def mock_ocr_response_with_multiple_pages(self):
-        """Create a mock PaddleOCR response with multiple pages"""
-        mock_response = {
-            "logId": "123",
-            "errorCode": "0",
-            "errorMsg": "Success",
-            "result": {
-                "layoutParsingResults": [
-                    {
-                        "markdown": {"text": "# Page 1"},
-                        "prunedResult": {},
-                    },
-                    {
-                        "markdown": {"text": "# Page 2"},
-                        "prunedResult": {},
-                    },
-                ],
-                "dataInfo": {
-                    "numPages": 2,
-                    "pages": [
-                        {"width": 512, "height": 512},
-                        {"width": 512, "height": 512},
-                    ],
-                    "type": "pdf",
-                },
-            },
-        }
-        return mock_response
-
-    @pytest.mark.parametrize(
-        "source_type",
-        ["file_path_str", "path_object", "bytestream"],
-    )
-    def test_run_with_local_sources(self, mock_ocr_response, tmp_path, source_type):
-        """Test processing with local source types (str, Path, ByteStream)"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        # Create temporary file
-        test_file = create_empty_image(tmp_path, "test.png")
-
-        # Create the source based on type
-        if source_type == "file_path_str":
-            source = str(test_file)
-        elif source_type == "path_object":
-            source = test_file
-        else:  # bytestream
-            source = ByteStream(data=test_file.read_bytes(), meta={"file_path": str(test_file)})
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            result = converter.run(sources=[source])
-
-            assert len(result["documents"]) == 1
-            assert isinstance(result["documents"][0], Document)
-            assert result["documents"][0].content == "# Sample Document\n\nThis is page 1."
-            assert len(result["raw_paddleocr_responses"]) == 1
-            assert result["raw_paddleocr_responses"][0] == mock_ocr_response
-
-    def test_run_with_multiple_sources(self, mock_ocr_response, tmp_path):
-        """Test processing with multiple source types"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        # Create temporary files
-        test_file1 = create_empty_image(tmp_path, "test1.png")
-        test_file2 = create_empty_image(tmp_path, "test2.png")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            sources = [
-                str(test_file1),
-                test_file2,
-                ByteStream(data=test_file1.read_bytes(), meta={"file_path": str(test_file1)}),
-            ]
-            result = converter.run(sources=sources)
-
-            assert len(result["documents"]) == 3
-            assert all(isinstance(doc, Document) for doc in result["documents"])
-            assert len(result["raw_paddleocr_responses"]) == 3
-
-    def test_run_handles_api_error(self, mock_ocr_response, tmp_path):
-        """Test error handling when API fails"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        test_file1 = create_empty_image(tmp_path, "test1.png")
-        test_file2 = create_empty_image(tmp_path, "test2.png")
-        test_file3 = create_empty_image(tmp_path, "test3.png")
-
-        with patch("requests.post") as mock_post:
-            error_response = MagicMock()
-            error_response.status_code = 404
-            error_response.raise_for_status.side_effect = requests.HTTPError("404 Client Error")
-
-            # First call succeeds, second fails, third succeeds
-            mock_post.side_effect = [
-                MagicMock(status_code=200, json=lambda: mock_ocr_response),
-                error_response,
-                MagicMock(status_code=200, json=lambda: mock_ocr_response),
-            ]
-
-            sources = [str(test_file1), str(test_file2), str(test_file3)]
-            result = converter.run(sources=sources)
-
-            # Should only return 2 documents (failed source skipped)
-            assert len(result["documents"]) == 2
-            assert len(result["raw_paddleocr_responses"]) == 2
-
-    def test_run_skips_source_that_cannot_be_read(self, mock_ocr_response):
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
-        )
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            result = converter.run(sources=["/non/existent/file.png"])
-
-            assert len(result["documents"]) == 0
-            assert len(result["raw_paddleocr_responses"]) == 0
-            mock_post.assert_not_called()
-
-    def test_run_handles_empty_text_response(self, tmp_path):
-        mock_response_empty_text = {
-            "result": {
-                "layoutParsingResults": [
-                    {"markdown": {"text": ""}, "prunedResult": {}},
-                ],
-                "dataInfo": {"width": 1024, "height": 1024, "type": "image"},
-            },
-        }
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
-        )
-        test_file = create_empty_image(tmp_path, "test.png")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_response_empty_text
-            mock_post.return_value = mock_response
-
-            result = converter.run(sources=[str(test_file)])
-
-            assert len(result["documents"]) == 1
-            assert result["documents"][0].content == ""
-
-    def test_run_omits_auth_header_when_token_missing(self, mock_ocr_response, tmp_path, monkeypatch):
-        monkeypatch.delenv("AISTUDIO_ACCESS_TOKEN", raising=False)
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_env_var("AISTUDIO_ACCESS_TOKEN", strict=False),
-        )
-        test_file = create_empty_image(tmp_path, "test.png")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            result = converter.run(sources=[str(test_file)])
-
-            assert len(result["documents"]) == 1
-            headers = mock_post.call_args[1]["headers"]
-            assert "Authorization" not in headers
-
-    def test_run_with_meta_single_dict(self, mock_ocr_response, tmp_path):
-        """Test that meta parameter with single dict is applied to all documents"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        test_file1 = create_empty_image(tmp_path, "test1.png")
-        test_file2 = create_empty_image(tmp_path, "test2.png")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            sources = [str(test_file1), str(test_file2)]
-            result = converter.run(sources=sources, meta={"department": "engineering", "year": 2024})
-
-            assert len(result["documents"]) == 2
-            # Both documents should have the same metadata
-            for doc in result["documents"]:
-                assert doc.meta["department"] == "engineering"
-                assert doc.meta["year"] == 2024
-                # File path metadata should still be present
-                assert "file_path" in doc.meta
-
-    def test_run_with_meta_list_of_dicts(self, mock_ocr_response, tmp_path):
-        """Test that meta parameter with list of dicts applies each dict to corresponding document"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        test_file1 = create_empty_image(tmp_path, "test1.png")
-        test_file2 = create_empty_image(tmp_path, "test2.png")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            sources = [str(test_file1), str(test_file2)]
-            result = converter.run(
-                sources=sources,
-                meta=[
-                    {"author": "Alice", "category": "report"},
-                    {"author": "Bob", "category": "invoice"},
-                ],
+    def test_invalid_file_type_value(self) -> None:
+        with pytest.raises(ValueError, match="Invalid `file_type` value"):
+            PaddleOCRVLDocumentConverter(
+                access_token=Secret.from_token("t"),
+                file_type=123,  # type: ignore[arg-type]
             )
 
-            assert len(result["documents"]) == 2
-            # First document
-            assert result["documents"][0].meta["author"] == "Alice"
-            assert result["documents"][0].meta["category"] == "report"
-            # Second document
-            assert result["documents"][1].meta["author"] == "Bob"
-            assert result["documents"][1].meta["category"] == "invoice"
-            # File path metadata should still be present in both
-            assert "file_path" in result["documents"][0].meta
-            assert "file_path" in result["documents"][1].meta
-
-    def test_run_with_meta_none(self, mock_ocr_response, tmp_path):
-        """Test that meta parameter with `None` works correctly"""
+    def test_all_optional_params(self) -> None:
         converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        test_file = create_empty_image(tmp_path, "test.png")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            sources = [str(test_file)]
-            result = converter.run(sources=sources, meta=None)
-
-            assert len(result["documents"]) == 1
-            # Only file path metadata should be present
-            assert "file_path" in result["documents"][0].meta
-
-    def test_parse_sends_all_optional_parameters_in_request(self, mock_ocr_response, tmp_path):
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
+            base_url="http://custom.example.com",
+            access_token=Secret.from_token("t"),
+            file_type="pdf",
             use_doc_orientation_classify=True,
             use_doc_unwarping=True,
             use_layout_detection=True,
@@ -675,7 +109,7 @@ class TestPaddleOCRVLDocumentConverter:
             layout_threshold=0.5,
             layout_nms=True,
             layout_unclip_ratio=1.5,
-            layout_merge_bboxes_mode="large",
+            layout_merge_bboxes_mode="merge",
             layout_shape_mode="auto",
             prompt_label="ocr",
             format_block_content=True,
@@ -687,355 +121,447 @@ class TestPaddleOCRVLDocumentConverter:
             max_new_tokens=500,
             merge_layout_blocks=True,
             markdown_ignore_labels=["footer"],
-            vlm_extra_args={"extra": "arg"},
+            vlm_extra_args={"k": "v"},
             prettify_markdown=True,
             show_formula_number=True,
             restructure_pages=True,
             merge_tables=True,
             relevel_titles=True,
             visualize=True,
-            additional_params={"logId": "custom-log-id"},
+            additional_params={"logId": "x"},
         )
-        test_file = create_empty_image(tmp_path, "test.png")
+        assert converter.base_url == "http://custom.example.com"
+        assert converter.file_type == 0
+        assert converter.use_doc_orientation_classify is True
+        assert converter.additional_params == {"logId": "x"}
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
 
-            result = converter.run(sources=[str(test_file)])
+class TestSerialisation:
+    def test_to_dict_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
+        from paddleocr import Model
 
-            assert len(result["documents"]) == 1
-            payload = mock_post.call_args[1]["json"]
-            assert payload["useDocOrientationClassify"] is True
-            assert payload["useDocUnwarping"] is True
-            assert payload["useLayoutDetection"] is True
-            assert payload["useChartRecognition"] is True
-            assert payload["useSealRecognition"] is True
-            assert payload["useOcrForImageBlock"] is True
-            assert payload["layoutThreshold"] == 0.5
-            assert payload["layoutNms"] is True
-            assert payload["layoutUnclipRatio"] == 1.5
-            assert payload["layoutMergeBboxesMode"] == "large"
-            assert payload["layoutShapeMode"] == "auto"
-            assert payload["promptLabel"] == "ocr"
-            assert payload["formatBlockContent"] is True
-            assert payload["repetitionPenalty"] == 1.1
-            assert payload["temperature"] == 0.7
-            assert payload["topP"] == 0.9
-            assert payload["minPixels"] == 100
-            assert payload["maxPixels"] == 1000
-            assert payload["maxNewTokens"] == 500
-            assert payload["mergeLayoutBlocks"] is True
-            assert payload["markdownIgnoreLabels"] == ["footer"]
-            assert payload["vlmExtraArgs"] == {"extra": "arg"}
-            assert payload["prettifyMarkdown"] is True
-            assert payload["showFormulaNumber"] is True
-            assert payload["restructurePages"] is True
-            assert payload["mergeTables"] is True
-            assert payload["relevelTitles"] is True
-            assert payload["visualize"] is True
-            assert payload["logId"] == "custom-log-id"
+        converter = PaddleOCRVLDocumentConverter()
+        d = converter.to_dict()
 
-    def test_parse_skips_none_optional_parameters(self, mock_ocr_response, tmp_path):
+        assert d["type"] == CLASS_TYPE
+        p = d["init_parameters"]
+        assert p["base_url"] is None
+        assert p["model"] == Model.PADDLE_OCR_VL_16.value
+        assert p["file_type"] is None
+        assert p["access_token"] == {
+            "type": "env_var",
+            "env_vars": ["PADDLEOCR_ACCESS_TOKEN"],
+            "strict": True,
+        }
+
+    def test_to_dict_custom(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "tok")
+        from paddleocr import Model
+
         converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
-            use_doc_orientation_classify=None,
-            use_doc_unwarping=None,
+            base_url="http://base.example.com",
+            model=Model.PADDLE_OCR_VL_15,
+            file_type="image",
+            temperature=0.5,
         )
-        test_file = create_empty_image(tmp_path, "test.png")
+        p = converter.to_dict()["init_parameters"]
+        assert p["base_url"] == "http://base.example.com"
+        assert p["model"] == "PaddleOCR-VL-1.5"
+        assert p["file_type"] == 1
+        assert p["temperature"] == 0.5
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
+    def test_from_dict_round_trip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
+        from paddleocr import Model
 
-            result = converter.run(sources=[str(test_file)])
-
-            assert len(result["documents"]) == 1
-            payload = mock_post.call_args[1]["json"]
-            assert "useDocOrientationClassify" not in payload
-            assert "useDocUnwarping" not in payload
-
-    def test_parse_raises_on_invalid_request_parameters(self, tmp_path):
         converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
+            base_url="http://base.example.com",
+            model=Model.PADDLE_OCR_VL_16,
+            temperature=0.3,
         )
+        restored = PaddleOCRVLDocumentConverter.from_dict(converter.to_dict())
+
+        assert restored.base_url == "http://base.example.com"
+        assert restored.model == Model.PADDLE_OCR_VL_16.value
+        assert restored.temperature == 0.3
+
+    def test_from_dict_with_model_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
+        data = {
+            "type": CLASS_TYPE,
+            "init_parameters": {
+                "access_token": {
+                    "type": "env_var",
+                    "env_vars": ["PADDLEOCR_ACCESS_TOKEN"],
+                    "strict": True,
+                },
+                "model": "PaddleOCR-VL-1.5",
+                "base_url": None,
+                "file_type": None,
+            },
+        }
+        converter = PaddleOCRVLDocumentConverter.from_dict(data)
+        assert converter.model == "PaddleOCR-VL-1.5"
+
+
+class TestRun:
+    @pytest.mark.parametrize("source_type", ["file_path_str", "path_object", "bytestream"])
+    def test_single_source(
+        self,
+        mock_client_ctx: MagicMock,
+        tmp_path: Path,
+        source_type: str,
+    ) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         test_file = create_empty_image(tmp_path, "test.png")
+
+        if source_type == "file_path_str":
+            source = str(test_file)
+        elif source_type == "path_object":
+            source = test_file
+        else:
+            source = ByteStream(data=test_file.read_bytes(), meta={"file_path": str(test_file)})
+
+        result = converter.run(sources=[source])
+
+        assert len(result["documents"]) == 1
+        assert isinstance(result["documents"][0], Document)
+        assert result["documents"][0].content == "# Sample Document\n\nThis is page 1."
+        assert len(result["raw_paddleocr_responses"]) == 1
+        mock_client_ctx.parse_document.assert_awaited_once()
+
+    def test_multiple_sources_concurrent(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f1 = create_empty_image(tmp_path, "a.png")
+        f2 = create_empty_image(tmp_path, "b.png")
+        f3 = create_empty_image(tmp_path, "c.png")
+
+        result = converter.run(sources=[str(f1), str(f2), str(f3)])
+
+        assert len(result["documents"]) == 3
+        assert mock_client_ctx.parse_document.await_count == 3
+
+    def test_multi_page_pdf(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        mock_client_ctx.parse_document.return_value = make_parse_result(["# Page 1", "# Page 2"])
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 test")
+
+        result = converter.run(sources=[str(pdf_file)])
+
+        assert result["documents"][0].content == "# Page 1\f# Page 2"
+
+    def test_partial_failure_skips_errored_source(self, tmp_path: Path) -> None:
+        f1 = create_empty_image(tmp_path, "ok.png")
+        f2 = create_empty_image(tmp_path, "fail.png")
+        f3 = create_empty_image(tmp_path, "ok2.png")
+
+        ok_result = make_parse_result(["# OK"])
+        side_effects = [ok_result, Exception("API error"), ok_result]
+
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client.parse_document = AsyncMock(side_effect=side_effects)
 
         with patch(
             "haystack_integrations.components.converters.paddleocr."
-            "paddleocr_vl_document_converter.PaddleOCRVLInferRequest",
-            side_effect=Exception("Validation failed"),
+            "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
+            return_value=client,
         ):
-            result = converter.run(sources=[str(test_file)])
-            assert len(result["documents"]) == 0
+            converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+            result = converter.run(sources=[str(f1), str(f2), str(f3)])
 
-    def test_parse_raises_on_invalid_json_response(self, tmp_path):
+        assert len(result["documents"]) == 2
+        assert len(result["raw_paddleocr_responses"]) == 2
+
+    def test_unknown_extension_skipped(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        unknown = tmp_path / "file.xyz"
+        unknown.write_bytes(b"data")
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+
+        result = converter.run(sources=[str(unknown)])
+
+        assert result == {"documents": [], "raw_paddleocr_responses": []}
+        mock_client_ctx.parse_document.assert_not_awaited()
+
+    def test_unreadable_source_skipped(self, mock_client_ctx: MagicMock) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        result = converter.run(sources=["/nonexistent/file.png"])
+        assert result["documents"] == []
+        mock_client_ctx.parse_document.assert_not_awaited()
+
+    def test_empty_text_produces_empty_document(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        mock_client_ctx.parse_document.return_value = make_parse_result([""])
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f = create_empty_image(tmp_path, "empty.png")
+
+        result = converter.run(sources=[str(f)])
+
+        assert len(result["documents"]) == 1
+        assert result["documents"][0].content == ""
+
+    def test_model_forwarded_to_parse_document(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        from paddleocr import Model
+
         converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
+            access_token=Secret.from_token("tok"),
+            model=Model.PADDLE_OCR_VL_15,
         )
-        test_file = create_empty_image(tmp_path, "test.png")
+        f = create_empty_image(tmp_path, "test.png")
+        converter.run(sources=[str(f)])
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.side_effect = ValueError("Invalid JSON")
-            mock_post.return_value = mock_response
+        call_kwargs = mock_client_ctx.parse_document.call_args
+        assert call_kwargs.kwargs["model"] == Model.PADDLE_OCR_VL_15
 
-            result = converter.run(sources=[str(test_file)])
-            assert len(result["documents"]) == 0
+    def test_options_non_none_fields_forwarded(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        from paddleocr import PaddleOCRVLOptions
 
-    def test_parse_raises_when_result_field_missing(self, tmp_path):
         converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
+            access_token=Secret.from_token("tok"),
+            temperature=0.7,
+            use_doc_orientation_classify=True,
+            use_doc_unwarping=None,
         )
-        test_file = create_empty_image(tmp_path, "test.png")
+        f = create_empty_image(tmp_path, "test.png")
+        converter.run(sources=[str(f)])
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = {"logId": "123", "errorMsg": "Error"}
-            mock_post.return_value = mock_response
+        options: PaddleOCRVLOptions = mock_client_ctx.parse_document.call_args.kwargs["options"]
+        assert options.temperature == 0.7
+        assert options.use_doc_orientation_classify is True
+        assert options.use_doc_unwarping is None
 
-            result = converter.run(sources=[str(test_file)])
-            assert len(result["documents"]) == 0
+    def test_meta_single_dict_applied_to_all(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f1 = create_empty_image(tmp_path, "a.png")
+        f2 = create_empty_image(tmp_path, "b.png")
 
-    def test_parse_raises_on_invalid_response_format(self, tmp_path):
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
-        )
-        test_file = create_empty_image(tmp_path, "test.png")
+        result = converter.run(sources=[str(f1), str(f2)], meta={"dept": "eng"})
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = {"result": {"invalid": "format"}}
-            mock_post.return_value = mock_response
+        for doc in result["documents"]:
+            assert doc.meta["dept"] == "eng"
 
-            result = converter.run(sources=[str(test_file)])
-            assert len(result["documents"]) == 0
+    def test_meta_list_applied_per_source(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f1 = create_empty_image(tmp_path, "a.png")
+        f2 = create_empty_image(tmp_path, "b.png")
 
-    def test_file_type_auto_detection_pdf(self, mock_ocr_response_with_multiple_pages, tmp_path):
-        """Test that file_type is automatically detected as PDF from .pdf extension"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        # Create a PDF file
-        pdf_file = create_empty_pdf(tmp_path, "test.pdf")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response_with_multiple_pages
-            mock_post.return_value = mock_response
-
-            result = converter.run(sources=[str(pdf_file)])
-
-            assert len(result["documents"]) == 1
-            # Verify that the correct file type (0 for PDF) was used in the API call
-            call_args = mock_post.call_args[1]["json"]
-            assert call_args["fileType"] == 0  # Should be 0 for PDF
-
-    def test_file_type_auto_detection_image(self, mock_ocr_response, tmp_path):
-        """Test that file_type is automatically detected as image from .png extension"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
-
-        # Create an image file
-        image_file = create_empty_image(tmp_path, "test.png")
-
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
-
-            result = converter.run(sources=[str(image_file)])
-
-            assert len(result["documents"]) == 1
-            # Verify that the correct file type (1 for image) was used in the API call
-            call_args = mock_post.call_args[1]["json"]
-            assert call_args["fileType"] == 1  # Should be 1 for image
-
-    def test_file_type_manual_specification_pdf(self, mock_ocr_response_with_multiple_pages, tmp_path):
-        """Test that manually specified file_type overrides auto-detection"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
-            file_type="pdf",  # Manually specify as PDF
+        result = converter.run(
+            sources=[str(f1), str(f2)],
+            meta=[{"author": "Alice"}, {"author": "Bob"}],
         )
 
-        # Create an image file (which would normally auto-detect as image)
-        image_file = create_empty_image(tmp_path, "test.png")
+        assert result["documents"][0].meta["author"] == "Alice"
+        assert result["documents"][1].meta["author"] == "Bob"
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response_with_multiple_pages
-            mock_post.return_value = mock_response
+    def test_file_type_pdf_tmp_suffix(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        pdf = tmp_path / "test.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
 
-            result = converter.run(sources=[str(image_file)])
+        converter.run(sources=[str(pdf)])
 
-            assert len(result["documents"]) == 1
-            # Verify that the manually specified file type (0 for PDF) was used
-            call_args = mock_post.call_args[1]["json"]
-            assert call_args["fileType"] == 0  # Should be 0 (PDF) despite being a PNG file
+        assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".pdf")
 
-    def test_file_type_manual_specification_image(self, mock_ocr_response, tmp_path):
-        """Test that manually specified file_type overrides auto-detection"""
+    def test_file_type_image_tmp_suffix(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f = create_empty_image(tmp_path, "test.png")
+
+        converter.run(sources=[str(f)])
+
+        assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".jpg")
+
+    def test_file_type_manual_override_uses_pdf_suffix(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com",
-            access_token=Secret.from_token("test-access-token"),
-            file_type="image",  # Manually specify as image
+            access_token=Secret.from_token("tok"), file_type="pdf"
         )
+        f = create_empty_image(tmp_path, "test.png")
+        converter.run(sources=[str(f)])
 
-        # Create a PDF file (which would normally auto-detect as PDF)
-        pdf_file = create_empty_pdf(tmp_path, "test.pdf")
+        assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".pdf")
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
+    def test_bytestream_with_file_path_meta(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f = create_empty_image(tmp_path, "img.jpg")
+        bs = ByteStream(data=f.read_bytes(), meta={"file_path": str(f)})
 
-            result = converter.run(sources=[str(pdf_file)])
+        assert len(converter.run(sources=[bs])["documents"]) == 1
 
-            assert len(result["documents"]) == 1
-            # Verify that the manually specified file type (1 for image) was used
-            call_args = mock_post.call_args[1]["json"]
-            assert call_args["fileType"] == 1  # Should be 1 (image) despite being a PDF file
+    def test_bytestream_without_file_path_uses_mime_type(
+        self, mock_client_ctx: MagicMock, tmp_path: Path
+    ) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f = create_empty_image(tmp_path, "img.png")
+        bs = ByteStream(data=f.read_bytes(), mime_type="image/png")
 
-    def test_file_type_auto_detection_unknown_extension(self, mock_ocr_response, tmp_path):
-        """Test that unknown file extensions result in skipping the file"""
+        assert len(converter.run(sources=[bs])["documents"]) == 1
+
+    def test_raw_response_structure(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f = create_empty_image(tmp_path, "test.png")
+
+        raw = converter.run(sources=[str(f)])["raw_paddleocr_responses"][0]
+
+        assert raw["job_id"] == "job-123"
+        assert "pages" in raw
+        assert "data_info" in raw
+
+    def test_base_url_forwarded_to_client(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client.parse_document = AsyncMock(return_value=make_parse_result(["text"]))
+
+        with patch(
+            "haystack_integrations.components.converters.paddleocr."
+            "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
+            return_value=client,
+        ) as mock_cls:
+            PaddleOCRVLDocumentConverter(
+                access_token=Secret.from_token("tok"),
+                base_url="http://custom.example.com",
+            ).run(sources=[str(create_empty_image(tmp_path, "test.png"))])
+
+        assert mock_cls.call_args.kwargs["base_url"] == "http://custom.example.com"
+
+    def test_token_passed_to_client(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client.parse_document = AsyncMock(return_value=make_parse_result(["text"]))
+
+        with patch(
+            "haystack_integrations.components.converters.paddleocr."
+            "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
+            return_value=client,
+        ) as mock_cls:
+            PaddleOCRVLDocumentConverter(
+                access_token=Secret.from_token("my-secret-token"),
+            ).run(sources=[str(create_empty_image(tmp_path, "test.png"))])
+
+        assert mock_cls.call_args.kwargs["token"] == "my-secret-token"
+
+    def test_empty_sources_list(self) -> None:
+        result = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok")).run(sources=[])
+        assert result == {"documents": [], "raw_paddleocr_responses": []}
+
+    def test_additional_params_as_extra_options(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        from paddleocr import PaddleOCRVLOptions
+
         converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
+            access_token=Secret.from_token("tok"),
+            additional_params={"logId": "custom"},
         )
+        converter.run(sources=[str(create_empty_image(tmp_path, "test.png"))])
 
-        # Create a file with unknown extension
-        unknown_file = tmp_path / "test.unknown"
-        unknown_file.write_bytes(b"dummy data")
+        options: PaddleOCRVLOptions = mock_client_ctx.parse_document.call_args.kwargs["options"]
+        assert options.extra_options == {"logId": "custom"}
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
+    def test_tmp_file_deleted_after_parse(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+        created_paths: list[str] = []
 
-            result = converter.run(sources=[str(unknown_file)])
+        import tempfile as _tmpmod
+        original_ntf = _tmpmod.NamedTemporaryFile
 
-            # Should skip the file due to unknown extension
-            assert len(result["documents"]) == 0
-            assert len(result["raw_paddleocr_responses"]) == 0
-            # requests.post should not be called at all
-            mock_post.assert_not_called()
+        def tracking_ntf(**kwargs: object) -> object:
+            f = original_ntf(**kwargs)
+            created_paths.append(str(f.name))
+            return f
 
-    def test_file_type_auto_detection_bytestream(self, mock_ocr_response, tmp_path):
-        """Test file_type auto-detection with ByteStream input"""
-        converter = PaddleOCRVLDocumentConverter(
-            api_url="http://test-api-url.com", access_token=Secret.from_token("test-access-token")
-        )
+        with patch("tempfile.NamedTemporaryFile", side_effect=tracking_ntf):
+            PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok")).run(
+                sources=[str(create_empty_image(tmp_path, "test.png"))]
+            )
 
-        # Create files
-        pdf_file = create_empty_pdf(tmp_path, "test.pdf")
-        image_file = create_empty_image(tmp_path, "test.png")
+        for p in created_paths:
+            assert not Path(p).exists(), f"Temp file {p} was not deleted"
 
-        with patch("requests.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = mock_ocr_response
-            mock_post.return_value = mock_response
 
-            # Test PDF ByteStream
-            pdf_bytestream = ByteStream(data=pdf_file.read_bytes(), meta={"file_path": str(pdf_file)})
-            result_pdf = converter.run(sources=[pdf_bytestream])
-
-            # Test image ByteStream
-            image_bytestream = ByteStream(data=image_file.read_bytes(), meta={"file_path": str(image_file)})
-            result_image = converter.run(sources=[image_bytestream])
-
-            # Both should succeed
-            assert len(result_pdf["documents"]) == 1
-            assert len(result_image["documents"]) == 1
-
-            # Verify API calls used correct file types
-            assert mock_post.call_count == 2
-            calls = mock_post.call_args_list
-            # First call should be for PDF (fileType=0)
-            assert calls[0][1]["json"]["fileType"] == 0
-            # Second call should be for image (fileType=1)
-            assert calls[1][1]["json"]["fileType"] == 1
+class TestInferFileType:
+    @pytest.mark.parametrize(
+        "extension,expected",
+        [
+            (".pdf", 0),
+            (".PDF", 0),
+            (".jpg", 1),
+            (".jpeg", 1),
+            (".png", 1),
+            (".bmp", 1),
+            (".tiff", 1),
+            (".tif", 1),
+            (".webp", 1),
+            (".unknown", None),
+            ("", None),
+        ],
+    )
+    def test_from_file_path(self, tmp_path: Path, extension: str, expected: "int | None") -> None:
+        assert _infer_file_type_from_source(tmp_path / f"file{extension}") == expected
 
     @pytest.mark.parametrize(
-        "mime_type, expected",
+        "mime_type,expected",
         [
             ("application/pdf", 0),
             ("APPLICATION/PDF", 0),
             ("image/png", 1),
             ("image/jpeg", 1),
+            ("image/webp", 1),
             ("text/plain", None),
             (None, None),
         ],
     )
-    def test_infer_file_type_from_mime_type(self, mime_type, expected):
-        source = ByteStream(data=b"dummy")
-        assert _infer_file_type_from_source(source, mime_type) == expected
+    def test_from_mime_type(self, mime_type: "str | None", expected: "int | None") -> None:
+        assert _infer_file_type_from_source(ByteStream(data=b"x"), mime_type) == expected
 
-    def test_infer_file_type_falls_back_to_mime_type_when_extension_unknown(self, tmp_path):
-        source = tmp_path / "file.unknown"
-        assert _infer_file_type_from_source(source, "application/pdf") == 0
-        assert _infer_file_type_from_source(source, "image/png") == 1
+    def test_extension_takes_priority_over_mime(self, tmp_path: Path) -> None:
+        assert _infer_file_type_from_source(tmp_path / "doc.pdf", "image/png") == 0
 
-    @pytest.mark.skipif(
-        not os.environ.get("PADDLEOCR_VL_API_URL") or not os.environ.get("AISTUDIO_ACCESS_TOKEN"),
-        reason="Export env vars `PADDLEOCR_VL_API_URL` and `AISTUDIO_ACCESS_TOKEN` to run this test.",
-    )
-    @pytest.mark.integration
+    def test_mime_fallback_for_unknown_extension(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.unknown"
+        assert _infer_file_type_from_source(f, "application/pdf") == 0
+        assert _infer_file_type_from_source(f, "image/jpeg") == 1
+
+    def test_bytestream_with_file_path_meta(self, tmp_path: Path) -> None:
+        bs = ByteStream(data=b"x", meta={"file_path": str(tmp_path / "doc.pdf")})
+        assert _infer_file_type_from_source(bs) == 0
+
+    def test_bytestream_without_meta_uses_mime(self) -> None:
+        bs = ByteStream(data=b"x")
+        assert _infer_file_type_from_source(bs, "image/png") == 1
+        assert _infer_file_type_from_source(bs, None) is None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("PADDLEOCR_VL_BASE_URL") or not os.environ.get("PADDLEOCR_ACCESS_TOKEN"),
+    reason="Export PADDLEOCR_VL_BASE_URL and PADDLEOCR_ACCESS_TOKEN to run integration tests.",
+)
+@pytest.mark.integration
+class TestIntegration:
+    @pytest.fixture
+    def test_files_path(self) -> Path:
+        return Path(__file__).parent / "test_files"
+
     @pytest.mark.parametrize(
         "source_files,expected_docs",
         [
-            (
-                [
-                    "sample_pdf.pdf",
-                ],
-                1,
-            ),
-            (
-                [
-                    "sample_img.jpg",
-                ],
-                1,
-            ),
-            (
-                [
-                    "sample_pdf.pdf",
-                    "sample_img.jpg",
-                ],
-                2,
-            ),
+            (["sample_pdf.pdf"], 1),
+            (["sample_img.jpg"], 1),
+            (["sample_pdf.pdf", "sample_img.jpg"], 2),
         ],
-        ids=["pdf_only", "image_only", "mixed_pdf_image"],
+        ids=["pdf_only", "image_only", "mixed"],
     )
-    def test_integration_run_with_files(self, test_files_path, source_files, expected_docs):
-        """Integration test with real API call using various file types"""
-
-        source_files = [test_files_path / file for file in source_files]
-
-        converter = PaddleOCRVLDocumentConverter(api_url=os.environ["PADDLEOCR_VL_API_URL"])
-
-        result = converter.run(sources=source_files)
+    def test_run_with_files(
+        self,
+        test_files_path: Path,
+        source_files: list[str],
+        expected_docs: int,
+    ) -> None:
+        converter = PaddleOCRVLDocumentConverter(
+            base_url=os.environ["PADDLEOCR_VL_BASE_URL"],
+        )
+        result = converter.run(sources=[test_files_path / f for f in source_files])
 
         assert len(result["documents"]) == expected_docs
-        assert all(isinstance(doc, Document) for doc in result["documents"])
-        assert all(len(doc.content) > 0 for doc in result["documents"])
-        assert "raw_paddleocr_responses" in result
+        assert all(isinstance(d, Document) for d in result["documents"])
+        assert all(len(d.content) > 0 for d in result["documents"])
         assert len(result["raw_paddleocr_responses"]) == expected_docs

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+import tempfile as _tmpmod
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,6 +10,7 @@ import pytest
 from haystack import Document
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret
+from paddleocr import Model, PaddleOCRVLOptions  # type: ignore[import-untyped]
 from PIL import Image
 
 from haystack_integrations.components.converters.paddleocr import (
@@ -40,11 +42,14 @@ def make_parse_result(pages_text: list[str]) -> MagicMock:
     return result
 
 
-CLASS_TYPE = "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.PaddleOCRVLDocumentConverter"
+CLASS_TYPE = (
+    "haystack_integrations.components.converters.paddleocr"
+    ".paddleocr_vl_document_converter.PaddleOCRVLDocumentConverter"
+)
 
 
 @pytest.fixture
-def mock_client_ctx(monkeypatch: pytest.MonkeyPatch):
+def mock_client_ctx():
     """Patch AsyncPaddleOCRClient so parse_document can be controlled per-test."""
     client_instance = MagicMock()
     client_instance.__aenter__ = AsyncMock(return_value=client_instance)
@@ -63,8 +68,6 @@ def mock_client_ctx(monkeypatch: pytest.MonkeyPatch):
 class TestInit:
     def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
-        from paddleocr import Model
-
         converter = PaddleOCRVLDocumentConverter()
 
         assert converter.base_url is None
@@ -139,8 +142,6 @@ class TestInit:
 class TestSerialisation:
     def test_to_dict_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
-        from paddleocr import Model
-
         converter = PaddleOCRVLDocumentConverter()
         d = converter.to_dict()
 
@@ -157,8 +158,6 @@ class TestSerialisation:
 
     def test_to_dict_custom(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "tok")
-        from paddleocr import Model
-
         converter = PaddleOCRVLDocumentConverter(
             base_url="http://base.example.com",
             model=Model.PADDLE_OCR_VL_15,
@@ -173,8 +172,6 @@ class TestSerialisation:
 
     def test_from_dict_round_trip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
-        from paddleocr import Model
-
         converter = PaddleOCRVLDocumentConverter(
             base_url="http://base.example.com",
             model=Model.PADDLE_OCR_VL_16,
@@ -303,8 +300,6 @@ class TestRun:
         assert result["documents"][0].content == ""
 
     def test_model_forwarded_to_parse_document(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
-        from paddleocr import Model
-
         converter = PaddleOCRVLDocumentConverter(
             access_token=Secret.from_token("tok"),
             model=Model.PADDLE_OCR_VL_15,
@@ -316,8 +311,6 @@ class TestRun:
         assert call_kwargs.kwargs["model"] == Model.PADDLE_OCR_VL_15
 
     def test_options_non_none_fields_forwarded(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
-        from paddleocr import PaddleOCRVLOptions
-
         converter = PaddleOCRVLDocumentConverter(
             access_token=Secret.from_token("tok"),
             temperature=0.7,
@@ -447,8 +440,6 @@ class TestRun:
         assert result == {"documents": [], "raw_paddleocr_responses": []}
 
     def test_additional_params_as_extra_options(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
-        from paddleocr import PaddleOCRVLOptions
-
         converter = PaddleOCRVLDocumentConverter(
             access_token=Secret.from_token("tok"),
             additional_params={"logId": "custom"},
@@ -460,8 +451,6 @@ class TestRun:
 
     def test_tmp_file_deleted_after_parse(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         created_paths: list[str] = []
-
-        import tempfile as _tmpmod
         original_ntf = _tmpmod.NamedTemporaryFile
 
         def tracking_ntf(**kwargs: object) -> object:

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 import os
 import tempfile as _tmpmod
 from pathlib import Path
@@ -461,6 +462,20 @@ class TestRun:
 
         for p in created_paths:
             assert not Path(p).exists(), f"Temp file {p} was not deleted"
+
+    def test_run_inside_existing_event_loop(
+        self,
+        mock_client_ctx: MagicMock,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
+        f = create_empty_image(tmp_path, "test.png")
+
+        async def _run() -> dict[str, list]:  # type: ignore[type-arg]
+            return converter.run(sources=[str(f)])  # type: ignore[return-value]
+
+        result = asyncio.run(_run())
+        assert len(result["documents"]) == 1
 
 
 class TestInferFileType:

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -68,16 +68,29 @@ class TestInit:
         assert converter.base_url is None
         assert converter.model == Model.PADDLE_OCR_VL_16
         assert converter.file_type is None
-        assert converter.use_doc_orientation_classify is None
-        assert converter.use_doc_unwarping is None
+        assert converter.use_doc_orientation_classify is False
+        assert converter.use_doc_unwarping is False
         assert converter.use_layout_detection is None
         assert converter.layout_threshold is None
+        assert converter.layout_nms is None
+        assert converter.layout_unclip_ratio is None
+        assert converter.layout_merge_bboxes_mode is None
+        assert converter.prompt_label is None
+        assert converter.format_block_content is None
+        assert converter.repetition_penalty is None
+        assert converter.temperature is None
+        assert converter.top_p is None
+        assert converter.min_pixels is None
+        assert converter.max_pixels is None
+        assert converter.prettify_markdown is None
+        assert converter.show_formula_number is None
+        assert converter.visualize is None
         assert converter.additional_params is None
 
     def test_custom_model_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
         converter = PaddleOCRVLDocumentConverter(model="PaddleOCR-VL-1.5")
-        assert converter.model == "PaddleOCR-VL-1.5"
+        assert converter.model == Model.PADDLE_OCR_VL_15
 
     def test_invalid_file_type_string(self) -> None:
         with pytest.raises(ValueError, match="Invalid `file_type` string"):
@@ -147,7 +160,7 @@ class TestSerialisation:
         assert p["file_type"] is None
         assert p["access_token"] == {
             "type": "env_var",
-            "env_vars": ["PADDLEOCR_ACCESS_TOKEN"],
+            "env_vars": ["PADDLEOCR_ACCESS_TOKEN", "AISTUDIO_ACCESS_TOKEN"],
             "strict": True,
         }
 
@@ -175,8 +188,33 @@ class TestSerialisation:
         restored = PaddleOCRVLDocumentConverter.from_dict(converter.to_dict())
 
         assert restored.base_url == "http://base.example.com"
-        assert restored.model == Model.PADDLE_OCR_VL_16.value
+        assert restored.model == Model.PADDLE_OCR_VL_16
         assert restored.temperature == 0.3
+
+    def test_from_dict_without_model_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
+        data = {
+            "type": CLASS_TYPE,
+            "init_parameters": {
+                "access_token": {"type": "env_var", "env_vars": ["PADDLEOCR_ACCESS_TOKEN"], "strict": True},
+            },
+        }
+        converter = PaddleOCRVLDocumentConverter.from_dict(data)
+        assert converter.model == Model.PADDLE_OCR_VL_16
+
+    def test_from_dict_with_unknown_model_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
+        data = {
+            "type": CLASS_TYPE,
+            "init_parameters": {
+                "access_token": {"type": "env_var", "env_vars": ["PADDLEOCR_ACCESS_TOKEN"], "strict": True},
+                "model": "SomeCustomModel",
+                "base_url": None,
+                "file_type": None,
+            },
+        }
+        converter = PaddleOCRVLDocumentConverter.from_dict(data)
+        assert converter.model == "SomeCustomModel"
 
     def test_from_dict_with_model_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("PADDLEOCR_ACCESS_TOKEN", "test-token")
@@ -194,7 +232,7 @@ class TestSerialisation:
             },
         }
         converter = PaddleOCRVLDocumentConverter.from_dict(data)
-        assert converter.model == "PaddleOCR-VL-1.5"
+        assert converter.model == Model.PADDLE_OCR_VL_15
 
 
 class TestRun:
@@ -304,6 +342,8 @@ class TestRun:
             temperature=0.7,
             use_doc_orientation_classify=True,
             use_doc_unwarping=None,
+            layout_nms=True,
+            prettify_markdown=True,
         )
         f = create_empty_image(tmp_path, "test.png")
         converter.run(sources=[str(f)])
@@ -312,6 +352,8 @@ class TestRun:
         assert options.temperature == 0.7
         assert options.use_doc_orientation_classify is True
         assert options.use_doc_unwarping is None
+        assert options.layout_nms is True
+        assert options.prettify_markdown is True
 
     def test_meta_single_dict_applied_to_all(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:  # noqa: ARG002
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
@@ -537,9 +579,7 @@ class TestIntegration:
         source_files: list[str],
         expected_docs: int,
     ) -> None:
-        converter = PaddleOCRVLDocumentConverter(
-            base_url=os.environ["PADDLEOCR_VL_BASE_URL"],
-        )
+        converter = PaddleOCRVLDocumentConverter()
         result = converter.run(sources=[test_files_path / f for f in source_files])
 
         assert len(result["documents"]) == expected_docs

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2025-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import asyncio
 import os
 import tempfile as _tmpmod
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from haystack import Document
@@ -47,18 +46,17 @@ CLASS_TYPE = (
     "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.PaddleOCRVLDocumentConverter"
 )
 
+_PATCH_CLIENT = "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.PaddleOCRClient"
+
 
 @pytest.fixture
 def mock_client_ctx():
-    """Patch AsyncPaddleOCRClient so parse_document can be controlled per-test."""
+    """Patch PaddleOCRClient so parse_document can be controlled per-test."""
     client_instance = MagicMock()
-    client_instance.__aenter__ = AsyncMock(return_value=client_instance)
-    client_instance.__aexit__ = AsyncMock(return_value=False)
-    client_instance.parse_document = AsyncMock(return_value=make_parse_result(["# Sample Document\n\nThis is page 1."]))
-    with patch(
-        "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.AsyncPaddleOCRClient",
-        return_value=client_instance,
-    ):
+    client_instance.__enter__ = MagicMock(return_value=client_instance)
+    client_instance.__exit__ = MagicMock(return_value=False)
+    client_instance.parse_document = MagicMock(return_value=make_parse_result(["# Sample Document\n\nThis is page 1."]))
+    with patch(_PATCH_CLIENT, return_value=client_instance):
         yield client_instance
 
 
@@ -70,8 +68,8 @@ class TestInit:
         assert converter.base_url is None
         assert converter.model == Model.PADDLE_OCR_VL_16
         assert converter.file_type is None
-        assert converter.use_doc_orientation_classify is False
-        assert converter.use_doc_unwarping is False
+        assert converter.use_doc_orientation_classify is None
+        assert converter.use_doc_unwarping is None
         assert converter.use_layout_detection is None
         assert converter.layout_threshold is None
         assert converter.additional_params is None
@@ -223,9 +221,9 @@ class TestRun:
         assert isinstance(result["documents"][0], Document)
         assert result["documents"][0].content == "# Sample Document\n\nThis is page 1."
         assert len(result["raw_paddleocr_responses"]) == 1
-        mock_client_ctx.parse_document.assert_awaited_once()
+        mock_client_ctx.parse_document.assert_called_once()
 
-    def test_multiple_sources_concurrent(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_multiple_sources(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         f1 = create_empty_image(tmp_path, "a.png")
         f2 = create_empty_image(tmp_path, "b.png")
@@ -234,7 +232,7 @@ class TestRun:
         result = converter.run(sources=[str(f1), str(f2), str(f3)])
 
         assert len(result["documents"]) == 3
-        assert mock_client_ctx.parse_document.await_count == 3
+        assert mock_client_ctx.parse_document.call_count == 3
 
     def test_multi_page_pdf(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         mock_client_ctx.parse_document.return_value = make_parse_result(["# Page 1", "# Page 2"])
@@ -252,18 +250,12 @@ class TestRun:
         f3 = create_empty_image(tmp_path, "ok2.png")
 
         ok_result = make_parse_result(["# OK"])
-        side_effects = [ok_result, Exception("API error"), ok_result]
-
         client = MagicMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=False)
-        client.parse_document = AsyncMock(side_effect=side_effects)
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.parse_document = MagicMock(side_effect=[ok_result, Exception("API error"), ok_result])
 
-        with patch(
-            "haystack_integrations.components.converters.paddleocr."
-            "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
-            return_value=client,
-        ):
+        with patch(_PATCH_CLIENT, return_value=client):
             converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
             result = converter.run(sources=[str(f1), str(f2), str(f3)])
 
@@ -278,13 +270,13 @@ class TestRun:
         result = converter.run(sources=[str(unknown)])
 
         assert result == {"documents": [], "raw_paddleocr_responses": []}
-        mock_client_ctx.parse_document.assert_not_awaited()
+        mock_client_ctx.parse_document.assert_not_called()
 
     def test_unreadable_source_skipped(self, mock_client_ctx: MagicMock) -> None:
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         result = converter.run(sources=["/nonexistent/file.png"])
         assert result["documents"] == []
-        mock_client_ctx.parse_document.assert_not_awaited()
+        mock_client_ctx.parse_document.assert_not_called()
 
     def test_empty_text_produces_empty_document(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         mock_client_ctx.parse_document.return_value = make_parse_result([""])
@@ -304,10 +296,9 @@ class TestRun:
         f = create_empty_image(tmp_path, "test.png")
         converter.run(sources=[str(f)])
 
-        call_kwargs = mock_client_ctx.parse_document.call_args
-        assert call_kwargs.kwargs["model"] == Model.PADDLE_OCR_VL_15
+        assert mock_client_ctx.parse_document.call_args.kwargs["model"] == Model.PADDLE_OCR_VL_15
 
-    def test_options_non_none_fields_forwarded(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_options_forwarded(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         converter = PaddleOCRVLDocumentConverter(
             access_token=Secret.from_token("tok"),
             temperature=0.7,
@@ -362,7 +353,7 @@ class TestRun:
 
         assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".jpg")
 
-    def test_file_type_manual_override_uses_pdf_suffix(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_file_type_manual_override(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"), file_type="pdf")
         f = create_empty_image(tmp_path, "test.png")
         converter.run(sources=[str(f)])
@@ -399,15 +390,11 @@ class TestRun:
 
     def test_base_url_forwarded_to_client(self, tmp_path: Path) -> None:
         client = MagicMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=False)
-        client.parse_document = AsyncMock(return_value=make_parse_result(["text"]))
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.parse_document = MagicMock(return_value=make_parse_result(["text"]))
 
-        with patch(
-            "haystack_integrations.components.converters.paddleocr."
-            "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
-            return_value=client,
-        ) as mock_cls:
+        with patch(_PATCH_CLIENT, return_value=client) as mock_cls:
             PaddleOCRVLDocumentConverter(
                 access_token=Secret.from_token("tok"),
                 base_url="http://custom.example.com",
@@ -417,15 +404,11 @@ class TestRun:
 
     def test_token_passed_to_client(self, tmp_path: Path) -> None:
         client = MagicMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=False)
-        client.parse_document = AsyncMock(return_value=make_parse_result(["text"]))
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.parse_document = MagicMock(return_value=make_parse_result(["text"]))
 
-        with patch(
-            "haystack_integrations.components.converters.paddleocr."
-            "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
-            return_value=client,
-        ) as mock_cls:
+        with patch(_PATCH_CLIENT, return_value=client) as mock_cls:
             PaddleOCRVLDocumentConverter(
                 access_token=Secret.from_token("my-secret-token"),
             ).run(sources=[str(create_empty_image(tmp_path, "test.png"))])
@@ -435,6 +418,18 @@ class TestRun:
     def test_empty_sources_list(self) -> None:
         result = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok")).run(sources=[])
         assert result == {"documents": [], "raw_paddleocr_responses": []}
+
+    def test_no_base_url_omitted_from_client_kwargs(self, tmp_path: Path) -> None:
+        f = create_empty_image(tmp_path, "test.png")
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.parse_document = MagicMock(return_value=make_parse_result(["text"]))
+
+        with patch(_PATCH_CLIENT, return_value=client) as mock_cls:
+            PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok")).run(sources=[str(f)])
+
+        assert "base_url" not in mock_cls.call_args.kwargs
 
     def test_additional_params_as_extra_options(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
         converter = PaddleOCRVLDocumentConverter(
@@ -462,20 +457,6 @@ class TestRun:
 
         for p in created_paths:
             assert not Path(p).exists(), f"Temp file {p} was not deleted"
-
-    def test_run_inside_existing_event_loop(
-        self,
-        mock_client_ctx: MagicMock,  # noqa: ARG002
-        tmp_path: Path,
-    ) -> None:
-        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
-        f = create_empty_image(tmp_path, "test.png")
-
-        async def _run() -> dict[str, list]:  # type: ignore[type-arg]
-            return converter.run(sources=[str(f)])  # type: ignore[return-value]
-
-        result = asyncio.run(_run())
-        assert len(result["documents"]) == 1
 
 
 class TestInferFileType:

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -43,8 +43,7 @@ def make_parse_result(pages_text: list[str]) -> MagicMock:
 
 
 CLASS_TYPE = (
-    "haystack_integrations.components.converters.paddleocr"
-    ".paddleocr_vl_document_converter.PaddleOCRVLDocumentConverter"
+    "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.PaddleOCRVLDocumentConverter"
 )
 
 
@@ -54,12 +53,9 @@ def mock_client_ctx():
     client_instance = MagicMock()
     client_instance.__aenter__ = AsyncMock(return_value=client_instance)
     client_instance.__aexit__ = AsyncMock(return_value=False)
-    client_instance.parse_document = AsyncMock(
-        return_value=make_parse_result(["# Sample Document\n\nThis is page 1."])
-    )
+    client_instance.parse_document = AsyncMock(return_value=make_parse_result(["# Sample Document\n\nThis is page 1."]))
     with patch(
-        "haystack_integrations.components.converters.paddleocr."
-        "paddleocr_vl_document_converter.AsyncPaddleOCRClient",
+        "haystack_integrations.components.converters.paddleocr.paddleocr_vl_document_converter.AsyncPaddleOCRClient",
         return_value=client_instance,
     ):
         yield client_instance
@@ -366,9 +362,7 @@ class TestRun:
         assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".jpg")
 
     def test_file_type_manual_override_uses_pdf_suffix(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
-        converter = PaddleOCRVLDocumentConverter(
-            access_token=Secret.from_token("tok"), file_type="pdf"
-        )
+        converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"), file_type="pdf")
         f = create_empty_image(tmp_path, "test.png")
         converter.run(sources=[str(f)])
 
@@ -382,7 +376,9 @@ class TestRun:
         assert len(converter.run(sources=[bs])["documents"]) == 1
 
     def test_bytestream_without_file_path_uses_mime_type(
-        self, mock_client_ctx: MagicMock, tmp_path: Path  # noqa: ARG002
+        self,
+        mock_client_ctx: MagicMock,  # noqa: ARG002
+        tmp_path: Path,
     ) -> None:
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         f = create_empty_image(tmp_path, "img.png")

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -71,10 +71,14 @@ class TestInit:
         assert converter.use_doc_orientation_classify is False
         assert converter.use_doc_unwarping is False
         assert converter.use_layout_detection is None
+        assert converter.use_chart_recognition is None
+        assert converter.use_seal_recognition is None
+        assert converter.use_ocr_for_image_block is None
         assert converter.layout_threshold is None
         assert converter.layout_nms is None
         assert converter.layout_unclip_ratio is None
         assert converter.layout_merge_bboxes_mode is None
+        assert converter.layout_shape_mode is None
         assert converter.prompt_label is None
         assert converter.format_block_content is None
         assert converter.repetition_penalty is None
@@ -82,8 +86,15 @@ class TestInit:
         assert converter.top_p is None
         assert converter.min_pixels is None
         assert converter.max_pixels is None
+        assert converter.max_new_tokens is None
+        assert converter.merge_layout_blocks is None
+        assert converter.markdown_ignore_labels is None
+        assert converter.vlm_extra_args is None
         assert converter.prettify_markdown is None
         assert converter.show_formula_number is None
+        assert converter.restructure_pages is None
+        assert converter.merge_tables is None
+        assert converter.relevel_titles is None
         assert converter.visualize is None
         assert converter.additional_params is None
 
@@ -555,8 +566,8 @@ class TestInferFileType:
 
 
 @pytest.mark.skipif(
-    not os.environ.get("PADDLEOCR_VL_BASE_URL") or not os.environ.get("PADDLEOCR_ACCESS_TOKEN"),
-    reason="Export PADDLEOCR_VL_BASE_URL and PADDLEOCR_ACCESS_TOKEN to run integration tests.",
+    not os.environ.get("PADDLEOCR_BASE_URL") or not os.environ.get("PADDLEOCR_ACCESS_TOKEN"),
+    reason="Export PADDLEOCR_BASE_URL and PADDLEOCR_ACCESS_TOKEN to run integration tests.",
 )
 @pytest.mark.integration
 class TestIntegration:

--- a/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
+++ b/integrations/paddleocr/tests/test_paddleocr_vl_document_converter.py
@@ -325,7 +325,7 @@ class TestRun:
         assert options.use_doc_orientation_classify is True
         assert options.use_doc_unwarping is None
 
-    def test_meta_single_dict_applied_to_all(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_meta_single_dict_applied_to_all(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:  # noqa: ARG002
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         f1 = create_empty_image(tmp_path, "a.png")
         f2 = create_empty_image(tmp_path, "b.png")
@@ -335,7 +335,7 @@ class TestRun:
         for doc in result["documents"]:
             assert doc.meta["dept"] == "eng"
 
-    def test_meta_list_applied_per_source(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_meta_list_applied_per_source(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:  # noqa: ARG002
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         f1 = create_empty_image(tmp_path, "a.png")
         f2 = create_empty_image(tmp_path, "b.png")
@@ -374,7 +374,7 @@ class TestRun:
 
         assert mock_client_ctx.parse_document.call_args.kwargs["file_path"].endswith(".pdf")
 
-    def test_bytestream_with_file_path_meta(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_bytestream_with_file_path_meta(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:  # noqa: ARG002
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         f = create_empty_image(tmp_path, "img.jpg")
         bs = ByteStream(data=f.read_bytes(), meta={"file_path": str(f)})
@@ -382,7 +382,7 @@ class TestRun:
         assert len(converter.run(sources=[bs])["documents"]) == 1
 
     def test_bytestream_without_file_path_uses_mime_type(
-        self, mock_client_ctx: MagicMock, tmp_path: Path
+        self, mock_client_ctx: MagicMock, tmp_path: Path  # noqa: ARG002
     ) -> None:
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         f = create_empty_image(tmp_path, "img.png")
@@ -390,7 +390,7 @@ class TestRun:
 
         assert len(converter.run(sources=[bs])["documents"]) == 1
 
-    def test_raw_response_structure(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_raw_response_structure(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:  # noqa: ARG002
         converter = PaddleOCRVLDocumentConverter(access_token=Secret.from_token("tok"))
         f = create_empty_image(tmp_path, "test.png")
 
@@ -449,7 +449,7 @@ class TestRun:
         options: PaddleOCRVLOptions = mock_client_ctx.parse_document.call_args.kwargs["options"]
         assert options.extra_options == {"logId": "custom"}
 
-    def test_tmp_file_deleted_after_parse(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:
+    def test_tmp_file_deleted_after_parse(self, mock_client_ctx: MagicMock, tmp_path: Path) -> None:  # noqa: ARG002
         created_paths: list[str] = []
         original_ntf = _tmpmod.NamedTemporaryFile
 


### PR DESCRIPTION

### Proposed Changes

Migrates the `PaddleOCR-VL` integration from a hand-rolled `requests`-based HTTP client and `paddlex[serving]` schema validation to the official `paddleocr` SDK's `PaddleOCRClient`.

- Replaces `api_url` with `base_url` (optional, falls back to `PADDLEOCR_BASE_URL` env var, then SDK default)
- Renames auth env var from `AISTUDIO_ACCESS_TOKEN` to `PADDLEOCR_ACCESS_TOKEN`
- Adds `model` parameter (default `Model.PADDLE_OCR_VL_16`) for selecting the document parsing model
- Removes `paddlex[serving]` and `requests` dependencies; bumps `paddleocr>=3.7.0`
- All inference parameters now passed via `PaddleOCRVLOptions`; `additional_params` mapped to `extra_options`
- Fixes `to_dict`/`from_dict` round-trip for `file_type` (integers 0/1 now accepted alongside `"pdf"`/`"image"`)

### How did you test it?

Unit tests (56) covering: init validation, serialization round-trip with `model` and `base_url`, all source types (str path, Path, ByteStream), multi-source processing, partial failure handling, unknown extension skipping, empty text, model/options forwarding, meta (single dict and per-source list), temp file cleanup, base URL and token forwarding to the SDK client.

Manual live verification against the PaddleOCR AI Studio API with a real PDF and image file.

### Notes for the reviewer

`additional_params` is now passed as `extra_options` to `PaddleOCRVLOptions` rather than merged into the top-level request dict — existing users relying on this for top-level API params will need to update.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
