### PR TITLE
chore: add none option to adaptive_thinking_effort

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -535,7 +535,7 @@ class AmazonBedrockChatGenerator:
         adaptive_thinking_effort = generation_kwargs.pop("adaptive_thinking_effort", None)
         if adaptive_thinking_effort is not None:
             thinking = generation_kwargs.setdefault("thinking", {})
-            if adaptive_thinking_effort == "disabled":
+            if adaptive_thinking_effort in ("disabled", "none"):
                 thinking.setdefault("type", "disabled")
             else:
                 thinking.setdefault("type", "adaptive")

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -684,6 +684,14 @@ class TestAmazonBedrockChatGenerator:
                     "thinking": {"type": "disabled"},
                 },
             ),
+            (
+                {
+                    "adaptive_thinking_effort": "none",
+                },
+                {
+                    "thinking": {"type": "disabled"},
+                },
+            ),
         ],
     )
     def test_prepare_request_params_with_flattened_generation_kwargs(

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -324,7 +324,7 @@ class AnthropicChatGenerator:
         adaptive_thinking_effort = generation_kwargs.pop("adaptive_thinking_effort", None)
         if adaptive_thinking_effort is not None:
             thinking = generation_kwargs.setdefault("thinking", {})
-            if adaptive_thinking_effort == "disabled":
+            if adaptive_thinking_effort in ("disabled", "none"):
                 thinking.setdefault("type", "disabled")
             else:
                 thinking.setdefault("type", "adaptive")

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -431,6 +431,14 @@ class TestAnthropicChatGenerator:
                     "thinking": {"type": "disabled"},
                 },
             ),
+            (
+                {
+                    "adaptive_thinking_effort": "none",
+                },
+                {
+                    "thinking": {"type": "disabled"},
+                },
+            ),
         ],
     )
     def test_run_with_flattened_generation_kwargs(


### PR DESCRIPTION
### Related Issues

None makes more sense in a semantic way and is more in line with other model provider's reasoning options. See:

<img width="475" height="737" alt="image" src="https://github.com/user-attachments/assets/d47c9000-4d36-4304-8ffe-5e9355d70fc3" />


### Proposed Changes:
- add `none` as option for `adaptive_thinking_effort` triggering similar behavior than (more anthropic native) `disabled` option

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
