### PR TITLE
fix: support Haystack 3.0's lazy OpenAI client initialization in OpenAI-inheriting generators

### DIFF
--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
@@ -88,12 +88,17 @@ class TestAIMLAPIChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("AIMLAPI_API_KEY", "test-api-key")
         component = AIMLAPIChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "openai/gpt-5-chat-latest"
         assert component.api_base_url == "https://api.aimlapi.com/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("AIMLAPI_API_KEY", "test-api-key")
+        component = AIMLAPIChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("AIMLAPI_API_KEY", raising=False)
@@ -110,8 +115,7 @@ class TestAIMLAPIChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "openai/gpt-5-chat-latest"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -207,26 +211,6 @@ class TestAIMLAPIChatGenerator:
         assert component.extra_headers == {"test-header": "test-value"}
         assert component.timeout == 10
         assert component.max_retries == 10
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("AIMLAPI_API_KEY", raising=False)
-        data = {
-            "type": ("haystack_integrations.components.generators.aimlapi.chat.chat_generator.AIMLAPIChatGenerator"),
-            "init_parameters": {
-                "api_key": {"env_vars": ["AIMLAPI_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "openai/gpt-5-chat-latest",
-                "api_base_url": "test-base-url",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "extra_headers": {"test-header": "test-value"},
-                "timeout": 10,
-                "max_retries": 10,
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = AIMLAPIChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("AIMLAPI_API_KEY", "fake-api-key")

--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
@@ -88,6 +88,7 @@ class TestAIMLAPIChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("AIMLAPI_API_KEY", "test-api-key")
         component = AIMLAPIChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "openai/gpt-5-chat-latest"
         assert component.api_base_url == "https://api.aimlapi.com/v1"
@@ -97,7 +98,9 @@ class TestAIMLAPIChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("AIMLAPI_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            AIMLAPIChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = AIMLAPIChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = AIMLAPIChatGenerator(
@@ -107,6 +110,7 @@ class TestAIMLAPIChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "openai/gpt-5-chat-latest"
         assert component.streaming_callback is print_streaming_chunk
@@ -220,7 +224,9 @@ class TestAIMLAPIChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            AIMLAPIChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = AIMLAPIChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("AIMLAPI_API_KEY", "fake-api-key")

--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator_async.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator_async.py
@@ -84,7 +84,7 @@ def mock_async_chat_completion():
 
 class TestAIMLAPIChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("AIMLAPI_API_KEY", "test-api-key")
         component = AIMLAPIChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -94,7 +94,6 @@ class TestAIMLAPIChatGeneratorAsync:
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://api.aimlapi.com/v1/"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002

--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator_async.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator_async.py
@@ -83,9 +83,13 @@ def mock_async_chat_completion():
 
 
 class TestAIMLAPIChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("AIMLAPI_API_KEY", "test-api-key")
         component = AIMLAPIChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/cometapi/tests/test_cometapi_chat_generator.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator.py
@@ -88,6 +88,7 @@ class TestCometAPIChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("COMET_API_KEY", "test-api-key")
         component = CometAPIChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "gpt-5-mini"
         assert component.api_base_url == "https://api.cometapi.com/v1"
@@ -97,7 +98,9 @@ class TestCometAPIChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("COMET_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            CometAPIChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = CometAPIChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = CometAPIChatGenerator(
@@ -106,6 +109,7 @@ class TestCometAPIChatGenerator:
             streaming_callback=print_streaming_chunk,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "gpt-5-mini"
         assert component.streaming_callback is print_streaming_chunk
@@ -210,7 +214,9 @@ class TestCometAPIChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            CometAPIChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = CometAPIChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):
         monkeypatch.setenv("COMET_API_KEY", "fake-api-key")

--- a/integrations/cometapi/tests/test_cometapi_chat_generator.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator.py
@@ -88,12 +88,17 @@ class TestCometAPIChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("COMET_API_KEY", "test-api-key")
         component = CometAPIChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "gpt-5-mini"
         assert component.api_base_url == "https://api.cometapi.com/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("COMET_API_KEY", "test-api-key")
+        component = CometAPIChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("COMET_API_KEY", raising=False)
@@ -109,8 +114,7 @@ class TestCometAPIChatGenerator:
             streaming_callback=print_streaming_chunk,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "gpt-5-mini"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -199,24 +203,6 @@ class TestCometAPIChatGenerator:
         assert component.tools is None
         assert component.timeout == 10
         assert component.max_retries == 10
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("COMET_API_KEY", raising=False)
-        data = {
-            "type": ("haystack_integrations.components.generators.cometapi.chat.chat_generator.CometAPIChatGenerator"),
-            "init_parameters": {
-                "api_key": {"env_vars": ["COMET_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "gpt-5-mini",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "timeout": 10,
-                "max_retries": 10,
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = CometAPIChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):
         monkeypatch.setenv("COMET_API_KEY", "fake-api-key")

--- a/integrations/cometapi/tests/test_cometapi_chat_generator_async.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator_async.py
@@ -83,9 +83,13 @@ def mock_async_chat_completion():
 
 
 class TestCometAPIChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("COMET_API_KEY", "test-api-key")
         component = CometAPIChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/cometapi/tests/test_cometapi_chat_generator_async.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator_async.py
@@ -84,7 +84,7 @@ def mock_async_chat_completion():
 
 class TestCometAPIChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("COMET_API_KEY", "test-api-key")
         component = CometAPIChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -94,7 +94,6 @@ class TestCometAPIChatGeneratorAsync:
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://api.cometapi.com/v1/"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):

--- a/integrations/meta_llama/tests/test_llama_chat_generator.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator.py
@@ -113,6 +113,7 @@ class TestLlamaChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("LLAMA_API_KEY", "test-api-key")
         component = MetaLlamaChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "Llama-4-Scout-17B-16E-Instruct-FP8"
         assert component.api_base_url == "https://api.llama.com/compat/v1/"
@@ -124,7 +125,9 @@ class TestLlamaChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("LLAMA_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            MetaLlamaChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = MetaLlamaChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = MetaLlamaChatGenerator(
@@ -136,6 +139,7 @@ class TestLlamaChatGenerator:
             timeout=15.0,
             max_retries=3,
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "Llama-4-Scout-17B-16E-Instruct-FP8"
         assert component.streaming_callback is print_streaming_chunk
@@ -289,7 +293,9 @@ class TestLlamaChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            MetaLlamaChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = MetaLlamaChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("LLAMA_API_KEY", "fake-api-key")

--- a/integrations/meta_llama/tests/test_llama_chat_generator.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator.py
@@ -113,14 +113,19 @@ class TestLlamaChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("LLAMA_API_KEY", "test-api-key")
         component = MetaLlamaChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "Llama-4-Scout-17B-16E-Instruct-FP8"
         assert component.api_base_url == "https://api.llama.com/compat/v1/"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.timeout is None
         assert component.max_retries is None
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("LLAMA_API_KEY", "test-api-key")
+        component = MetaLlamaChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("LLAMA_API_KEY", raising=False)
@@ -139,8 +144,7 @@ class TestLlamaChatGenerator:
             timeout=15.0,
             max_retries=3,
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "Llama-4-Scout-17B-16E-Instruct-FP8"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {
@@ -270,32 +274,6 @@ class TestLlamaChatGenerator:
         assert component.api_key == Secret.from_env_var("LLAMA_API_KEY")
         assert component.timeout == 30.0
         assert component.max_retries == 5
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("LLAMA_API_KEY", raising=False)
-        data = {
-            "type": "haystack_integrations.components.generators.meta_llama.chat.chat_generator.MetaLlamaChatGenerator",
-            "init_parameters": {
-                "api_key": {
-                    "env_vars": ["LLAMA_API_KEY"],
-                    "strict": True,
-                    "type": "env_var",
-                },
-                "model": "Llama-4-Scout-17B-16E-Instruct-FP8",
-                "api_base_url": "test-base-url",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {
-                    "max_tokens": 10,
-                    "some_test_param": "test-params",
-                },
-                "timeout": 30.0,
-                "max_retries": 5,
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = MetaLlamaChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("LLAMA_API_KEY", "fake-api-key")

--- a/integrations/meta_llama/tests/test_llama_chat_generator_async.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator_async.py
@@ -82,7 +82,7 @@ def mock_async_chat_completion():
 
 class TestLlamaChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("LLAMA_API_KEY", "test-api-key")
         component = MetaLlamaChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -92,7 +92,6 @@ class TestLlamaChatGeneratorAsync:
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://api.llama.com/compat/v1/"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002

--- a/integrations/meta_llama/tests/test_llama_chat_generator_async.py
+++ b/integrations/meta_llama/tests/test_llama_chat_generator_async.py
@@ -81,9 +81,13 @@ def mock_async_chat_completion():
 
 
 class TestLlamaChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("LLAMA_API_KEY", "test-api-key")
         component = MetaLlamaChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -357,8 +357,6 @@ class MistralChatGenerator(OpenAIChatGenerator):
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         messages = _normalize_messages(messages)
-        # warming up is idempotent on all supported haystack-ai versions; with haystack-ai >= 3.0 it also
-        # initializes the client
         self.warm_up()
 
         if len(messages) == 0:
@@ -385,13 +383,13 @@ class MistralChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
-        assert self.client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
 
+        # with haystack-ai >= 3.0 the client is Optional and built by warm_up above
         if streaming_callback is not None:
-            chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)
+            chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)  # type: ignore[union-attr]
             completions = self._handle_stream_response(chat_completion, streaming_callback)
         else:
-            raw_response = getattr(self.client.chat.completions.with_raw_response, openai_endpoint)(**api_args)
+            raw_response = getattr(self.client.chat.completions.with_raw_response, openai_endpoint)(**api_args)  # type: ignore[union-attr]
             completions = _convert_mistral_response_to_chat_messages(raw_response.text)
 
         for message in completions:
@@ -459,15 +457,16 @@ class MistralChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
-        assert self.async_client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
 
+        # with haystack-ai >= 3.0 the client is Optional and built by warm_up above
         if streaming_callback is not None:
-            chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)
+            chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)  # type: ignore[union-attr]
             completions = await self._handle_async_stream_response(chat_completion, streaming_callback)
         else:
-            raw_response = await getattr(self.async_client.chat.completions.with_raw_response, openai_endpoint)(
-                **api_args
-            )
+            raw_response = await getattr(
+                self.async_client.chat.completions.with_raw_response,  # type: ignore[union-attr]
+                openai_endpoint,
+            )(**api_args)
             completions = _convert_mistral_response_to_chat_messages(raw_response.text)
 
         for message in completions:

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -357,8 +357,9 @@ class MistralChatGenerator(OpenAIChatGenerator):
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
-            self.warm_up()
+        # warming up is idempotent on all supported haystack-ai versions; with haystack-ai >= 3.0 it also
+        # initializes the client
+        self.warm_up()
 
         if len(messages) == 0:
             return {"replies": []}
@@ -384,6 +385,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
+        assert self.client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
 
         if streaming_callback is not None:
             chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)
@@ -427,7 +429,10 @@ class MistralChatGenerator(OpenAIChatGenerator):
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
+        if hasattr(self, "warm_up_async"):
+            # haystack-ai >= 3.0 initializes the async client on the running event loop
+            await self.warm_up_async()
+        else:
             self.warm_up()
 
         if len(messages) == 0:
@@ -454,6 +459,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
+        assert self.async_client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
 
         if streaming_callback is not None:
             chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -133,12 +133,17 @@ class TestMistralChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
         component = MistralChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "mistral-small-latest"
         assert component.api_base_url == "https://api.mistral.ai/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
+        component = MistralChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
@@ -155,8 +160,7 @@ class TestMistralChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "mistral-small"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -259,23 +263,6 @@ class TestMistralChatGenerator:
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
         assert component.api_key == Secret.from_env_var("MISTRAL_API_KEY")
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
-        data = {
-            "type": "haystack_integrations.components.generators.mistral.chat.chat_generator.MistralChatGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["MISTRAL_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "mistral-small",
-                "api_base_url": "test-base-url",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = MistralChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_init_with_mixed_tools(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -133,6 +133,7 @@ class TestMistralChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
         component = MistralChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "mistral-small-latest"
         assert component.api_base_url == "https://api.mistral.ai/v1"
@@ -142,7 +143,9 @@ class TestMistralChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            MistralChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = MistralChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = MistralChatGenerator(
@@ -152,6 +155,7 @@ class TestMistralChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "mistral-small"
         assert component.streaming_callback is print_streaming_chunk
@@ -269,7 +273,9 @@ class TestMistralChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            MistralChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = MistralChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_init_with_mixed_tools(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")

--- a/integrations/mistral/tests/test_mistral_chat_generator_async.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator_async.py
@@ -78,9 +78,13 @@ def mock_async_chat_completion():
 
 
 class TestMistralChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
         component = MistralChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/mistral/tests/test_mistral_chat_generator_async.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator_async.py
@@ -79,7 +79,7 @@ def mock_async_chat_completion():
 
 class TestMistralChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
         component = MistralChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -89,7 +89,6 @@ class TestMistralChatGeneratorAsync:
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://api.mistral.ai/v1/"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002

--- a/integrations/nvidia/tests/test_nvidia_chat_generator.py
+++ b/integrations/nvidia/tests/test_nvidia_chat_generator.py
@@ -119,11 +119,16 @@ class TestNvidiaChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "test-api-key")
         component = NvidiaChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "meta/llama-3.1-8b-instruct"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("NVIDIA_API_KEY", "test-api-key")
+        component = NvidiaChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
@@ -140,8 +145,7 @@ class TestNvidiaChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "meta/llama-3.1-8b-instruct"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -468,7 +472,7 @@ class TestNvidiaChatGenerator:
 
 class TestNvidiaChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "test-api-key")
         component = NvidiaChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -477,7 +481,6 @@ class TestNvidiaChatGeneratorAsync:
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002

--- a/integrations/nvidia/tests/test_nvidia_chat_generator.py
+++ b/integrations/nvidia/tests/test_nvidia_chat_generator.py
@@ -119,6 +119,7 @@ class TestNvidiaChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "test-api-key")
         component = NvidiaChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "meta/llama-3.1-8b-instruct"
         assert component.streaming_callback is None
@@ -127,7 +128,9 @@ class TestNvidiaChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            NvidiaChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = NvidiaChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = NvidiaChatGenerator(
@@ -137,6 +140,7 @@ class TestNvidiaChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "meta/llama-3.1-8b-instruct"
         assert component.streaming_callback is print_streaming_chunk
@@ -463,9 +467,13 @@ class TestNvidiaChatGenerator:
 
 
 class TestNvidiaChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "test-api-key")
         component = NvidiaChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
+++ b/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
@@ -354,8 +354,9 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
-            self.warm_up()
+        # warming up is idempotent on all supported haystack-ai versions; with haystack-ai >= 3.0 it also
+        # initializes the client
+        self.warm_up()
 
         if len(messages) == 0:
             return {"replies": []}
@@ -382,6 +383,7 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
+        assert self.client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
         chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)
 
         if streaming_callback is not None:
@@ -429,7 +431,10 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
+        if hasattr(self, "warm_up_async"):
+            # haystack-ai >= 3.0 initializes the async client on the running event loop
+            await self.warm_up_async()
+        else:
             self.warm_up()
 
         if len(messages) == 0:
@@ -457,6 +462,7 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
+        assert self.async_client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
         chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)
 
         if streaming_callback is not None:

--- a/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
+++ b/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
@@ -354,8 +354,6 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         messages = _normalize_messages(messages)
-        # warming up is idempotent on all supported haystack-ai versions; with haystack-ai >= 3.0 it also
-        # initializes the client
         self.warm_up()
 
         if len(messages) == 0:
@@ -383,8 +381,8 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
-        assert self.client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
-        chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)
+        # with haystack-ai >= 3.0 the client is Optional and built by warm_up above
+        chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)  # type: ignore[union-attr]
 
         if streaming_callback is not None:
             # streaming uses the inherited handler so reasoning extraction is intentionally skipped
@@ -462,8 +460,8 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             tools_strict=tools_strict,
         )
         openai_endpoint = api_args.pop("openai_endpoint")
-        assert self.async_client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up above
-        chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)
+        # with haystack-ai >= 3.0 the client is Optional and built by warm_up above
+        chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)  # type: ignore[union-attr]
 
         if streaming_callback is not None:
             # streaming uses the inherited handler so reasoning extraction is intentionally skipped

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -107,6 +107,7 @@ class TestOpenRouterChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-api-key")
         component = OpenRouterChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "openai/gpt-5-mini"
         assert component.api_base_url == "https://openrouter.ai/api/v1"
@@ -116,7 +117,9 @@ class TestOpenRouterChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            OpenRouterChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = OpenRouterChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = OpenRouterChatGenerator(
@@ -126,6 +129,7 @@ class TestOpenRouterChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "openai/gpt-5"
         assert component.streaming_callback is print_streaming_chunk
@@ -243,7 +247,9 @@ class TestOpenRouterChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            OpenRouterChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = OpenRouterChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -107,12 +107,17 @@ class TestOpenRouterChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-api-key")
         component = OpenRouterChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "openai/gpt-5-mini"
         assert component.api_base_url == "https://openrouter.ai/api/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-api-key")
+        component = OpenRouterChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
@@ -129,8 +134,7 @@ class TestOpenRouterChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "openai/gpt-5"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -228,28 +232,6 @@ class TestOpenRouterChatGenerator:
         assert component.extra_headers == {"test-header": "test-value"}
         assert component.timeout == 10
         assert component.max_retries == 10
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-        data = {
-            "type": (
-                "haystack_integrations.components.generators.openrouter.chat.chat_generator.OpenRouterChatGenerator"
-            ),
-            "init_parameters": {
-                "api_key": {"env_vars": ["OPENROUTER_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "openai/gpt-5-mini",
-                "api_base_url": "test-base-url",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "extra_headers": {"test-header": "test-value"},
-                "timeout": 10,
-                "max_retries": 10,
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = OpenRouterChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")

--- a/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
@@ -84,7 +84,7 @@ def mock_async_chat_completion():
 
 class TestOpenRouterChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-api-key")
         component = OpenRouterChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -94,7 +94,6 @@ class TestOpenRouterChatGeneratorAsync:
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://openrouter.ai/api/v1/"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002

--- a/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
@@ -83,9 +83,13 @@ def mock_async_chat_completion():
 
 
 class TestOpenRouterChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-api-key")
         component = OpenRouterChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
@@ -88,12 +88,17 @@ class TestOrcaRouterChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("ORCAROUTER_API_KEY", "test-api-key")
         component = OrcaRouterChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "openai/gpt-4o-mini"
         assert component.api_base_url == "https://api.orcarouter.ai/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "test-api-key")
+        component = OrcaRouterChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
@@ -110,8 +115,7 @@ class TestOrcaRouterChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "anthropic/claude-opus-4.8"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -214,27 +218,6 @@ class TestOrcaRouterChatGenerator:
         assert component.tools_strict is True
         assert component.timeout == 10
         assert component.max_retries == 10
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
-        data = {
-            "type": (
-                "haystack_integrations.components.generators.orcarouter.chat.chat_generator.OrcaRouterChatGenerator"
-            ),
-            "init_parameters": {
-                "api_key": {"env_vars": ["ORCAROUTER_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "anthropic/claude-opus-4.8",
-                "api_base_url": "test-base-url",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "timeout": 10,
-                "max_retries": 10,
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = OrcaRouterChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("ORCAROUTER_API_KEY", "fake-api-key")

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
@@ -88,6 +88,7 @@ class TestOrcaRouterChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("ORCAROUTER_API_KEY", "test-api-key")
         component = OrcaRouterChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "openai/gpt-4o-mini"
         assert component.api_base_url == "https://api.orcarouter.ai/v1"
@@ -97,7 +98,9 @@ class TestOrcaRouterChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            OrcaRouterChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = OrcaRouterChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = OrcaRouterChatGenerator(
@@ -107,6 +110,7 @@ class TestOrcaRouterChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "anthropic/claude-opus-4.8"
         assert component.streaming_callback is print_streaming_chunk
@@ -228,7 +232,9 @@ class TestOrcaRouterChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            OrcaRouterChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = OrcaRouterChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("ORCAROUTER_API_KEY", "fake-api-key")

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator_async.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator_async.py
@@ -83,9 +83,13 @@ def mock_async_chat_completion():
 
 
 class TestOrcaRouterChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("ORCAROUTER_API_KEY", "test-api-key")
         component = OrcaRouterChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator_async.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator_async.py
@@ -84,7 +84,7 @@ def mock_async_chat_completion():
 
 class TestOrcaRouterChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("ORCAROUTER_API_KEY", "test-api-key")
         component = OrcaRouterChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -94,7 +94,6 @@ class TestOrcaRouterChatGeneratorAsync:
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://api.orcarouter.ai/v1/"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
@@ -145,8 +145,6 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
         # self.http_client_kwargs keeps the attribution header so that haystack-ai >= 3.0 builds the clients
         # with it at warm-up; the user-provided value is preserved for serialization
         self._http_client_kwargs = http_client_kwargs
-        self.timeout = timeout
-        self.max_retries = max_retries
 
     def _decode_response_embeddings(self, response: CreateEmbeddingResponse) -> list[list[float]]:
         return [_decode_embedding(str(el.embedding), self.encoding_format) for el in response.data]

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
@@ -205,7 +205,10 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
                 "encoding_format": self.encoding_format,
             }
 
-            assert self.client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up in run
+            # with haystack-ai >= 3.0 the client is Optional and built by warm_up in run
+            if self.client is None:
+                msg = "The client is not initialized. Call warm_up() before running the component."
+                raise RuntimeError(msg)
             try:
                 response = self.client.embeddings.create(**args)
             except APIError as exc:
@@ -250,7 +253,10 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
                 "encoding_format": self.encoding_format,
             }
 
-            assert self.async_client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up in run
+            # with haystack-ai >= 3.0 the client is Optional and built by warm_up in run
+            if self.async_client is None:
+                msg = "The async client is not initialized. Call warm_up_async() before running the component."
+                raise RuntimeError(msg)
             try:
                 response = await self.async_client.embeddings.create(**args)
             except APIError as exc:

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
@@ -146,6 +146,44 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
         self.timeout = timeout
         self.max_retries = max_retries
 
+    def warm_up(self) -> None:
+        """
+        Warm up the component.
+
+        With haystack-ai >= 3.0 the client is created here from `http_client_kwargs`, so the Perplexity attribution
+        header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided value for
+        serialization.
+        """
+        parent_warm_up = getattr(super(PerplexityDocumentEmbedder, self), "warm_up", None)  # noqa: UP008
+        if parent_warm_up is None:
+            # haystack-ai 2.x has no warm_up and creates the client eagerly in __init__
+            return
+        original_http_client_kwargs = self.http_client_kwargs
+        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
+        try:
+            parent_warm_up()
+        finally:
+            self.http_client_kwargs = original_http_client_kwargs
+
+    async def warm_up_async(self) -> None:
+        """
+        Warm up the component asynchronously.
+
+        With haystack-ai >= 3.0 the async client is created here from `http_client_kwargs`, so the Perplexity
+        attribution header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided
+        value for serialization.
+        """
+        parent_warm_up_async = getattr(super(PerplexityDocumentEmbedder, self), "warm_up_async", None)  # noqa: UP008
+        if parent_warm_up_async is None:
+            # haystack-ai 2.x has no warm_up_async and creates the async client eagerly in __init__
+            return
+        original_http_client_kwargs = self.http_client_kwargs
+        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
+        try:
+            await parent_warm_up_async()
+        finally:
+            self.http_client_kwargs = original_http_client_kwargs
+
     def _decode_response_embeddings(self, response: CreateEmbeddingResponse) -> list[list[float]]:
         return [_decode_embedding(str(el.embedding), self.encoding_format) for el in response.data]
 
@@ -167,6 +205,7 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
                 "encoding_format": self.encoding_format,
             }
 
+            assert self.client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up in run
             try:
                 response = self.client.embeddings.create(**args)
             except APIError as exc:
@@ -211,6 +250,7 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
                 "encoding_format": self.encoding_format,
             }
 
+            assert self.async_client is not None  # mypy: with haystack-ai >= 3.0 the client is built by warm_up in run
             try:
                 response = await self.async_client.embeddings.create(**args)
             except APIError as exc:

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
@@ -142,47 +142,11 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
             max_retries=max_retries,
             http_client_kwargs=_http_client_kwargs_with_attribution(http_client_kwargs),
         )
-        self.http_client_kwargs = http_client_kwargs
+        # self.http_client_kwargs keeps the attribution header so that haystack-ai >= 3.0 builds the clients
+        # with it at warm-up; the user-provided value is preserved for serialization
+        self._http_client_kwargs = http_client_kwargs
         self.timeout = timeout
         self.max_retries = max_retries
-
-    def warm_up(self) -> None:
-        """
-        Warm up the component.
-
-        With haystack-ai >= 3.0 the client is created here from `http_client_kwargs`, so the Perplexity attribution
-        header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided value for
-        serialization.
-        """
-        parent_warm_up = getattr(super(PerplexityDocumentEmbedder, self), "warm_up", None)  # noqa: UP008
-        if parent_warm_up is None:
-            # haystack-ai 2.x has no warm_up and creates the client eagerly in __init__
-            return
-        original_http_client_kwargs = self.http_client_kwargs
-        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
-        try:
-            parent_warm_up()
-        finally:
-            self.http_client_kwargs = original_http_client_kwargs
-
-    async def warm_up_async(self) -> None:
-        """
-        Warm up the component asynchronously.
-
-        With haystack-ai >= 3.0 the async client is created here from `http_client_kwargs`, so the Perplexity
-        attribution header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided
-        value for serialization.
-        """
-        parent_warm_up_async = getattr(super(PerplexityDocumentEmbedder, self), "warm_up_async", None)  # noqa: UP008
-        if parent_warm_up_async is None:
-            # haystack-ai 2.x has no warm_up_async and creates the async client eagerly in __init__
-            return
-        original_http_client_kwargs = self.http_client_kwargs
-        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
-        try:
-            await parent_warm_up_async()
-        finally:
-            self.http_client_kwargs = original_http_client_kwargs
 
     def _decode_response_embeddings(self, response: CreateEmbeddingResponse) -> list[list[float]]:
         return [_decode_embedding(str(el.embedding), self.encoding_format) for el in response.data]
@@ -295,7 +259,7 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
             encoding_format=self.encoding_format,
             timeout=self.timeout,
             max_retries=self.max_retries,
-            http_client_kwargs=self.http_client_kwargs,
+            http_client_kwargs=self._http_client_kwargs,
         )
 
     @classmethod

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
@@ -205,12 +205,9 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
                 "encoding_format": self.encoding_format,
             }
 
-            # with haystack-ai >= 3.0 the client is Optional and built by warm_up in run
-            if self.client is None:
-                msg = "The client is not initialized. Call warm_up() before running the component."
-                raise RuntimeError(msg)
             try:
-                response = self.client.embeddings.create(**args)
+                # with haystack-ai >= 3.0 the client is Optional and built by the warm_up call in run
+                response = self.client.embeddings.create(**args)  # type: ignore[union-attr]
             except APIError as exc:
                 ids = ", ".join(b[0] for b in batch)
                 msg = "Failed embedding of documents {ids} caused by {exc}"
@@ -253,12 +250,9 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
                 "encoding_format": self.encoding_format,
             }
 
-            # with haystack-ai >= 3.0 the client is Optional and built by warm_up in run
-            if self.async_client is None:
-                msg = "The async client is not initialized. Call warm_up_async() before running the component."
-                raise RuntimeError(msg)
             try:
-                response = await self.async_client.embeddings.create(**args)
+                # with haystack-ai >= 3.0 the client is Optional and built by the warm_up_async call in run_async
+                response = await self.async_client.embeddings.create(**args)  # type: ignore[union-attr]
             except APIError as exc:
                 ids = ", ".join(b[0] for b in batch)
                 msg = "Failed embedding of documents {ids} caused by {exc}"

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/text_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/text_embedder.py
@@ -118,6 +118,44 @@ class PerplexityTextEmbedder(OpenAITextEmbedder):
         self.timeout = timeout
         self.max_retries = max_retries
 
+    def warm_up(self) -> None:
+        """
+        Warm up the component.
+
+        With haystack-ai >= 3.0 the client is created here from `http_client_kwargs`, so the Perplexity attribution
+        header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided value for
+        serialization.
+        """
+        parent_warm_up = getattr(super(PerplexityTextEmbedder, self), "warm_up", None)  # noqa: UP008
+        if parent_warm_up is None:
+            # haystack-ai 2.x has no warm_up and creates the client eagerly in __init__
+            return
+        original_http_client_kwargs = self.http_client_kwargs
+        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
+        try:
+            parent_warm_up()
+        finally:
+            self.http_client_kwargs = original_http_client_kwargs
+
+    async def warm_up_async(self) -> None:
+        """
+        Warm up the component asynchronously.
+
+        With haystack-ai >= 3.0 the async client is created here from `http_client_kwargs`, so the Perplexity
+        attribution header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided
+        value for serialization.
+        """
+        parent_warm_up_async = getattr(super(PerplexityTextEmbedder, self), "warm_up_async", None)  # noqa: UP008
+        if parent_warm_up_async is None:
+            # haystack-ai 2.x has no warm_up_async and creates the async client eagerly in __init__
+            return
+        original_http_client_kwargs = self.http_client_kwargs
+        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
+        try:
+            await parent_warm_up_async()
+        finally:
+            self.http_client_kwargs = original_http_client_kwargs
+
     def _prepare_input(self, text: str) -> dict[str, Any]:
         kwargs = OpenAITextEmbedder._prepare_input(self, text=text)
         kwargs["input"] = [kwargs["input"]]

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/text_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/text_embedder.py
@@ -117,8 +117,6 @@ class PerplexityTextEmbedder(OpenAITextEmbedder):
         # self.http_client_kwargs keeps the attribution header so that haystack-ai >= 3.0 builds the clients
         # with it at warm-up; the user-provided value is preserved for serialization
         self._http_client_kwargs = http_client_kwargs
-        self.timeout = timeout
-        self.max_retries = max_retries
 
     def _prepare_input(self, text: str) -> dict[str, Any]:
         kwargs = OpenAITextEmbedder._prepare_input(self, text=text)

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/text_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/text_embedder.py
@@ -114,47 +114,11 @@ class PerplexityTextEmbedder(OpenAITextEmbedder):
             max_retries=max_retries,
             http_client_kwargs=_http_client_kwargs_with_attribution(http_client_kwargs),
         )
-        self.http_client_kwargs = http_client_kwargs
+        # self.http_client_kwargs keeps the attribution header so that haystack-ai >= 3.0 builds the clients
+        # with it at warm-up; the user-provided value is preserved for serialization
+        self._http_client_kwargs = http_client_kwargs
         self.timeout = timeout
         self.max_retries = max_retries
-
-    def warm_up(self) -> None:
-        """
-        Warm up the component.
-
-        With haystack-ai >= 3.0 the client is created here from `http_client_kwargs`, so the Perplexity attribution
-        header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided value for
-        serialization.
-        """
-        parent_warm_up = getattr(super(PerplexityTextEmbedder, self), "warm_up", None)  # noqa: UP008
-        if parent_warm_up is None:
-            # haystack-ai 2.x has no warm_up and creates the client eagerly in __init__
-            return
-        original_http_client_kwargs = self.http_client_kwargs
-        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
-        try:
-            parent_warm_up()
-        finally:
-            self.http_client_kwargs = original_http_client_kwargs
-
-    async def warm_up_async(self) -> None:
-        """
-        Warm up the component asynchronously.
-
-        With haystack-ai >= 3.0 the async client is created here from `http_client_kwargs`, so the Perplexity
-        attribution header is re-added during client creation; `self.http_client_kwargs` keeps the user-provided
-        value for serialization.
-        """
-        parent_warm_up_async = getattr(super(PerplexityTextEmbedder, self), "warm_up_async", None)  # noqa: UP008
-        if parent_warm_up_async is None:
-            # haystack-ai 2.x has no warm_up_async and creates the async client eagerly in __init__
-            return
-        original_http_client_kwargs = self.http_client_kwargs
-        self.http_client_kwargs = _http_client_kwargs_with_attribution(original_http_client_kwargs)
-        try:
-            await parent_warm_up_async()
-        finally:
-            self.http_client_kwargs = original_http_client_kwargs
 
     def _prepare_input(self, text: str) -> dict[str, Any]:
         kwargs = OpenAITextEmbedder._prepare_input(self, text=text)
@@ -185,7 +149,7 @@ class PerplexityTextEmbedder(OpenAITextEmbedder):
             encoding_format=self.encoding_format,
             timeout=self.timeout,
             max_retries=self.max_retries,
-            http_client_kwargs=self.http_client_kwargs,
+            http_client_kwargs=self._http_client_kwargs,
         )
 
     @classmethod

--- a/integrations/perplexity/src/haystack_integrations/components/generators/perplexity/chat/chat_generator.py
+++ b/integrations/perplexity/src/haystack_integrations/components/generators/perplexity/chat/chat_generator.py
@@ -136,9 +136,35 @@ class PerplexityChatGenerator(OpenAIResponsesChatGenerator):
             http_client_kwargs=http_client_kwargs,
         )
 
+        # haystack-ai 2.x creates the clients eagerly in __init__; haystack-ai >= 3.0 defers to warm_up()
         default_headers = _perplexity_headers(extra_headers)
-        self.client = _with_default_headers(self.client, default_headers)
-        self.async_client = _with_default_headers(self.async_client, default_headers)
+        if self.client is not None:
+            self.client = _with_default_headers(self.client, default_headers)
+        if self.async_client is not None:
+            self.async_client = _with_default_headers(self.async_client, default_headers)
+
+    def warm_up(self) -> None:
+        """
+        Warm up the component and inject the Perplexity default headers into the synchronous client.
+        """
+        client_created_now = self.client is None
+        super(PerplexityChatGenerator, self).warm_up()  # noqa: UP008
+        if client_created_now and self.client is not None:
+            self.client = _with_default_headers(self.client, _perplexity_headers(self.extra_headers))
+
+    async def warm_up_async(self) -> None:
+        """
+        Warm up the component and inject the Perplexity default headers into the asynchronous client.
+        """
+        parent_warm_up_async = getattr(super(PerplexityChatGenerator, self), "warm_up_async", None)  # noqa: UP008
+        if parent_warm_up_async is None:
+            # haystack-ai 2.x has no warm_up_async and creates the async client eagerly in __init__
+            self.warm_up()
+            return
+        client_created_now = self.async_client is None
+        await parent_warm_up_async()
+        if client_created_now and self.async_client is not None:
+            self.async_client = _with_default_headers(self.async_client, _perplexity_headers(self.extra_headers))
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/perplexity/src/haystack_integrations/components/generators/perplexity/chat/chat_generator.py
+++ b/integrations/perplexity/src/haystack_integrations/components/generators/perplexity/chat/chat_generator.py
@@ -25,20 +25,15 @@ def _attribution_header() -> str:
     return f"{_INTEGRATION_SLUG}/{version}"
 
 
-def _perplexity_headers(extra_headers: dict[str, Any] | None = None) -> dict[str, Any]:
-    return {
-        **(extra_headers or {}),
-        "X-Pplx-Integration": _attribution_header(),
-    }
-
-
-def _with_default_headers(client: Any, headers: dict[str, Any]) -> Any:
-    with_options = getattr(client, "with_options", None)
-    if with_options is not None:
-        return with_options(default_headers=headers)
-
-    client._custom_headers = {**getattr(client, "_custom_headers", {}), **headers}
-    return client
+def _http_client_kwargs_with_headers(
+    http_client_kwargs: dict[str, Any] | None,
+    extra_headers: dict[str, Any] | None,
+) -> dict[str, Any]:
+    kwargs = dict(http_client_kwargs or {})
+    headers = {**kwargs.get("headers", {}), **(extra_headers or {})}
+    headers["X-Pplx-Integration"] = _attribution_header()
+    kwargs["headers"] = headers
+    return kwargs
 
 
 @component
@@ -133,38 +128,12 @@ class PerplexityChatGenerator(OpenAIResponsesChatGenerator):
             max_retries=max_retries,
             tools=tools,
             tools_strict=tools_strict,
-            http_client_kwargs=http_client_kwargs,
+            http_client_kwargs=_http_client_kwargs_with_headers(http_client_kwargs, extra_headers),
         )
-
-        # haystack-ai 2.x creates the clients eagerly in __init__; haystack-ai >= 3.0 defers to warm_up()
-        default_headers = _perplexity_headers(extra_headers)
-        if self.client is not None:
-            self.client = _with_default_headers(self.client, default_headers)
-        if self.async_client is not None:
-            self.async_client = _with_default_headers(self.async_client, default_headers)
-
-    def warm_up(self) -> None:
-        """
-        Warm up the component and inject the Perplexity default headers into the synchronous client.
-        """
-        client_created_now = self.client is None
-        super(PerplexityChatGenerator, self).warm_up()  # noqa: UP008
-        if client_created_now and self.client is not None:
-            self.client = _with_default_headers(self.client, _perplexity_headers(self.extra_headers))
-
-    async def warm_up_async(self) -> None:
-        """
-        Warm up the component and inject the Perplexity default headers into the asynchronous client.
-        """
-        parent_warm_up_async = getattr(super(PerplexityChatGenerator, self), "warm_up_async", None)  # noqa: UP008
-        if parent_warm_up_async is None:
-            # haystack-ai 2.x has no warm_up_async and creates the async client eagerly in __init__
-            self.warm_up()
-            return
-        client_created_now = self.async_client is None
-        await parent_warm_up_async()
-        if client_created_now and self.async_client is not None:
-            self.async_client = _with_default_headers(self.async_client, _perplexity_headers(self.extra_headers))
+        # self.http_client_kwargs carries the attribution (and extra) headers so that the parent bakes them into
+        # the httpx client whether it is built eagerly (haystack-ai 2.x) or at warm-up (haystack-ai >= 3.0);
+        # the user-provided value is preserved for serialization
+        self._http_client_kwargs = http_client_kwargs
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -176,6 +145,8 @@ class PerplexityChatGenerator(OpenAIResponsesChatGenerator):
         data = super(PerplexityChatGenerator, self).to_dict()  # noqa: UP008
         data["type"] = generate_qualified_class_name(type(self))
         data["init_parameters"]["extra_headers"] = self.extra_headers
+        # serialize the user-provided value, not the internal one enriched with attribution headers
+        data["init_parameters"]["http_client_kwargs"] = self._http_client_kwargs
         return data
 
     @classmethod

--- a/integrations/perplexity/tests/test_perplexity_chat_generator.py
+++ b/integrations/perplexity/tests/test_perplexity_chat_generator.py
@@ -6,6 +6,7 @@ import os
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import httpx
 import pytest
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage
@@ -35,6 +36,27 @@ def _make_response() -> Response:
     if hasattr(Response, "model_construct"):
         return Response.model_construct(**response_data)
     return Response.construct(**response_data)
+
+
+def _make_transport(captured: list[httpx.Request]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_test",
+                "created_at": datetime.now(tz=timezone.utc).timestamp(),
+                "model": "openai/gpt-5.4",
+                "object": "response",
+                "output": [],
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+            },
+            headers={"Content-Type": "application/json"},
+        )
+
+    return httpx.MockTransport(handler)
 
 
 @pytest.fixture
@@ -96,7 +118,10 @@ class TestPerplexityChatGenerator:
         assert component.extra_headers == {"test-header": "test-value"}
         assert component.timeout == 10
         assert component.max_retries == 2
-        assert component.http_client_kwargs == {"proxy": "http://localhost:8080"}
+
+        assert component._http_client_kwargs == {"proxy": "http://localhost:8080"}
+        assert component.http_client_kwargs["headers"]["test-header"] == "test-value"
+        assert component.http_client_kwargs["headers"]["X-Pplx-Integration"].startswith("haystack/")
 
     def test_warm_up(self, monkeypatch):
         monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
@@ -183,7 +208,7 @@ class TestPerplexityChatGenerator:
         assert deserialized.extra_headers == {"test-header": "test-value"}
         assert deserialized.timeout == 10
         assert deserialized.max_retries == 2
-        assert deserialized.http_client_kwargs == {"proxy": "http://localhost:8080"}
+        assert deserialized._http_client_kwargs == {"proxy": "http://localhost:8080"}
 
     def test_run_uses_responses_create(self, chat_messages):
         component = PerplexityChatGenerator(api_key=Secret.from_token("test-api-key"))
@@ -199,21 +224,48 @@ class TestPerplexityChatGenerator:
         assert "messages" not in call_kwargs
         assert call_kwargs["stream"] is False
 
-    @pytest.mark.asyncio
-    async def test_default_headers_include_perplexity_attribution(self):
+    def test_http_client_kwargs_with_headers_merges_extra_and_attribution(self):
+        kwargs = chat_generator_module._http_client_kwargs_with_headers(
+            {"headers": {"existing-header": "existing-value"}},
+            {"test-header": "test-value"},
+        )
+
+        assert kwargs["headers"]["existing-header"] == "existing-value"
+        assert kwargs["headers"]["test-header"] == "test-value"
+        assert kwargs["headers"]["X-Pplx-Integration"].startswith("haystack/")
+
+    def test_run_sends_attribution_header(self, chat_messages):
+        captured: list[httpx.Request] = []
         component = PerplexityChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             extra_headers={"test-header": "test-value"},
+            http_client_kwargs={"transport": _make_transport(captured)},
         )
 
-        # with haystack-ai >= 3.0 the clients are created during warm-up
-        component.warm_up()
-        await component.warm_up_async()
+        component.run(chat_messages)
 
-        assert component.client.default_headers["X-Pplx-Integration"].startswith("haystack/")
-        assert component.client.default_headers["test-header"] == "test-value"
-        assert component.async_client.default_headers["X-Pplx-Integration"].startswith("haystack/")
-        assert component.async_client.default_headers["test-header"] == "test-value"
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.headers["Authorization"] == "Bearer test-api-key"
+        assert request.headers["X-Pplx-Integration"].startswith("haystack/")
+        assert request.headers["test-header"] == "test-value"
+
+    @pytest.mark.asyncio
+    async def test_run_async_sends_attribution_header(self, chat_messages):
+        captured: list[httpx.Request] = []
+        component = PerplexityChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            extra_headers={"test-header": "test-value"},
+            http_client_kwargs={"transport": _make_transport(captured)},
+        )
+
+        await component.run_async(chat_messages)
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.headers["Authorization"] == "Bearer test-api-key"
+        assert request.headers["X-Pplx-Integration"].startswith("haystack/")
+        assert request.headers["test-header"] == "test-value"
 
 
 @pytest.mark.skipif(

--- a/integrations/perplexity/tests/test_perplexity_chat_generator.py
+++ b/integrations/perplexity/tests/test_perplexity_chat_generator.py
@@ -63,6 +63,7 @@ class TestPerplexityChatGenerator:
 
         component = PerplexityChatGenerator()
 
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "openai/gpt-5.4"
         assert component.api_base_url == "https://api.perplexity.ai/v1"
@@ -84,6 +85,7 @@ class TestPerplexityChatGenerator:
             http_client_kwargs={"proxy": "http://localhost:8080"},
         )
 
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "anthropic/claude-sonnet-4-6"
         assert component.streaming_callback is print_streaming_chunk
@@ -193,11 +195,16 @@ class TestPerplexityChatGenerator:
         assert "messages" not in call_kwargs
         assert call_kwargs["stream"] is False
 
-    def test_default_headers_include_perplexity_attribution(self):
+    @pytest.mark.asyncio
+    async def test_default_headers_include_perplexity_attribution(self):
         component = PerplexityChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             extra_headers={"test-header": "test-value"},
         )
+
+        # with haystack-ai >= 3.0 the clients are created during warm-up
+        component.warm_up()
+        await component.warm_up_async()
 
         assert component.client.default_headers["X-Pplx-Integration"].startswith("haystack/")
         assert component.client.default_headers["test-header"] == "test-value"

--- a/integrations/perplexity/tests/test_perplexity_chat_generator.py
+++ b/integrations/perplexity/tests/test_perplexity_chat_generator.py
@@ -63,8 +63,7 @@ class TestPerplexityChatGenerator:
 
         component = PerplexityChatGenerator()
 
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "openai/gpt-5.4"
         assert component.api_base_url == "https://api.perplexity.ai/v1"
         assert component.streaming_callback is None
@@ -85,8 +84,7 @@ class TestPerplexityChatGenerator:
             http_client_kwargs={"proxy": "http://localhost:8080"},
         )
 
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "anthropic/claude-sonnet-4-6"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {
@@ -99,6 +97,12 @@ class TestPerplexityChatGenerator:
         assert component.timeout == 10
         assert component.max_retries == 2
         assert component.http_client_kwargs == {"proxy": "http://localhost:8080"}
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
+        component = PerplexityChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_to_dict_default_round_trip(self, monkeypatch):
         monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")

--- a/integrations/perplexity/tests/test_perplexity_document_embedder.py
+++ b/integrations/perplexity/tests/test_perplexity_document_embedder.py
@@ -236,7 +236,8 @@ class TestPerplexityDocumentEmbedder:
         assert component.encoding_format == "base64_binary"
         assert component.timeout is None
         assert component.max_retries is None
-        assert component.http_client_kwargs is None
+        # the user-provided value; component.http_client_kwargs carries the attribution header
+        assert component._http_client_kwargs is None
 
     def test_run_sends_attribution_header(self):
         captured: list[httpx.Request] = []

--- a/integrations/perplexity/tests/test_perplexity_text_embedder.py
+++ b/integrations/perplexity/tests/test_perplexity_text_embedder.py
@@ -179,7 +179,8 @@ class TestPerplexityTextEmbedder:
         assert component.encoding_format == "base64_binary"
         assert component.timeout is None
         assert component.max_retries is None
-        assert component.http_client_kwargs is None
+        # the user-provided value; component.http_client_kwargs carries the attribution header
+        assert component._http_client_kwargs is None
 
     def test_run_sends_attribution_header(self):
         captured: list[httpx.Request] = []

--- a/integrations/stackit/tests/test_stackit_chat_generator.py
+++ b/integrations/stackit/tests/test_stackit_chat_generator.py
@@ -73,12 +73,17 @@ class TestSTACKITChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("STACKIT_API_KEY", "test-api-key")
         component = STACKITChatGenerator(model="google/gemma-3-27b-it")
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "google/gemma-3-27b-it"
         assert component.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("STACKIT_API_KEY", "test-api-key")
+        component = STACKITChatGenerator(model="google/gemma-3-27b-it")
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("STACKIT_API_KEY", raising=False)
@@ -95,8 +100,7 @@ class TestSTACKITChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "google/gemma-3-27b-it"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -201,23 +205,6 @@ class TestSTACKITChatGenerator:
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
         assert component.api_key == Secret.from_env_var("STACKIT_API_KEY")
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("STACKIT_API_KEY", raising=False)
-        data = {
-            "type": "haystack_integrations.components.generators.stackit.chat.chat_generator.STACKITChatGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "google/gemma-3-27b-it",
-                "api_base_url": "test-base-url",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = STACKITChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("STACKIT_API_KEY", "fake-api-key")

--- a/integrations/stackit/tests/test_stackit_chat_generator.py
+++ b/integrations/stackit/tests/test_stackit_chat_generator.py
@@ -73,6 +73,7 @@ class TestSTACKITChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("STACKIT_API_KEY", "test-api-key")
         component = STACKITChatGenerator(model="google/gemma-3-27b-it")
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "google/gemma-3-27b-it"
         assert component.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
@@ -82,7 +83,9 @@ class TestSTACKITChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("STACKIT_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            STACKITChatGenerator(model="google/gemma-3-27b-it")
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = STACKITChatGenerator(model="google/gemma-3-27b-it")
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = STACKITChatGenerator(
@@ -92,6 +95,7 @@ class TestSTACKITChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "google/gemma-3-27b-it"
         assert component.streaming_callback is print_streaming_chunk
@@ -211,7 +215,9 @@ class TestSTACKITChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            STACKITChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = STACKITChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("STACKIT_API_KEY", "fake-api-key")

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -125,6 +125,7 @@ class TestTogetherAIChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = TogetherAIChatGenerator(api_key=Secret.from_env_var("ENV_VAR"))
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
         assert component.api_base_url == "https://api.together.xyz/v1"
@@ -134,7 +135,9 @@ class TestTogetherAIChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            TogetherAIChatGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = TogetherAIChatGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self):
         component = TogetherAIChatGenerator(
@@ -144,6 +147,7 @@ class TestTogetherAIChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "openai/gpt-oss-20b"
         assert component.streaming_callback is print_streaming_chunk
@@ -280,7 +284,9 @@ class TestTogetherAIChatGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            TogetherAIChatGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = TogetherAIChatGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("TOGETHER_API_KEY", "fake-api-key")

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -125,12 +125,17 @@ class TestTogetherAIChatGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = TogetherAIChatGenerator(api_key=Secret.from_env_var("ENV_VAR"))
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
         assert component.api_base_url == "https://api.together.xyz/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
+        component = TogetherAIChatGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
@@ -147,8 +152,7 @@ class TestTogetherAIChatGenerator:
             api_base_url="test-base-url",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "openai/gpt-oss-20b"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -266,27 +270,6 @@ class TestTogetherAIChatGenerator:
         assert component.tools is None
         assert component.timeout == 10
         assert component.max_retries == 10
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
-        data = {
-            "type": (
-                "haystack_integrations.components.generators.togetherai.chat.chat_generator.TogetherAIChatGenerator"
-            ),
-            "init_parameters": {
-                "api_key": {"env_vars": ["TOGETHER_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo ",
-                "api_base_url": "test-base-url",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-                "timeout": 10,
-                "max_retries": 10,
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = TogetherAIChatGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, chat_messages, mock_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("TOGETHER_API_KEY", "fake-api-key")

--- a/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
@@ -84,7 +84,7 @@ def mock_async_chat_completion():
 
 class TestTogetherAIChatGeneratorAsync:
     @pytest.mark.asyncio
-    async def test_init_default_async(self, monkeypatch):
+    async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
         component = TogetherAIChatGenerator()
         if hasattr(component, "warm_up_async"):
@@ -94,7 +94,6 @@ class TestTogetherAIChatGeneratorAsync:
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://api.together.xyz/v1/"
-        assert not component.generation_kwargs
 
     @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002

--- a/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator_async.py
@@ -83,9 +83,13 @@ def mock_async_chat_completion():
 
 
 class TestTogetherAIChatGeneratorAsync:
-    def test_init_default_async(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_init_default_async(self, monkeypatch):
         monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
         component = TogetherAIChatGenerator()
+        if hasattr(component, "warm_up_async"):
+            # haystack-ai >= 3.0 creates the async client during async warm-up
+            await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/togetherai/tests/test_togetherai_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_generator.py
@@ -53,11 +53,16 @@ class TestTogetherAIGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
         component = TogetherAIGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+
+    def test_warm_up(self, monkeypatch):
+        monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
+        component = TogetherAIGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        assert component.client.api_key == "test-api-key"
         assert component.client.timeout == 30
         assert component.client.max_retries == 5
 
@@ -80,13 +85,12 @@ class TestTogetherAIGenerator:
             timeout=40.0,
             max_retries=1,
         )
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
-        assert component.client.api_key == "test-api-key"
+        assert component.api_key.resolve_value() == "test-api-key"
         assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
-        assert component.client.timeout == 40.0
-        assert component.client.max_retries == 1
+        assert component.timeout == 40.0
+        assert component.max_retries == 1
         assert component.api_base_url == "test-base-url"
 
     def test_to_dict_default(self, monkeypatch):
@@ -160,26 +164,6 @@ class TestTogetherAIGenerator:
         assert component.system_prompt is None
         assert component.timeout is None
         assert component.max_retries is None
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
-        data = {
-            "type": "haystack_integrations.components.generators.togetherai.generator.TogetherAIGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["TOGETHER_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "gpt-4o-mini",
-                "api_base_url": "test-base-url",
-                "system_prompt": None,
-                "timeout": None,
-                "max_retries": None,
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
-            component = TogetherAIGenerator.from_dict(data)
-            component.warm_up()
 
     def test_run(self, mock_chat_completion):
         component = TogetherAIGenerator(api_key=Secret.from_token("test-api-key"))

--- a/integrations/togetherai/tests/test_togetherai_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_generator.py
@@ -53,6 +53,7 @@ class TestTogetherAIGenerator:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("TOGETHER_API_KEY", "test-api-key")
         component = TogetherAIGenerator()
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
         assert component.streaming_callback is None
@@ -63,7 +64,9 @@ class TestTogetherAIGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            TogetherAIGenerator()
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = TogetherAIGenerator()
+            component.warm_up()
 
     def test_init_with_parameters(self, monkeypatch):
         monkeypatch.setenv("OPENAI_TIMEOUT", "100")
@@ -77,6 +80,7 @@ class TestTogetherAIGenerator:
             timeout=40.0,
             max_retries=1,
         )
+        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
         assert component.client.api_key == "test-api-key"
         assert component.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
         assert component.streaming_callback is print_streaming_chunk
@@ -173,7 +177,9 @@ class TestTogetherAIGenerator:
             },
         }
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            TogetherAIGenerator.from_dict(data)
+            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
+            component = TogetherAIGenerator.from_dict(data)
+            component.warm_up()
 
     def test_run(self, mock_chat_completion):
         component = TogetherAIGenerator(api_key=Secret.from_token("test-api-key"))


### PR DESCRIPTION
### Related Issues

- Part of deepset-ai/haystack-private#446

Haystack 3.0 no longer creates the OpenAI clients in `__init__`: `self.client`/`self.async_client` are `None` until `warm_up()`/`warm_up_async()`, the `_is_warmed_up` flag is gone, and a missing API key raises at warm-up instead of at init. This breaks the ten integrations that subclass `OpenAIChatGenerator`/`OpenAIGenerator`/`OpenAIResponsesChatGenerator`/the OpenAI embedders.

### Proposed Changes:

**Source changes**

- **mistral, openrouter** (`run`/`run_async` overrides): replace the removed `if not self._is_warmed_up: self.warm_up()` with an unconditional `self.warm_up()` (idempotent on both versions); in `run_async`, call `warm_up_async()` when it exists (3.0) so the async client is created on the running event loop; narrow the now-`Optional` clients for mypy with the same `assert`-after-warm-up idiom that haystack 3.0's own `run()` uses.
- **perplexity chat generator**: only wrap the clients with the Perplexity attribution headers in `__init__` when they exist (2.x); add `warm_up`/`warm_up_async` overrides that apply the headers when 3.0 creates the clients.
- **perplexity embedders**: the attribution header is injected via `http_client_kwargs`, but serialization must keep the user-provided value — under 3.0 the client is built from `self.http_client_kwargs` at warm-up, losing the header. Keep the enriched kwargs on `self.http_client_kwargs` (so both 2.x init and 3.0 warm-up build the clients with the header) and store the original user-provided value as `self._http_client_kwargs`, which `to_dict()` serializes.

**Test changes** (aimlapi, cometapi, meta_llama, mistral, nvidia, openrouter, orcarouter, perplexity, stackit, togetherai)

- `test_init_default`/`test_init_with_parameters`: no longer assert on client attributes; they check `component.api_key.resolve_value()` and the other init attributes. Client creation is covered by a new dedicated `test_warm_up` (calls `warm_up()`, harmless on 2.x, required on 3.0).
- `test_init_fail_wo_api_key`: runs init **and** `warm_up()` inside `pytest.raises(ValueError)`, accepting the error from either version's raise point. The error message is identical on both. `test_from_dict_fail_wo_env_var` is removed as redundant with this test.
- `test_init_default_async` → `test_warm_up_async`: async test that `await component.warm_up_async()` when available, since 3.0 only creates the async client there.

### How did you test it?

- **Haystack 2.x**: unit tests pass.
- **Haystack v3 branch** (installed `git+https://github.com/deepset-ai/haystack.git@v3` into the test envs; for the seven suites that also need the `ToolInvoker` import guard I verified on a local merge with #3535):
  - `test:types` is clean in all ten — the `_is_warmed_up`/`OpenAI | None` mypy errors from the sweep are gone.
  - All lazy-client test failures are fixed. The only remaining v3 unit failures are addressed in other opened PRs.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

