### PR TITLE
test: run test suites against Haystack v3 branch (do not merge)

### DIFF
--- a/integrations/aimlapi/pyproject.toml
+++ b/integrations/aimlapi/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/aimlapi#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.generators.aimlapi {args}"

--- a/integrations/alloydb/pyproject.toml
+++ b/integrations/alloydb/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "pgvector>=0.3.0",
   "psycopg[binary]",
   "google-cloud-alloydb-connector[psycopg]>=1.0.0",
@@ -40,6 +40,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -72,7 +75,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.document_stores.alloydb -p haystack_integrations.components.retrievers.alloydb {args}"

--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "boto3>=1.42.84,<2", "aiobotocore>=3.4.0,<4"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "boto3>=1.42.84,<2", "aiobotocore>=3.4.0,<4"]
 
 
 
@@ -34,6 +34,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.common.amazon_bedrock \

--- a/integrations/amazon_sagemaker/pyproject.toml
+++ b/integrations/amazon_sagemaker/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "boto3>=1.28.57"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "boto3>=1.28.57"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_sagemaker_haystack#readme"
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.generators.amazon_sagemaker {args}"
 

--- a/integrations/amazon_textract/pyproject.toml
+++ b/integrations/amazon_textract/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=2.24.1",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     "boto3>=1.42.84,<2",
 ]
 
@@ -41,6 +41,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -72,7 +75,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.amazon_textract {args}"
 

--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "anthropic>=0.74.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "anthropic>=0.74.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/anthropic#readme"
@@ -33,6 +33,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.generators.anthropic {args}"

--- a/integrations/arangodb/pyproject.toml
+++ b/integrations/arangodb/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "python-arango>=8.0.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "python-arango>=8.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/arangodb#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.document_stores.arangodb -p haystack_integrations.components.retrievers.arangodb {args}"
 

--- a/integrations/arcadedb/pyproject.toml
+++ b/integrations/arcadedb/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.26.1",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "requests>=2.28.0",
 ]
 
@@ -35,6 +35,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.document_stores.arcadedb -p haystack_integrations.components.retrievers.arcadedb {args}"
 

--- a/integrations/astra/pyproject.toml
+++ b/integrations/astra/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "astrapy>=1.5.2,<2.0",
-  "haystack-ai>=2.26.1",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "pydantic",
   "typing_extensions",
 ]
@@ -37,6 +37,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.document_stores.astra \
 -p haystack_integrations.components.retrievers.astra {args}"""

--- a/integrations/azure_ai_search/pyproject.toml
+++ b/integrations/azure_ai_search/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.26.1",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "azure-search-documents>=12.0.0",
   "azure-identity"
 ]
@@ -36,6 +36,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.document_stores.azure_ai_search \

--- a/integrations/azure_doc_intelligence/pyproject.toml
+++ b/integrations/azure_doc_intelligence/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=2.22.0",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     "azure-ai-documentintelligence>=1.0.0",
 ]
 
@@ -43,6 +43,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -75,7 +78,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.azure_doc_intelligence {args}"
 

--- a/integrations/azure_form_recognizer/pyproject.toml
+++ b/integrations/azure_form_recognizer/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=2.22.0",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     "azure-ai-formrecognizer>=3.3.0",
     "pandas>=2.3.3",
 ]
@@ -45,6 +45,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -77,7 +80,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.azure_form_recognizer {args}"
 

--- a/integrations/brave/pyproject.toml
+++ b/integrations/brave/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "httpx>=0.27.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "httpx>=0.27.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/brave#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.websearch.brave {args}"
 

--- a/integrations/chonkie/pyproject.toml
+++ b/integrations/chonkie/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "chonkie[all]>=1.6.4"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "chonkie[all]>=1.6.4"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chonkie#readme"
@@ -31,6 +31,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -63,7 +66,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.preprocessors.chonkie {args}"
 

--- a/integrations/chroma/pyproject.toml
+++ b/integrations/chroma/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "chromadb>=1.5.4"
 ]
 
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -67,7 +70,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.retrievers.chroma -p haystack_integrations.document_stores.chroma {args}"

--- a/integrations/cognee/pyproject.toml
+++ b/integrations/cognee/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.24.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "cognee>=1.0.9",
 ]
 
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -67,7 +70,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.retrievers.cognee -p haystack_integrations.components.writers.cognee -p haystack_integrations.memory_stores.cognee {args}"

--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "cohere>=5.17.0", "pydantic>=2.12.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "cohere>=5.17.0", "pydantic>=2.12.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -67,7 +70,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.embedders.cohere \

--- a/integrations/cometapi/pyproject.toml
+++ b/integrations/cometapi/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cometapi#readme"
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.generators.cometapi {args}"

--- a/integrations/datadog/pyproject.toml
+++ b/integrations/datadog/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "ddtrace>=3.16.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "ddtrace>=3.16.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/datadog#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.connectors.datadog -p haystack_integrations.tracing.datadog {args}"
 

--- a/integrations/deepeval/pyproject.toml
+++ b/integrations/deepeval/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "deepeval>=2.9.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "deepeval>=2.9.0"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/deepeval"
@@ -32,6 +32,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -63,7 +66,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.evaluators.deepeval {args}"
 

--- a/integrations/docling/pyproject.toml
+++ b/integrations/docling/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.8.0,<3.0.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "docling>=2.32.0,<3.0.0",
   "lxml>=6.0.2",
 ]
@@ -45,6 +45,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations", "src/docling_haystack"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -78,7 +81,7 @@ unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = "bash -c 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m integration {args:tests}; ret=$?; [ $ret -eq 5 ] && exit 0 || exit $ret'"
 types = "mypy -p haystack_integrations.components.converters.docling {args}"
 

--- a/integrations/docling_serve/pyproject.toml
+++ b/integrations/docling_serve/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.9.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "httpx>=0.27.0",
 ]
 
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -67,7 +70,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.docling_serve {args}"
 

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "dspy>=3.1.3", "litellm!=1.82.7,!=1.82.8"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "dspy>=3.1.3", "litellm!=1.82.7,!=1.82.8"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/dspy#readme"
@@ -63,7 +63,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.generators.dspy {args}"

--- a/integrations/e2b/pyproject.toml
+++ b/integrations/e2b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.19.0", "e2b>=2.0.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "e2b>=2.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/e2b#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.tools.e2b {args}"
 

--- a/integrations/elasticsearch/pyproject.toml
+++ b/integrations/elasticsearch/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "elasticsearch>=8,<9",
   "aiohttp>=3.9.0" # for async support https://elasticsearch-py.readthedocs.io/en/latest/async.html#valueerror-when-initializing-asyncelasticsearch
 ]
@@ -36,6 +36,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.document_stores.elasticsearch \

--- a/integrations/faiss/pyproject.toml
+++ b/integrations/faiss/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.26.1",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "faiss-cpu>=1.8.0",
   "numpy>=1.22,<2; python_version < '3.13'",
 ]
@@ -36,6 +36,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.document_stores.faiss -p haystack_integrations.components.retrievers.faiss {args}"

--- a/integrations/falkordb/pyproject.toml
+++ b/integrations/falkordb/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Database",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = ["haystack-ai>=2.26.1", "falkordb>=1.1,<2"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "falkordb>=1.1,<2"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/falkordb#readme"
@@ -34,6 +34,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -73,7 +76,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.document_stores.falkordb -p haystack_integrations.components.retrievers.falkordb {args}"
 

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "fastembed>=0.4.2"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "fastembed>=0.4.2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"
@@ -31,6 +31,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -63,7 +66,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.embedders.fastembed \
 -p haystack_integrations.components.rankers.fastembed {args}"""

--- a/integrations/firecrawl/pyproject.toml
+++ b/integrations/firecrawl/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=2.24.1",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     "firecrawl-py>=4.0.0",
 ]
 
@@ -42,6 +42,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -74,7 +77,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.fetchers.firecrawl -p haystack_integrations.components.websearch.firecrawl {args}"
 

--- a/integrations/funasr/pyproject.toml
+++ b/integrations/funasr/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=2.9.0",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     "funasr>=1.0.0",
     "torch",
     "torchaudio",
@@ -38,6 +38,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -71,7 +74,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.audio.funasr {args}"
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/github"
@@ -32,6 +32,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.connectors.github \

--- a/integrations/google_ai/pyproject.toml
+++ b/integrations/google_ai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0", "google-generativeai>=0.6.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "google-generativeai>=0.6.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_ai_haystack#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/integrations/google_drive/pyproject.toml
+++ b/integrations/google_drive/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.17.0", "httpx>=0.28.0", "tenacity>=8.2.3"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "httpx>=0.28.0", "tenacity>=8.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_drive#readme"
@@ -38,6 +38,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.common.google_drive -p haystack_integrations.components.retrievers.google_drive -p haystack_integrations.components.fetchers.google_drive {args}"
 

--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "google-genai[aiohttp]>=1.56.0", "jsonref>=1.0.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "google-genai[aiohttp]>=1.56.0", "jsonref>=1.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_genai#readme"
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.generators.google_genai \

--- a/integrations/google_vertex/pyproject.toml
+++ b/integrations/google_vertex/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.11.0", "google-cloud-aiplatform>=1.61"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "google-cloud-aiplatform>=1.61"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_vertex#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/integrations/hanlp/pyproject.toml
+++ b/integrations/hanlp/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.22.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "hanlp>=2.1.1",
   # the following pins can be removed once HanLP supports transformers 5
   "transformers>=4.1.1,<5",
@@ -39,6 +39,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -71,7 +74,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.preprocessors.hanlp {args}"""
 

--- a/integrations/huggingface_api/pyproject.toml
+++ b/integrations/huggingface_api/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "huggingface_hub[inference]>=0.35.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "huggingface_hub[inference]>=0.35.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/huggingface_api#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.common.huggingface_api \
 -p haystack_integrations.components.embedders.huggingface_api \

--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["httpx>=0.28.0", "haystack-ai>=2.22.0"]
+dependencies = ["httpx>=0.28.0", "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/jina#readme"
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.connectors.jina \

--- a/integrations/kreuzberg/pyproject.toml
+++ b/integrations/kreuzberg/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.version]
 source = "vcs"
 tag-pattern = 'integrations\/kreuzberg-v(?P<version>.*)'
@@ -34,7 +37,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=2.22.0",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     "kreuzberg>=4.4.6,<=4.7.4", # 4.7.4 is the last version with MIT license
 ]
 
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.kreuzberg {args}"
 

--- a/integrations/langdetect/pyproject.toml
+++ b/integrations/langdetect/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "langdetect>=1.0.9"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "langdetect>=1.0.9"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langdetect#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = "bash -c 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m integration {args:tests}; ret=$?; [ $ret -eq 5 ] && exit 0 || exit $ret'"
 types = """mypy -p haystack_integrations.components.classifiers.langdetect \
 -p haystack_integrations.components.routers.langdetect {args}"""

--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "langfuse>=4.0.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "langfuse>=4.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"
@@ -30,6 +30,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.connectors.langfuse -p haystack_integrations.tracing.langfuse {args}"

--- a/integrations/lara/pyproject.toml
+++ b/integrations/lara/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-dependencies = ["haystack-ai>=2.24.1", "lara-sdk"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "lara-sdk"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/lara#readme"
@@ -38,6 +38,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = 'mypy -p haystack_integrations.components.translators.lara {args}'
 

--- a/integrations/libreoffice/pyproject.toml
+++ b/integrations/libreoffice/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/libreoffice#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.libreoffice {args}"
 

--- a/integrations/litellm/pyproject.toml
+++ b/integrations/litellm/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 # litellm 1.82.7 and 1.82.8 were malicious releases and are excluded.
-dependencies = ["haystack-ai>=2.30.0", "litellm>=1.60.0,<2.0,!=1.82.7,!=1.82.8"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "litellm>=1.60.0,<2.0,!=1.82.7,!=1.82.8"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/litellm#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.generators.litellm {args}"
 

--- a/integrations/llama_cpp/pyproject.toml
+++ b/integrations/llama_cpp/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "haystack-ai>=2.30.0", "llama-cpp-python>=0.2.87"
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "llama-cpp-python>=0.2.87"
 ]
 
 [project.urls]
@@ -37,6 +37,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.generators.llama_cpp {args}"
 

--- a/integrations/llama_stack/pyproject.toml
+++ b/integrations/llama_stack/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "llama-stack>=0.4.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "llama-stack>=0.4.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/llama-stack#readme"
@@ -30,6 +30,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -62,7 +65,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.generators.llama_stack {args}"

--- a/integrations/markitdown/pyproject.toml
+++ b/integrations/markitdown/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "markitdown>=0.1.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "markitdown>=0.1.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/markitdown#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.markitdown {args}"
 

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.8.0",
-    "haystack-ai>=2.23.0",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     "exceptiongroup",  # Backport of ExceptionGroup for Python < 3.11
     "httpx"  # HTTP client library used for SSE connections
 ]
@@ -42,6 +42,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -78,7 +81,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.tools.mcp {args}"""
 

--- a/integrations/mem0/pyproject.toml
+++ b/integrations/mem0/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.19.0", "mem0ai>=0.1.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "mem0ai>=0.1.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mem0#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.retrievers.mem0 -p haystack_integrations.components.writers.mem0 -p haystack_integrations.memory_stores.mem0 -p haystack_integrations.tools.mem0 {args}"
 

--- a/integrations/meta_llama/pyproject.toml
+++ b/integrations/meta_llama/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/meta_llama#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.generators.meta_llama {args}"

--- a/integrations/microsoft_sharepoint/pyproject.toml
+++ b/integrations/microsoft_sharepoint/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.17.0", "httpx>=0.28.0", "tenacity>=8.2.3"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "httpx>=0.28.0", "tenacity>=8.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/microsoft_sharepoint#readme"
@@ -38,6 +38,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.common.microsoft_sharepoint -p haystack_integrations.components.retrievers.microsoft_sharepoint -p haystack_integrations.components.fetchers.microsoft_sharepoint {args}"
 

--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 # mistralai 2.4.6 is excluded because of security issue https://github.com/mistralai/client-python/security/advisories/GHSA-wx9m-wx4f-4cmg
-dependencies = ["haystack-ai>=2.30.0", "mistralai>=2.0.0,!=2.4.6"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "mistralai>=2.0.0,!=2.4.6"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mistral#readme"
@@ -33,6 +33,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.embedders.mistral \

--- a/integrations/mongodb_atlas/pyproject.toml
+++ b/integrations/mongodb_atlas/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "pymongo[srv]>=4.13.0"
 ]
 
@@ -35,6 +35,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -67,7 +70,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.retrievers.mongodb_atlas \

--- a/integrations/nvidia/pyproject.toml
+++ b/integrations/nvidia/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "requests>=2.25.0", "tqdm>=4.21.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "requests>=2.25.0", "tqdm>=4.21.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/nvidia#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.embedders.nvidia \

--- a/integrations/oauth/pyproject.toml
+++ b/integrations/oauth/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "httpx>=0.28.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "httpx>=0.28.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/oauth#readme"
@@ -36,6 +36,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.connectors.oauth \
 -p haystack_integrations.utils.oauth {args}"""

--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "ollama>=0.5.4", "pydantic>=2.12.0", "tenacity>=8.2.3"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "ollama>=0.5.4", "pydantic>=2.12.0", "tenacity>=8.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ollama#readme"
@@ -36,6 +36,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -69,7 +72,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.embedders.ollama \

--- a/integrations/openapi/pyproject.toml
+++ b/integrations/openapi/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.23.0", "openapi-llm>=0.4.1", "openapi3>=1.8.2"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "openapi-llm>=0.4.1", "openapi3>=1.8.2"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/openapi#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.connectors.openapi -p haystack_integrations.components.converters.openapi {args}"
 

--- a/integrations/openrouter/pyproject.toml
+++ b/integrations/openrouter/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/openrouter#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.generators.openrouter {args}"

--- a/integrations/opensearch/pyproject.toml
+++ b/integrations/opensearch/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "opensearch-py[async]>=3.0.0"
 ]
 
@@ -36,6 +36,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -71,7 +74,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.document_stores.opensearch \

--- a/integrations/opentelemetry/pyproject.toml
+++ b/integrations/opentelemetry/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "opentelemetry-sdk>=1.20.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "opentelemetry-sdk>=1.20.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/opentelemetry#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.connectors.opentelemetry -p haystack_integrations.tracing.opentelemetry {args}"
 

--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.22.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "optimum[onnxruntime]>=1.21.0",
   # The main export function of Optimum into ONNX has hidden dependencies.
   # It depends on either "sentence-transformers", "diffusers" or "timm", based
@@ -46,6 +46,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -78,7 +81,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.embedders.optimum {args}"

--- a/integrations/oracle/pyproject.toml
+++ b/integrations/oracle/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "oracledb>=2.1.0,<3.0.0",
 ]
 
@@ -37,6 +37,9 @@ dev = [
 [project.urls]
 "Source Code" = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/oracle"
 "Bug Tracker" = "https://github.com/deepset-ai/haystack-core-integrations/issues"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -73,7 +76,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.document_stores.oracle -p haystack_integrations.components.retrievers.oracle {args}"
 

--- a/integrations/orcarouter/pyproject.toml
+++ b/integrations/orcarouter/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/orcarouter#readme"
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.generators.orcarouter {args}"
 

--- a/integrations/paddleocr/pyproject.toml
+++ b/integrations/paddleocr/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.22.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "paddleocr>=3.7.0",
 ]
 
@@ -34,6 +34,9 @@ Source = "https://github.com/haystack-core-integrations/tree/main/integrations/p
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -67,7 +70,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.paddleocr {args}"
 

--- a/integrations/perplexity/pyproject.toml
+++ b/integrations/perplexity/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "httpx>=0.27.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "httpx>=0.27.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/perplexity#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -65,7 +68,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.websearch.perplexity \
 -p haystack_integrations.components.generators.perplexity \

--- a/integrations/pgvector/pyproject.toml
+++ b/integrations/pgvector/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "pgvector>=0.3.0",
   "psycopg[binary]"
 ]
@@ -36,6 +36,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.document_stores.pgvector -p haystack_integrations.components.retrievers.pgvector {args}"

--- a/integrations/pinecone/pyproject.toml
+++ b/integrations/pinecone/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "pinecone[asyncio]>=7.0.0",
 ]
 
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.retrievers.pinecone \

--- a/integrations/presidio/pyproject.toml
+++ b/integrations/presidio/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.9.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "presidio-analyzer>=2.2.0",
   "presidio-anonymizer>=2.2.0",
   "click>=8.0.0",
@@ -37,6 +37,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -69,7 +72,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.preprocessors.presidio {args} -p haystack_integrations.components.extractors.presidio {args}"
 

--- a/integrations/pyversity/pyproject.toml
+++ b/integrations/pyversity/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.2.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "pyversity>=0.2.0",
 ]
 
@@ -38,6 +38,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.rankers.pyversity {args}"
 

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.29.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "qdrant-client>=1.12.0"
 ]
 
@@ -39,6 +39,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -71,7 +74,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.document_stores.qdrant \

--- a/integrations/ragas/pyproject.toml
+++ b/integrations/ragas/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 # langchain-community pinned due to https://github.com/vibrantlabsai/ragas/issues/2741
-dependencies = ["haystack-ai>=2.22.0", "ragas>=0.4.3", "langchain-community>=0.3.9,<0.4.2"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "ragas>=0.4.3", "langchain-community>=0.3.9,<0.4.2"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ragas"
@@ -34,6 +34,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.evaluators.ragas {args}"

--- a/integrations/searchapi/pyproject.toml
+++ b/integrations/searchapi/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "httpx>=0.27.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "httpx>=0.27.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/searchapi#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.websearch.searchapi {args}"
 

--- a/integrations/sentence_transformers/pyproject.toml
+++ b/integrations/sentence_transformers/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.0", "sentence-transformers>=5.4.0", "pillow>=11.3.0", "pypdfium2>=4.0.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "sentence-transformers>=5.4.0", "pillow>=11.3.0", "pypdfium2>=4.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/sentence_transformers#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.embedders.sentence_transformers \
 -p haystack_integrations.components.rankers.sentence_transformers {args}"""

--- a/integrations/serperdev/pyproject.toml
+++ b/integrations/serperdev/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "httpx>=0.27.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "httpx>=0.27.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/serperdev#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.websearch.serperdev {args}"
 

--- a/integrations/snowflake/pyproject.toml
+++ b/integrations/snowflake/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.22.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "adbc_driver_snowflake>=1.4.0",
   "polars[pandas,pyarrow]>=1.23.0",
   "snowflake-connector-python>=3.12.0",
@@ -38,6 +38,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -71,7 +74,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.retrievers.snowflake {args}"

--- a/integrations/spacy/pyproject.toml
+++ b/integrations/spacy/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 # `click` is required to make spacy work but not declared by spacy itself.
 # See https://github.com/explosion/spaCy/issues/13971
-dependencies = ["haystack-ai>=2.23.0", "spacy>=3.8.13,<3.9", "click>=8.0.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "spacy>=3.8.13,<3.9", "click>=8.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/spacy#readme"
@@ -34,6 +34,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.extractors.spacy {args}"
 

--- a/integrations/sqlalchemy/pyproject.toml
+++ b/integrations/sqlalchemy/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.22.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "sqlalchemy>=2.0.36",
   "pandas>=2.2.3; python_version < '3.11'",
   "pandas>=3.0.0; python_version >= '3.11'",
@@ -37,6 +37,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.retrievers.sqlalchemy {args}"

--- a/integrations/stackit/pyproject.toml
+++ b/integrations/stackit/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/stackit#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.embedders.stackit \
 -p haystack_integrations.components.generators.stackit {args}"""

--- a/integrations/supabase/pyproject.toml
+++ b/integrations/supabase/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.26.1", "pgvector-haystack>=6.3.0", "supabase>=2.23.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "pgvector-haystack>=6.3.0", "supabase>=2.23.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/supabase#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -65,7 +68,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations.document_stores.supabase --cov=haystack_integrations.components.retrievers.supabase --cov=haystack_integrations.components.downloaders.supabase --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations.document_stores.supabase --cov=haystack_integrations.components.retrievers.supabase --cov=haystack_integrations.components.downloaders.supabase -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations.document_stores.supabase --cov=haystack_integrations.components.retrievers.supabase --cov=haystack_integrations.components.downloaders.supabase --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.document_stores.supabase -p haystack_integrations.components.retrievers.supabase -p haystack_integrations.components.downloaders.supabase {args}"
 

--- a/integrations/tavily/pyproject.toml
+++ b/integrations/tavily/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "tavily-python>=0.5.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "tavily-python>=0.5.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/tavily#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.websearch.tavily {args}"
 

--- a/integrations/tika/pyproject.toml
+++ b/integrations/tika/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.9.0", "tika==3.1.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "tika==3.1.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/tika#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.converters.tika {args}"
 

--- a/integrations/togetherai/pyproject.toml
+++ b/integrations/togetherai/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/togetherai#readme"
@@ -33,6 +33,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.generators.togetherai {args}"""

--- a/integrations/transformers/pyproject.toml
+++ b/integrations/transformers/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "transformers[torch,sentencepiece]>=4.57.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "transformers[torch,sentencepiece]>=4.57.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/transformers#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.common.transformers \
 -p haystack_integrations.components.classifiers.transformers \

--- a/integrations/twelvelabs/pyproject.toml
+++ b/integrations/twelvelabs/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["twelvelabs>=1.2.8", "haystack-ai>=2.22.0"]
+dependencies = ["twelvelabs>=1.2.8", "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/twelvelabs#readme"
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -67,7 +70,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.embedders.twelvelabs \

--- a/integrations/unstructured/pyproject.toml
+++ b/integrations/unstructured/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.22.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "unstructured>=0.15.0",
   "unstructured-client>=0.21.0",
 ]
@@ -37,6 +37,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -69,7 +72,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.converters.unstructured {args}"

--- a/integrations/valkey/pyproject.toml
+++ b/integrations/valkey/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "haystack-ai>=2.28.0",
+    "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
     # 2.4.0 wheels are missing the glide_shared._fast_response extension, which
     # breaks `import glide_sync`. See https://github.com/valkey-io/valkey-glide/pull/6020.
     "valkey-glide>=2.2.0,!=2.4.0",
@@ -41,6 +41,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -73,7 +76,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = "mypy -p haystack_integrations.components.retrievers.valkey -p haystack_integrations.document_stores.valkey {args}"

--- a/integrations/vespa/pyproject.toml
+++ b/integrations/vespa/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.28.0", "pyvespa>=0.58.0"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "pyvespa>=0.58.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/vespa#readme"
@@ -41,6 +41,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -73,7 +76,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.document_stores.vespa -p haystack_integrations.components.retrievers.vespa {args}"
 

--- a/integrations/vllm/pyproject.toml
+++ b/integrations/vllm/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 # fastapi temporarily pinned due to https://github.com/vllm-project/vllm/issues/45596
-dependencies = ["haystack-ai>=2.30.0", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0", "fastapi<0.137"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0", "fastapi<0.137"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/vllm#readme"
@@ -32,6 +32,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -64,7 +67,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.generators.vllm -p haystack_integrations.components.embedders.vllm -p haystack_integrations.components.rankers.vllm -p haystack_integrations.common.vllm {args}"
 

--- a/integrations/watsonx/pyproject.toml
+++ b/integrations/watsonx/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["haystack-ai>=2.30.0", "ibm-watsonx-ai>=1.3.26", "pandas>=2.2.3"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "ibm-watsonx-ai>=1.3.26", "pandas>=2.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/watsonx#readme"
@@ -31,6 +31,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -66,7 +69,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.generators.watsonx \
 -p haystack_integrations.components.embedders.watsonx  {args}"""

--- a/integrations/weave/pyproject.toml
+++ b/integrations/weave/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "weave>=0.52.7"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3", "weave>=0.52.7"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"
@@ -32,6 +32,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -63,7 +66,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = """mypy -p haystack_integrations.components.connectors.weave \
 -p haystack_integrations.tracing.weave {args}"""

--- a/integrations/weaviate/pyproject.toml
+++ b/integrations/weaviate/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.28.0",
+  "haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3",
   "weaviate-client>=4.20",
   "python-dateutil>=2.7.0",
 ]
@@ -36,6 +36,9 @@ Issues = "https://github.com/deepset-ai/haystack-core-integrations/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -68,7 +71,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.document_stores.weaviate \

--- a/integrations/whisper/pyproject.toml
+++ b/integrations/whisper/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 # `openai` ships with `haystack-ai` and is used by `RemoteWhisperTranscriber`. `openai-whisper` (used by
 # `LocalWhisperTranscriber`) is imported lazily, so it is an optional dependency that users install only if
 # they want local transcription: `pip install "openai-whisper>=20231106"`.
-dependencies = ["haystack-ai>=2.24.1"]
+dependencies = ["haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/whisper#readme"
@@ -35,6 +35,9 @@ Source = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/int
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/haystack_integrations"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -70,7 +73,7 @@ dependencies = [
 unit = 'pytest -m "not integration" {args:tests}'
 integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
-unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
+unit-cov-retry = 'pytest --cov=haystack_integrations -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 types = "mypy -p haystack_integrations.components.audio.whisper {args}"
 


### PR DESCRIPTION
### Related Issues

- addresses https://github.com/deepset-ai/haystack-private/issues/446 (test the `v3` branch against haystack-core-integrations)

### Proposed Changes:

- Point the `haystack-ai` dependency of all 92 integrations at the Haystack `v3` draft branch (`haystack-ai @ git+https://github.com/deepset-ai/haystack.git@v3`) so every integration's CI workflow runs against the 3.0 draft
- Add `[tool.hatch.metadata] allow-direct-references = true` where missing, so hatch accepts the git dependency
- Remove `--reruns 3 --reruns-delay 30 -x` from the `unit-cov-retry` script so CI reports **all** unit-test failures instead of stopping at the first one

This follows the approach from #3467, extended to all integrations and targeting `v3` instead of `lifecycle`.

⚠️ **Draft / do not merge** — this PR only exists to collect CI results against the v3 draft.

### How did you test it?

Verified locally for the `anthropic` integration that hatch resolves and installs Haystack from the `v3` branch and that the unit tests run. Two tests already fail there against v3 (`test_to_dict_with_parameters`, `test_serde_in_pipeline` — serialization output differences), which is exactly the kind of incompatibility this PR is meant to surface.

### Notes for the reviewer

The CI results on this PR are the deliverable: each integration's workflow shows which test suites break against the v3 draft.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)