### PR TITLE
test: make Tool/Agent serialization assertions version-agnostic for Haystack 2.x/3.x

### DIFF
--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
@@ -482,17 +482,8 @@ class TestAIMLAPIChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.aimlapi.com/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_aimlapi_chat_generator.weather",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "extra_headers": None,
                         "timeout": None,
@@ -505,21 +496,6 @@ class TestAIMLAPIChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
@@ -469,6 +469,11 @@ class TestAIMLAPIChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -482,8 +487,6 @@ class TestAIMLAPIChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.aimlapi.com/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "extra_headers": None,
                         "timeout": None,

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -205,6 +205,11 @@ class TestAnthropicChatGenerator:
         )
         data = component.to_dict()
 
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # from_dict round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = data["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
+
         expected_dict = {
             "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
             "init_parameters": {
@@ -213,14 +218,16 @@ class TestAnthropicChatGenerator:
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "ignore_tools_thinking_messages": True,
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                # serialize the tool with the installed haystack-ai version so the expected fields match it
-                "tools": [tool.to_dict()],
                 "timeout": 10.0,
                 "max_retries": 1,
             },
         }
 
         assert data == expected_dict
+
+        # deserializing the serialized component must reproduce the original tool
+        loaded = AnthropicChatGenerator.from_dict(component.to_dict())
+        assert loaded.tools == [tool]
 
     def test_from_dict(self, monkeypatch):
         """
@@ -456,6 +463,11 @@ class TestAnthropicChatGenerator:
         pipeline.add_component("generator", generator)
 
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         type_ = "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator"
 
         expected_dict = {
@@ -471,8 +483,6 @@ class TestAnthropicChatGenerator:
                         "generation_kwargs": {"temperature": 0.6},
                         "ignore_tools_thinking_messages": True,
                         "streaming_callback": None,
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                         "timeout": None,
                         "max_retries": None,
                     },

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -213,34 +213,12 @@ class TestAnthropicChatGenerator:
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "ignore_tools_thinking_messages": True,
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "tools": [
-                    {
-                        "data": {
-                            "description": "description",
-                            "function": "builtins.print",
-                            "name": "name",
-                            "parameters": {
-                                "x": {
-                                    "type": "string",
-                                },
-                            },
-                        },
-                        "type": "haystack.tools.tool.Tool",
-                    }
-                ],
+                # serialize the tool with the installed haystack-ai version so the expected fields match it
+                "tools": [tool.to_dict()],
                 "timeout": 10.0,
                 "max_retries": 1,
             },
         }
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = tool.outputs_to_string
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = tool.inputs_from_state
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = tool.outputs_to_state
 
         assert data == expected_dict
 
@@ -493,17 +471,8 @@ class TestAnthropicChatGenerator:
                         "generation_kwargs": {"temperature": 0.6},
                         "ignore_tools_thinking_messages": True,
                         "streaming_callback": None,
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "name",
-                                    "description": "description",
-                                    "parameters": {"x": {"type": "string"}},
-                                    "function": "builtins.print",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                         "timeout": None,
                         "max_retries": None,
                     },
@@ -514,21 +483,6 @@ class TestAnthropicChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/cometapi/tests/test_cometapi_chat_generator.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator.py
@@ -445,6 +445,11 @@ class TestCometAPIChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -462,8 +467,6 @@ class TestCometAPIChatGenerator:
                         "api_key": {"type": "env_var", "env_vars": ["COMET_API_KEY"], "strict": True},
                         "timeout": None,
                         "max_retries": None,
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                         "tools_strict": False,
                         "http_client_kwargs": None,
                     },

--- a/integrations/cometapi/tests/test_cometapi_chat_generator.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator.py
@@ -462,17 +462,8 @@ class TestCometAPIChatGenerator:
                         "api_key": {"type": "env_var", "env_vars": ["COMET_API_KEY"], "strict": True},
                         "timeout": None,
                         "max_retries": None,
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "test_cometapi_chat_generator.weather",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                         "tools_strict": False,
                         "http_client_kwargs": None,
                     },
@@ -484,21 +475,6 @@ class TestCometAPIChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/github/tests/test_file_editor_tool.py
+++ b/integrations/github/tests/test_file_editor_tool.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import unittest
+import unittest.mock
 
 from haystack import Pipeline
 from haystack.components.agents import Agent
@@ -143,16 +143,6 @@ class TestGitHubFileEditorTool:
 
         pipeline_dict = pipeline.to_dict()
 
-        # Remove parameters introduced after haystack-ai==2.12.0 (the minimum supported version)
-        # to maintain compatibility
-        try:
-            pipeline_dict["components"]["agent"]["init_parameters"]["chat_generator"]["init_parameters"].pop(
-                "http_client_kwargs", None
-            )
-            pipeline_dict["components"]["agent"]["init_parameters"].pop("tool_invoker_kwargs", None)
-        except KeyError:
-            pass
-
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -205,12 +195,20 @@ class TestGitHubFileEditorTool:
             "connection_type_validation": True,
         }
 
-        # Compatibility with newer versions of Haystack that include these parameters
-        for key in ["confirmation_strategies", "required_variables", "user_prompt"]:
-            if key in pipeline_dict["components"]["agent"]["init_parameters"]:
-                expected_dict["components"]["agent"]["init_parameters"][key] = pipeline_dict["components"]["agent"][
-                    "init_parameters"
-                ][key]
+        # The Agent and the OpenAIChatGenerator belong to haystack-ai, and their init parameters vary across the
+        # haystack-ai versions this integration supports. Accept whatever the installed version adds beyond the
+        # expected baseline: this test only pins the serialization of GitHubFileEditorTool.
+        actual_agent_params = pipeline_dict["components"]["agent"]["init_parameters"]
+        expected_agent_params = expected_dict["components"]["agent"]["init_parameters"]
+        for actual_params, expected_params in [
+            (actual_agent_params, expected_agent_params),
+            (
+                actual_agent_params["chat_generator"]["init_parameters"],
+                expected_agent_params["chat_generator"]["init_parameters"],
+            ),
+        ]:
+            for key in actual_params.keys() - expected_params.keys():
+                expected_params[key] = actual_params[key]
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/github/tests/test_file_editor_tool.py
+++ b/integrations/github/tests/test_file_editor_tool.py
@@ -213,6 +213,8 @@ class TestGitHubFileEditorTool:
         assert pipeline_dict == expected_dict
 
         deserialized_pipeline = Pipeline.from_dict(pipeline_dict)
+        assert deserialized_pipeline == pipeline
+
         deserialized_components = [instance for _, instance in deserialized_pipeline.graph.nodes(data="instance")]
         deserialized_agent = deserialized_components[0]
         assert isinstance(deserialized_agent, Agent)

--- a/integrations/huggingface_api/tests/test_chat_generator.py
+++ b/integrations/huggingface_api/tests/test_chat_generator.py
@@ -270,8 +270,10 @@ class TestHuggingFaceAPIChatGenerator:
         assert init_params["token"] == {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"}
         assert init_params["generation_kwargs"] == {"temperature": 0.6, "stop": ["stop", "words"], "max_tokens": 512}
         assert init_params["streaming_callback"] is None
-        # serialize the tool with the installed haystack-ai version so the expected fields match it
-        assert init_params["tools"] == [tool.to_dict()]
+
+        # deserializing the serialized component must reproduce the original tool
+        loaded = HuggingFaceAPIChatGenerator.from_dict(result)
+        assert loaded.tools == [tool]
 
     def test_from_dict(self, mock_check_valid_model):
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
@@ -311,6 +313,11 @@ class TestHuggingFaceAPIChatGenerator:
         pipeline.add_component("generator", generator)
 
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         assert pipeline_dict == {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -325,8 +332,6 @@ class TestHuggingFaceAPIChatGenerator:
                         "token": {"type": "env_var", "env_vars": ["ENV_VAR"], "strict": False},
                         "generation_kwargs": {"temperature": 0.6, "stop": ["stop", "words"], "max_tokens": 512},
                         "streaming_callback": None,
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                     },
                 }
             },
@@ -1165,8 +1170,10 @@ class TestHuggingFaceAPIChatGenerator:
         )
         data = generator.to_dict()
 
-        # serialize the toolset with the installed haystack-ai version so the expected fields match it
-        assert data["init_parameters"]["tools"] == toolset.to_dict()
+        # deserializing the serialized component must reproduce the original toolset
+        loaded = HuggingFaceAPIChatGenerator.from_dict(data)
+        assert isinstance(loaded.tools, Toolset)
+        assert list(loaded.tools) == list(toolset)
 
     def test_convert_tools_to_hfapi_tools(self):
         assert _convert_tools_to_hfapi_tools(None) is None

--- a/integrations/huggingface_api/tests/test_chat_generator.py
+++ b/integrations/huggingface_api/tests/test_chat_generator.py
@@ -270,20 +270,8 @@ class TestHuggingFaceAPIChatGenerator:
         assert init_params["token"] == {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"}
         assert init_params["generation_kwargs"] == {"temperature": 0.6, "stop": ["stop", "words"], "max_tokens": 512}
         assert init_params["streaming_callback"] is None
-        assert init_params["tools"] == [
-            {
-                "type": "haystack.tools.tool.Tool",
-                "data": {
-                    "description": "description",
-                    "function": "builtins.print",
-                    "inputs_from_state": None,
-                    "name": "name",
-                    "outputs_to_state": None,
-                    "outputs_to_string": None,
-                    "parameters": {"x": {"type": "string"}},
-                },
-            }
-        ]
+        # serialize the tool with the installed haystack-ai version so the expected fields match it
+        assert init_params["tools"] == [tool.to_dict()]
 
     def test_from_dict(self, mock_check_valid_model):
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
@@ -337,20 +325,8 @@ class TestHuggingFaceAPIChatGenerator:
                         "token": {"type": "env_var", "env_vars": ["ENV_VAR"], "strict": False},
                         "generation_kwargs": {"temperature": 0.6, "stop": ["stop", "words"], "max_tokens": 512},
                         "streaming_callback": None,
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "inputs_from_state": None,
-                                    "name": "name",
-                                    "outputs_to_state": None,
-                                    "outputs_to_string": None,
-                                    "description": "description",
-                                    "parameters": {"x": {"type": "string"}},
-                                    "function": "builtins.print",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                     },
                 }
             },
@@ -1189,30 +1165,8 @@ class TestHuggingFaceAPIChatGenerator:
         )
         data = generator.to_dict()
 
-        expected_tools_data = {
-            "type": "haystack.tools.toolset.Toolset",
-            "data": {
-                "tools": [
-                    {
-                        "type": "haystack.tools.tool.Tool",
-                        "data": {
-                            "name": "weather",
-                            "description": "useful to determine the weather in a given location",
-                            "parameters": {
-                                "type": "object",
-                                "properties": {"city": {"type": "string"}},
-                                "required": ["city"],
-                            },
-                            "function": "tests.test_chat_generator.get_weather",
-                            "outputs_to_string": None,
-                            "inputs_from_state": None,
-                            "outputs_to_state": None,
-                        },
-                    }
-                ]
-            },
-        }
-        assert data["init_parameters"]["tools"] == expected_tools_data
+        # serialize the toolset with the installed haystack-ai version so the expected fields match it
+        assert data["init_parameters"]["tools"] == toolset.to_dict()
 
     def test_convert_tools_to_hfapi_tools(self):
         assert _convert_tools_to_hfapi_tools(None) is None

--- a/integrations/meta_llama/tests/test_llama_chat_generator.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator.py
@@ -607,17 +607,8 @@ class TestLlamaChatGenerator:
                         "generation_kwargs": {"temperature": 0.7},
                         "timeout": None,
                         "max_retries": None,
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_llama_chat_generator.weather",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                     },
                 }
             },
@@ -626,21 +617,6 @@ class TestLlamaChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/meta_llama/tests/test_llama_chat_generator.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator.py
@@ -585,6 +585,11 @@ class TestLlamaChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -607,8 +612,6 @@ class TestLlamaChatGenerator:
                         "generation_kwargs": {"temperature": 0.7},
                         "timeout": None,
                         "max_retries": None,
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                     },
                 }
             },

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -786,6 +786,11 @@ class TestMistralChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -799,8 +804,6 @@ class TestMistralChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.mistral.ai/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "timeout": None,
                         "max_retries": None,

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -799,17 +799,8 @@ class TestMistralChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.mistral.ai/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_mistral_chat_generator.weather",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "timeout": None,
                         "max_retries": None,
@@ -821,21 +812,6 @@ class TestMistralChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -601,6 +601,11 @@ class TestOpenRouterChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -614,8 +619,6 @@ class TestOpenRouterChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://openrouter.ai/api/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "extra_headers": None,
                         "timeout": None,

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -614,17 +614,8 @@ class TestOpenRouterChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://openrouter.ai/api/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_openrouter_chat_generator.weather",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "extra_headers": None,
                         "timeout": None,
@@ -637,21 +628,6 @@ class TestOpenRouterChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
@@ -490,17 +490,8 @@ class TestOrcaRouterChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.orcarouter.ai/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_orcarouter_chat_generator.weather",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "organization": None,
                         "tools_strict": False,
@@ -514,21 +505,6 @@ class TestOrcaRouterChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
@@ -477,6 +477,11 @@ class TestOrcaRouterChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -490,8 +495,6 @@ class TestOrcaRouterChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.orcarouter.ai/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "organization": None,
                         "tools_strict": False,

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -589,17 +589,8 @@ class TestTogetherAIChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.together.xyz/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_togetherai_chat_generator.weather",
-                                },
-                            }
-                        ],
+                        # serialize the tool with the installed haystack-ai version so the expected fields match it
+                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "timeout": None,
                         "max_retries": None,
@@ -611,21 +602,6 @@ class TestTogetherAIChatGenerator:
 
         if not hasattr(pipeline, "_connection_type_validation"):
             expected_dict.pop("connection_type_validation")
-
-        # add outputs_to_string, inputs_from_state and outputs_to_state tool parameters for compatibility with
-        # haystack-ai>=2.12.0
-        if hasattr(tool, "outputs_to_string"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_string"] = (
-                tool.outputs_to_string
-            )
-        if hasattr(tool, "inputs_from_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["inputs_from_state"] = (
-                tool.inputs_from_state
-            )
-        if hasattr(tool, "outputs_to_state"):
-            expected_dict["components"]["generator"]["init_parameters"]["tools"][0]["data"]["outputs_to_state"] = (
-                tool.outputs_to_state
-            )
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -576,6 +576,11 @@ class TestTogetherAIChatGenerator:
 
         # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -589,8 +594,6 @@ class TestTogetherAIChatGenerator:
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "api_base_url": "https://api.together.xyz/v1",
                         "generation_kwargs": {"temperature": 0.7},
-                        # serialize the tool with the installed haystack-ai version so the expected fields match it
-                        "tools": [tool.to_dict()],
                         "http_client_kwargs": None,
                         "timeout": None,
                         "max_retries": None,

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -206,8 +206,10 @@ class TestTransformersChatGenerator:
         assert init_params["streaming_callback"] is None
         assert init_params["chat_template"] == "irrelevant"
         assert init_params["enable_thinking"] is True
-        # serialize the tools with the installed haystack-ai version so the expected fields match it
-        assert init_params["tools"] == [tool.to_dict() for tool in tools]
+
+        # deserializing the serialized component must reproduce the original tools
+        loaded = TransformersChatGenerator.from_dict(result)
+        assert loaded.tools == tools
 
     def test_from_dict(self, model_info_mock, tools):
         generator = TransformersChatGenerator(
@@ -790,8 +792,10 @@ class TestTransformersChatGeneratorAsync:
         generator.pipeline = mock_pipeline_with_tokenizer
         data = generator.to_dict()
 
-        # serialize the toolset with the installed haystack-ai version so the expected fields match it
-        assert data["init_parameters"]["tools"] == toolset.to_dict()
+        # deserializing the serialized component must reproduce the original toolset
+        loaded = TransformersChatGenerator.from_dict(data)
+        assert isinstance(loaded.tools, Toolset)
+        assert list(loaded.tools) == list(toolset)
 
     @pytest.mark.asyncio
     async def test_run_async_with_streaming_callback(self, model_info_mock, mock_pipeline_with_tokenizer):

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -206,20 +206,8 @@ class TestTransformersChatGenerator:
         assert init_params["streaming_callback"] is None
         assert init_params["chat_template"] == "irrelevant"
         assert init_params["enable_thinking"] is True
-        assert init_params["tools"] == [
-            {
-                "type": "haystack.tools.tool.Tool",
-                "data": {
-                    "inputs_from_state": None,
-                    "name": "weather",
-                    "outputs_to_state": None,
-                    "outputs_to_string": None,
-                    "description": "useful to determine the weather in a given location",
-                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
-                    "function": "tests.test_chat_generator.get_weather",
-                },
-            }
-        ]
+        # serialize the tools with the installed haystack-ai version so the expected fields match it
+        assert init_params["tools"] == [tool.to_dict() for tool in tools]
 
     def test_from_dict(self, model_info_mock, tools):
         generator = TransformersChatGenerator(
@@ -802,30 +790,8 @@ class TestTransformersChatGeneratorAsync:
         generator.pipeline = mock_pipeline_with_tokenizer
         data = generator.to_dict()
 
-        expected_tools_data = {
-            "type": "haystack.tools.toolset.Toolset",
-            "data": {
-                "tools": [
-                    {
-                        "type": "haystack.tools.tool.Tool",
-                        "data": {
-                            "name": "weather",
-                            "description": "useful to determine the weather in a given location",
-                            "parameters": {
-                                "type": "object",
-                                "properties": {"city": {"type": "string"}},
-                                "required": ["city"],
-                            },
-                            "function": "tests.test_chat_generator.get_weather",
-                            "outputs_to_string": None,
-                            "inputs_from_state": None,
-                            "outputs_to_state": None,
-                        },
-                    }
-                ]
-            },
-        }
-        assert data["init_parameters"]["tools"] == expected_tools_data
+        # serialize the toolset with the installed haystack-ai version so the expected fields match it
+        assert data["init_parameters"]["tools"] == toolset.to_dict()
 
     @pytest.mark.asyncio
     async def test_run_async_with_streaming_callback(self, model_info_mock, mock_pipeline_with_tokenizer):

--- a/integrations/watsonx/tests/test_chat_generator.py
+++ b/integrations/watsonx/tests/test_chat_generator.py
@@ -206,6 +206,11 @@ class TestWatsonxChatGenerator:
 
         data = generator.to_dict()
 
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # from_dict round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = data["init_parameters"].pop("tools")
+        assert len(tools_entries) == len(tools)
+
         expected = {
             "type": "haystack_integrations.components.generators.watsonx.chat.chat_generator.WatsonxChatGenerator",
             "init_parameters": {
@@ -218,11 +223,13 @@ class TestWatsonxChatGenerator:
                 "timeout": None,
                 "max_retries": None,
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                # serialize the tools with the installed haystack-ai version so the expected fields match it
-                "tools": [tool.to_dict() for tool in tools],
             },
         }
         assert data == expected
+
+        # deserializing the serialized component must reproduce the original tools
+        loaded = WatsonxChatGenerator.from_dict(generator.to_dict())
+        assert loaded.tools == tools
 
     def test_from_dict(self, mock_watsonx):
         assert mock_watsonx is not None

--- a/integrations/watsonx/tests/test_chat_generator.py
+++ b/integrations/watsonx/tests/test_chat_generator.py
@@ -218,24 +218,8 @@ class TestWatsonxChatGenerator:
                 "timeout": None,
                 "max_retries": None,
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "tools": [
-                    {
-                        "data": {
-                            "description": "useful to determine the weather in a given location",
-                            "function": "tests.test_chat_generator.weather",
-                            "inputs_from_state": None,
-                            "name": "weather",
-                            "outputs_to_state": None,
-                            "outputs_to_string": None,
-                            "parameters": {
-                                "properties": {"city": {"type": "string"}},
-                                "required": ["city"],
-                                "type": "object",
-                            },
-                        },
-                        "type": "haystack.tools.tool.Tool",
-                    },
-                ],
+                # serialize the tools with the installed haystack-ai version so the expected fields match it
+                "tools": [tool.to_dict() for tool in tools],
             },
         }
         assert data == expected


### PR DESCRIPTION
### Related Issues

- Part of deepset-ai/haystack-private#446

Serialization tests in five integrations compared `to_dict()` output against hard-coded expected dicts that pin the exact `Tool`/`Toolset`/`Agent` serialization format of one haystack-ai version. Haystack 3.0 adds fields (e.g. `Tool.to_dict()` now includes `async_function`; `Agent` gained `tool_concurrency_limit`, `hooks`, `tool_streaming_callback_passthrough`), which broke these tests. This PR makes them version-agnostic so they pass on both 2.x and the current `v3` branch:

### Proposed Changes:

- **anthropic, huggingface_api, transformers, watsonx**: the `to_dict` tests no longer pin the haystack-owned tools serialization format at all. They exclude the tools entries from the pinned-dict comparison and instead do a real `from_dict(component.to_dict())` round-trip, asserting the recovered tools equal the originals.
- **aimlapi, cometapi, meta_llama, mistral, openrouter, orcarouter, togetherai**: the same for their `test_serde_in_pipeline` tests — the tools entries are popped from the pinned pipeline dict; tool fidelity is covered by the `Pipeline.loads(pipeline.dumps())` round-trip (`Pipeline.__eq__` compares serialized forms) plus explicit attribute checks on the loaded generator.
- **github** (`test_pipeline_serialization`): the test pins the full pipeline dict including `Agent` and `OpenAIChatGenerator` init parameters, which belong to haystack-ai and change between versions. It now copies any init parameters the installed haystack-ai adds beyond the expected baseline before comparing, replacing the two existing single-key compat shims (`http_client_kwargs`/`tool_invoker_kwargs` pops and the `confirmation_strategies`/`required_variables`/`user_prompt` loop). The test keeps pinning what the integration owns: the `GitHubFileEditorTool` serialization. It also now asserts `Pipeline.from_dict(pipeline.to_dict()) == pipeline`.
- **github**: also changed `import unittest` to `import unittest.mock` — the test uses `unittest.mock.ANY` and only worked because haystack-ai 2.x happened to import `unittest.mock` transitively; with v3 installed it fails with `AttributeError: module 'unittest' has no attribute 'mock'`.

### How did you test it?

- Haystack 2.x: `fmt-check`, `test:types`, and full unit suites pass for all touched integrations.
- Haystack v3 (installed `git+https://github.com/deepset-ai/haystack.git@v3`): the previously failing serialization tests now pass. Verified on a local merge with #3535 (needed for collection) and #3537 (the serde tests deserialize test-module functions, so `Pipeline.loads` needs the trusted-modules allowlist) — anthropic, aimlapi, transformers, watsonx, huggingface_api, and github unit suites are all fully green on that combined state.

### Notes for the reviewer

- Reviewing this uncovered that cometapi's `test_serde_in_pipeline` never deserialized anything (it compared the original generator to itself), which was hiding a real bug: `CometAPIChatGenerator` could not be deserialized in a pipeline at all. That fix, together with the missing round-trip, was extracted into #3542 (now merged); main has been merged back into this branch, so cometapi's `test_serde_in_pipeline` here combines both changes.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

