### PR TITLE
ci(microsoft_sharepoint): temporarily disable integration tests

### DIFF
--- a/.github/workflows/microsoft_sharepoint.yml
+++ b/.github/workflows/microsoft_sharepoint.yml
@@ -115,8 +115,10 @@ jobs:
       # Exchanges the stored refresh token for a short-lived delegated Microsoft Graph access token and
       # exposes it to later steps as MS_SHAREPOINT_ACCESS_TOKEN. Skipped when the secrets are absent
       # (e.g. on fork PRs), in which case the live integration tests skip themselves.
+      #
+      # TEMPORARILY DISABLED (2026-06)
       - name: Mint Microsoft Graph access token
-        if: env.HAS_MS_GRAPH_SECRETS == 'true'
+        if: false && env.HAS_MS_GRAPH_SECRETS == 'true'
         shell: bash
         env:
           MS_GRAPH_TENANT_ID: ${{ secrets.MS_GRAPH_TENANT_ID }}
@@ -142,7 +144,9 @@ jobs:
           echo "MS_SHAREPOINT_ACCESS_TOKEN=${access_token}" >> "$GITHUB_ENV"
           echo 'Minted a Microsoft Graph access token (value masked).'
 
+      # TEMPORARILY DISABLED (2026-06)
       - name: Run integration tests
+        if: false
         env:
           MS_SHAREPOINT_TEST_FILE_URL: ${{ secrets.MS_SHAREPOINT_TEST_FILE_URL }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/microsoft_sharepoint.yml
+++ b/.github/workflows/microsoft_sharepoint.yml
@@ -146,7 +146,7 @@ jobs:
 
       # TEMPORARILY DISABLED (2026-06)
       - name: Run integration tests
-        if: false
+        if: false && env.HAS_MS_GRAPH_SECRETS == 'true'
         env:
           MS_SHAREPOINT_TEST_FILE_URL: ${{ secrets.MS_SHAREPOINT_TEST_FILE_URL }}
         run: hatch run test:integration-cov-append-retry


### PR DESCRIPTION
### Related Issues

- Microsoft Sharepoint integration tests are currently failing due to account issues.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR temporarily disables the steps `Mint Microsoft Graph access token` and `Run integration tests` for the Microsoft Sharepoint integration.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
