### PR TITLE
docs(google_drive): Update OAuth resolver references in doc strings to OAuthTokenResolver

### DIFF
--- a/integrations/google_drive/src/haystack_integrations/components/retrievers/google_drive/retriever.py
+++ b/integrations/google_drive/src/haystack_integrations/components/retrievers/google_drive/retriever.py
@@ -59,7 +59,7 @@ class GoogleDriveRetriever:
     file content is needed.
 
     The retriever takes a per-user `access_token` as a run input, typically wired from an upstream
-    `OAuthResolver`. The token must carry a delegated Google OAuth scope that allows search
+    `OAuthTokenResolver`. The token must carry a delegated Google OAuth scope that allows search
     (for example `https://www.googleapis.com/auth/drive.readonly`). The metadata-only
     `drive.metadata.readonly` scope cannot search file content or export documents.
 
@@ -67,15 +67,15 @@ class GoogleDriveRetriever:
     ```python
     from haystack import Pipeline
     from haystack.utils import Secret
-    from haystack_integrations.components.connectors.oauth import OAuthResolver
-    from haystack_integrations.utils.oauth import RefreshTokenSource
+    from haystack_integrations.components.connectors.oauth import OAuthTokenResolver
+    from haystack_integrations.utils.oauth import OAuthRefreshTokenSource
     from haystack_integrations.components.retrievers.google_drive import GoogleDriveRetriever
 
     pipeline = Pipeline()
     pipeline.add_component(
         "resolver",
-        OAuthResolver(
-            token_source=RefreshTokenSource(
+        OAuthTokenResolver(
+            token_source=OAuthRefreshTokenSource(
                 token_url="https://oauth2.googleapis.com/token",
                 client_id="aaa-bbb-ccc",
                 refresh_token=Secret.from_env_var("GOOGLE_REFRESH_TOKEN"),
@@ -150,7 +150,7 @@ class GoogleDriveRetriever:
         :param query: The search query string, matched against the full text of files via
             `fullText contains`.
         :param access_token: A delegated Google OAuth bearer token for the user whose Drive is searched,
-            typically wired from an upstream `OAuthResolver` (which emits a plain `str`). A `Secret` is also
+            typically wired from an upstream `OAuthTokenResolver` (which emits a plain `str`). A `Secret` is also
             accepted and resolved internally.
         :param top_k: Overrides the `top_k` configured at initialization for this run.
         :returns: A dictionary with a `documents` key holding the list of retrieved `Document` objects.
@@ -187,7 +187,7 @@ class GoogleDriveRetriever:
         :param query: The search query string, matched against the full text of files via
             `fullText contains`.
         :param access_token: A delegated Google OAuth bearer token for the user whose Drive is searched,
-            typically wired from an upstream `OAuthResolver` (which emits a plain `str`). A `Secret` is also
+            typically wired from an upstream `OAuthTokenResolver` (which emits a plain `str`). A `Secret` is also
             accepted and resolved internally.
         :param top_k: Overrides the `top_k` configured at initialization for this run.
         :returns: A dictionary with a `documents` key holding the list of retrieved `Document` objects.


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR fixes the dox strings in the GoogleDRiveRetriever bu updating mentions of OAuthResolver to OAuthTokenResolver and RefreshTokenSource to OAuthRefreshTokenSource.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
