### PR TITLE
chore: support sync streaming callbacks in async contexts for Haystack 2.x/3.x compatibility

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
@@ -5,7 +6,6 @@ from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.dataclasses.streaming_chunk import (
-    AsyncStreamingCallbackT,
     ComponentInfo,
     StreamingCallbackT,
     StreamingChunk,
@@ -403,7 +403,7 @@ class AnthropicChatGenerator:
     async def _process_response_async(
         self,
         response: Any,
-        streaming_callback: AsyncStreamingCallbackT | None = None,
+        streaming_callback: StreamingCallbackT | None = None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Process the response from the Anthropic API asynchronously.
@@ -442,7 +442,10 @@ class AnthropicChatGenerator:
                     )
                     chunks.append(streaming_chunk)
                     if streaming_callback:
-                        await streaming_callback(streaming_chunk)
+                        # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+                        callback_result = streaming_callback(streaming_chunk)
+                        if inspect.isawaitable(callback_result):
+                            await callback_result
 
             completion = _convert_streaming_chunks_to_chat_message(chunks)
             reasoning = _process_reasoning_contents(chunks)

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, ClassVar, Literal, get_args
@@ -6,7 +7,6 @@ from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses import ChatMessage, ComponentInfo, ImageContent, TextContent, ToolCall
 from haystack.dataclasses.streaming_chunk import (
-    AsyncStreamingCallbackT,
     FinishReason,
     StreamingCallbackT,
     StreamingChunk,
@@ -351,7 +351,7 @@ def _parse_streaming_response(
 async def _parse_async_streaming_response(
     response: AsyncIterator[StreamedChatResponseV2],
     model: str,
-    streaming_callback: AsyncStreamingCallbackT,
+    streaming_callback: StreamingCallbackT,
     component_info: ComponentInfo,
 ) -> ChatMessage:
     """
@@ -375,7 +375,10 @@ async def _parse_async_streaming_response(
 
         original_chunks.append(chunk)
         chunks.append(streaming_chunk)
-        await streaming_callback(streaming_chunk)
+        # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+        callback_result = streaming_callback(streaming_chunk)
+        if inspect.isawaitable(callback_result):
+            await callback_result
 
     return _convert_streaming_chunks_to_chat_message(chunks=chunks)
 

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, ClassVar, Literal
 
@@ -10,7 +11,7 @@ from haystack import logging
 from haystack.components.generators.utils import _normalize_messages
 from haystack.core.component import component
 from haystack.core.serialization import default_from_dict, default_to_dict
-from haystack.dataclasses import AsyncStreamingCallbackT, ComponentInfo, StreamingCallbackT, select_streaming_callback
+from haystack.dataclasses import ComponentInfo, StreamingCallbackT, select_streaming_callback
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole
 from haystack.tools import (
     ToolsType,
@@ -344,7 +345,7 @@ class GoogleGenAIChatGenerator:
             raise RuntimeError(msg) from e
 
     async def _handle_streaming_response_async(
-        self, response_stream: AsyncIterator[types.GenerateContentResponse], streaming_callback: AsyncStreamingCallbackT
+        self, response_stream: AsyncIterator[types.GenerateContentResponse], streaming_callback: StreamingCallbackT
     ) -> dict[str, list[ChatMessage]]:
         """
         Handle async streaming response from Google Gen AI generate_content_stream.
@@ -367,7 +368,10 @@ class GoogleGenAIChatGenerator:
                 chunks.append(streaming_chunk)
 
                 # Stream the chunk
-                await streaming_callback(streaming_chunk)
+                # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+                callback_result = streaming_callback(streaming_chunk)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
                 i += 1
 
             # Use custom aggregation that supports reasoning content

--- a/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import json
 from collections.abc import AsyncIterable, Iterable
 from datetime import datetime, timezone
@@ -10,7 +11,6 @@ from typing import Any, Union
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses import (
-    AsyncStreamingCallbackT,
     ChatMessage,
     ComponentInfo,
     ReasoningContent,
@@ -680,7 +680,7 @@ class HuggingFaceAPIChatGenerator:
         self,
         messages: list[dict[str, str]],
         generation_kwargs: dict[str, Any],
-        streaming_callback: AsyncStreamingCallbackT,
+        streaming_callback: StreamingCallbackT,
     ) -> dict[str, list[ChatMessage]]:
         api_output: AsyncIterable[ChatCompletionStreamOutput] = await self._async_client.chat_completion(
             messages,
@@ -696,7 +696,10 @@ class HuggingFaceAPIChatGenerator:
                 chunk=chunk, previous_chunks=streaming_chunks, component_info=component_info
             )
             streaming_chunks.append(stream_chunk)
-            await streaming_callback(stream_chunk)
+            # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+            callback_result = streaming_callback(stream_chunk)
+            if inspect.isawaitable(callback_result):
+                await callback_result
 
         message = _convert_streaming_chunks_to_chat_message(chunks=streaming_chunks)
         if message.meta.get("usage") is None:

--- a/integrations/litellm/src/haystack_integrations/components/generators/litellm/chat/chat_generator.py
+++ b/integrations/litellm/src/haystack_integrations/components/generators/litellm/chat/chat_generator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import json
 from typing import Any
 
@@ -9,7 +10,6 @@ from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.dataclasses.streaming_chunk import (
-    AsyncStreamingCallbackT,
     ComponentInfo,
     FinishReason,
     StreamingCallbackT,
@@ -218,13 +218,16 @@ class LiteLLMChatGenerator:
             callback(stream_chunk)
         return [_convert_streaming_chunks_to_chat_message(chunks=chunks)]
 
-    async def _ahandle_streaming(self, stream_response: Any, callback: AsyncStreamingCallbackT) -> list[ChatMessage]:
+    async def _ahandle_streaming(self, stream_response: Any, callback: StreamingCallbackT) -> list[ChatMessage]:
         component_info = ComponentInfo.from_component(self)
         chunks: list[StreamingChunk] = []
         async for chunk in stream_response:
             stream_chunk = _convert_litellm_chunk_to_streaming_chunk(chunk, chunks, component_info)
             chunks.append(stream_chunk)
-            await callback(stream_chunk)
+            # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+            callback_result = callback(stream_chunk)
+            if inspect.isawaitable(callback_result):
+                await callback_result
         return [_convert_streaming_chunks_to_chat_message(chunks=chunks)]
 
     def to_dict(self) -> dict[str, Any]:

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import replace
@@ -6,7 +7,6 @@ from typing import Any, Literal
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.utils import _normalize_messages
 from haystack.dataclasses import (
-    AsyncStreamingCallbackT,
     ChatMessage,
     StreamingCallbackT,
     SyncStreamingCallbackT,
@@ -445,7 +445,7 @@ class OllamaChatGenerator:
     async def _handle_streaming_response_async(
         self,
         response_iter: AsyncIterator[ChatResponse],
-        callback: AsyncStreamingCallbackT | None,
+        callback: StreamingCallbackT | None,
     ) -> dict[str, list[ChatMessage]]:
         """
         Merge an Ollama async streaming response into a single ChatMessage, preserving tool calls.
@@ -497,7 +497,10 @@ class OllamaChatGenerator:
                     arg_by_index[key] = args
 
             if callback is not None:
-                await callback(chunk)
+                # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+                callback_result = callback(chunk)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
 
             index += 1
 

--- a/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
+++ b/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
@@ -4,11 +4,12 @@
 
 import asyncio
 import copy
+import inspect
 from typing import Any
 
 import torch
 from haystack import logging
-from haystack.dataclasses import AsyncStreamingCallbackT, ComponentInfo, StreamingChunk, SyncStreamingCallbackT
+from haystack.dataclasses import ComponentInfo, StreamingCallbackT, StreamingChunk, SyncStreamingCallbackT
 from haystack.utils.auth import Secret
 from haystack.utils.device import ComponentDevice
 from huggingface_hub import model_info
@@ -198,7 +199,7 @@ class _AsyncHFTokenStreamingHandler(TextStreamer):
     Async streaming handler for TransformersChatGenerator.
 
     Note: This is a helper class for TransformersChatGenerator enabling
-    async streaming of generated text via Haystack Callable[StreamingChunk, Awaitable[None]] callbacks.
+    async streaming of generated text via Haystack StreamingCallbackT callbacks.
 
     Do not use this class directly.
     """
@@ -206,7 +207,7 @@ class _AsyncHFTokenStreamingHandler(TextStreamer):
     def __init__(
         self,
         tokenizer: PreTrainedTokenizerBase,
-        stream_handler: AsyncStreamingCallbackT,
+        stream_handler: StreamingCallbackT,
         stop_words: list[str] | None = None,
         component_info: ComponentInfo | None = None,
     ) -> None:
@@ -228,7 +229,10 @@ class _AsyncHFTokenStreamingHandler(TextStreamer):
         while True:
             try:
                 chunk = await self._queue.get()
-                await self.token_handler(chunk)
+                # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+                callback_result = self.token_handler(chunk)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
                 self._queue.task_done()
             except asyncio.CancelledError:
                 break

--- a/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
+++ b/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import inspect
 import json
 from typing import Any
 
@@ -17,7 +18,6 @@ from haystack.core.component import component
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.dataclasses.chat_message import ReasoningContent
 from haystack.dataclasses.streaming_chunk import (
-    AsyncStreamingCallbackT,
     ComponentInfo,
     StreamingCallbackT,
     StreamingChunk,
@@ -385,7 +385,7 @@ class VLLMChatGenerator:
         return [_convert_streaming_chunks_to_chat_message(chunks=chunks)]
 
     async def _handle_async_stream_response(
-        self, chat_completion: AsyncStream[ChatCompletionChunk], callback: AsyncStreamingCallbackT
+        self, chat_completion: AsyncStream[ChatCompletionChunk], callback: StreamingCallbackT
     ) -> list[ChatMessage]:
         """Handle an asynchronous streaming response, extracting reasoning content from vLLM's reasoning chunks."""
         component_info = ComponentInfo.from_component(self)
@@ -423,7 +423,10 @@ class VLLMChatGenerator:
                         content_started = True
 
                 chunks.append(streaming_chunk)
-                await callback(streaming_chunk)
+                # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+                callback_result = callback(streaming_chunk)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
         except asyncio.CancelledError:
             await asyncio.shield(chat_completion.close())
             raise

--- a/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
+++ b/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import json
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -10,7 +11,6 @@ from typing import Any, ClassVar, Literal, get_args
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message, _normalize_messages
 from haystack.dataclasses import (
-    AsyncStreamingCallbackT,
     ChatMessage,
     ChatRole,
     ComponentInfo,
@@ -510,7 +510,7 @@ class WatsonxChatGenerator:
         self,
         *,
         api_args: dict[str, Any],
-        callback: AsyncStreamingCallbackT,
+        callback: StreamingCallbackT,
     ) -> dict[str, list[ChatMessage]]:
         """Handle asynchronous streaming response."""
         chunks: list[StreamingChunk] = []
@@ -525,7 +525,10 @@ class WatsonxChatGenerator:
 
             streaming_chunk = self._convert_chunk_to_streaming_chunk(chunk, component_info)
             chunks.append(streaming_chunk)
-            await callback(streaming_chunk)
+            # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+            callback_result = callback(streaming_chunk)
+            if inspect.isawaitable(callback_result):
+                await callback_result
 
         chat_message = _convert_streaming_chunks_to_chat_message(chunks)
         message_tool_calls = [


### PR DESCRIPTION
### Related Issues

- Part of deepset-ai/haystack-private#446

Haystack 3.0 changes the semantics of `select_streaming_callback(requires_async=True)`: instead of raising `ValueError` for a sync callback in an async context, it now accepts it with a warning (the callback runs inline on the event loop). Accordingly, its return type widened from `AsyncStreamingCallbackT | None` to `StreamingCallbackT | None`, which fails mypy in every integration that passes the result to an async-only-typed internal handler.

### Proposed Changes:

Rather than casting the union away, this PR makes the nine affected chat generators actually support what 3.0 allows:

- Widen the async streaming handlers' callback parameter from `AsyncStreamingCallbackT` to `StreamingCallbackT` in **anthropic, cohere, google_genai, huggingface_api, litellm, ollama, transformers (`_AsyncHFTokenStreamingHandler`), vllm, watsonx**.
- Replace each `await callback(chunk)` with a call that awaits the result only if it is awaitable (the same pattern as haystack 3.0's internal `_invoke_streaming_callback`).

Haystack 2.x behavior is unchanged.

### How did you test it?

- Haystack 2.x tests pass.
- Haystack v3 branch (installed `git+https://github.com/deepset-ai/haystack.git@v3`): `hatch run test:types` is clean.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
