### PR TITLE
feat: add Python 3.14 support to vLLM integration

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -36,8 +36,7 @@ env:
   VLLM_CPU_KVCACHE_SPACE: "4"
   # we only test on Ubuntu to keep vLLM server running simple
   TEST_MATRIX_OS: '["ubuntu-latest"]'
-  # vLLM is not compatible with Python 3.14. https://github.com/vllm-project/vllm/issues/34096
-  TEST_MATRIX_PYTHON: '["3.10", "3.13"]'
+  TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 
 jobs:
   compute-test-matrix:

--- a/integrations/vllm/pyproject.toml
+++ b/integrations/vllm/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
### Related Issues

- closes #3124

### Proposed Changes

vLLM upstream issue [vllm-project/vllm#34096](https://github.com/vllm-project/vllm/issues/34096) is now closed  Python 3.14 support landed in vLLM v0.24.0 (released June 29, 2026). The CPU wheel uses the stable ABI (`cp38-abi3`), so a single wheel covers Python 3.8 through 3.14+ without needing a separate per-version build.

- Remove the outdated "vLLM is not compatible with Python 3.14" comment from the CI workflow
- Update `TEST_MATRIX_PYTHON` from `["3.10", "3.13"]` to `["3.10", "3.14"]`
- Add `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`

### How did you test it?

- Verified that vLLM v0.24.0 ships a `cp38-abi3` manylinux CPU wheel, which is compatible with Python 3.14 by the stable ABI guarantee
- Confirmed the upstream tracking issue is closed and the fix PR ([vllm-project/vllm#34770](https://github.com/vllm-project/vllm/pull/34770)) is merged
- CI will run the full integration test suite on Python 3.14 once this PR is open

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `feat:`