### PR TITLE
test: force CPU in LocalWhisperTranscriber integration tests

### DIFF
--- a/integrations/whisper/tests/test_whisper_local.py
+++ b/integrations/whisper/tests/test_whisper_local.py
@@ -235,7 +235,7 @@ class TestLocalWhisperTranscriber:
         path = test_files_path / "audio" / "the context for this answer is here.wav"
         assert path.absolute() == docs[1].meta["audio_file"]
 
-        # `answer.wav` is a single isolated word, which models transcribe inconsistently 
+        # `answer.wav` is a single isolated word, which models transcribe inconsistently
         # Therefore, we only assert that something was transcribed to a temporary file.
         assert docs[2].content.strip()
         # meta.audio_file should contain the temp path where we dumped the audio bytes

--- a/integrations/whisper/tests/test_whisper_local.py
+++ b/integrations/whisper/tests/test_whisper_local.py
@@ -213,7 +213,13 @@ class TestLocalWhisperTranscriber:
     @pytest.mark.integration
     @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="ffmpeg not installed on Windows CI")
     def test_whisper_local_transcriber(self, test_files_path):
-        comp = LocalWhisperTranscriber(model="base", whisper_params={"language": "english"})
+        # Force CPU. By default the component resolves to the best available device, which is MPS on Apple
+        # Silicon. Whisper inference on MPS is unreliable on the GitHub-hosted macOS runners and produced
+        # multilingual garbage for clean English audio (the model size made no difference), which made this
+        # test flaky. CPU inference is deterministic across all platforms, matching what the Linux CI does.
+        comp = LocalWhisperTranscriber(
+            model="tiny", device=ComponentDevice.from_str("cpu"), whisper_params={"language": "english"}
+        )
         output = comp.run(
             sources=[
                 test_files_path / "audio" / "this is the content of the document.wav",
@@ -246,7 +252,8 @@ class TestLocalWhisperTranscriber:
     def test_whisper_local_transcriber_pipeline_and_url_source(self):
         pipe = Pipeline()
         pipe.add_component("fetcher", LinkContentFetcher())
-        pipe.add_component("transcriber", LocalWhisperTranscriber(model="base"))
+        # Force CPU: Whisper inference on MPS (the default device on Apple Silicon CI runners) is unreliable.
+        pipe.add_component("transcriber", LocalWhisperTranscriber(model="tiny", device=ComponentDevice.from_str("cpu")))
 
         pipe.connect("fetcher", "transcriber")
         result = pipe.run(


### PR DESCRIPTION
### Related Issues
None

Follow-up to #3504. The `LocalWhisperTranscriber` integration test kept failing on the macOS CI runners even after #3504 switched `tiny` → `base`.

Failing run (macOS only): https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28231824934

### Proposed Changes:
- **Pin the two local-model integration tests to CPU** (`device=ComponentDevice.from_str("cpu")`). This is the actual fix.
- Revert the model from `base` back to `tiny`: model size was a red herring (it failed with both), and `tiny` on CPU is reliable and faster to download in CI.
- Update the explanatory comments to reflect the real root cause.

**Root cause:** By default the component resolves to the best available device, which is **MPS on Apple Silicon**. Whisper inference on MPS is unreliable on the GitHub-hosted macOS runners — it produced long multilingual hallucinations for clean English audio (e.g. `), icon透 opinions guidance...достаточно美味...這是...`), regardless of model size. The matrix made this unmistakable:

| OS | result |
|----|--------|
| Linux (CPU) | ✅ pass |
| Windows | ✅ (test skipped, no ffmpeg) |
| macOS (MPS) | ❌ multilingual garbage with both `tiny` and `base` |

Because Whisper is deterministic per environment, the existing `--reruns 3 --reruns-delay 30` reproduced the exact same garbage on every attempt. Forcing CPU makes macOS use the same deterministic path that Linux already passes on.

### How did you test it?
- Reproduced locally: confirmed `ComponentDevice.resolve_device(None)` → `mps` on Apple Silicon, while the raw `whisper.load_model()` used in my earlier ad-hoc check defaulted to CPU (which is why #3504 looked fine locally but failed on CI).
- Ran the whisper integration tests locally with the CPU pin: both pass.
- Ran `hatch run fmt-check` (passed).

### Notes for the reviewer
Separately, it may be worth considering whether `LocalWhisperTranscriber` should default to MPS at all, given Whisper's MPS support is unreliable — but that's a component-level behavior change, out of scope for this test fix.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)