### PR TITLE
ci: Add retry to windows libreoffice install

### DIFF
--- a/.github/workflows/libreoffice.yml
+++ b/.github/workflows/libreoffice.yml
@@ -87,10 +87,14 @@ jobs:
 
       - name: Install LibreOffice headless (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          choco install libreoffice-fresh -y
-          echo "C:\Program Files\LibreOffice\program" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 4
+          max_attempts: 3
+          shell: pwsh
+          command: |
+            choco install libreoffice-fresh -y
+            echo "C:\Program Files\LibreOffice\program" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install LibreOffice headless (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28630404002/job/84905887200

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add a retry action to retry installing windows in case it fails to install.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
