### PR TITLE
test: relax Transformers and Sentence Transformers score assertions

### DIFF
--- a/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
@@ -454,9 +454,9 @@ class TestSentenceTransformersSimilarityRanker:
         assert docs_after[0].content == expected_first_text
 
         sorted_scores = sorted(expected_scores, reverse=True)
-        assert docs_after[0].score == pytest.approx(sorted_scores[0], abs=0.05)
-        assert docs_after[1].score == pytest.approx(sorted_scores[1], abs=0.05)
-        assert docs_after[2].score == pytest.approx(sorted_scores[2], abs=0.05)
+        assert docs_after[0].score == pytest.approx(sorted_scores[0], abs=0.1)
+        assert docs_after[1].score == pytest.approx(sorted_scores[1], abs=0.1)
+        assert docs_after[2].score == pytest.approx(sorted_scores[2], abs=0.1)
 
         for doc in docs_after:
             assert isinstance(doc.score, float)

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
@@ -454,9 +454,9 @@ class TestSentenceTransformersSimilarityRanker:
         assert docs_after[0].content == expected_first_text
 
         sorted_scores = sorted(expected_scores, reverse=True)
-        assert docs_after[0].score == pytest.approx(sorted_scores[0], abs=1e-6)
-        assert docs_after[1].score == pytest.approx(sorted_scores[1], abs=1e-6)
-        assert docs_after[2].score == pytest.approx(sorted_scores[2], abs=1e-6)
+        assert docs_after[0].score == pytest.approx(sorted_scores[0], abs=0.05)
+        assert docs_after[1].score == pytest.approx(sorted_scores[1], abs=0.05)
+        assert docs_after[2].score == pytest.approx(sorted_scores[2], abs=0.05)
 
         for doc in docs_after:
             assert isinstance(doc.score, float)

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -938,26 +938,11 @@ def test_t5(del_hf_env_vars_if_empty):
 @pytest.mark.integration
 def test_roberta(del_hf_env_vars_if_empty):
     reader = TransformersExtractiveReader("deepset/tinyroberta-squad2")
-    answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
-        "answers"
-    ]  # remove indices when batching is reintroduced
+    answers = reader.run(example_queries[0], example_documents[0], top_k=2)["answers"]
     assert answers[0].data == "Olaf Scholz"
-    assert answers[0].score == pytest.approx(0.8614975214004517)
+    assert answers[0].score == pytest.approx(0.8614975214004517, abs=0.01)
     assert answers[1].data == "Angela Merkel"
-    assert answers[1].score == pytest.approx(0.857952892780304)
+    assert answers[1].score == pytest.approx(0.857952892780304, abs=0.01)
     assert answers[2].data is None
-    assert answers[2].score == pytest.approx(0.019673851661650588, abs=1e-5)
+    assert answers[2].score == pytest.approx(0.019673851661650588, abs=0.01)
     assert len(answers) == 3
-    # uncomment assertions below when there is batching in v2
-    # assert answers[0][0].data == "Olaf Scholz"
-    # assert answers[0][0].score == pytest.approx(0.8614975214004517)
-    # assert answers[0][1].data == "Angela Merkel"
-    # assert answers[0][1].score == pytest.approx(0.857952892780304)
-    # assert answers[0][2].data is None
-    # assert answers[0][2].score == pytest.approx(0.0196738764278237)
-    # assert answers[1][0].data == "Jerry"
-    # assert answers[1][0].score == pytest.approx(0.7048940658569336)
-    # assert answers[1][1].data == "Olaf Scholz"
-    # assert answers[1][1].score == pytest.approx(0.6604189872741699)
-    # assert answers[1][2].data is None
-    # assert answers[1][2].score == pytest.approx(0.1002123719777046)


### PR DESCRIPTION
### Related Issues

- failing tests on macOS runners: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28724280654/job/85178749838; https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28724377796/job/85179016297

### Proposed Changes:
- relax the assertions on scores

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
