### PR TITLE
fix: NvidiaRanker missing /ranking path for local NIM deployments

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
+++ b/integrations/nvidia/src/haystack_integrations/utils/nvidia/nim_backend.py
@@ -42,6 +42,11 @@ class NimBackend:
         self.session.headers.update(headers)
 
         self.api_url = api_url
+        # Hosted ranking models are assigned a per-model endpoint that already includes the
+        # full path (e.g. ".../nv-rerankqa-mistral-4b-v3/reranking"), unlike other hosted
+        # endpoints which only override the host. `rank()` uses this to decide whether it
+        # still needs to append the `/ranking` path itself.
+        self._has_custom_ranking_endpoint = False
         if isinstance(client, str):
             client = Client.from_str(client)
         validated_model: Model | None = None
@@ -64,6 +69,8 @@ class NimBackend:
                 # we override the endpoint to use the custom endpoint
                 self.api_url = validated_model.endpoint
                 self.model_type = validated_model.model_type
+                if validated_model.model_type == "ranking":
+                    self._has_custom_ranking_endpoint = True
 
         self.model = validated_model.id if validated_model else model
         self.model_kwargs = model_kwargs or {}
@@ -189,7 +196,10 @@ class NimBackend:
 
     def rank(self, query_text: str, document_texts: list[str]) -> list[dict[str, Any]]:
         """Rank documents by relevance to a query via the NIM API."""
-        url = self.api_url
+        # Hosted ranking models already carry the full path in their custom endpoint;
+        # everything else (local NIM containers, non-ranking-table models) needs the
+        # `/ranking` suffix appended explicitly, like the other endpoints below do.
+        url = self.api_url if self._has_custom_ranking_endpoint else f"{self.api_url}/ranking"
 
         try:
             res = self.session.post(

--- a/integrations/nvidia/tests/test_nim_backend.py
+++ b/integrations/nvidia/tests/test_nim_backend.py
@@ -289,6 +289,28 @@ class TestNimBackend:
                 timeout=60.0,
             )
 
+    def test_rank_local_nim_appends_ranking_path(self, monkeypatch):
+        # Local/self-hosted NIM deployments have no model-specific endpoint override,
+        # so `rank()` must append the `/ranking` path itself instead of relying on
+        # `validate_hosted_model` having already baked it into `self.api_url`.
+        with patch("requests.sessions.Session.post", side_effect=mock_rank_post_response) as mock_post:
+            monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+            backend = NimBackend(model="custom-rerank-model", api_url="http://localhost:8000/v1", client="NvidiaRanker")
+            query_text = "query"
+            document_texts = ["text1", "text2"]
+            backend.rank(query_text=query_text, document_texts=document_texts)
+
+            expected_url = "http://localhost:8000/v1/ranking"
+            mock_post.assert_called_once_with(
+                expected_url,
+                json={
+                    "model": "custom-rerank-model",
+                    "query": {"text": query_text},
+                    "passages": [{"text": text} for text in document_texts],
+                },
+                timeout=60.0,
+            )
+
     def test_rank_raises_on_http_error(self, monkeypatch):
         error_response = requests.Response()
         error_response.status_code = 500

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -211,6 +211,7 @@ class TestNvidiaRanker:
         client = NvidiaRanker(
             model=os.environ["NVIDIA_NIM_RANKER_MODEL"],
             api_url=os.environ["NVIDIA_NIM_RANKER_ENDPOINT_URL"],
+            api_key=None,
             top_k=2,
         )
         client.warm_up()

--- a/integrations/nvidia/tests/test_ranker.py
+++ b/integrations/nvidia/tests/test_ranker.py
@@ -120,6 +120,36 @@ class TestNvidiaRanker:
         assert response[0].content == documents[1].content
         assert response[0].score == 4.2
 
+    @pytest.mark.parametrize(
+        ("model", "api_url", "expected_url"),
+        [
+            (
+                _DEFAULT_MODEL,
+                None,
+                "https://ai.api.nvidia.com/v1/retrieval/nvidia/nv-rerankqa-mistral-4b-v3/reranking",
+            ),
+            ("custom-rerank-model", "http://localhost:8000/v1", "http://localhost:8000/v1/ranking"),
+        ],
+        ids=["hosted", "local-nim"],
+    )
+    def test_ranking_url(self, requests_mock, monkeypatch, model, api_url, expected_url) -> None:
+        # Hosted models are assigned a per-model endpoint that already includes the full path,
+        # while local/self-hosted NIM deployments get no such override and need `/ranking`
+        # appended to the base URL. Registering only the exact expected URL means any other
+        # URL raises NoMockAddress instead of silently passing.
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+        requests_mock.post(expected_url, json={"rankings": [{"index": 0, "logit": 1.0}]}, complete_qs=True)
+
+        api_url_param = {} if api_url is None else {"api_url": api_url}
+        client = NvidiaRanker(model=model, top_k=1, **api_url_param)
+        client.warm_up()
+
+        response = client.run(query="q", documents=[Document(content="doc")])["documents"]
+
+        assert len(response) == 1
+        assert requests_mock.last_request is not None
+        assert requests_mock.last_request.url == expected_url
+
     @pytest.mark.parametrize("truncate", [True, False, 1, 0, 1.0, "START", "BOGUS"])
     def test_truncate_invalid(self, truncate: Any) -> None:
         with pytest.raises(ValueError) as e:


### PR DESCRIPTION
## Summary

Closes #1457 - `NvidiaRanker` sends ranking requests to the wrong endpoint for self-hosted/local NIM deployments.

**The bug:**
`NimBackend.rank()` used `self.api_url` directly, while `embed()`, `generate()`, and `models()` all append their own endpoint suffix (`/embeddings`, `/chat/completions`, `/models`). Only `rank()` was missing its suffix.

This went unnoticed in the existing unit test because hosted ranking models get their `api_url` fully overridden by `validate_hosted_model()` to a model-specific endpoint that already includes the complete path (e.g. `.../nv-rerankqa-mistral-4b-v3/reranking`). For self-hosted or local NIM ranking containers - where no model-specific override applies - `self.api_url` stays as the bare base URL (e.g. `http://localhost:8000/v1`), so requests were sent to the wrong endpoint instead of `{api_url}/ranking`.

**The fix:**
Track whether the hosted override already supplied a full ranking path (`_has_custom_ranking_endpoint`). Only append `/ranking` when it did not, so both hosted models (unchanged behavior) and local/self-hosted NIM ranking deployments (the actual bug) hit the correct endpoint.

**Tests:**
- Added `test_rank_local_nim_appends_ranking_path` exercising the non-hosted path that the original bug affected
- Existing `test_rank` (hosted model with custom endpoint override) still passes unchanged
- All 204 unit tests pass
- `mypy` and `ruff` clean