### PR TITLE
fix(elasticsearch): remove duplicate delete/create in delete_all_documents(recreate_index=True)

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -912,12 +912,6 @@ class ElasticsearchDocumentStore:
             self._client.indices.delete(index=self._index)  # type: ignore
             self._client.indices.create(index=self._index, settings=settings, mappings=mappings)  # type: ignore
 
-            # delete index
-            self._client.indices.delete(index=self._index)  # type: ignore
-
-            # recreate with mappings
-            self._client.indices.create(index=self._index, mappings=mappings)  # type: ignore
-
         else:
             result = self._client.delete_by_query(**self._prepare_delete_all_request(is_async=False, refresh=refresh))  # type: ignore
             logger.info(

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -709,6 +709,36 @@ async def test_sparse_vector_retrieval_async_builds_query_with_filters():
     )
 
 
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.AsyncElasticsearch")
+@patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
+def test_delete_all_documents_recreate_preserves_settings(_mock_es, _mock_async_es):
+    """delete_all_documents(recreate_index=True) must delete+create exactly once and include settings."""
+    index_name = "default"
+    mappings = {"properties": {"content": {"type": "text"}}}
+    settings = {"index": {"number_of_replicas": "2", "refresh_interval": "30s"}}
+
+    mock_client = Mock()
+    mock_client.info.return_value = {}
+    mock_client.indices.exists.return_value = True
+    mock_client.indices.get.return_value = {
+        index_name: {"mappings": mappings, "settings": {"index": dict(settings["index"])}}
+    }
+    _mock_es.return_value = mock_client
+    _mock_async_es.return_value = Mock()
+
+    store = ElasticsearchDocumentStore(hosts="http://testhost:9200")
+    store.delete_all_documents(recreate_index=True)
+
+    # delete and create must each be called exactly once
+    assert mock_client.indices.delete.call_count == 1
+    assert mock_client.indices.create.call_count == 1
+
+    # the single create call must include both settings and mappings
+    create_kwargs = mock_client.indices.create.call_args[1]
+    assert "settings" in create_kwargs, "settings must be preserved on recreate"
+    assert "mappings" in create_kwargs, "mappings must be preserved on recreate"
+
+
 @pytest.mark.integration
 class TestDocumentStore(
     DocumentStoreBaseExtendedTests,


### PR DESCRIPTION
## Summary

Fixes #3521.

`ElasticsearchDocumentStore.delete_all_documents(recreate_index=True)` was calling `indices.delete` and `indices.create` **twice**. The second `create` omitted `settings`, silently dropping custom index configuration (replica count, custom analyzers, refresh interval, etc.) on every call.

**Before (buggy):**
```python
self._client.indices.delete(index=self._index)
self._client.indices.create(index=self._index, settings=settings, mappings=mappings)  # ✓
# delete index
self._client.indices.delete(index=self._index)   # ← redundant
# recreate with mappings
self._client.indices.create(index=self._index, mappings=mappings)  # ← drops settings
```

**After (fixed):**
```python
self._client.indices.delete(index=self._index)
self._client.indices.create(index=self._index, settings=settings, mappings=mappings)
```

The async version (`delete_all_documents_async`) already did this correctly — this brings the sync version in line.

## Test plan

New unit test `test_delete_all_documents_recreate_preserves_settings` verifies:
- `indices.delete` called exactly once
- `indices.create` called exactly once
- The single `create` call includes both `settings` and `mappings`

The existing integration test `test_delete_all_documents_index_recreation` (which runs against a real ES cluster) also covers this path end-to-end.