### PR TITLE
test: twelvelabs - add unit tests

### DIFF
--- a/integrations/twelvelabs/tests/test_video_converter.py
+++ b/integrations/twelvelabs/tests/test_video_converter.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from haystack.utils import Secret
@@ -11,6 +11,7 @@ from haystack_integrations.components.converters.twelvelabs import TwelveLabsVid
 
 _MODULE = "haystack_integrations.components.converters.twelvelabs.video_converter"
 ANALYZE = f"{_MODULE}.TwelveLabsVideoConverter._analyze_source"
+CLIENT = f"{_MODULE}.TwelveLabs"
 _SAMPLE_VIDEO_URL = "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4"
 
 
@@ -54,6 +55,61 @@ def test_run_skips_failing_sources():
     # The failing source is skipped, the good one is kept.
     assert len(result["documents"]) == 1
     assert result["documents"][0].content == "ok"
+
+
+def test_analyze_source_with_url_passes_video_context_url():
+    converter = TwelveLabsVideoConverter(api_key=Secret.from_token("tlk_test"))
+    with patch(CLIENT) as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.analyze.return_value = MagicMock(data="  A description.  ", id="analysis_42")
+        text, analysis_id, asset_id = converter._analyze_source("https://example.com/clip.mp4", "tlk_test")
+    assert text == "A description."
+    assert analysis_id == "analysis_42"
+    assert asset_id is None
+    # URLs are passed straight through without uploading an asset.
+    client.assets.create.assert_not_called()
+    assert client.analyze.call_args.kwargs["video"].url == "https://example.com/clip.mp4"
+
+
+def test_analyze_source_uploads_local_file_then_analyzes(tmp_path):
+    video_file = tmp_path / "clip.mp4"
+    video_file.write_bytes(b"fake video bytes")
+    converter = TwelveLabsVideoConverter(api_key=Secret.from_token("tlk_test"))
+    with patch(CLIENT) as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.assets.create.return_value = MagicMock(id="asset_99")
+        client.assets.retrieve.return_value = MagicMock(status="ready")
+        client.analyze.return_value = MagicMock(data="Local analysis.", id="analysis_7")
+        text, analysis_id, asset_id = converter._analyze_source(str(video_file), "tlk_test")
+    assert text == "Local analysis."
+    assert analysis_id == "analysis_7"
+    assert asset_id == "asset_99"
+    assert client.analyze.call_args.kwargs["video"].asset_id == "asset_99"
+
+
+@pytest.mark.parametrize("data", ["", "   ", None])
+def test_analyze_source_raises_when_pegasus_returns_no_text(data):
+    converter = TwelveLabsVideoConverter(api_key=Secret.from_token("tlk_test"))
+    with patch(CLIENT) as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.analyze.return_value = MagicMock(data=data, id="analysis_1")
+        with pytest.raises(RuntimeError, match="produced no text"):
+            converter._analyze_source("https://example.com/clip.mp4", "tlk_test")
+
+
+def test_upload_asset_rejects_missing_and_oversized_files(tmp_path, monkeypatch):
+    converter = TwelveLabsVideoConverter(api_key=Secret.from_token("tlk_test"))
+    client = MagicMock()
+
+    with pytest.raises(FileNotFoundError, match="not found"):
+        converter._upload_asset(client, str(tmp_path / "does_not_exist.mp4"))
+
+    oversized = tmp_path / "huge.mp4"
+    oversized.write_bytes(b"x")
+    monkeypatch.setattr(f"{_MODULE}._MAX_DIRECT_UPLOAD_BYTES", 0)
+    with pytest.raises(ValueError, match="200 MB"):
+        converter._upload_asset(client, str(oversized))
+    client.assets.create.assert_not_called()
 
 
 @pytest.mark.skipif(not os.environ.get("TWELVELABS_API_KEY"), reason="TWELVELABS_API_KEY env var not set")


### PR DESCRIPTION
### Related Issues

- Twelve Labs integration is below 90% combined coverage

### Proposed Changes:

- add unit tests targeted to uncovered paths (with AI help)

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
