### PR TITLE
docs(elasticsearch): add security and TLS connection examples to README

### DIFF
--- a/integrations/elasticsearch/README.md
+++ b/integrations/elasticsearch/README.md
@@ -8,6 +8,92 @@
 
 ---
 
+## Connecting with security enabled
+
+Since Elasticsearch 8.0, **security is on by default**: the cluster listens on HTTPS with a self-signed
+certificate and requires authentication. Connecting to `http://localhost:9200` without credentials will fail
+with a `ConnectionError` or `AuthenticationException`.
+
+All extra keyword arguments passed to `ElasticsearchDocumentStore` are forwarded directly to the
+underlying `elasticsearch-py` client, so every authentication and TLS option the client supports is
+available here.
+
+### Option 1 — API key (recommended for Elastic Cloud and self-managed clusters)
+
+```python
+import os
+from haystack.utils import Secret
+from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
+
+# base64-encoded "id:secret" string (the value shown in the Kibana "Create API key" dialog)
+document_store = ElasticsearchDocumentStore(
+    hosts="https://my-cluster.es.io:443",
+    api_key=Secret.from_env_var("ELASTIC_API_KEY"),
+)
+
+# or pass it directly as a string (not recommended for production)
+document_store = ElasticsearchDocumentStore(
+    hosts="https://my-cluster.es.io:443",
+    api_key="<base64-encoded-id:secret>",
+)
+```
+
+### Option 2 — Username / password with TLS verification via CA certificate
+
+This is the default setup for a self-managed cluster with a custom CA. Copy the CA certificate
+from the cluster (usually at `/etc/elasticsearch/certs/http_ca.crt`) to your application host.
+
+```python
+document_store = ElasticsearchDocumentStore(
+    hosts="https://localhost:9200",
+    basic_auth=("elastic", os.environ["ELASTIC_PASSWORD"]),
+    ca_certs="/path/to/http_ca.crt",
+)
+```
+
+### Option 3 — Username / password with certificate fingerprint
+
+A lighter alternative to copying the CA file. Obtain the fingerprint with:
+
+```sh
+openssl s_client -connect localhost:9200 -showcerts </dev/null 2>/dev/null \
+  | openssl x509 -fingerprint -sha256 -noout
+```
+
+```python
+document_store = ElasticsearchDocumentStore(
+    hosts="https://localhost:9200",
+    basic_auth=("elastic", os.environ["ELASTIC_PASSWORD"]),
+    ssl_assert_fingerprint="AA:BB:CC:...",  # SHA-256 fingerprint without colons also accepted
+)
+```
+
+### Option 4 — Disable TLS verification (development only)
+
+Only use this in a local dev environment where the certificate cannot be trusted. **Do not use in production.**
+
+```python
+document_store = ElasticsearchDocumentStore(
+    hosts="https://localhost:9200",
+    basic_auth=("elastic", os.environ["ELASTIC_PASSWORD"]),
+    verify_certs=False,
+)
+```
+
+### Elastic Cloud (cloud_id)
+
+```python
+document_store = ElasticsearchDocumentStore(
+    cloud_id="deployment-name:dXMtZWFzdC0x...",
+    api_key=Secret.from_env_var("ELASTIC_API_KEY"),
+)
+```
+
+For the full list of connection and authentication options, see the official
+[elasticsearch-py connecting guide](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html).
+
+---
+
 ## Contributing
 
 Refer to the general [Contribution Guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Closes #661.

Since Elasticsearch 8.0, security is enabled by default — the cluster listens on HTTPS with a self-signed certificate and requires credentials. Connecting with `http://localhost:9200` (no auth, no TLS) raises a `ConnectionError` or `AuthenticationException`. This was a common point of confusion and the README had no guidance.

The `ElasticsearchDocumentStore` already passes all `**kwargs` through to the underlying `elasticsearch-py` client, so every auth/TLS option already works — it just wasn't documented.

This PR adds a **"Connecting with security enabled"** section to the README covering the four typical setups:

1. **API key** — recommended for Elastic Cloud and self-managed clusters
2. **Username / password + CA certificate** — standard self-managed setup
3. **Username / password + certificate fingerprint** — lighter alternative, no cert file needed
4. **Disable TLS verification** — local dev only, with explicit warning against production use
5. **Elastic Cloud `cloud_id`** — Elastic Cloud shorthand

All examples are copy-pasteable and use environment variables for secrets.