### PR TITLE
adding allowlist regex validator before interpolation + tests

### DIFF
--- a/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
+++ b/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import replace
 from datetime import datetime
 from typing import Any, Literal
@@ -20,6 +21,8 @@ from redis.exceptions import ResponseError
 import falkordb  # type: ignore[import-untyped,import-not-found]
 
 logger = logging.getLogger(__name__)
+
+_CYPHER_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # Haystack filter operators → Cypher comparison operators.
 _COMPARISON_OPS: dict[str, str] = {
@@ -857,6 +860,9 @@ def _build_clause(node: dict[str, Any], params: dict[str, Any], counter: list[in
     # Because meta fields are stored flat (no prefix), all fields map to d.<field>.
     # We strip 'meta.' from the field name if Haystack adds it.
     actual_field = field[5:] if field.startswith("meta.") else field
+    if not _CYPHER_IDENTIFIER_RE.fullmatch(actual_field):
+        msg = f"Invalid filter field name: {actual_field!r}"
+        raise FilterError(msg)
     cypher_field = f"d.{actual_field}"
 
     param_name = f"p{counter[0]}"

--- a/integrations/falkordb/tests/test_document_store.py
+++ b/integrations/falkordb/tests/test_document_store.py
@@ -107,6 +107,13 @@ class TestFalkorDBDocumentStoreUnit:
                 "coalesce(d.year = $p0, false)",
                 {"p0": 2024},
             ),
+            # underscore-prefixed identifiers are valid Cypher and must be accepted
+            ({"field": "_id", "operator": "==", "value": "x"}, "coalesce(d._id = $p0, false)", {"p0": "x"}),
+            (
+                {"field": "meta._private", "operator": "==", "value": "y"},
+                "coalesce(d._private = $p0, false)",
+                {"p0": "y"},
+            ),
             (
                 {
                     "operator": "OR",
@@ -137,6 +144,21 @@ class TestFalkorDBDocumentStoreUnit:
             ({"field": "x", "operator": "in", "value": "scalar"}, "requires a list value"),
             ({"field": "x", "operator": "not in", "value": "scalar"}, "requires a list value"),
             ({"field": "x", "operator": "regex", "value": "."}, "Unsupported filter operator"),
+            # Cypher injection via field identifier (CVE: unsanitized interpolation)
+            (
+                {"field": "tenant = $p0, false) OR true RETURN d //", "operator": "==", "value": "alice"},
+                "Invalid filter field name",
+            ),
+            ({"field": "x; DROP DATABASE", "operator": "==", "value": 1}, "Invalid filter field name"),
+            ({"field": "x.y", "operator": "==", "value": 1}, "Invalid filter field name"),
+            ({"field": "meta.x.y", "operator": "==", "value": 1}, "Invalid filter field name"),
+            # empty identifier after meta. stripping
+            ({"field": "meta.", "operator": "==", "value": 1}, "Invalid filter field name"),
+            # digit-leading identifier
+            ({"field": "2fast", "operator": "==", "value": 1}, "Invalid filter field name"),
+            # hyphen in field name (common meta key, but not a valid Cypher identifier)
+            ({"field": "created-by", "operator": "==", "value": "alice"}, "Invalid filter field name"),
+            ({"field": "meta.created-by", "operator": "==", "value": "alice"}, "Invalid filter field name"),
         ],
     )
     def test_convert_filters_errors(self, filter_node, match):


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack-private#428

### Proposed Changes:

- adds an allowlist regex `^[A-Za-z_][A-Za-z0-9_]*$` validated against the field identifier before it is interpolated into the query. 
- any field name that does not match raises a `FilterError`,  closing the injection surface

### How did you test it?

Added unit tests to test_convert_filters_errors covering:
  - The exact PoC payload from the issue report (tenant = $p0, false) OR true RETURN d //)
  - Semicolon injection (x; DROP DATABASE)
  - Dot-separated identifiers (x.y, meta.x.y)
  - Empty identifier after meta. stripping (meta.)
  - Digit-leading identifiers (2fast)
  - Hyphen-containing identifiers (created-by, meta.created-by)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
