### PR TITLE
validating meta fields to prevent SQL injection

### DIFF
--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
@@ -18,19 +18,12 @@ from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumen
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils import Secret, deserialize_secrets_inplace
 
-from .filters import FilterTranslator
+from .filters import FilterTranslator, _validate_field_path
 
 logger = logging.getLogger(__name__)
 
 _SAFE_TABLE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_$#]{0,127}$")
-_SAFE_FIELD_PATH = re.compile(r"^[A-Za-z0-9_.]+$")
 MAX_INDEX_NAME_LEN = 128
-
-
-def _validate_field_path(field_path: str) -> None:
-    if not _SAFE_FIELD_PATH.match(field_path):
-        msg = f"Invalid metadata field name: {field_path!r}"
-        raise ValueError(msg)
 
 
 def _try_parse_number(value: Any) -> Any:

--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/filters.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/filters.py
@@ -2,12 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from datetime import datetime
 from typing import Any, ClassVar
 
 from haystack.errors import FilterError
 
 _RANGE_OPS = {">", ">=", "<", "<="}
+_SAFE_FIELD_PATH = re.compile(r"^[A-Za-z0-9_.]+$")
+
+
+def _validate_field_path(field_path: str) -> None:
+    if not _SAFE_FIELD_PATH.match(field_path):
+        msg = f"Invalid metadata field name: {field_path!r}"
+        raise ValueError(msg)
 
 
 class FilterTranslator:
@@ -123,14 +131,9 @@ class FilterTranslator:
             return "id"
         if field == "content":
             return "text"
-        if field.startswith("meta."):
-            key = field[len("meta.") :]
-            json_path = f"JSON_VALUE(metadata, '$.{key}')"
-            if isinstance(value, (int, float)) and not isinstance(value, bool):
-                return f"TO_NUMBER({json_path})"
-            return json_path
-        # Fallback: treat as top-level JSON key
-        json_path = f"JSON_VALUE(metadata, '$.{field}')"
+        key = field[len("meta.") :] if field.startswith("meta.") else field
+        _validate_field_path(key)
+        json_path = f"JSON_VALUE(metadata, '$.{key}')"
         if isinstance(value, (int, float)) and not isinstance(value, bool):
             return f"TO_NUMBER({json_path})"
         return json_path

--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/filters.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/filters.py
@@ -15,7 +15,7 @@ _SAFE_FIELD_PATH = re.compile(r"^[A-Za-z0-9_.]+$")
 def _validate_field_path(field_path: str) -> None:
     if not _SAFE_FIELD_PATH.match(field_path):
         msg = f"Invalid metadata field name: {field_path!r}"
-        raise ValueError(msg)
+        raise FilterError(msg)
 
 
 class FilterTranslator:

--- a/integrations/oracle/tests/test_filter_translator.py
+++ b/integrations/oracle/tests/test_filter_translator.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from haystack.errors import FilterError
 
 from haystack_integrations.document_stores.oracle.filters import FilterTranslator
 
@@ -139,18 +140,18 @@ def test_param_counter_increments_correctly():
 
 
 def test_sql_injection_via_field_name_raises():
-    with pytest.raises(ValueError, match="Invalid metadata field name"):
+    with pytest.raises(FilterError, match="Invalid metadata field name"):
         _translate({"field": "meta.x') = 'x' OR 1=1 OR ('a", "operator": "==", "value": "y"})
 
 
 def test_sql_injection_via_fallback_field_raises():
     # Injection via the non-meta fallback path
-    with pytest.raises(ValueError, match="Invalid metadata field name"):
+    with pytest.raises(FilterError, match="Invalid metadata field name"):
         _translate({"field": "x') OR 1=1--", "operator": "==", "value": "y"})
 
 
 def test_sql_injection_in_not_in_raises():
-    with pytest.raises(ValueError, match="Invalid metadata field name"):
+    with pytest.raises(FilterError, match="Invalid metadata field name"):
         _translate({"field": "meta.x') OR 1=1--", "operator": "in", "value": ["a", "b"]})
 
 

--- a/integrations/oracle/tests/test_filter_translator.py
+++ b/integrations/oracle/tests/test_filter_translator.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from haystack_integrations.document_stores.oracle.filters import FilterTranslator
 
 
@@ -134,3 +136,24 @@ def test_param_counter_increments_correctly():
         }
     )
     assert set(params.keys()) == {"p0", "p1", "p2"}
+
+
+def test_sql_injection_via_field_name_raises():
+    with pytest.raises(ValueError, match="Invalid metadata field name"):
+        _translate({"field": "meta.x') = 'x' OR 1=1 OR ('a", "operator": "==", "value": "y"})
+
+
+def test_sql_injection_via_fallback_field_raises():
+    # Injection via the non-meta fallback path
+    with pytest.raises(ValueError, match="Invalid metadata field name"):
+        _translate({"field": "x') OR 1=1--", "operator": "==", "value": "y"})
+
+
+def test_sql_injection_in_not_in_raises():
+    with pytest.raises(ValueError, match="Invalid metadata field name"):
+        _translate({"field": "meta.x') OR 1=1--", "operator": "in", "value": ["a", "b"]})
+
+
+def test_valid_nested_field_path_accepted():
+    sql, _ = _translate({"field": "meta.author.city", "operator": "==", "value": "Berlin"})
+    assert "'$.author.city'" in sql


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack-private#429
- fixes https://github.com/deepset-ai/haystack-private/issues/430
- `FilterTranslator._field_to_sql` was interpolating filter field names directly into `JSON_VALUE()` SQL expressions without any validation

### Proposed Changes:

- Moves `_SAFE_FIELD_PATH` and `_validate_field_path` from `document_store.py` into `filters.py`
- To avoid circular imports, `document_store.py` already imports FilterTranslator from filters.py
- Calls `_validate_field_path` inside `_field_to_sql` before any interpolation

### How did you test it?

- new unit tests in `test_filter_translator.py` covering the use cases raised in the issue

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
