### PR TITLE
fix(amazon-bedrock): forward dimensions/normalize for Titan V2 embedders

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -101,7 +101,7 @@ class AmazonBedrockDocumentEmbedder:
             Can be used to tune [retry behavior](https://docs.aws.amazon.com/boto3/latest/guide/retries.html)
             and other low-level settings like timeouts and connection management.
         :param kwargs: Additional parameters to pass for model inference. For example, `input_type` and `truncate` for
-            Cohere models.
+            Cohere models, or `dimensions` and `normalize` for Amazon Titan Text Embeddings V2.
         :raises ValueError: If the model is not supported.
         :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly.
         """
@@ -209,9 +209,17 @@ class AmazonBedrockDocumentEmbedder:
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
 
+        titan_body: dict[str, Any] = {}
+        if "v2" in self.model:
+            # `dimensions` and `normalize` are only supported by Amazon Titan Text Embeddings V2
+            if (dimensions := self.kwargs.get("dimensions")) is not None:
+                titan_body["dimensions"] = dimensions
+            if (normalize := self.kwargs.get("normalize")) is not None:
+                titan_body["normalize"] = normalize
+
         all_embeddings = []
         for text in tqdm(texts_to_embed, disable=not self.progress_bar, desc="Creating embeddings"):
-            body = {"inputText": text}
+            body = {"inputText": text, **titan_body}
             try:
                 response = self._client.invoke_model(
                     body=json.dumps(body), modelId=self.model, accept="*/*", contentType="application/json"

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/document_embedder.py
@@ -210,7 +210,7 @@ class AmazonBedrockDocumentEmbedder:
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
 
         titan_body: dict[str, Any] = {}
-        if "v2" in self.model:
+        if self.model.startswith("amazon.titan-embed-text-v2"):
             # `dimensions` and `normalize` are only supported by Amazon Titan Text Embeddings V2
             if (dimensions := self.kwargs.get("dimensions")) is not None:
                 titan_body["dimensions"] = dimensions

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
@@ -82,7 +82,7 @@ class AmazonBedrockTextEmbedder:
             Can be used to tune [retry behavior](https://docs.aws.amazon.com/boto3/latest/guide/retries.html)
             and other low-level settings like timeouts and connection management.
         :param kwargs: Additional parameters to pass for model inference. For example, `input_type` and `truncate` for
-            Cohere models.
+            Cohere models, or `dimensions` and `normalize` for Amazon Titan Text Embeddings V2.
         :raises ValueError: If the model is not supported.
         :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly.
         """
@@ -151,6 +151,12 @@ class AmazonBedrockTextEmbedder:
             body = {
                 "inputText": text,
             }
+            if "v2" in self.model:
+                # `dimensions` and `normalize` are only supported by Amazon Titan Text Embeddings V2
+                if (dimensions := self.kwargs.get("dimensions")) is not None:
+                    body["dimensions"] = dimensions
+                if (normalize := self.kwargs.get("normalize")) is not None:
+                    body["normalize"] = normalize
 
         try:
             response = self._client.invoke_model(

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/embedders/amazon_bedrock/text_embedder.py
@@ -151,7 +151,7 @@ class AmazonBedrockTextEmbedder:
             body = {
                 "inputText": text,
             }
-            if "v2" in self.model:
+            if self.model.startswith("amazon.titan-embed-text-v2"):
                 # `dimensions` and `normalize` are only supported by Amazon Titan Text Embeddings V2
                 if (dimensions := self.kwargs.get("dimensions")) is not None:
                     body["dimensions"] = dimensions

--- a/integrations/amazon_bedrock/tests/test_document_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_document_embedder.py
@@ -324,6 +324,63 @@ class TestAmazonBedrockDocumentEmbedder:
             assert doc.content == docs[i].content
             assert doc.embedding == [0.1, 0.2, 0.3]
 
+    def test_embed_titan_v2_with_dimensions_and_normalize(self, mock_boto3_session):
+        embedder = AmazonBedrockDocumentEmbedder(
+            model="amazon.titan-embed-text-v2:0",
+            dimensions=512,
+            normalize=False,
+        )
+
+        mock_response = {"body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}')}
+
+        def mock_invoke_model(*args, **kwargs):
+            mock_response["body"].seek(0)
+            return mock_response
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            embedder._embed_titan(documents=[Document(content="some text")])
+
+        assert (
+            mock_client.invoke_model.call_args_list[0][1]["body"]
+            == '{"inputText": "some text", "dimensions": 512, "normalize": false}'
+        )
+
+    def test_embed_titan_v2_without_extra_params(self, mock_boto3_session):
+        embedder = AmazonBedrockDocumentEmbedder(model="amazon.titan-embed-text-v2:0")
+
+        mock_response = {"body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}')}
+
+        def mock_invoke_model(*args, **kwargs):
+            mock_response["body"].seek(0)
+            return mock_response
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            embedder._embed_titan(documents=[Document(content="some text")])
+
+        assert mock_client.invoke_model.call_args_list[0][1]["body"] == '{"inputText": "some text"}'
+
+    def test_embed_titan_v1_ignores_dimensions_and_normalize(self, mock_boto3_session):
+        # Titan G1 (v1) does not support `dimensions`/`normalize`, so they must not be sent.
+        embedder = AmazonBedrockDocumentEmbedder(
+            model="amazon.titan-embed-text-v1",
+            dimensions=512,
+            normalize=False,
+        )
+
+        mock_response = {"body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}')}
+
+        def mock_invoke_model(*args, **kwargs):
+            mock_response["body"].seek(0)
+            return mock_response
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            embedder._embed_titan(documents=[Document(content="some text")])
+
+        assert mock_client.invoke_model.call_args_list[0][1]["body"] == '{"inputText": "some text"}'
+
     def test_run_cohere_does_not_modify_original_documents(self, mock_boto3_session):
         embedder = AmazonBedrockDocumentEmbedder(model="cohere.embed-english-v3")
 

--- a/integrations/amazon_bedrock/tests/test_document_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_document_embedder.py
@@ -381,6 +381,25 @@ class TestAmazonBedrockDocumentEmbedder:
 
         assert mock_client.invoke_model.call_args_list[0][1]["body"] == '{"inputText": "some text"}'
 
+    def test_embed_titan_non_text_v2_ignores_dimensions_and_normalize(self, mock_boto3_session):
+        embedder = AmazonBedrockDocumentEmbedder(
+            model="amazon.titan-embed-image-v2:0",
+            dimensions=512,
+            normalize=False,
+        )
+
+        mock_response = {"body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}')}
+
+        def mock_invoke_model(*args, **kwargs):
+            mock_response["body"].seek(0)
+            return mock_response
+
+        with patch.object(embedder, "_client") as mock_client:
+            mock_client.invoke_model.side_effect = mock_invoke_model
+            embedder._embed_titan(documents=[Document(content="some text")])
+
+        assert mock_client.invoke_model.call_args_list[0][1]["body"] == '{"inputText": "some text"}'
+
     def test_run_cohere_does_not_modify_original_documents(self, mock_boto3_session):
         embedder = AmazonBedrockDocumentEmbedder(model="cohere.embed-english-v3")
 

--- a/integrations/amazon_bedrock/tests/test_text_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_text_embedder.py
@@ -204,6 +204,63 @@ class TestAmazonBedrockTextEmbedder:
 
             assert result == {"embedding": [0.1, 0.2, 0.3]}
 
+    def test_titan_v2_invocation_with_dimensions_and_normalize(self, mock_boto3_session):
+        embedder = AmazonBedrockTextEmbedder(
+            model="amazon.titan-embed-text-v2:0",
+            dimensions=512,
+            normalize=False,
+        )
+
+        with patch.object(embedder._client, "invoke_model") as mock_invoke_model:
+            mock_invoke_model.return_value = {
+                "body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}'),
+            }
+            embedder.run(text="some text")
+
+            mock_invoke_model.assert_called_once_with(
+                body='{"inputText": "some text", "dimensions": 512, "normalize": false}',
+                modelId="amazon.titan-embed-text-v2:0",
+                accept="*/*",
+                contentType="application/json",
+            )
+
+    def test_titan_v2_invocation_without_extra_params(self, mock_boto3_session):
+        embedder = AmazonBedrockTextEmbedder(model="amazon.titan-embed-text-v2:0")
+
+        with patch.object(embedder._client, "invoke_model") as mock_invoke_model:
+            mock_invoke_model.return_value = {
+                "body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}'),
+            }
+            embedder.run(text="some text")
+
+            mock_invoke_model.assert_called_once_with(
+                body='{"inputText": "some text"}',
+                modelId="amazon.titan-embed-text-v2:0",
+                accept="*/*",
+                contentType="application/json",
+            )
+
+    def test_titan_v1_ignores_dimensions_and_normalize(self, mock_boto3_session):
+        # Titan G1 (v1) does not support `dimensions`/`normalize`, so they must not be sent.
+        embedder = AmazonBedrockTextEmbedder(
+            model="amazon.titan-embed-text-v1",
+            dimensions=512,
+            normalize=False,
+        )
+
+        with patch.object(embedder._client, "invoke_model") as mock_invoke_model:
+            mock_invoke_model.return_value = {
+                "body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}'),
+            }
+            embedder.run(text="some text")
+
+            mock_invoke_model.assert_called_once_with(
+                body='{"inputText": "some text"}',
+                modelId="amazon.titan-embed-text-v1",
+                accept="*/*",
+                contentType="application/json",
+            )
+
     def test_run_invocation_error(self, mock_boto3_session):
         embedder = AmazonBedrockTextEmbedder(model="cohere.embed-english-v3")
 

--- a/integrations/amazon_bedrock/tests/test_text_embedder.py
+++ b/integrations/amazon_bedrock/tests/test_text_embedder.py
@@ -261,6 +261,26 @@ class TestAmazonBedrockTextEmbedder:
                 contentType="application/json",
             )
 
+    def test_titan_non_text_v2_ignores_dimensions_and_normalize(self, mock_boto3_session):
+        embedder = AmazonBedrockTextEmbedder(
+            model="amazon.titan-embed-image-v2:0",
+            dimensions=512,
+            normalize=False,
+        )
+
+        with patch.object(embedder._client, "invoke_model") as mock_invoke_model:
+            mock_invoke_model.return_value = {
+                "body": io.StringIO('{"embedding": [0.1, 0.2, 0.3]}'),
+            }
+            embedder.run(text="some text")
+
+            mock_invoke_model.assert_called_once_with(
+                body='{"inputText": "some text"}',
+                modelId="amazon.titan-embed-image-v2:0",
+                accept="*/*",
+                contentType="application/json",
+            )
+
     def test_run_invocation_error(self, mock_boto3_session):
         embedder = AmazonBedrockTextEmbedder(model="cohere.embed-english-v3")
 


### PR DESCRIPTION
Thanks for the clean Bedrock embedder design — this PR fills in a gap in the existing kwargs-forwarding convention rather than adding a new behavior.

### Related Issues

- Fixes #3476

### Proposed Changes

The `AmazonBedrockTextEmbedder` and `AmazonBedrockDocumentEmbedder` Titan branches built the request body as `{"inputText": text}` only, so `dimensions`/`normalize` passed via `**kwargs` were silently dropped. The Cohere branch already forwards `input_type`/`truncate` from `self.kwargs` into the body; this PR does the same for Titan's `dimensions`/`normalize`, **gated on Titan V2** (`"v2" in self.model`).

Amazon Titan G1 (`amazon.titan-embed-text-v1`) does not support inference parameters — only `inputText` — so the gate ensures v1 requests are unchanged. The docstring already promised "Additional parameters to pass for model inference", so this matches the documented intent; it has been extended to name `dimensions`/`normalize` for Titan V2.

AWS reference: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html — V2 request supports optional `dimensions` (1024 default / 512 / 256) and `normalize` (default `true`); G1 request supports only `inputText`.

### Before / After

| Case | Before | After |
|------|--------|-------|
| Titan **v2** + `dimensions=512, normalize=False` | ❌ body `{"inputText": "..."}` (params dropped, always 1024-dim normalized) | ✅ body `{"inputText": "...", "dimensions": 512, "normalize": false}` |
| Titan **v2**, no extra params | `{"inputText": "..."}` | ✅ `{"inputText": "..."}` (unchanged) |
| Titan **v1** + `dimensions`/`normalize` | `{"inputText": "..."}` | ✅ `{"inputText": "..."}` (v1 has no inference params; not sent) |
| Cohere `input_type`/`truncate` | ✅ forwarded | ✅ forwarded (unchanged) |
| Public API / constructor args / output keys | — | ✅ Unchanged |
| Titan batching (one-by-one), Cohere batching | — | ✅ Unchanged |

### How did you test it?

Added mock-based unit tests (no AWS keys needed) to both `test_text_embedder.py` and `test_document_embedder.py`, asserting the exact request `body`: v2 forwards the params, v2 without params is unchanged, and v1 ignores them.

To prove the new tests catch the bug, I reverted only the source (kept the new tests) and re-ran them — the two "v2 forwards params" tests fail:

```
E       assert '{"inputText": "some text"}' == '{"inputText"...lize": false}'
E         - {"inputText": "some text", "dimensions": 512, "normalize": false}
E         + {"inputText": "some text"}
FAILED tests/test_text_embedder.py::...::test_titan_v2_invocation_with_dimensions_and_normalize
FAILED tests/test_document_embedder.py::...::test_embed_titan_v2_with_dimensions_and_normalize
================== 2 failed, 4 passed, 35 deselected ==================
```

Restoring the source, all pass, plus types and format:

```
hatch run test:unit  -> 35 passed, 6 deselected
hatch run test:types -> Success: no issues found in 20 source files
hatch run fmt        -> All checks passed! / 37 files left unchanged
```

(run from `integrations/amazon_bedrock`)

### Notes for the reviewer

- Minimal diff: the Titan branch reuses the existing Cohere `self.kwargs.get(...)` idiom; no new params on `__init__`, no public API change.
- A more complete follow-up could also expose `embeddingTypes` (binary/float) for V2, but this PR is scoped to the reported `dimensions`/`normalize` drop.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct
- [x] I added unit tests and updated the docstrings
- [x] I've used a conventional commit type for my PR title: `fix:`

---

*This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the AWS-documented rationale, and the test results before submitting.*
