### PR TITLE
docs: replace old haystack core imports with haystack_integrations paths

### DIFF
--- a/integrations/alloydb/examples/embedding_retrieval.py
+++ b/integrations/alloydb/examples/embedding_retrieval.py
@@ -20,10 +20,13 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.alloydb import AlloyDBEmbeddingRetriever
 from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
 

--- a/integrations/alloydb/examples/hybrid_retrieval.py
+++ b/integrations/alloydb/examples/hybrid_retrieval.py
@@ -20,11 +20,14 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.alloydb import AlloyDBEmbeddingRetriever, AlloyDBKeywordRetriever
 from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
 

--- a/integrations/arcadedb/src/haystack_integrations/components/retrievers/arcadedb/embedding_retriever.py
+++ b/integrations/arcadedb/src/haystack_integrations/components/retrievers/arcadedb/embedding_retriever.py
@@ -19,8 +19,14 @@ class ArcadeDBEmbeddingRetriever:
 
     ```python
     from haystack import Document
-    from haystack.components.embedders import SentenceTransformersTextEmbedder
-    from haystack_integrations.components.retrievers.arcadedb import ArcadeDBEmbeddingRetriever
+
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import (
+        SentenceTransformersTextEmbedder,
+    )
+    from haystack_integrations.components.retrievers.arcadedb import (
+        ArcadeDBEmbeddingRetriever,
+    )
     from haystack_integrations.document_stores.arcadedb import ArcadeDBDocumentStore
 
     store = ArcadeDBDocumentStore(database="mydb")

--- a/integrations/astra/examples/example.py
+++ b/integrations/astra/examples/example.py
@@ -3,12 +3,15 @@ from pathlib import Path
 
 from haystack import Pipeline, logging
 from haystack.components.converters import TextFileToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentCleaner, DocumentSplitter
 from haystack.components.routers import FileTypeRouter
 from haystack.components.writers import DocumentWriter
 from haystack.document_stores.types import DuplicatePolicy
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.astra import AstraEmbeddingRetriever
 from haystack_integrations.document_stores.astra import AstraDocumentStore
 

--- a/integrations/astra/examples/pipeline_example.py
+++ b/integrations/astra/examples/pipeline_example.py
@@ -3,12 +3,15 @@ import os
 from haystack import Document, Pipeline, logging
 from haystack.components.builders import ChatPromptBuilder
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.writers import DocumentWriter
 from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.astra import AstraEmbeddingRetriever
 from haystack_integrations.document_stores.astra import AstraDocumentStore
 

--- a/integrations/azure_ai_search/example/embedding_retrieval.py
+++ b/integrations/azure_ai_search/example/embedding_retrieval.py
@@ -1,6 +1,9 @@
 from haystack import Document, Pipeline
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.writers import DocumentWriter
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 
 from haystack_integrations.components.retrievers.azure_ai_search import AzureAISearchEmbeddingRetriever
 from haystack_integrations.document_stores.azure_ai_search import AzureAISearchDocumentStore
@@ -32,7 +35,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder(model=model)
-document_embedder.warm_up()
 
 # Indexing Pipeline
 indexing_pipeline = Pipeline()

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/elasticsearch_hybrid_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/elasticsearch_hybrid_retriever.py
@@ -41,7 +41,9 @@ class ElasticsearchHybridRetriever:
 
     ```python
     from haystack import Document
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
     from haystack_integrations.components.retrievers.elasticsearch import ElasticsearchHybridRetriever
     from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
 
@@ -63,7 +65,6 @@ class ElasticsearchHybridRetriever:
 
     # Embed the documents and add them to the document store
     doc_embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
-    doc_embedder.warm_up()
     docs = doc_embedder.run(docs)
     doc_store.write_documents(docs['documents'])
 

--- a/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
+++ b/integrations/elasticsearch/src/haystack_integrations/components/retrievers/elasticsearch/embedding_retriever.py
@@ -20,9 +20,17 @@ class ElasticsearchEmbeddingRetriever:
     Usage example:
     ```python
     from haystack import Document
-    from haystack.components.embedders import SentenceTransformersTextEmbedder
-    from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
-    from haystack_integrations.components.retrievers.elasticsearch import ElasticsearchEmbeddingRetriever
+
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import (
+        SentenceTransformersTextEmbedder,
+    )
+    from haystack_integrations.document_stores.elasticsearch import (
+        ElasticsearchDocumentStore,
+    )
+    from haystack_integrations.components.retrievers.elasticsearch import (
+        ElasticsearchEmbeddingRetriever,
+    )
 
     document_store = ElasticsearchDocumentStore(hosts="http://localhost:9200")
     retriever = ElasticsearchEmbeddingRetriever(document_store=document_store)
@@ -37,7 +45,6 @@ class ElasticsearchEmbeddingRetriever:
     document_store.write_documents(documents)
 
     te = SentenceTransformersTextEmbedder()
-    te.warm_up()
     query_embeddings = te.run("Who lives in Berlin?")["embedding"]
 
     result = retriever.run(query=query_embeddings)

--- a/integrations/faiss/src/haystack_integrations/components/retrievers/faiss/embedding_retriever.py
+++ b/integrations/faiss/src/haystack_integrations/components/retrievers/faiss/embedding_retriever.py
@@ -20,7 +20,9 @@ class FAISSEmbeddingRetriever:
     Example usage:
     ```python
     from haystack import Document, Pipeline
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
     from haystack.document_stores.types import DuplicatePolicy
 
     from haystack_integrations.document_stores.faiss import FAISSDocumentStore
@@ -35,7 +37,6 @@ class FAISSEmbeddingRetriever:
     ]
 
     document_embedder = SentenceTransformersDocumentEmbedder()
-    document_embedder.warm_up()
     documents_with_embeddings = document_embedder.run(documents)["documents"]
 
     document_store.write_documents(documents_with_embeddings, policy=DuplicatePolicy.OVERWRITE)

--- a/integrations/langfuse/example/basic_rag.py
+++ b/integrations/langfuse/example/basic_rag.py
@@ -6,12 +6,15 @@ os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 from datasets import load_dataset
 from haystack import Document, Pipeline
 from haystack.components.builders import PromptBuilder
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.generators import OpenAIGenerator
 from haystack.components.retrievers import InMemoryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 
 
 def get_pipeline(document_store: InMemoryDocumentStore):
@@ -54,7 +57,6 @@ if __name__ == "__main__":
     document_store = InMemoryDocumentStore()
     dataset = load_dataset("bilgeyucel/seven-wonders", split="train")
     embedder = SentenceTransformersDocumentEmbedder("sentence-transformers/all-MiniLM-L6-v2")
-    embedder.warm_up()
     docs_with_embeddings = embedder.run([Document(**ds) for ds in dataset]).get("documents") or []  # type: ignore
     document_store.write_documents(docs_with_embeddings)
 

--- a/integrations/langfuse/example/chat.py
+++ b/integrations/langfuse/example/chat.py
@@ -9,7 +9,7 @@ os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
 from haystack import Pipeline
 from haystack.components.builders import ChatPromptBuilder
-from haystack.components.generators.chat import HuggingFaceAPIChatGenerator, OpenAIChatGenerator
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack.utils.auth import Secret
 from haystack.utils.hf import HFGenerationAPIType
@@ -17,6 +17,7 @@ from haystack.utils.hf import HFGenerationAPIType
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
 from haystack_integrations.components.generators.cohere import CohereChatGenerator
+from haystack_integrations.components.generators.huggingface_api import HuggingFaceAPIChatGenerator
 
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 

--- a/integrations/llama_cpp/examples/rag_pipeline_example.py
+++ b/integrations/llama_cpp/examples/rag_pipeline_example.py
@@ -1,12 +1,15 @@
 from datasets import load_dataset
 from haystack import Document, Pipeline
 from haystack.components.builders import ChatPromptBuilder
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.retrievers import InMemoryEmbeddingRetriever
 from haystack.components.writers import DocumentWriter
 from haystack.dataclasses import ChatMessage
 from haystack.document_stores import InMemoryDocumentStore
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.generators.llama_cpp import LlamaCppChatGenerator
 
 # Load first 100 rows of the Simple Wikipedia Dataset from HuggingFace

--- a/integrations/mongodb_atlas/examples/embedding_retrieval.py
+++ b/integrations/mongodb_atlas/examples/embedding_retrieval.py
@@ -10,10 +10,13 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.mongodb_atlas import MongoDBAtlasEmbeddingRetriever
 from haystack_integrations.document_stores.mongodb_atlas import MongoDBAtlasDocumentStore
 

--- a/integrations/mongodb_atlas/examples/hybrid_retrieval.py
+++ b/integrations/mongodb_atlas/examples/hybrid_retrieval.py
@@ -10,11 +10,14 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.mongodb_atlas import (
     MongoDBAtlasEmbeddingRetriever,
     MongoDBAtlasFullTextRetriever,

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
@@ -37,7 +37,9 @@ class OpenSearchHybridRetriever:
 
     ```python
     from haystack import Document
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
     from haystack_integrations.components.retrievers.opensearch import OpenSearchHybridRetriever
     from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 
@@ -59,7 +61,6 @@ class OpenSearchHybridRetriever:
 
     # Embed the documents and add them to the document store
     doc_embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
-    doc_embedder.warm_up()
     docs = doc_embedder.run(docs)
     doc_store.write_documents(docs['documents'])
 

--- a/integrations/pgvector/examples/embedding_retrieval.py
+++ b/integrations/pgvector/examples/embedding_retrieval.py
@@ -14,10 +14,13 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.pgvector import PgvectorEmbeddingRetriever
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 

--- a/integrations/pgvector/examples/hybrid_retrieval.py
+++ b/integrations/pgvector/examples/hybrid_retrieval.py
@@ -14,11 +14,14 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.pgvector import PgvectorEmbeddingRetriever, PgvectorKeywordRetriever
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
 

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
@@ -21,7 +21,9 @@ class PgvectorEmbeddingRetriever:
     ```python
     from haystack.document_stores import DuplicatePolicy
     from haystack import Document, Pipeline
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
 
     from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
     from haystack_integrations.components.retrievers.pgvector import PgvectorEmbeddingRetriever
@@ -40,7 +42,6 @@ class PgvectorEmbeddingRetriever:
                  Document(content="In certain places, you can witness the phenomenon of bioluminescent waves.")]
 
     document_embedder = SentenceTransformersDocumentEmbedder()
-    document_embedder.warm_up()
     documents_with_embeddings = document_embedder.run(documents)
 
     document_store.write_documents(documents_with_embeddings.get("documents"), policy=DuplicatePolicy.OVERWRITE)

--- a/integrations/pinecone/examples/example.py
+++ b/integrations/pinecone/examples/example.py
@@ -12,11 +12,14 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 from haystack.utils import Secret
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.pinecone import PineconeEmbeddingRetriever
 from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 

--- a/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
+++ b/integrations/pinecone/src/haystack_integrations/components/retrievers/pinecone/embedding_retriever.py
@@ -22,7 +22,9 @@ class PineconeEmbeddingRetriever:
     from haystack.document_stores.types import DuplicatePolicy
     from haystack import Document
     from haystack import Pipeline
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
     from haystack_integrations.components.retrievers.pinecone import PineconeEmbeddingRetriever
     from haystack_integrations.document_stores.pinecone import PineconeDocumentStore
 
@@ -34,7 +36,6 @@ class PineconeEmbeddingRetriever:
                  Document(content="In certain places, you can witness the phenomenon of bioluminescent waves.")]
 
     document_embedder = SentenceTransformersDocumentEmbedder()
-    document_embedder.warm_up()
     documents_with_embeddings = document_embedder.run(documents)
 
     document_store.write_documents(documents_with_embeddings.get("documents"), policy=DuplicatePolicy.OVERWRITE)

--- a/integrations/pyversity/examples/pipeline.py
+++ b/integrations/pyversity/examples/pipeline.py
@@ -3,11 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack import Document, Pipeline
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.retrievers import InMemoryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from pyversity import Strategy
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.rankers.pyversity import PyversityRanker
 
 # Index documents

--- a/integrations/qdrant/examples/embedding_retrieval.py
+++ b/integrations/qdrant/examples/embedding_retrieval.py
@@ -9,9 +9,12 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 
 from haystack_integrations.components.retrievers.qdrant import QdrantEmbeddingRetriever
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore

--- a/integrations/supabase/src/haystack_integrations/components/retrievers/supabase/embedding_retriever.py
+++ b/integrations/supabase/src/haystack_integrations/components/retrievers/supabase/embedding_retriever.py
@@ -31,7 +31,9 @@ class SupabasePgvectorEmbeddingRetriever(PgvectorEmbeddingRetriever):
     ```python
     from haystack import Document, Pipeline
     from haystack.document_stores.types.policy import DuplicatePolicy
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
 
     from haystack_integrations.document_stores.supabase import SupabasePgvectorDocumentStore
     from haystack_integrations.components.retrievers.supabase import SupabasePgvectorEmbeddingRetriever
@@ -47,7 +49,6 @@ class SupabasePgvectorEmbeddingRetriever(PgvectorEmbeddingRetriever):
                  Document(content="In certain places, you can witness the phenomenon of bioluminescent waves.")]
 
     document_embedder = SentenceTransformersDocumentEmbedder()
-    document_embedder.warm_up()
     documents_with_embeddings = document_embedder.run(documents)
     document_store.write_documents(documents_with_embeddings.get("documents"), policy=DuplicatePolicy.OVERWRITE)
 

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
@@ -24,7 +24,9 @@ class TransformersZeroShotTextRouter:
 
     ```python
     from haystack import Document
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
     from haystack.components.retrievers import InMemoryEmbeddingRetriever
     from haystack.core.pipeline import Pipeline
     from haystack.document_stores.in_memory import InMemoryDocumentStore

--- a/integrations/valkey/examples/example.py
+++ b/integrations/valkey/examples/example.py
@@ -26,10 +26,13 @@ import glob
 
 from haystack import Pipeline
 from haystack.components.converters import MarkdownToDocument
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.valkey import ValkeyEmbeddingRetriever
 from haystack_integrations.document_stores.valkey import ValkeyDocumentStore
 

--- a/integrations/valkey/src/haystack_integrations/components/retrievers/valkey/embedding_retriever.py
+++ b/integrations/valkey/src/haystack_integrations/components/retrievers/valkey/embedding_retriever.py
@@ -31,7 +31,9 @@ class ValkeyEmbeddingRetriever:
     from haystack.document_stores.types import DuplicatePolicy
     from haystack import Document
     from haystack import Pipeline
-    from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
+    # Requires: pip install sentence-transformers-haystack
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersTextEmbedder
+    from haystack_integrations.components.embedders.sentence_transformers import SentenceTransformersDocumentEmbedder
     from haystack_integrations.components.retrievers.valkey import ValkeyEmbeddingRetriever
     from haystack_integrations.document_stores.valkey import ValkeyDocumentStore
 
@@ -42,7 +44,6 @@ class ValkeyEmbeddingRetriever:
                  Document(content="In certain places, you can witness the phenomenon of bioluminescent waves.")]
 
     document_embedder = SentenceTransformersDocumentEmbedder()
-    document_embedder.warm_up()
     documents_with_embeddings = document_embedder.run(documents)
 
     document_store.write_documents(documents_with_embeddings.get("documents"), policy=DuplicatePolicy.OVERWRITE)

--- a/integrations/vespa/examples/embedding_retrieval.py
+++ b/integrations/vespa/examples/embedding_retrieval.py
@@ -13,10 +13,13 @@
 import logging
 
 from haystack import Pipeline
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.writers import DocumentWriter
 from haystack.dataclasses import Document
 
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
 from haystack_integrations.components.retrievers.vespa import VespaEmbeddingRetriever
 from haystack_integrations.document_stores.vespa import VespaDocumentStore
 

--- a/integrations/weave/example/hybrid_retrieval.py
+++ b/integrations/weave/example/hybrid_retrieval.py
@@ -1,11 +1,14 @@
 from haystack import Document, Pipeline
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.joiners import DocumentJoiner
-from haystack.components.rankers import TransformersSimilarityRanker
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever, InMemoryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 from haystack_integrations.components.connectors.weave import WeaveConnector
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+    SentenceTransformersTextEmbedder,
+)
+from haystack_integrations.components.rankers.sentence_transformers import SentenceTransformersSimilarityRanker
 
 
 def index():
@@ -33,7 +36,7 @@ def hybrid_pipeline(document_store):
     embedding_retriever = InMemoryEmbeddingRetriever(document_store)
     bm25_retriever = InMemoryBM25Retriever(document_store)
     document_joiner = DocumentJoiner()
-    ranker = TransformersSimilarityRanker(model="BAAI/bge-reranker-base")
+    ranker = SentenceTransformersSimilarityRanker(model="BAAI/bge-reranker-base")
 
     hybrid_retrieval = Pipeline()
     hybrid_retrieval.add_component("text_embedder", text_embedder)


### PR DESCRIPTION
### Related Issues

- Part of https://github.com/deepset-ai/haystack-private/issues/449

### Proposed Changes:

- Replace stale `from haystack.components.embedders import SentenceTransformers...` imports with the new `from haystack_integrations.components.embedders.sentence_transformers import ...` paths in the usage examples of retriever docstrings (these generate the API reference pages): arcadedb, elasticsearch (x2), faiss, opensearch, pgvector, pinecone, supabase, valkey, and the transformers `TransformersZeroShotTextRouter`
- Add a `# Requires: pip install sentence-transformers-haystack` comment above the new imports in docstring examples
- Same import replacement in example scripts of alloydb, astra, azure_ai_search, langfuse, llama_cpp, mongodb_atlas, pgvector, pinecone, pyversity, qdrant, valkey, vespa, and weave (plus `HuggingFaceAPIChatGenerator` in the langfuse chat example)
- Rename `TransformersSimilarityRanker` → `SentenceTransformersSimilarityRanker` in the weave hybrid-retrieval example (old core class name and old import path)
- Remove explicit `warm_up()` calls on SentenceTransformers embedders in docstrings/examples — their `run()` auto-invokes warm-up

### How did you test it?

- `python -m py_compile` on all changed files
- `hatch fmt --check` passes on the changed sources; a scan confirms zero remaining old-path imports of migrated classes in the repo

### Notes for the reviewer

I chose not to mention the extra new dependency in example files but only in the docstring examples. Happy to discuss other options. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)