### PR TITLE
test: guard ToolInvoker imports so chat-generator tests run under Haystack 3.0

### DIFF
--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
@@ -6,7 +6,11 @@ import pytest
 import pytz
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
 from haystack.tools import Tool
 from haystack.utils.auth import Secret
@@ -415,6 +419,7 @@ class TestAIMLAPIChatGenerator:
         reason="Export an env var called AIMLAPI_API_KEY containing the AIMLAPI API key to run this test.",
     )
     @pytest.mark.integration
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_aimlapi_chat_generator(self, tools):
         """
         Test that the AIMLAPIChatGenerator component can be used in a pipeline

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -8,7 +8,11 @@ from botocore.exceptions import ClientError
 from haystack import Pipeline
 from haystack.components.agents import Agent
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import (
     ChatMessage,
     ChatRole,
@@ -1447,6 +1451,7 @@ class TestAmazonBedrockChatGeneratorInference:
         assert "cache_details" in usage
 
     @pytest.mark.parametrize("model_name", MODELS_TO_TEST_WITH_TOOLS[:1])  # just one model is enough
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_amazon_bedrock_chat_generator(self, model_name, tools):
         """
         Test that the AmazonBedrockChatGenerator component can be used in a pipeline

--- a/integrations/cohere/tests/test_chat_generator.py
+++ b/integrations/cohere/tests/test_chat_generator.py
@@ -5,7 +5,11 @@ import pytest
 from cohere.core import ApiError
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, ImageContent, ToolCall
 from haystack.dataclasses.streaming_chunk import StreamingChunk
 from haystack.tools import Tool, Toolset
@@ -742,6 +746,7 @@ class TestCohereChatGeneratorInference:
         assert len(final_message.text) > 0
         assert "paris" in final_message.text.lower()
 
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_cohere_chat_generator(self):
         """
         Test that the CohereChatGenerator component can be used in a pipeline

--- a/integrations/cometapi/tests/test_cometapi_chat_generator.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator.py
@@ -7,7 +7,11 @@ import pytest
 import pytz
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
 from haystack.tools import Tool
 from haystack.utils.auth import Secret
@@ -392,6 +396,7 @@ class TestCometAPIChatGenerator:
         reason="Export an env var called COMET_API_KEY containing the OpenAI API key to run this test.",
     )
     @pytest.mark.integration
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_cometapi_chat_generator(self, tools):
         """
         Test that the CometAPIChatGenerator component can be used in a pipeline

--- a/integrations/meta_llama/tests/test_llama_chat_generator.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator.py
@@ -9,7 +9,11 @@ import pytest
 import pytz
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
 from haystack.tools import Tool, Toolset
 from haystack.utils.auth import Secret
@@ -532,6 +536,7 @@ class TestLlamaChatGenerator:
         reason="Llama OpenAI-compat endpoint returns 403 for the CI key; see https://github.com/deepset-ai/haystack-core-integrations/issues/3438"
     )
     @pytest.mark.integration
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_llama_chat_generator(self, tools):
         """
         Test that the MetaLlamaChatGenerator component can be used in a pipeline

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -6,7 +6,11 @@ from unittest.mock import ANY, AsyncMock, patch
 import pytest
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import (
     ChatMessage,
     ChatRole,
@@ -732,6 +736,7 @@ class TestMistralChatGenerator:
         reason="Export an env var called MISTRAL_API_KEY containing the OpenAI API key to run this test.",
     )
     @pytest.mark.integration
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_mistral_chat_generator(self, tools):
         """
         Test that the MistralChatGenerator component can be used in a pipeline

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import (
     ChatMessage,
     ChatRole,
@@ -1481,6 +1485,7 @@ class TestOllamaChatGeneratorLiveInference:
         if streaming_callback:
             streaming_callback.assert_called()
 
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_live_run_with_thinking_and_tools(self):
         @tool
         def add(a: int, b: int) -> int:
@@ -1518,6 +1523,7 @@ class TestOllamaChatGeneratorLiveInference:
         assert new_response.tool_calls[0].arguments == {"a": 5, "b": 10}
 
     @pytest.mark.parametrize("streaming_callback", [None, print_streaming_chunk])
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_live_run_with_repeated_tool_calls(self, tools, streaming_callback):
         component = OllamaChatGenerator(model="qwen3:0.6b", tools=tools, streaming_callback=streaming_callback)
         tool_invoker = ToolInvoker(tools=tools)

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -9,7 +9,11 @@ import pytest
 import pytz
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, ReasoningContent, StreamingChunk, ToolCall
 from haystack.tools import Tool, Toolset
 from haystack.utils.auth import Secret
@@ -494,6 +498,7 @@ class TestOpenRouterChatGenerator:
         reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
     )
     @pytest.mark.integration
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_openrouter_chat_generator(self, tools):
         """
         Test that the OpenRouterChatGenerator component can be used in a pipeline

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
@@ -6,7 +6,11 @@ import pytest
 import pytz
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
 from haystack.tools import Tool
 from haystack.utils.auth import Secret
@@ -423,6 +427,7 @@ class TestOrcaRouterChatGenerator:
         reason="Export an env var called ORCAROUTER_API_KEY containing the OrcaRouter API key to run this test.",
     )
     @pytest.mark.integration
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_orcarouter_chat_generator(self, tools):
         """
         Test that the OrcaRouterChatGenerator component can be used in a pipeline

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -7,7 +7,11 @@ import pytest
 import pytz
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.components.tools import ToolInvoker
+
+try:
+    from haystack.components.tools import ToolInvoker
+except ImportError:  # ToolInvoker was removed in Haystack 3.0
+    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk, ToolCall
 from haystack.tools import Tool, Toolset
 from haystack.utils.auth import Secret
@@ -522,6 +526,7 @@ class TestTogetherAIChatGenerator:
         reason="Export an env var called TOGETHER_API_KEY containing the Together AI API key to run this test.",
     )
     @pytest.mark.integration
+    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_pipeline_with_togetherai_chat_generator(self, tools):
         """
         Test that the TogetherAIChatGenerator component can be used in a pipeline


### PR DESCRIPTION
### Related Issues

- Part of deepset-ai/haystack-private#446

Haystack 3.0 removes `haystack.components.tools` (`ToolInvoker` has no drop-in replacement; tool execution moved into the `Agent`). In ten chat-generator test suites, the module-level `from haystack.components.tools import ToolInvoker` fails. As a consequence, none of the tests are run.

### Proposed Changes:

For **aimlapi, amazon_bedrock, cohere, cometapi, meta_llama, mistral, ollama, openrouter, orcarouter, togetherai**:

- Wrap the import in `try/except ImportError` with a `ToolInvoker = None` fallback (as prototyped in #3467).
- Add `@pytest.mark.skipif(ToolInvoker is None, ...)` to the tests that actually use `ToolInvoker` (one pipeline/live test per suite; two in ollama).

### How did you test it?

- Haystack 2.x: unit tests pass.
- Haystack v3 branch (installed `git+https://github.com/deepset-ai/haystack.git@v3` into the test envs): all ten suites now **collect and run**. The failures this unmasks belong to the other known v3-incompatibility categories (lazy OpenAI client init and serialization changes).

The failing tests are predominantly `test_init_*`/`test_from_dict_fail_wo_env_var` (v3's lazy OpenAI client init — no client, and no API-key error, at `__init__` anymore), `test_serde_in_pipeline`/`test_to_dict` (v3 serialization format changes), and the async `test_run_async*` suites in mistral/openrouter (same lazy-client root cause). Those are tracked separately in the compatibility effort.

cohere's `chat_generator.py` also mentions `haystack.components.tools` in its docstring usage example — that is not a runtime import and is left for a follow-up that reworks the example for 3.0.

### Notes for the reviewer

The skipped-on-3.0 tests are integration/live pipeline tests that chain generator → `ToolInvoker`. Once the 3.0 migration path for tool invocation in these examples is decided (e.g. `Agent`), they can be rewritten instead of skipped.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
