### PR TITLE
feat: dspy - Enable DSPy with dynamic context (e.g. from RAG)

### DIFF
--- a/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
+++ b/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
@@ -86,6 +86,7 @@ class DSPySignatureChatGenerator:
         generation_kwargs: dict[str, Any] | None = None,
         module_kwargs: dict[str, Any] | None = None,
         input_mapping: dict[str, str] | None = None,
+        pipeline_inputs: list[str] | None = None,
     ):
         """
         Initialize the DSPySignatureChatGenerator.
@@ -101,9 +102,13 @@ class DSPySignatureChatGenerator:
             For example, use `{"tools": [tool1, tool2]}` when using the `"ReAct"` module type.
         :param input_mapping: Maps DSPy signature input field names to `run()` kwarg names.
             For example, if your signature has an input field `"context"` but your pipeline
-            provides it as `"documents"`, use `{"context": "documents"}`. When not provided,
-            the first input field receives the last user message text, and remaining fields
-            are matched by name from `**kwargs`.
+            provides it as `"documents"`, use `{"context": "documents"}`. When neither
+            `input_mapping` nor `pipeline_inputs` is provided, the first input field receives
+            the last user message text, and remaining fields are matched by name from `**kwargs`.
+        :param pipeline_inputs: Signature input fields exposed as Haystack pipeline input
+            sockets, so upstream components (e.g. a retriever or a text input) can connect
+            to them. Each name in this list must be a signature input field and becomes a
+            real `str` socket on the component.
         """
         if module_type not in VALID_MODULE_TYPES:
             msg = f"Invalid module_type '{module_type}'. Must be one of {sorted(VALID_MODULE_TYPES)}"
@@ -117,6 +122,7 @@ class DSPySignatureChatGenerator:
         self.generation_kwargs = generation_kwargs or {}
         self.module_kwargs = module_kwargs or {}
         self.input_mapping = input_mapping
+        self.pipeline_inputs = pipeline_inputs
 
         self._lm = _create_dspy_lm(
             model=self.model,
@@ -127,6 +133,9 @@ class DSPySignatureChatGenerator:
         module_class = _get_dspy_module_class(self.module_type)
         self._module = module_class(self.signature, **self.module_kwargs)
         self._module.set_lm(self._lm)
+
+        for extra_input in self.pipeline_inputs or []:
+            component.set_input_type(self, extra_input, str, "")
 
     def _build_dspy_inputs(self, prompt: str, **kwargs: Any) -> dict[str, Any]:
         """Build the input dict for the DSPy module call."""

--- a/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
+++ b/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
@@ -223,6 +223,7 @@ class DSPySignatureChatGenerator:
             "generation_kwargs": self.generation_kwargs,
             "module_kwargs": self.module_kwargs,
             "input_mapping": self.input_mapping,
+            "pipeline_inputs": self.pipeline_inputs,
         }
         return default_to_dict(self, **kwargs)
 

--- a/integrations/dspy/tests/test_chat_generator.py
+++ b/integrations/dspy/tests/test_chat_generator.py
@@ -3,7 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import dspy
 import pytest
+from haystack import Document, Pipeline, component
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.dataclasses import ChatMessage
+from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 from haystack_integrations.components.generators.dspy.chat.chat_generator import (
     VALID_MODULE_TYPES,
@@ -427,6 +430,51 @@ class TestDSPySignatureChatGenerator:
         call_kwargs = mock_dspy_module.call_args.kwargs
         assert call_kwargs.get("context") == "Machine learning is a subset of AI."
         assert call_kwargs.get("question") == "What is ML?"
+
+    def test_rag_pipeline_question_with_dependent_context(self, mock_dspy_module):
+        """
+        Test case where the context passed to DSPy is dynamic and depends on the question asked by the user.
+        """
+
+        doc_store = InMemoryDocumentStore()
+        doc_store.write_documents(
+            [
+                Document(content="Paris is the capital of France."),
+                Document(content="Tokyo is the capital of Japan."),
+                Document(content="Bananas are yellow fruits."),
+            ]
+        )
+
+        @component
+        class DocsToString:
+            @component.output_types(text=str)
+            def run(self, documents: list[Document]) -> dict:
+                return {"text": "\n".join(d.content for d in documents)}
+
+        generator = DSPySignatureChatGenerator(
+            signature="question, context -> answer",
+            pipeline_inputs=["context"],
+        )
+
+        pipeline = Pipeline()
+        pipeline.add_component("retriever", InMemoryBM25Retriever(doc_store, top_k=1))
+        pipeline.add_component("docs_to_text", DocsToString())
+        pipeline.add_component("llm", generator)
+        pipeline.connect("retriever.documents", "docs_to_text.documents")
+        pipeline.connect("docs_to_text.text", "llm.context")
+
+        question = "What is the capital of Japan?"  # context should be Japan-related
+        pipeline.run(
+            {
+                "retriever": {"query": question},
+                "llm": {"messages": [ChatMessage.from_user(question)]},
+            }
+        )
+
+        call_kwargs = mock_dspy_module.call_args.kwargs
+        assert call_kwargs["question"] == question
+        assert "Tokyo is the capital of Japan." in call_kwargs["context"]
+        assert "Paris" not in call_kwargs["context"]
 
     def test_run_with_wrong_model(self, mock_dspy_module):
         mock_dspy_module.side_effect = Exception("Invalid model name")

--- a/integrations/dspy/tests/test_chat_generator.py
+++ b/integrations/dspy/tests/test_chat_generator.py
@@ -202,6 +202,7 @@ class TestDSPySignatureChatGenerator:
                 "generation_kwargs": {},
                 "module_kwargs": {},
                 "input_mapping": None,
+                "pipeline_inputs": None,
             },
         }
 
@@ -227,6 +228,7 @@ class TestDSPySignatureChatGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "module_kwargs": {},
                 "input_mapping": {"context": "context", "question": "question"},
+                "pipeline_inputs": None,
             },
         }
 
@@ -315,6 +317,16 @@ class TestDSPySignatureChatGenerator:
         }
         with pytest.raises(ValueError, match="Unknown signature type 'unknown'"):
             DSPySignatureChatGenerator.from_dict(data)
+
+    def test_to_dict_from_dict_roundtrip_restores_pipeline_inputs(self, mock_dspy_module):
+        original = DSPySignatureChatGenerator(
+            signature="question, my_context -> answer",
+            pipeline_inputs=["my_context"],
+        )
+        restored = DSPySignatureChatGenerator.from_dict(original.to_dict())
+
+        assert restored.pipeline_inputs == ["my_context"]
+        assert "my_context" in restored.__haystack_input__
 
     def test_run(self, chat_messages, mock_dspy_module):
         component = DSPySignatureChatGenerator(
@@ -452,8 +464,8 @@ class TestDSPySignatureChatGenerator:
                 return {"text": "\n".join(d.content for d in documents)}
 
         generator = DSPySignatureChatGenerator(
-            signature="question, context -> answer",
-            pipeline_inputs=["context"],
+            signature="question, my_context -> answer",
+            pipeline_inputs=["my_context"],
         )
 
         pipeline = Pipeline()
@@ -461,7 +473,7 @@ class TestDSPySignatureChatGenerator:
         pipeline.add_component("docs_to_text", DocsToString())
         pipeline.add_component("llm", generator)
         pipeline.connect("retriever.documents", "docs_to_text.documents")
-        pipeline.connect("docs_to_text.text", "llm.context")
+        pipeline.connect("docs_to_text.text", "llm.my_context")
 
         question = "What is the capital of Japan?"  # context should be Japan-related
         pipeline.run(
@@ -473,8 +485,8 @@ class TestDSPySignatureChatGenerator:
 
         call_kwargs = mock_dspy_module.call_args.kwargs
         assert call_kwargs["question"] == question
-        assert "Tokyo is the capital of Japan." in call_kwargs["context"]
-        assert "Paris" not in call_kwargs["context"]
+        assert "Tokyo is the capital of Japan." in call_kwargs["my_context"]
+        assert "Paris" not in call_kwargs["my_context"]
 
     def test_run_with_wrong_model(self, mock_dspy_module):
         mock_dspy_module.side_effect = Exception("Invalid model name")


### PR DESCRIPTION
### Related Issues

- Related to #1635

### Context

Reopening #3145 after addressing review feedback.

The [original DSPy + Haystack cookbook notebook](https://github.com/deepset-ai/haystack-cookbook/blob/main/notebooks/prompt_optimization_with_dspy.ipynb) demonstrates a RAG flow where a retriever **dynamically** looks up the context for each question. With the recently merged `DSPySignatureChatGenerator` (#2831), this exact use case is not yet possible inside a Haystack `Pipeline`:

- `run()` declares only `messages` and `generation_kwargs` as input sockets.
- Signature fields like `context` live behind `**kwargs`, so `Pipeline.connect()` cannot bind anything to them.

### Proposed Changes

Add a `pipeline_inputs: list[str]` parameter to `DSPySignatureChatGenerator`. When set, the listed signature input fields are registered as real Haystack input sockets via `component.set_input_type(self, name, str, "")`.

Also persist `pipeline_inputs` in `to_dict()` so dynamic sockets are restored after deserialization.

### How did you test it?

- `test_rag_pipeline_question_with_dependent_context` — wires a retriever to the generator in a Pipeline
- `test_to_dict_from_dict_roundtrip_restores_pipeline_inputs` — asserts sockets survive serialize/deserialize
- `pytest -m "not integration" tests/test_chat_generator.py` — 36 passed

### Checklist

- [x] I have read the contributors guidelines and the code of conduct
- [x] I added unit tests and updated the docstrings
- [x] CLA signed

Made with [Cursor](https://cursor.com)