### PR TITLE
Add close() and close_async() to QdrantDocumentStore

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -130,6 +130,18 @@ class QdrantEmbeddingRetriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,
@@ -357,6 +369,18 @@ class QdrantSparseEmbeddingRetriever:
         if filter_policy := data["init_parameters"].get("filter_policy"):
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
 
     @component.output_types(documents=list[Document])
     def run(
@@ -595,6 +619,18 @@ class QdrantHybridRetriever:
         if filter_policy := data["init_parameters"].get("filter_policy"):
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
 
     @component.output_types(documents=list[Document])
     def run(

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -301,6 +301,22 @@ class QdrantDocumentStore:
                 self.payload_fields_to_index,
             )
 
+    def close(self) -> None:
+        """
+        Close the synchronous Qdrant client connection.
+        """
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """
+        Close the asynchronous Qdrant client connection.
+        """
+        if self._async_client:
+            await self._async_client.close()
+            self._async_client = None
+
     def count_documents(self) -> int:
         """
         Returns the number of documents present in the Document Store.

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -1,5 +1,6 @@
 import inspect
 from collections.abc import AsyncGenerator, Generator
+from contextlib import suppress
 from dataclasses import replace
 from itertools import islice
 from typing import Any, ClassVar, cast
@@ -303,18 +304,20 @@ class QdrantDocumentStore:
 
     def close(self) -> None:
         """
-        Close the synchronous Qdrant client connection.
+        Release the associated synchronous resources.
         """
-        if self._client:
-            self._client.close()
+        if self._client is not None:
+            with suppress(Exception):
+                self._client.close()
             self._client = None
 
     async def close_async(self) -> None:
         """
-        Close the asynchronous Qdrant client connection.
+        Release the associated asynchronous resources.
         """
-        if self._async_client:
-            await self._async_client.close()
+        if self._async_client is not None:
+            with suppress(Exception):
+                await self._async_client.close()
             self._async_client = None
 
     def count_documents(self) -> int:

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -370,6 +370,27 @@ class TestQdrantDocumentStoreUnit:
         ):
             assert getattr(document_store, method_name)(*args) == expected
 
+    def test_close(self):
+        document_store = QdrantDocumentStore(":memory:", recreate_index=True)
+
+        # Initialise the client
+        document_store._initialize_client()
+        assert document_store._client is not None
+
+        document_store.close()
+        assert document_store._client is None
+
+        # The client should be re-initialized lazily and still be usable
+        assert document_store.count_documents() == 0
+
+    def test_close_before_initialization_is_safe(self):
+        document_store = QdrantDocumentStore(":memory:", recreate_index=True)
+        assert document_store._client is None
+
+        # Should not raise even though the client was never initialized
+        document_store.close()
+        assert document_store._client is None
+
 
 @pytest.mark.integration
 class TestQdrantDocumentStore(

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -370,7 +370,7 @@ class TestQdrantDocumentStoreUnit:
         ):
             assert getattr(document_store, method_name)(*args) == expected
 
-    def test_close(self):
+    def test_close_and_reopen(self):
         document_store = QdrantDocumentStore(":memory:", recreate_index=True)
 
         # Initialise the client
@@ -382,6 +382,15 @@ class TestQdrantDocumentStoreUnit:
 
         # The client should be re-initialized lazily and still be usable
         assert document_store.count_documents() == 0
+
+    def test_close_is_exception_safe(self):
+        document_store = QdrantDocumentStore(":memory:", recreate_index=True)
+        document_store._client = MagicMock()
+        document_store._client.close.side_effect = RuntimeError("boom")
+
+        document_store.close()
+
+        assert document_store._client is None
 
     def test_close_before_initialization_is_safe(self):
         document_store = QdrantDocumentStore(":memory:", recreate_index=True)

--- a/integrations/qdrant/tests/test_document_store_async.py
+++ b/integrations/qdrant/tests/test_document_store_async.py
@@ -162,6 +162,27 @@ class TestQdrantDocumentStoreAsyncUnit:
         ):
             assert await getattr(document_store, method_name)(*args) == expected
 
+    async def test_close_async(self):
+        document_store = QdrantDocumentStore(":memory:", recreate_index=True)
+
+        # Initialise the async client
+        await document_store._initialize_async_client()
+        assert document_store._async_client is not None
+
+        await document_store.close_async()
+        assert document_store._async_client is None
+
+        # The client should be re-initialized lazily and still be usable
+        assert await document_store.count_documents_async() == 0
+
+    async def test_close_async_before_initialization_is_safe(self):
+        document_store = QdrantDocumentStore(":memory:", recreate_index=True)
+        assert document_store._async_client is None
+
+        # Should not raise even though the client was never initialized
+        await document_store.close_async()
+        assert document_store._async_client is None
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio

--- a/integrations/qdrant/tests/test_document_store_async.py
+++ b/integrations/qdrant/tests/test_document_store_async.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -162,7 +162,7 @@ class TestQdrantDocumentStoreAsyncUnit:
         ):
             assert await getattr(document_store, method_name)(*args) == expected
 
-    async def test_close_async(self):
+    async def test_close_async_and_reopen(self):
         document_store = QdrantDocumentStore(":memory:", recreate_index=True)
 
         # Initialise the async client
@@ -174,6 +174,15 @@ class TestQdrantDocumentStoreAsyncUnit:
 
         # The client should be re-initialized lazily and still be usable
         assert await document_store.count_documents_async() == 0
+
+    async def test_close_async_is_exception_safe(self):
+        document_store = QdrantDocumentStore(":memory:", recreate_index=True)
+        document_store._async_client = AsyncMock()
+        document_store._async_client.close.side_effect = RuntimeError("boom")
+
+        await document_store.close_async()
+
+        assert document_store._async_client is None
 
     async def test_close_async_before_initialization_is_safe(self):
         document_store = QdrantDocumentStore(":memory:", recreate_index=True)

--- a/integrations/qdrant/tests/test_embedding_retriever.py
+++ b/integrations/qdrant/tests/test_embedding_retriever.py
@@ -21,6 +21,26 @@ class TestQdrantRetriever:
         with pytest.raises(ValueError, match="must be an instance of QdrantDocumentStore"):
             QdrantEmbeddingRetriever(document_store="not a document store")
 
+    def test_close(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        retriever = QdrantEmbeddingRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once_with()
+        assert retriever._document_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        mock_store.close_async = AsyncMock()
+        retriever = QdrantEmbeddingRetriever(document_store=mock_store)
+
+        await retriever.close_async()
+
+        mock_store.close_async.assert_awaited_once_with()
+        assert retriever._document_store is mock_store
+
     def test_init_default(self):
         document_store = QdrantDocumentStore(location=":memory:", index="test", use_sparse_embeddings=False)
         retriever = QdrantEmbeddingRetriever(document_store=document_store)

--- a/integrations/qdrant/tests/test_hybrid_retriever.py
+++ b/integrations/qdrant/tests/test_hybrid_retriever.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from haystack.dataclasses import Document, SparseEmbedding
@@ -15,6 +15,26 @@ class TestQdrantHybridRetriever:
     def test_init_raises_when_document_store_is_not_qdrant(self):
         with pytest.raises(ValueError, match="must be an instance of QdrantDocumentStore"):
             QdrantHybridRetriever(document_store="not a document store")
+
+    def test_close(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        retriever = QdrantHybridRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once_with()
+        assert retriever._document_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        mock_store.close_async = AsyncMock()
+        retriever = QdrantHybridRetriever(document_store=mock_store)
+
+        await retriever.close_async()
+
+        mock_store.close_async.assert_awaited_once_with()
+        assert retriever._document_store is mock_store
 
     def test_init_default(self):
         document_store = QdrantDocumentStore(location=":memory:", index="test", use_sparse_embeddings=True)

--- a/integrations/qdrant/tests/test_sparse_embedding_retriever.py
+++ b/integrations/qdrant/tests/test_sparse_embedding_retriever.py
@@ -20,6 +20,26 @@ class TestQdrantSparseEmbeddingRetriever:
         with pytest.raises(ValueError, match="must be an instance of QdrantDocumentStore"):
             QdrantSparseEmbeddingRetriever(document_store="not a document store")
 
+    def test_close(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        retriever = QdrantSparseEmbeddingRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once_with()
+        assert retriever._document_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        mock_store.close_async = AsyncMock()
+        retriever = QdrantSparseEmbeddingRetriever(document_store=mock_store)
+
+        await retriever.close_async()
+
+        mock_store.close_async.assert_awaited_once_with()
+        assert retriever._document_store is mock_store
+
     def test_init_default(self):
         document_store = QdrantDocumentStore(location=":memory:", index="test")
         retriever = QdrantSparseEmbeddingRetriever(document_store=document_store)


### PR DESCRIPTION
Part of #1628

QdrantDocumentStore lazily creates a `QdrantClient` and `AsyncQdrantClient` on first use but never released either one, so long-running processes and test suites had no way to release the underlying HTTP connections.

`WeaviateDocumentStore`, `PineconeDocumentStore`, and `ValkeyDocumentStore` already expose this same `close()`/`close_async()` pair (introduced in #2891), so this follows the same convention: each method releases its respective client and resets it to `None`, letting it be lazily re-initialized on the next call.

Usage after this PR:

    document_store = QdrantDocumentStore(...)
    try:
        document_store.write_documents(docs)
    finally:
        document_store.close()

Test plan: four new tests covering the sync and async client, both the normal case (initialize, close, verify it's `None`, confirm lazy re-initialization still works) and the safety case (calling close before the client was ever created should be a no-op). All use Qdrant's `:memory:` mode, so no external server is required.

Verified locally: all 260 existing + new tests pass, `ruff check` / `ruff format --check` are clean, and `mypy` reports no issues.