### PR TITLE
fix(cometapi): make CometAPIChatGenerator deserializable in pipelines

### DIFF
--- a/integrations/cometapi/src/haystack_integrations/components/generators/cometapi/chat/chat_generator.py
+++ b/integrations/cometapi/src/haystack_integrations/components/generators/cometapi/chat/chat_generator.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from haystack import component, default_to_dict
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import (
     StreamingCallbackT,
@@ -7,10 +8,12 @@ from haystack.dataclasses import (
 from haystack.tools import (
     Tool,
     Toolset,
+    serialize_tools_or_toolset,
 )
-from haystack.utils import Secret
+from haystack.utils import Secret, serialize_callable
 
 
+@component
 class CometAPIChatGenerator(OpenAIChatGenerator):
     """
     A chat generator that uses the CometAPI for generating chat responses.
@@ -48,7 +51,8 @@ class CometAPIChatGenerator(OpenAIChatGenerator):
         """
         api_base_url = "https://api.cometapi.com/v1"
 
-        super().__init__(
+        # the @component decorator recreates the class, so the zero-argument form of super() cannot be used
+        super(CometAPIChatGenerator, self).__init__(  # noqa: UP008
             api_key=api_key,
             model=model,
             api_base_url=api_base_url,
@@ -59,4 +63,30 @@ class CometAPIChatGenerator(OpenAIChatGenerator):
             tools=tools,
             tools_strict=tools_strict,
             http_client_kwargs=http_client_kwargs,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+
+        :returns:
+            The serialized component as a dictionary.
+        """
+        callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
+
+        # if we didn't implement the to_dict method here then the to_dict method of the superclass would be used
+        # which would serialize some fields that we don't want to serialize (e.g. the ones we don't have in
+        # the __init__)
+        # it would be hard to maintain the compatibility as superclass changes
+        return default_to_dict(
+            self,
+            api_key=self.api_key.to_dict(),
+            model=self.model,
+            streaming_callback=callback_name,
+            generation_kwargs=self.generation_kwargs,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+            tools=serialize_tools_or_toolset(self.tools),
+            tools_strict=self.tools_strict,
+            http_client_kwargs=self.http_client_kwargs,
         )

--- a/integrations/cometapi/tests/test_cometapi_chat_generator.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator.py
@@ -125,7 +125,6 @@ class TestCometAPIChatGenerator:
             "api_key": {"env_vars": ["COMET_API_KEY"], "strict": True, "type": "env_var"},
             "model": "gpt-5-mini",
             "streaming_callback": None,
-            "api_base_url": "https://api.cometapi.com/v1",
             "generation_kwargs": {},
             "timeout": None,
             "max_retries": None,
@@ -158,7 +157,6 @@ class TestCometAPIChatGenerator:
         expected_params = {
             "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
             "model": "gpt-5-mini",
-            "api_base_url": "https://api.cometapi.com/v1",
             "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
             "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             "timeout": 10,
@@ -456,8 +454,6 @@ class TestCometAPIChatGenerator:
                     "init_parameters": {
                         "model": "gpt-5-mini",
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                        "api_base_url": "https://api.cometapi.com/v1",
-                        "organization": None,
                         "generation_kwargs": {"temperature": 0.7},
                         "api_key": {"type": "env_var", "env_vars": ["COMET_API_KEY"], "strict": True},
                         "timeout": None,
@@ -502,8 +498,13 @@ class TestCometAPIChatGenerator:
 
         assert pipeline_dict == expected_dict
 
+        # Test YAML serialization/deserialization
+        pipeline_yaml = pipeline.dumps()
+        new_pipeline = Pipeline.loads(pipeline_yaml)
+        assert new_pipeline == pipeline
+
         # Verify the loaded pipeline's generator has the same configuration
-        loaded_generator = pipeline.get_component("generator")
+        loaded_generator = new_pipeline.get_component("generator")
         assert loaded_generator.model == generator.model
         assert loaded_generator.generation_kwargs == generator.generation_kwargs
         assert loaded_generator.streaming_callback == generator.streaming_callback


### PR DESCRIPTION
### Related Issues

- None (found while working on #3533)
- `CometAPIChatGenerator` could not be deserialized as part of a pipeline: `Pipeline.from_dict` / `Pipeline.loads` failed for any pipeline containing it. Two bugs, both fixed here:
- The class was never registered with the `@component` decorator. 
- The `to_dict` inherited from `OpenAIChatGenerator` serialized init parameters that `CometAPIChatGenerator.__init__` does not accept (`api_base_url`, `organization`), so even a registered component failed to deserialize with `TypeError: __init__() got an unexpected keyword argument 'api_base_url'`. 

### Proposed Changes:

- Added the decorator (and the two-argument `super(CometAPIChatGenerator, self).__init__` form it requires, since the decorator recreates the class — same pattern as `OpenRouterChatGenerator`).
Added a `to_dict` override that serializes exactly the component's own init parameters, mirroring openrouter.



### How did you test it?

The test now does a real `pipeline.dumps()` / `Pipeline.loads()` round-trip and asserts the loaded pipeline equals the original.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
