### PR TITLE
feat: add Scavio web search integration

### DIFF
--- a/integrations/scavio/CHANGELOG.md
+++ b/integrations/scavio/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [integrations/scavio-v0.1.0]
+
+### 🚀 Features
+
+- Add ScavioWebSearch component

--- a/integrations/scavio/LICENSE.txt
+++ b/integrations/scavio/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023-present deepset GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integrations/scavio/README.md
+++ b/integrations/scavio/README.md
@@ -1,0 +1,14 @@
+# scavio-haystack
+
+[![PyPI - Version](https://img.shields.io/pypi/v/scavio-haystack.svg)](https://pypi.org/project/scavio-haystack)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/scavio-haystack.svg)](https://pypi.org/project/scavio-haystack)
+
+- [Changelog](https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/scavio/CHANGELOG.md)
+
+---
+
+## Contributing
+
+Refer to the general [Contribution Guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md).
+
+To run integration tests locally, you need to export the `SCAVIO_API_KEY` environment variable.

--- a/integrations/scavio/pydoc/config_docusaurus.yml
+++ b/integrations/scavio/pydoc/config_docusaurus.yml
@@ -1,0 +1,13 @@
+loaders:
+  - modules:
+      - haystack_integrations.components.websearch.scavio.scavio_websearch
+    search_path: [../src]
+processors:
+  - type: filter
+    documented_only: true
+    skip_empty_modules: true
+renderer:
+  description: Scavio integration for Haystack
+  id: integrations-scavio
+  filename: scavio.md
+  title: Scavio

--- a/integrations/scavio/pyproject.toml
+++ b/integrations/scavio/pyproject.toml
@@ -1,0 +1,159 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "scavio-haystack"
+dynamic = ["version"]
+description = "Haystack integration for Scavio Web Search"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+keywords = ["Haystack", "Scavio", "Web Search", "AI Search"]
+authors = [{ name = "deepset GmbH", email = "info@deepset.ai" }]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = ["haystack-ai>=2.24.1", "scavio>=0.2.1"]
+
+[project.urls]
+Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/scavio#readme"
+Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/scavio"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/haystack_integrations"]
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = 'integrations\/scavio-v(?P<version>.*)'
+
+[tool.hatch.version.raw-options]
+root = "../.."
+git_describe_command = 'git describe --tags --match="integrations/scavio-v[0-9]*"'
+
+[tool.hatch.envs.default]
+installer = "uv"
+dependencies = ["haystack-pydoc-tools", "ruff"]
+
+[tool.hatch.envs.default.scripts]
+docs = ["haystack-pydoc pydoc/config_docusaurus.yml"]
+fmt = "ruff check --fix {args}; ruff format {args}"
+fmt-check = "ruff check {args} && ruff format --check {args}"
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-rerunfailures",
+    "mypy",
+    "pip",
+]
+
+[tool.hatch.envs.test.scripts]
+unit = 'pytest -m "not integration" {args:tests}'
+integration = 'pytest -m "integration" {args:tests}'
+all = 'pytest {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
+types = "mypy -p haystack_integrations.components.websearch.scavio {args}"
+
+[tool.mypy]
+install_types = true
+non_interactive = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = ["scavio.*"]
+ignore_missing_imports = true
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C",
+    "D102",
+    "D103",
+    "D205",
+    "D209",
+    "D213",
+    "D417",
+    "D419",
+    "DTZ",
+    "E",
+    "EM",
+    "F",
+    "I",
+    "ICN",
+    "ISC",
+    "N",
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    "Q",
+    "RUF",
+    "S",
+    "T",
+    "TID",
+    "UP",
+    "W",
+    "YTT",
+]
+ignore = [
+    "B027",
+    "B008",
+    "S105",
+    "S106",
+    "S107",
+    "C901",
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+    "ANN401",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["haystack_integrations"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "parents"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*" = ["PLR2004", "S101", "TID252", "D", "ANN"]
+
+[tool.coverage.run]
+source = ["haystack_integrations"]
+branch = true
+relative_files = true
+parallel = false
+
+[tool.coverage.report]
+omit = ["*/tests/*", "*/__init__.py"]
+show_missing = true
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+  "integration: integration tests",
+]
+log_cli = true
+asyncio_default_fixture_loop_scope = "function"

--- a/integrations/scavio/src/haystack_integrations/components/websearch/scavio/__init__.py
+++ b/integrations/scavio/src/haystack_integrations/components/websearch/scavio/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack_integrations.components.websearch.scavio.scavio_websearch import ScavioWebSearch
+
+__all__ = ["ScavioWebSearch"]

--- a/integrations/scavio/src/haystack_integrations/components/websearch/scavio/scavio_websearch.py
+++ b/integrations/scavio/src/haystack_integrations/components/websearch/scavio/scavio_websearch.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack import Document, component, logging
+from haystack.utils import Secret
+
+from scavio import AsyncScavioClient, ScavioClient
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class ScavioWebSearch:
+    """
+    A component that uses Scavio to search the web and return results as Haystack Documents.
+
+    This component wraps the Scavio Google web search endpoint, enabling real-time web search
+    queries that return structured documents with content and links.
+
+    Scavio is a unified search API for AI agents. You need a Scavio API key from
+    [dashboard.scavio.dev](https://dashboard.scavio.dev).
+
+    ### Usage example
+
+    ```python
+    from haystack_integrations.components.websearch.scavio import ScavioWebSearch
+    from haystack.utils import Secret
+
+    websearch = ScavioWebSearch(
+        api_key=Secret.from_env_var("SCAVIO_API_KEY"),
+        top_k=5,
+    )
+    result = websearch.run(query="What is Haystack by deepset?")
+    documents = result["documents"]
+    links = result["links"]
+    ```
+    """
+
+    def __init__(
+        self,
+        api_key: Secret = Secret.from_env_var("SCAVIO_API_KEY"),
+        top_k: int | None = 10,
+        search_params: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Initialize the ScavioWebSearch component.
+
+        :param api_key:
+            API key for Scavio. Defaults to the `SCAVIO_API_KEY` environment variable.
+        :param top_k:
+            Maximum number of results to return.
+        :param search_params:
+            Additional parameters passed to the Scavio Google search endpoint. Supported keys
+            include: `country_code`, `language`, `page`, `search_type`, `device`, `nfpr`,
+            `light_request`.
+        """
+        self.api_key = api_key
+        self.top_k = top_k
+        self.search_params = search_params
+        self._scavio_client: ScavioClient | None = None
+        self._async_scavio_client: AsyncScavioClient | None = None
+
+    def warm_up(self) -> None:
+        """
+        Initialize the Scavio sync and async clients.
+
+        Called automatically on first use. Can be called explicitly to avoid cold-start latency.
+        """
+        if self._scavio_client is None:
+            self._scavio_client = ScavioClient(api_key=self.api_key.resolve_value())
+        if self._async_scavio_client is None:
+            self._async_scavio_client = AsyncScavioClient(api_key=self.api_key.resolve_value())
+
+    @component.output_types(documents=list[Document], links=list[str])
+    def run(
+        self,
+        query: str,
+        search_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Search the web using Scavio and return results as Documents.
+
+        :param query: Search query string.
+        :param search_params:
+            Optional per-run override of search parameters.
+            If provided, fully replaces the init-time `search_params`.
+        :returns: A dictionary with:
+            - `documents`: List of Documents containing search result content.
+            - `links`: List of URLs from the search results.
+        """
+        if self._scavio_client is None:
+            self.warm_up()
+        if self._scavio_client is None:
+            msg = "ScavioWebSearch client failed to initialize."
+            raise RuntimeError(msg)
+
+        params = (search_params if search_params is not None else self.search_params or {}).copy()
+        response = self._scavio_client.google.search(query, **params)
+        return self._parse_response(response, self.top_k)
+
+    @component.output_types(documents=list[Document], links=list[str])
+    async def run_async(
+        self,
+        query: str,
+        search_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Asynchronously search the web using Scavio and return results as Documents.
+
+        :param query: Search query string.
+        :param search_params:
+            Optional per-run override of search parameters.
+            If provided, fully replaces the init-time `search_params`.
+        :returns: A dictionary with:
+            - `documents`: List of Documents containing search result content.
+            - `links`: List of URLs from the search results.
+        """
+        if self._async_scavio_client is None:
+            self.warm_up()
+        if self._async_scavio_client is None:
+            msg = "ScavioWebSearch async client failed to initialize."
+            raise RuntimeError(msg)
+
+        params = (search_params if search_params is not None else self.search_params or {}).copy()
+        response = await self._async_scavio_client.google.search(query, **params)
+        return self._parse_response(response, self.top_k)
+
+    @staticmethod
+    def _parse_response(response: dict[str, Any], top_k: int | None) -> dict[str, Any]:
+        """
+        Convert a Scavio search response to Haystack Documents and links.
+
+        :param response: Scavio search response dictionary.
+        :param top_k: Maximum number of results to keep.
+        :returns: Dictionary with `documents` and `links` keys.
+        """
+        documents: list[Document] = []
+        links: list[str] = []
+
+        results = response.get("results", [])
+        if top_k is not None:
+            results = results[:top_k]
+
+        for result in results:
+            url = result.get("url", "")
+            title = result.get("title", "")
+            content = result.get("content", "")
+
+            documents.append(Document(content=content, meta={"title": title, "url": url}))
+            if url:
+                links.append(url)
+
+        return {"documents": documents, "links": links}

--- a/integrations/scavio/tests/__init__.py
+++ b/integrations/scavio/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/integrations/scavio/tests/test_scavio_websearch.py
+++ b/integrations/scavio/tests/test_scavio_websearch.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from haystack import Document
+from haystack.core.serialization import component_from_dict, component_to_dict
+from haystack.utils import Secret
+
+from haystack_integrations.components.websearch.scavio import ScavioWebSearch
+
+
+class TestScavioWebSearch:
+    @pytest.fixture
+    def search_response(self):
+        return {
+            "results": [
+                {"title": "Example Title", "url": "https://example.com", "content": "Example content", "position": 1}
+            ]
+        }
+
+    @pytest.fixture
+    def mock_client(self, search_response):
+        client = MagicMock()
+        client.google.search.return_value = search_response
+        return client
+
+    @pytest.fixture
+    def mock_async_client(self, search_response):
+        client = MagicMock()
+        client.google.search = AsyncMock(return_value=search_response)
+        return client
+
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("SCAVIO_API_KEY", "test-key")
+        ws = ScavioWebSearch()
+        assert ws.top_k == 10
+        assert ws.search_params is None
+        assert ws.api_key.resolve_value() == "test-key"
+
+    def test_init_with_params(self):
+        ws = ScavioWebSearch(
+            api_key=Secret.from_token("custom-key"),
+            top_k=5,
+            search_params={"country_code": "us"},
+        )
+        assert ws.top_k == 5
+        assert ws.search_params == {"country_code": "us"}
+
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("SCAVIO_API_KEY", "test-key")
+        ws = ScavioWebSearch(top_k=5, search_params={"country_code": "us"})
+        data = component_to_dict(ws, "ScavioWebSearch")
+        assert data["type"] == "haystack_integrations.components.websearch.scavio.scavio_websearch.ScavioWebSearch"
+        assert data["init_parameters"]["top_k"] == 5
+        assert data["init_parameters"]["search_params"] == {"country_code": "us"}
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("SCAVIO_API_KEY", "test-key")
+        data = {
+            "type": "haystack_integrations.components.websearch.scavio.scavio_websearch.ScavioWebSearch",
+            "init_parameters": {
+                "top_k": 3,
+                "search_params": {"language": "en"},
+                "api_key": {"env_vars": ["SCAVIO_API_KEY"], "strict": True, "type": "env_var"},
+            },
+        }
+        ws = component_from_dict(ScavioWebSearch, data, "ScavioWebSearch")
+        assert ws.top_k == 3
+        assert ws.search_params == {"language": "en"}
+
+    def test_run_returns_documents_and_links(self, mock_client):
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"), top_k=10)
+        ws._scavio_client = mock_client
+
+        result = ws.run(query="test query")
+
+        assert len(result["documents"]) == 1
+        assert isinstance(result["documents"][0], Document)
+        assert result["documents"][0].content == "Example content"
+        assert result["documents"][0].meta["url"] == "https://example.com"
+        assert result["documents"][0].meta["title"] == "Example Title"
+        assert result["links"] == ["https://example.com"]
+        mock_client.google.search.assert_called_once_with("test query")
+
+    def test_run_overrides_params_at_runtime(self, mock_client):
+        ws = ScavioWebSearch(
+            api_key=Secret.from_token("test-key"),
+            top_k=10,
+            search_params={"country_code": "gb"},
+        )
+        ws._scavio_client = mock_client
+
+        ws.run(query="test", search_params={"country_code": "us"})
+
+        mock_client.google.search.assert_called_once_with("test", country_code="us")
+
+    def test_run_respects_top_k(self, mock_client):
+        mock_client.google.search.return_value = {
+            "results": [{"title": f"r{i}", "url": f"https://x/{i}", "content": "c"} for i in range(20)]
+        }
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"), top_k=3)
+        ws._scavio_client = mock_client
+        result = ws.run(query="test")
+        assert len(result["documents"]) == 3
+        assert len(result["links"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_run_async(self, mock_async_client):
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"), top_k=10)
+        ws._async_scavio_client = mock_async_client
+
+        result = await ws.run_async(query="test query")
+
+        assert len(result["documents"]) == 1
+        assert result["links"] == ["https://example.com"]
+        mock_async_client.google.search.assert_awaited_once()
+
+    def test_run_raises_on_error(self, mock_client):
+        mock_client.google.search.side_effect = Exception("API error")
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+        ws._scavio_client = mock_client
+
+        with pytest.raises(Exception, match="API error"):
+            ws.run(query="test")
+
+    @pytest.mark.asyncio
+    async def test_run_async_raises_on_error(self, mock_async_client):
+        mock_async_client.google.search = AsyncMock(side_effect=Exception("API error"))
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+        ws._async_scavio_client = mock_async_client
+
+        with pytest.raises(Exception, match="API error"):
+            await ws.run_async(query="test")
+
+    def test_warm_up_initializes_clients(self):
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+        assert ws._scavio_client is None
+        assert ws._async_scavio_client is None
+        ws.warm_up()
+        assert ws._scavio_client is not None
+        assert ws._async_scavio_client is not None
+
+    def test_run_triggers_warm_up(self, search_response):
+        with (
+            patch("haystack_integrations.components.websearch.scavio.scavio_websearch.ScavioClient") as mock_cls,
+            patch("haystack_integrations.components.websearch.scavio.scavio_websearch.AsyncScavioClient"),
+        ):
+            mock_cls.return_value.google.search.return_value = search_response
+            ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+            ws.run(query="test")
+            mock_cls.assert_called_once_with(api_key="test-key")
+
+    @pytest.mark.asyncio
+    async def test_run_async_triggers_warm_up(self, search_response):
+        with (
+            patch("haystack_integrations.components.websearch.scavio.scavio_websearch.ScavioClient"),
+            patch("haystack_integrations.components.websearch.scavio.scavio_websearch.AsyncScavioClient") as mock_cls,
+        ):
+            mock_cls.return_value.google.search = AsyncMock(return_value=search_response)
+            ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+            await ws.run_async(query="test")
+            mock_cls.assert_called_once_with(api_key="test-key")
+
+    def test_run_empty_results(self, mock_client):
+        mock_client.google.search.return_value = {"results": []}
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+        ws._scavio_client = mock_client
+        result = ws.run(query="obscure query")
+        assert result["documents"] == []
+        assert result["links"] == []
+
+    def test_run_raises_runtime_error_when_warm_up_fails_to_initialize_client(self, monkeypatch):
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+        monkeypatch.setattr(ws, "warm_up", lambda: None)
+        with pytest.raises(RuntimeError, match="ScavioWebSearch client failed to initialize"):
+            ws.run(query="test")
+
+    @pytest.mark.asyncio
+    async def test_run_async_raises_runtime_error_when_warm_up_fails_to_initialize_client(self, monkeypatch):
+        ws = ScavioWebSearch(api_key=Secret.from_token("test-key"))
+        monkeypatch.setattr(ws, "warm_up", lambda: None)
+        with pytest.raises(RuntimeError, match="ScavioWebSearch async client failed to initialize"):
+            await ws.run_async(query="test")
+
+    @pytest.mark.skipif(
+        not os.environ.get("SCAVIO_API_KEY"),
+        reason="Export SCAVIO_API_KEY to run integration tests.",
+    )
+    @pytest.mark.integration
+    def test_run_integration(self):
+        ws = ScavioWebSearch(api_key=Secret.from_env_var("SCAVIO_API_KEY"), top_k=3)
+        result = ws.run(query="What is Haystack by deepset?")
+        assert len(result["documents"]) > 0
+        assert len(result["links"]) > 0
+        assert isinstance(result["documents"][0], Document)


### PR DESCRIPTION
### Related Issues

- New integration (no existing issue).

### Proposed Changes:

Adds a new `scavio-haystack` integration: `ScavioWebSearch`, a web search component backed by the [Scavio](https://scavio.dev) API, mirroring the existing `TavilyWebSearch` / `ExaWebSearch` components.

- New package under `integrations/scavio/` (`scavio-haystack`), depending on `haystack-ai` and the `scavio` SDK.
- `ScavioWebSearch` `@component` with `run` and `run_async`, returning `documents` (Haystack `Document`s) and `links`. API key via `Secret` (`SCAVIO_API_KEY`), `top_k`, and pass-through `search_params` (country_code, language, etc.).
- Follows the `websearch` component layout: `src/haystack_integrations/components/websearch/scavio/`, `pydoc/`, tests, README, CHANGELOG, hatch `pyproject.toml`.

Scavio is a unified search API for AI agents; this component uses its Google web-search endpoint.

### How did you test it?

- Unit tests (`tests/test_scavio_websearch.py`): init/to_dict/from_dict, run + run_async, top_k, error handling, warm-up — 16 pass.
- `ruff check` + `ruff format --check` clean; `mypy` clean.
- Integration test (`-m integration`) passes against the live Scavio API with `SCAVIO_API_KEY` exported.

### Notes for the reviewer

Mirrors the Tavily integration structure closely. Get a key at https://dashboard.scavio.dev.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct
- [x] I added unit tests and updated the docstrings
- [x] I've used a conventional commit type for my PR title (`feat:`)
