### PR TITLE
fix: deserialization of flattened system_cachepoint_config in AmazonBedrockChatGenerator

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -409,6 +409,12 @@ class AmazonBedrockChatGenerator:
         if stop_words:
             logger.warning(msg)
 
+        system_cachepoint_config_ttl = init_params.pop("system_cachepoint_config_ttl", None)
+        if system_cachepoint_config_ttl is not None:
+            system_cachepoint_config = init_params.setdefault("system_cachepoint_config", {})
+            system_cachepoint_config["ttl"] = system_cachepoint_config_ttl
+            system_cachepoint_config.setdefault("type", "default")
+
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
             data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
@@ -547,12 +553,6 @@ class AmazonBedrockChatGenerator:
             tools_cachepoint_config = generation_kwargs.setdefault("tools_cachepoint_config", {})
             tools_cachepoint_config["ttl"] = tools_cachepoint_config_ttl
             tools_cachepoint_config.setdefault("type", "default")
-
-        system_cachepoint_config_ttl = generation_kwargs.pop("system_cachepoint_config_ttl", None)
-        if system_cachepoint_config_ttl is not None:
-            system_cachepoint_config = generation_kwargs.setdefault("system_cachepoint_config", {})
-            system_cachepoint_config["ttl"] = system_cachepoint_config_ttl
-            system_cachepoint_config.setdefault("type", "default")
 
         return generation_kwargs
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -415,6 +415,12 @@ class AmazonBedrockChatGenerator:
             system_cachepoint_config["ttl"] = system_cachepoint_config_ttl
             system_cachepoint_config.setdefault("type", "default")
 
+        tools_cachepoint_config_ttl = init_params.pop("tools_cachepoint_config_ttl", None)
+        if tools_cachepoint_config_ttl is not None:
+            tools_cachepoint_config = init_params.setdefault("tools_cachepoint_config", {})
+            tools_cachepoint_config["ttl"] = tools_cachepoint_config_ttl
+            tools_cachepoint_config.setdefault("type", "default")
+
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
             data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
@@ -547,12 +553,6 @@ class AmazonBedrockChatGenerator:
                 thinking.setdefault("type", "adaptive")
                 output_config = generation_kwargs.setdefault("output_config", {})
                 output_config["effort"] = adaptive_thinking_effort
-
-        tools_cachepoint_config_ttl = generation_kwargs.pop("tools_cachepoint_config_ttl", None)
-        if tools_cachepoint_config_ttl is not None:
-            tools_cachepoint_config = generation_kwargs.setdefault("tools_cachepoint_config", {})
-            tools_cachepoint_config["ttl"] = tools_cachepoint_config_ttl
-            tools_cachepoint_config.setdefault("type", "default")
 
         return generation_kwargs
 

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -769,22 +769,35 @@ class TestAmazonBedrockChatGenerator:
         result = AmazonBedrockChatGenerator._resolve_flattened_generation_kwargs(
             {
                 "tools_cachepoint_config_ttl": "5m",
-                "system_cachepoint_config_ttl": "10m",
             }
         )
         assert result["tools_cachepoint_config"] == {"type": "default", "ttl": "5m"}
-        assert result["system_cachepoint_config"] == {"type": "default", "ttl": "10m"}
         assert "tools_cachepoint_config_ttl" not in result
-        assert "system_cachepoint_config_ttl" not in result
 
-    def test_resolve_flattened_kwargs_cachepoint_ttl_preserves_existing_type(self):
-        result = AmazonBedrockChatGenerator._resolve_flattened_generation_kwargs(
+    def test_from_dict_resolves_system_cachepoint_config_ttl(self, mock_boto3_session):
+        generator = AmazonBedrockChatGenerator.from_dict(
             {
-                "system_cachepoint_config": {"type": "custom"},
-                "system_cachepoint_config_ttl": "5m",
+                "type": CLASS_TYPE,
+                "init_parameters": {
+                    "model": "global.anthropic.claude-sonnet-4-6",
+                    "system_cachepoint_config_ttl": "1h",
+                },
             }
         )
-        assert result["system_cachepoint_config"] == {"type": "custom", "ttl": "5m"}
+        assert generator.system_cachepoint_config == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+    def test_from_dict_resolves_system_cachepoint_config_ttl_preserves_existing_type(self, mock_boto3_session):
+        generator = AmazonBedrockChatGenerator.from_dict(
+            {
+                "type": CLASS_TYPE,
+                "init_parameters": {
+                    "model": "global.anthropic.claude-sonnet-4-6",
+                    "system_cachepoint_config": {"type": "default"},
+                    "system_cachepoint_config_ttl": "5m",
+                },
+            }
+        )
+        assert generator.system_cachepoint_config == {"cachePoint": {"type": "default", "ttl": "5m"}}
 
     def test_run_completion(self, mock_boto3_session, set_env_variables):
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -765,14 +765,30 @@ class TestAmazonBedrockChatGenerator:
                 {"disable_parallel_tool_use": True, "parallel_tool_use": True}
             )
 
-    def test_resolve_flattened_kwargs_cachepoint_ttl(self):
-        result = AmazonBedrockChatGenerator._resolve_flattened_generation_kwargs(
+    def test_from_dict_resolves_tools_cachepoint_config_ttl(self, mock_boto3_session):
+        generator = AmazonBedrockChatGenerator.from_dict(
             {
-                "tools_cachepoint_config_ttl": "5m",
+                "type": CLASS_TYPE,
+                "init_parameters": {
+                    "model": "global.anthropic.claude-sonnet-4-6",
+                    "tools_cachepoint_config_ttl": "1h",
+                },
             }
         )
-        assert result["tools_cachepoint_config"] == {"type": "default", "ttl": "5m"}
-        assert "tools_cachepoint_config_ttl" not in result
+        assert generator.tools_cachepoint_config == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+    def test_from_dict_resolves_tools_cachepoint_config_ttl_preserves_existing_type(self, mock_boto3_session):
+        generator = AmazonBedrockChatGenerator.from_dict(
+            {
+                "type": CLASS_TYPE,
+                "init_parameters": {
+                    "model": "global.anthropic.claude-sonnet-4-6",
+                    "tools_cachepoint_config": {"type": "default"},
+                    "tools_cachepoint_config_ttl": "5m",
+                },
+            }
+        )
+        assert generator.tools_cachepoint_config == {"cachePoint": {"type": "default", "ttl": "5m"}}
 
     def test_from_dict_resolves_system_cachepoint_config_ttl(self, mock_boto3_session):
         generator = AmazonBedrockChatGenerator.from_dict(


### PR DESCRIPTION
### Related Issues

- fixes system_cachepoint_config_ttl being deserialized as root level init param, not as generation_kwarg
- support tools_cachepoint_config_ttl as well

### Proposed Changes:
expect
```yaml
init_parameters:
  model: global.anthropic.claude-sonnet-4-6
  system_cachepoint_config_ttl: 1h
```

instead of 
```yaml
init_parameters:
  model: global.anthropic.claude-sonnet-4-6
  generation_kwargs:
    system_cachepoint_config_ttl: 1h
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
