### PR TITLE
test: whisper - modify lowest direct dependencies test setup to avoid breaking numba

### DIFF
--- a/.github/workflows/whisper.yml
+++ b/.github/workflows/whisper.yml
@@ -130,7 +130,11 @@ jobs:
       - name: Run unit tests with lowest direct dependencies
         if: github.event_name != 'push'
         run: |
-          hatch run uv pip compile pyproject.toml --resolution lowest-direct --output-file requirements_lowest_direct.txt
+          # `numba` (a dependency of `openai-whisper`) is not compatible with `numpy>=2.5`. Since `openai-whisper`
+          # is only a test dependency, it does not influence requirements_lowest_direct.txt, which may install
+          # `numpy>=2.5` and break `numba`. For that reason, we constrain `numpy` using `constraints.txt`.
+          echo "numpy<2.5" > constraints.txt
+          hatch run uv pip compile pyproject.toml --resolution lowest-direct --constraint constraints.txt --output-file requirements_lowest_direct.txt
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 


### PR DESCRIPTION
### Related Issues

- failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28067720888/job/83095600461
- since `openai-whisper` is an optional test dependency, it's not used to build the virtual environment for "Run unit tests with lowest direct dependencies" -> this breaks numba


### Proposed Changes:
- modify lowest direct dependencies test setup to constrain numpy and not break numba

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
