### PR TITLE
feat: add system_cachepoint_config to AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -198,6 +198,7 @@ class AmazonBedrockChatGenerator:
         *,
         guardrail_config: dict[str, str] | None = None,
         tools_cachepoint_config: dict[str, str] | None = None,
+        system_cachepoint_config: dict[str, str] | None = None,
     ) -> None:
         """
         Initializes the `AmazonBedrockChatGenerator` with the provided parameters.
@@ -273,6 +274,10 @@ class AmazonBedrockChatGenerator:
             The dictionary must match the
             [CachePointBlock schema](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html).
             Example: `{"type": "default", "ttl": "5m"}`
+        :param system_cachepoint_config: Optional configuration to use prompt caching for system messages.
+            The dictionary must match the
+            [CachePointBlock schema](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html).
+            Example: `{"type": "default", "ttl": "5m"}`
 
 
         :raises ValueError: If the model name is empty or None.
@@ -299,6 +304,9 @@ class AmazonBedrockChatGenerator:
 
         self.tools_cachepoint_config = (
             _validate_and_format_cache_point(tools_cachepoint_config) if tools_cachepoint_config else None
+        )
+        self.system_cachepoint_config = (
+            _validate_and_format_cache_point(system_cachepoint_config) if system_cachepoint_config else None
         )
 
         def resolve_secret(secret: Secret | str | None) -> str | None:
@@ -382,6 +390,7 @@ class AmazonBedrockChatGenerator:
             tools=serialize_tools_or_toolset(self.tools),
             guardrail_config=self.guardrail_config,
             tools_cachepoint_config=self.tools_cachepoint_config,
+            system_cachepoint_config=self.system_cachepoint_config,
         )
 
     @classmethod
@@ -464,7 +473,9 @@ class AmazonBedrockChatGenerator:
             }
 
         # Format messages to Bedrock format
-        system_prompts, messages_list = _format_messages(messages)
+        system_prompts, messages_list = _format_messages(
+            messages, system_cachepoint_config=self.system_cachepoint_config
+        )
 
         # Build API parameters
         params = {
@@ -527,6 +538,18 @@ class AmazonBedrockChatGenerator:
             thinking.setdefault("type", "adaptive")
             output_config = generation_kwargs.setdefault("output_config", {})
             output_config["effort"] = adaptive_thinking_effort
+
+        tools_cachepoint_config_ttl = generation_kwargs.pop("tools_cachepoint_config_ttl", None)
+        if tools_cachepoint_config_ttl is not None:
+            tools_cachepoint_config = generation_kwargs.setdefault("tools_cachepoint_config", {})
+            tools_cachepoint_config["ttl"] = tools_cachepoint_config_ttl
+            tools_cachepoint_config.setdefault("type", "default")
+
+        system_cachepoint_config_ttl = generation_kwargs.pop("system_cachepoint_config_ttl", None)
+        if system_cachepoint_config_ttl is not None:
+            system_cachepoint_config = generation_kwargs.setdefault("system_cachepoint_config", {})
+            system_cachepoint_config["ttl"] = system_cachepoint_config_ttl
+            system_cachepoint_config.setdefault("type", "default")
 
         return generation_kwargs
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -386,7 +386,9 @@ def _validate_and_format_cache_point(cache_point: dict[str, str] | None) -> dict
     return {"cachePoint": cache_point}
 
 
-def _format_messages(messages: list[ChatMessage]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+def _format_messages(
+    messages: list[ChatMessage], system_cachepoint_config: dict[str, dict[str, str]] | None = None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Format a list of Haystack ChatMessages to the format expected by Bedrock API.
 
@@ -394,6 +396,7 @@ def _format_messages(messages: list[ChatMessage]) -> tuple[list[dict[str, Any]],
     and tool results.
 
     :param messages: List of ChatMessage objects to format for Bedrock API.
+    :param system_cachepoint_config: Optional cache point configuration for system messages.
     :returns: Tuple containing (system_prompts, non_system_messages) in Bedrock format,
               where system_prompts is a list of system message dictionaries and
               non_system_messages is a list of properly formatted message dictionaries.
@@ -409,6 +412,8 @@ def _format_messages(messages: list[ChatMessage]) -> tuple[list[dict[str, Any]],
             system_prompts.append({"text": msg.text})
             if cache_point:
                 system_prompts.append(cache_point)
+            elif system_cachepoint_config:
+                system_prompts.append(system_cachepoint_config)
             continue
 
         if msg.tool_calls:

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -238,6 +238,7 @@ class TestAmazonBedrockChatGenerator:
                     "guardrailVersion": "test",
                 },
                 "tools_cachepoint_config": None,
+                "system_cachepoint_config": None,
             },
         }
 
@@ -428,6 +429,7 @@ class TestAmazonBedrockChatGenerator:
                         ],
                         "guardrail_config": None,
                         "tools_cachepoint_config": None,
+                        "system_cachepoint_config": None,
                     },
                 }
             },
@@ -465,6 +467,21 @@ class TestAmazonBedrockChatGenerator:
             "guardrailIdentifier": "test",
             "guardrailVersion": "test",
         }
+
+    def test_constructor_with_system_cachepoint_config(self, mock_boto3_session):
+        generator = AmazonBedrockChatGenerator(
+            model="global.anthropic.claude-sonnet-4-6",
+            system_cachepoint_config={"type": "default"},
+        )
+        assert generator.system_cachepoint_config == {"cachePoint": {"type": "default"}}
+
+    def test_to_dict_with_system_cachepoint_config(self, mock_boto3_session):
+        generator = AmazonBedrockChatGenerator(
+            model="global.anthropic.claude-sonnet-4-6",
+            system_cachepoint_config={"type": "default"},
+        )
+        serialized = generator.to_dict()
+        assert serialized["init_parameters"]["system_cachepoint_config"] == {"cachePoint": {"type": "default"}}
 
     def test_prepare_request_params_response_format(self, mock_boto3_session, set_env_variables):
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
@@ -727,6 +744,27 @@ class TestAmazonBedrockChatGenerator:
             AmazonBedrockChatGenerator._resolve_flattened_generation_kwargs(
                 {"disable_parallel_tool_use": True, "parallel_tool_use": True}
             )
+
+    def test_resolve_flattened_kwargs_cachepoint_ttl(self):
+        result = AmazonBedrockChatGenerator._resolve_flattened_generation_kwargs(
+            {
+                "tools_cachepoint_config_ttl": "5m",
+                "system_cachepoint_config_ttl": "10m",
+            }
+        )
+        assert result["tools_cachepoint_config"] == {"type": "default", "ttl": "5m"}
+        assert result["system_cachepoint_config"] == {"type": "default", "ttl": "10m"}
+        assert "tools_cachepoint_config_ttl" not in result
+        assert "system_cachepoint_config_ttl" not in result
+
+    def test_resolve_flattened_kwargs_cachepoint_ttl_preserves_existing_type(self):
+        result = AmazonBedrockChatGenerator._resolve_flattened_generation_kwargs(
+            {
+                "system_cachepoint_config": {"type": "custom"},
+                "system_cachepoint_config_ttl": "5m",
+            }
+        )
+        assert result["system_cachepoint_config"] == {"type": "custom", "ttl": "5m"}
 
     def test_run_completion(self, mock_boto3_session, set_env_variables):
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -314,6 +314,37 @@ class TestAmazonBedrockChatGeneratorUtils:
             },
         ]
 
+    def test_format_messages_with_system_cachepoint_config(self):
+        system_cachepoint_config = {"cachePoint": {"type": "default"}}
+        messages = [
+            ChatMessage.from_system("You are a helpful assistant."),
+            ChatMessage.from_user("Hello"),
+        ]
+        formatted_system_prompts, formatted_messages = _format_messages(
+            messages, system_cachepoint_config=system_cachepoint_config
+        )
+        assert formatted_system_prompts == [
+            {"text": "You are a helpful assistant."},
+            {"cachePoint": {"type": "default"}},
+        ]
+        assert formatted_messages == [
+            {"role": "user", "content": [{"text": "Hello"}]},
+        ]
+
+    def test_format_messages_system_cachepoint_config_does_not_double_append_when_per_message_cache_point_set(self):
+        system_cachepoint_config = {"cachePoint": {"type": "default"}}
+        # per-message cache point (raw, before _validate_and_format_cache_point wrapping)
+        messages = [
+            ChatMessage.from_system("You are a helpful assistant.", meta={"cachePoint": {"type": "default"}}),
+            ChatMessage.from_user("Hello"),
+        ]
+        formatted_system_prompts, _ = _format_messages(messages, system_cachepoint_config=system_cachepoint_config)
+        # per-message cache point takes priority; system_cachepoint_config is not also appended
+        assert formatted_system_prompts == [
+            {"text": "You are a helpful assistant."},
+            {"cachePoint": {"type": "default"}},
+        ]
+
     def test_format_messages_tool_result_with_image(self):
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="


### PR DESCRIPTION
### Related Issues

- coming back to bedrock prompt caching: 
  - cache order is tools -> system -> messages (according to [docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html#prompt-caching-get-started))
  - assuming system is mostly static, we should be able to include it into the cache without having to deal with ChatPromptBuilder or the message itself

### Proposed Changes:
- added `system_cachepoint_config` init param

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
