### PR TITLE
test: trust test modules under Haystack 3.0's deserialization allowlist

### DIFF
--- a/integrations/aimlapi/tests/conftest.py
+++ b/integrations/aimlapi/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/cometapi/tests/conftest.py
+++ b/integrations/cometapi/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/hanlp/tests/conftest.py
+++ b/integrations/hanlp/tests/conftest.py
@@ -1,11 +1,4 @@
-from pathlib import Path
-
 import pytest
-
-
-@pytest.fixture()
-def test_files_path():
-    return Path(__file__).parent / "test_files"
 
 
 @pytest.fixture(autouse=True)

--- a/integrations/huggingface_api/tests/conftest.py
+++ b/integrations/huggingface_api/tests/conftest.py
@@ -27,3 +27,13 @@ def del_hf_env_vars_if_empty(monkeypatch):
     for var in ("HF_API_TOKEN", "HF_TOKEN"):
         if not os.environ.get(var, "").strip():
             monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/langfuse/tests/conftest.py
+++ b/integrations/langfuse/tests/conftest.py
@@ -1,11 +1,4 @@
-from pathlib import Path
-
 import pytest
-
-
-@pytest.fixture()
-def test_files_path():
-    return Path(__file__).parent / "test_files"
 
 
 @pytest.fixture(autouse=True)

--- a/integrations/llama_cpp/tests/conftest.py
+++ b/integrations/llama_cpp/tests/conftest.py
@@ -1,11 +1,4 @@
-from pathlib import Path
-
 import pytest
-
-
-@pytest.fixture()
-def test_files_path():
-    return Path(__file__).parent / "test_files"
 
 
 @pytest.fixture(autouse=True)

--- a/integrations/mcp/tests/conftest.py
+++ b/integrations/mcp/tests/conftest.py
@@ -128,3 +128,13 @@ def mcp_calculator_server():
     for script_path in script_paths:
         if os.path.exists(script_path):
             os.remove(script_path)
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/meta_llama/tests/conftest.py
+++ b/integrations/meta_llama/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/mistral/tests/conftest.py
+++ b/integrations/mistral/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/nvidia/tests/conftest.py
+++ b/integrations/nvidia/tests/conftest.py
@@ -47,3 +47,13 @@ def mock_local_models(requests_mock: Mocker) -> None:
             ]
         },
     )
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/oauth/tests/conftest.py
+++ b/integrations/oauth/tests/conftest.py
@@ -1,11 +1,4 @@
-from pathlib import Path
-
 import pytest
-
-
-@pytest.fixture()
-def test_files_path():
-    return Path(__file__).parent / "test_files"
 
 
 @pytest.fixture(autouse=True)

--- a/integrations/oauth/tests/test_resolver.py
+++ b/integrations/oauth/tests/test_resolver.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 import pytest
 from haystack import Pipeline
+from haystack.core.errors import DeserializationError
 from haystack.utils import Secret
 
 from haystack_integrations.components.connectors.oauth import OAuthTokenResolver
@@ -183,7 +184,9 @@ class TestOAuthTokenResolverSerialization:
             "type": "haystack_integrations.components.connectors.oauth.resolver.OAuthTokenResolver",
             "init_parameters": {"token_source": {"type": "some.unknown.Source", "init_parameters": {}}},
         }
-        with pytest.raises(ImportError):
+        # haystack-ai 2.x fails to import the unknown module; haystack-ai >= 3.0 refuses it upfront
+        # because it is not on the trusted-module allowlist
+        with pytest.raises((ImportError, DeserializationError)):
             OAuthTokenResolver.from_dict(data)
 
 

--- a/integrations/openrouter/tests/conftest.py
+++ b/integrations/openrouter/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/orcarouter/tests/conftest.py
+++ b/integrations/orcarouter/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/togetherai/tests/conftest.py
+++ b/integrations/togetherai/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/transformers/tests/conftest.py
+++ b/integrations/transformers/tests/conftest.py
@@ -27,3 +27,13 @@ def del_hf_env_vars_if_empty(monkeypatch):
 @pytest.fixture()
 def in_memory_doc_store():
     return InMemoryDocumentStore()
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/watsonx/tests/conftest.py
+++ b/integrations/watsonx/tests/conftest.py
@@ -1,11 +1,4 @@
-from pathlib import Path
-
 import pytest
-
-
-@pytest.fixture()
-def test_files_path():
-    return Path(__file__).parent / "test_files"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Related Issues

- Part of deepset-ai/haystack-private#446

Haystack 3.0 introduces a trusted-module allowlist for deserialization: `from_dict`/`Pipeline.loads` raise `DeserializationError` for classes and callables from modules outside `haystack*`, `builtins`, `typing`, and `collections`. Tests in ten integrations round-trip tools, splitting functions (hanlp), MCP transports, or OAuth token sources **defined in the test modules themselves**, which are not on that allowlist.

### Proposed Changes:

For **google_genai, hanlp, huggingface_api, langfuse, llama_cpp, mcp, nvidia, oauth, transformers, watsonx**, plus (second commit) **aimlapi, cometapi, meta_llama, mistral, openrouter, orcarouter, togetherai** — whose `test_serde_in_pipeline` tests round-trip test-module tool functions through `Pipeline.loads` and hit the same guard once #3533/#3535 fix their other failures:

- Add an autouse conftest fixture that sets `HAYSTACK_DESERIALIZATION_ALLOWLIST="tests,test_*"` — Haystack 3.0's documented opt-in mechanism, read per deserialization call, so `monkeypatch.setenv` is enough. Haystack 2.x ignores the variable entirely, so nothing changes there.
- **oauth**: `test_from_dict_unknown_source_type_raises` now accepts `DeserializationError` in addition to `ImportError` — for an unknown/untrusted module, 3.0 refuses upfront with `DeserializationError` where 2.x fails at import time. (The guard working as intended for genuinely unknown types.)

### How did you test it?

- Haystack 2.x unit tests pass.
- Haystack v3 branch (installed `git+https://github.com/deepset-ai/haystack.git@v3` into the test envs): **every trusted-modules `DeserializationError` failure is gone.** google_genai, hanlp, langfuse, llama_cpp, mcp, and oauth unit suites are now fully green under v3. The remaining v3 failures in the other four are exactly the ones addressed by the sibling draft PRs: `to_dict`-format tests in huggingface_api/transformers/watsonx (#3533) and lazy-client init tests in nvidia (#3536).
- For the seven suites from the second commit I verified on a local merge of all four sibling branches (#3533, #3535, #3536, this one): all seven unit suites are **fully green under v3** on that combined state.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
