### PR TITLE
feat: hardcode client name for Tavily

### DIFF
--- a/integrations/tavily/pyproject.toml
+++ b/integrations/tavily/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "tavily-python>=0.5.0"]
+dependencies = ["haystack-ai>=2.24.1", "tavily-python>=0.7.24"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/tavily#readme"

--- a/integrations/tavily/src/haystack_integrations/components/websearch/tavily/tavily_websearch.py
+++ b/integrations/tavily/src/haystack_integrations/components/websearch/tavily/tavily_websearch.py
@@ -71,9 +71,9 @@ class TavilyWebSearch:
         Called automatically on first use. Can be called explicitly to avoid cold-start latency.
         """
         if self._tavily_client is None:
-            self._tavily_client = TavilyClient(api_key=self.api_key.resolve_value())
+            self._tavily_client = TavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
         if self._async_tavily_client is None:
-            self._async_tavily_client = AsyncTavilyClient(api_key=self.api_key.resolve_value())
+            self._async_tavily_client = AsyncTavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
 
     @component.output_types(documents=list[Document], links=list[str])
     def run(

--- a/integrations/tavily/tests/test_tavily_websearch.py
+++ b/integrations/tavily/tests/test_tavily_websearch.py
@@ -143,7 +143,7 @@ class TestTavilyWebSearch:
             mock_cls.return_value.search.return_value = search_response
             ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
             ws.run(query="test")
-            mock_cls.assert_called_once_with(api_key="test-key")
+            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
 
     @pytest.mark.asyncio
     async def test_run_async_triggers_warm_up(self, search_response):
@@ -154,7 +154,7 @@ class TestTavilyWebSearch:
             mock_cls.return_value.search = AsyncMock(return_value=search_response)
             ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
             await ws.run_async(query="test")
-            mock_cls.assert_called_once_with(api_key="test-key")
+            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
 
     def test_run_empty_results(self, mock_client):
         mock_client.search.return_value = {"results": []}


### PR DESCRIPTION
### Related Issues

- N/A

### Proposed Changes:

Adds Tavily request attribution for the Haystack integration by passing `client_name="haystack"` when initializing both `TavilyClient` and `AsyncTavilyClient`.

This makes Tavily API requests from `TavilyWebSearch` identifiable as coming from the Haystack integration.

### How did you test it?

- Ran Tavily unit tests:

`UV_CACHE_DIR=/private/tmp/uv-cache uv run --project . --with pytest --with pytest-asyncio python -m pytest -m "not integration" tests/test_tavily_websearch.py`

Result: `15 passed, 2 deselected`

- Ran Ruff on the touched files:

`UV_CACHE_DIR=/private/tmp/uv-cache uv run --project . --with ruff ruff check integrations/tavily/src/haystack_integrations/components/websearch/tavily/tavily_websearch.py integrations/tavily/tests/test_tavily_websearch.py`

Result: `All checks passed`

- Manually verified with a live Tavily request and confirmed server-side attribution showed `CLIENT_NAME = haystack`.

### Notes for the reviewer

The change intentionally uses the Tavily Python SDK’s `client_name` parameter instead of manually setting HTTP headers.

### Checklist

- I have read the [[contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md)](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [[code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [[conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.