### PR TITLE
test: force Transformers and Sentence Transformers integration tests to run on CPU

### DIFF
--- a/integrations/sentence_transformers/tests/test_hybrid_rag_e2e.py
+++ b/integrations/sentence_transformers/tests/test_hybrid_rag_e2e.py
@@ -14,6 +14,7 @@ from haystack.components.retrievers.in_memory import InMemoryBM25Retriever, InMe
 from haystack.components.writers import DocumentWriter
 from haystack.dataclasses import ChatMessage
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.utils import ComponentDevice
 
 from haystack_integrations.components.embedders.sentence_transformers import (
     SentenceTransformersDocumentEmbedder,
@@ -41,7 +42,8 @@ def test_hybrid_retrieval_rag_pipeline(tmp_path):
     ]
     indexing_pipeline = Pipeline()
     indexing_pipeline.add_component(
-        instance=SentenceTransformersDocumentEmbedder(model=EMBEDDING_MODEL), name="document_embedder"
+        instance=SentenceTransformersDocumentEmbedder(model=EMBEDDING_MODEL, device=ComponentDevice.from_str("cpu")),
+        name="document_embedder",
     )
     indexing_pipeline.add_component(instance=DocumentWriter(document_store=document_store), name="document_writer")
     indexing_pipeline.connect("document_embedder", "document_writer")
@@ -60,13 +62,19 @@ def test_hybrid_retrieval_rag_pipeline(tmp_path):
 
     rag_pipeline = Pipeline()
     rag_pipeline.add_component(instance=InMemoryBM25Retriever(document_store=document_store), name="bm25_retriever")
-    rag_pipeline.add_component(instance=SentenceTransformersTextEmbedder(model=EMBEDDING_MODEL), name="text_embedder")
+    rag_pipeline.add_component(
+        instance=SentenceTransformersTextEmbedder(model=EMBEDDING_MODEL, device=ComponentDevice.from_str("cpu")),
+        name="text_embedder",
+    )
     rag_pipeline.add_component(
         instance=InMemoryEmbeddingRetriever(document_store=document_store), name="embedding_retriever"
     )
     rag_pipeline.add_component(instance=DocumentJoiner(), name="joiner")
     rag_pipeline.add_component(
-        instance=SentenceTransformersSimilarityRanker(model=RANKER_MODEL, top_k=3), name="ranker"
+        instance=SentenceTransformersSimilarityRanker(
+            model=RANKER_MODEL, top_k=3, device=ComponentDevice.from_str("cpu")
+        ),
+        name="ranker",
     )
     rag_pipeline.add_component(
         instance=ChatPromptBuilder(template=prompt_template, required_variables="*"), name="prompt_builder"

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_diversity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_diversity.py
@@ -598,7 +598,9 @@ class TestSentenceTransformersDiversityRanker:
     @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
     def test_run_real_world_use_case(self, similarity, del_hf_env_vars_if_empty):
         ranker = SentenceTransformersDiversityRanker(
-            model="sentence-transformers-testing/stsb-bert-tiny-safetensors", similarity=similarity
+            model="sentence-transformers-testing/stsb-bert-tiny-safetensors",
+            similarity=similarity,
+            device=ComponentDevice.from_str("cpu"),
         )
         query = "What are the reasons for long-standing animosities between Russia and Poland?"
 
@@ -685,6 +687,7 @@ class TestSentenceTransformersDiversityRanker:
             model="sentence-transformers-testing/stsb-bert-tiny-safetensors",
             similarity=similarity,
             strategy="maximum_margin_relevance",
+            device=ComponentDevice.from_str("cpu"),
         )
 
         # lambda_threshold=1, the most relevant document should be returned first

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_doc_image_embedder.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_doc_image_embedder.py
@@ -321,7 +321,9 @@ class TestSentenceTransformersDocumentImageEmbedder:
         ),
     )
     def test_live_run(self, test_files_path, del_hf_env_vars_if_empty):
-        embedder = SentenceTransformersDocumentImageEmbedder(model="sentence-transformers/clip-ViT-B-32")
+        embedder = SentenceTransformersDocumentImageEmbedder(
+            model="sentence-transformers/clip-ViT-B-32", device=ComponentDevice.from_str("cpu")
+        )
 
         documents = [
             Document(

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from posixpath import devnull
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -439,7 +440,9 @@ class TestSentenceTransformersSimilarityRanker:
 
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
-        ranker = SentenceTransformersSimilarityRanker(model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce")
+        ranker = SentenceTransformersSimilarityRanker(
+            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", device="cpu"
+        )
 
         query = "City in Bosnia and Herzegovina"
         docs_before_texts = ["Berlin", "Belgrade", "Sarajevo"]

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from posixpath import devnull
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -441,7 +440,7 @@ class TestSentenceTransformersSimilarityRanker:
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
         ranker = SentenceTransformersSimilarityRanker(
-            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", device="cpu"
+            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", device=ComponentDevice.from_str("cpu")
         )
 
         query = "City in Bosnia and Herzegovina"

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
@@ -466,7 +466,7 @@ class TestSentenceTransformersSimilarityRanker:
     @pytest.mark.integration
     def test_run_top_k(self, del_hf_env_vars_if_empty):
         ranker = SentenceTransformersSimilarityRanker(
-            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", top_k=2
+            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", top_k=2, device=ComponentDevice.from_str("cpu")
         )
 
         query = "City in Bosnia and Herzegovina"
@@ -489,7 +489,7 @@ class TestSentenceTransformersSimilarityRanker:
     @pytest.mark.integration
     def test_run_single_document(self, del_hf_env_vars_if_empty):
         ranker = SentenceTransformersSimilarityRanker(
-            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", device=None
+            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", device=ComponentDevice.from_str("cpu")
         )
         docs_before = [Document(content="Berlin")]
         output = ranker.run(query="City in Germany", documents=docs_before)

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_text_embedder.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_text_embedder.py
@@ -397,7 +397,9 @@ class TestSentenceTransformersTextEmbedder:
         checkpoint = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
         text = "a nice text to embed"
 
-        embedder_trunc = SentenceTransformersTextEmbedder(model=checkpoint, truncate_dim=64)
+        embedder_trunc = SentenceTransformersTextEmbedder(
+            model=checkpoint, truncate_dim=64, device=ComponentDevice.from_str("cpu")
+        )
         result_trunc = embedder_trunc.run(text=text)
         embedding_trunc = result_trunc["embedding"]
 
@@ -413,7 +415,9 @@ class TestSentenceTransformersTextEmbedder:
         checkpoint = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
         text = "a nice text to embed"
 
-        embedder_def = SentenceTransformersTextEmbedder(model=checkpoint, precision="int8")
+        embedder_def = SentenceTransformersTextEmbedder(
+            model=checkpoint, precision="int8", device=ComponentDevice.from_str("cpu")
+        )
         result_def = embedder_def.run(text=text)
         embedding_def = result_def["embedding"]
 

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -504,7 +504,11 @@ class TestTransformersChatGenerator:
         """Test live run with default behavior (no thinking)."""
         messages = [ChatMessage.from_user("Please create a summary about the following topic: Climate change")]
 
-        llm = TransformersChatGenerator(model="Qwen/Qwen3-0.6B", generation_kwargs={"max_new_tokens": 50})
+        llm = TransformersChatGenerator(
+            model="Qwen/Qwen3-0.6B",
+            generation_kwargs={"max_new_tokens": 50},
+            device=ComponentDevice.from_str("cpu"),
+        )
 
         result = llm.run(messages)
 
@@ -519,7 +523,10 @@ class TestTransformersChatGenerator:
         messages = [ChatMessage.from_user("What is 2+2?")]
 
         llm = TransformersChatGenerator(
-            model="Qwen/Qwen3-0.6B", generation_kwargs={"max_new_tokens": 450}, enable_thinking=True
+            model="Qwen/Qwen3-0.6B",
+            generation_kwargs={"max_new_tokens": 450},
+            enable_thinking=True,
+            device=ComponentDevice.from_str("cpu"),
         )
 
         result = llm.run(messages)
@@ -846,7 +853,10 @@ class TestTransformersChatGeneratorAsync:
             streaming_chunks.append(chunk)
 
         llm = TransformersChatGenerator(
-            model="Qwen/Qwen3-0.6B", generation_kwargs={"max_new_tokens": 50}, streaming_callback=streaming_callback
+            model="Qwen/Qwen3-0.6B",
+            generation_kwargs={"max_new_tokens": 50},
+            streaming_callback=streaming_callback,
+            device=ComponentDevice.from_str("cpu"),
         )
 
         response = await llm.run_async(

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -914,7 +914,7 @@ class TestDeduplication:
 
 @pytest.mark.integration
 def test_t5(del_hf_env_vars_if_empty):
-    reader = TransformersExtractiveReader("sjrhuschlee/flan-t5-base-squad2", device="cpu")
+    reader = TransformersExtractiveReader("sjrhuschlee/flan-t5-base-squad2", device=ComponentDevice.from_str("cpu"))
     answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
         "answers"
     ]  # remove indices when batching support is reintroduced

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -915,9 +915,7 @@ class TestDeduplication:
 @pytest.mark.integration
 def test_t5(del_hf_env_vars_if_empty):
     reader = TransformersExtractiveReader("sjrhuschlee/flan-t5-base-squad2", device=ComponentDevice.from_str("cpu"))
-    answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
-        "answers"
-    ]  # remove indices when batching support is reintroduced
+    answers = reader.run(example_queries[0], example_documents[0], top_k=2)["answers"]
     assert answers[0].data == "Olaf Scholz"
     assert answers[0].score == pytest.approx(0.8085031509399414, abs=1e-5)
     assert answers[1].data == "Angela Merkel"
@@ -925,22 +923,12 @@ def test_t5(del_hf_env_vars_if_empty):
     assert answers[2].data is None
     assert answers[2].score == pytest.approx(0.0378925803599941, abs=1e-5)
     assert len(answers) == 3
-    # Uncomment assertions below when batching is reintroduced
-    # assert answers[0][2].score == pytest.approx(0.051331606147570596)
-    # assert answers[1][0].data == "Jerry"
-    # assert answers[1][0].score == pytest.approx(0.7413333654403687)
-    # assert answers[1][1].data == "Olaf Scholz"
-    # assert answers[1][1].score == pytest.approx(0.7266613841056824)
-    # assert answers[1][2].data is None
-    # assert answers[1][2].score == pytest.approx(0.0707035798685709)
 
 
 @pytest.mark.integration
 def test_roberta(del_hf_env_vars_if_empty):
-    reader = TransformersExtractiveReader("deepset/tinyroberta-squad2")
-    answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
-        "answers"
-    ]  # remove indices when batching is reintroduced
+    reader = TransformersExtractiveReader("deepset/tinyroberta-squad2", device=ComponentDevice.from_str("cpu"))
+    answers = reader.run(example_queries[0], example_documents[0], top_k=2)["answers"]
     assert answers[0].data == "Olaf Scholz"
     assert answers[0].score == pytest.approx(0.8614975214004517)
     assert answers[1].data == "Angela Merkel"
@@ -948,16 +936,3 @@ def test_roberta(del_hf_env_vars_if_empty):
     assert answers[2].data is None
     assert answers[2].score == pytest.approx(0.019673851661650588, abs=1e-5)
     assert len(answers) == 3
-    # uncomment assertions below when there is batching in v2
-    # assert answers[0][0].data == "Olaf Scholz"
-    # assert answers[0][0].score == pytest.approx(0.8614975214004517)
-    # assert answers[0][1].data == "Angela Merkel"
-    # assert answers[0][1].score == pytest.approx(0.857952892780304)
-    # assert answers[0][2].data is None
-    # assert answers[0][2].score == pytest.approx(0.0196738764278237)
-    # assert answers[1][0].data == "Jerry"
-    # assert answers[1][0].score == pytest.approx(0.7048940658569336)
-    # assert answers[1][1].data == "Olaf Scholz"
-    # assert answers[1][1].score == pytest.approx(0.6604189872741699)
-    # assert answers[1][2].data is None
-    # assert answers[1][2].score == pytest.approx(0.1002123719777046)

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -914,7 +914,7 @@ class TestDeduplication:
 
 @pytest.mark.integration
 def test_t5(del_hf_env_vars_if_empty):
-    reader = TransformersExtractiveReader("sjrhuschlee/flan-t5-base-squad2")
+    reader = TransformersExtractiveReader("sjrhuschlee/flan-t5-base-squad2", device="cpu")
     answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
         "answers"
     ]  # remove indices when batching support is reintroduced

--- a/integrations/transformers/tests/test_named_entity_extractor.py
+++ b/integrations/transformers/tests/test_named_entity_extractor.py
@@ -227,7 +227,7 @@ def test_named_entity_extractor_run_fails_with_wrong_number_of_annotations():
 
 @pytest.mark.integration
 def test_ner_extractor_init(del_hf_env_vars_if_empty):
-    extractor = TransformersNamedEntityExtractor(model="dslim/bert-base-NER")
+    extractor = TransformersNamedEntityExtractor(model="dslim/bert-base-NER", device=ComponentDevice.from_str("cpu"))
     extractor.warm_up()
     assert extractor.initialized
 
@@ -235,7 +235,7 @@ def test_ner_extractor_init(del_hf_env_vars_if_empty):
 @pytest.mark.integration
 @pytest.mark.parametrize("batch_size", [1, 3])
 def test_ner_extractor(raw_texts, hf_annotations, batch_size, del_hf_env_vars_if_empty):
-    extractor = TransformersNamedEntityExtractor(model="dslim/bert-base-NER")
+    extractor = TransformersNamedEntityExtractor(model="dslim/bert-base-NER", device=ComponentDevice.from_str("cpu"))
     extractor.warm_up()
 
     _extract_and_check_predictions(extractor, raw_texts, hf_annotations, batch_size)
@@ -248,7 +248,7 @@ def test_ner_extractor(raw_texts, hf_annotations, batch_size, del_hf_env_vars_if
     reason="Export an env var called HF_API_TOKEN or HF_TOKEN containing the Hugging Face token to run this test.",
 )
 def test_ner_extractor_private_models(raw_texts, hf_annotations, batch_size):
-    extractor = TransformersNamedEntityExtractor(model="deepset/bert-base-NER")
+    extractor = TransformersNamedEntityExtractor(model="deepset/bert-base-NER", device=ComponentDevice.from_str("cpu"))
     extractor.warm_up()
 
     _extract_and_check_predictions(extractor, raw_texts, hf_annotations, batch_size)
@@ -260,7 +260,7 @@ def test_ner_extractor_in_pipeline(raw_texts, hf_annotations, batch_size, del_hf
     pipeline = Pipeline()
     pipeline.add_component(
         name="ner_extractor",
-        instance=TransformersNamedEntityExtractor(model="dslim/bert-base-NER"),
+        instance=TransformersNamedEntityExtractor(model="dslim/bert-base-NER", device=ComponentDevice.from_str("cpu")),
     )
 
     outputs = pipeline.run(

--- a/integrations/transformers/tests/test_text_router.py
+++ b/integrations/transformers/tests/test_text_router.py
@@ -173,7 +173,9 @@ class TestTransformersTextRouter:
 
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
-        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection")
+        router = TransformersTextRouter(
+            model="papluca/xlm-roberta-base-language-detection", device=ComponentDevice.from_str("cpu")
+        )
         out = router.run("What is the color of the sky?")
         assert set(router.labels) == {
             "ar",
@@ -202,6 +204,10 @@ class TestTransformersTextRouter:
 
     @pytest.mark.integration
     def test_wrong_labels(self, del_hf_env_vars_if_empty):
-        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection", labels=["en", "de"])
+        router = TransformersTextRouter(
+            model="papluca/xlm-roberta-base-language-detection",
+            labels=["en", "de"],
+            device=ComponentDevice.from_str("cpu"),
+        )
         with pytest.raises(ValueError):
             router.warm_up()

--- a/integrations/transformers/tests/test_zero_shot_document_classifier.py
+++ b/integrations/transformers/tests/test_zero_shot_document_classifier.py
@@ -167,7 +167,9 @@ class TestTransformersZeroShotDocumentClassifier:
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
         component = TransformersZeroShotDocumentClassifier(
-            model="cross-encoder/nli-deberta-v3-xsmall", labels=["positive", "negative"]
+            model="cross-encoder/nli-deberta-v3-xsmall",
+            labels=["positive", "negative"],
+            device=ComponentDevice.from_str("cpu"),
         )
         positive_document = Document(content="That's good. I like it. " * 1000)
         negative_document = Document(content="That's bad. I don't like it.")

--- a/integrations/transformers/tests/test_zero_shot_text_router.py
+++ b/integrations/transformers/tests/test_zero_shot_text_router.py
@@ -111,7 +111,7 @@ class TestTransformersZeroShotTextRouter:
 
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
-        router = TransformersZeroShotTextRouter(labels=["query", "passage"])
+        router = TransformersZeroShotTextRouter(labels=["query", "passage"], device=ComponentDevice.from_str("cpu"))
         out = router.run("What is the color of the sky?")
         assert router.pipeline is not None
         assert out == {"query": "What is the color of the sky?"}


### PR DESCRIPTION
### Related Issues

- failing tests on macOS runners: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28724280654/job/85178749838; https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28724377796/job/85179016297
- Hard to debug/find information sources but it seems that MPS support on GitHub runners is not reliable

### Proposed Changes:
- force the device to CPU in every integration test

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
