### PR TITLE
build: funasr - pin numba to avoid errors when testing lowest supported deps

### DIFF
--- a/integrations/funasr/pyproject.toml
+++ b/integrations/funasr/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
     "funasr>=1.0.0",
     "torch",
     "torchaudio",
-    # numba is a transtive depedency of funasr. We pin it to avoid installing versions without 3.14 support.
-    "numba>=0.62",
+    # numba is a transitive dependency of funasr. We pin it to avoid installing versions without 3.14 support.
+    "numba>=0.63",
 ]
 
 [project.urls]

--- a/integrations/funasr/pyproject.toml
+++ b/integrations/funasr/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "funasr>=1.0.0",
     "torch",
     "torchaudio",
+    # numba is a transtive depedency of funasr. We pin it to avoid installing versions without 3.14 support.
+    "numba>=0.62",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- failed tests with lowest direct deps: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28067461994/job/83094831716

### Proposed Changes:
- pin numba which is a transitive dependency of funasr to the first version that support 3.14 wheels

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
