### PR TITLE
chore(vllm): unpin fastapi

### DIFF
--- a/integrations/vllm/pyproject.toml
+++ b/integrations/vllm/pyproject.toml
@@ -23,8 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-# fastapi temporarily pinned due to https://github.com/vllm-project/vllm/issues/45596
-dependencies = ["haystack-ai>=2.30.0", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0", "fastapi<0.137"]
+dependencies = ["haystack-ai>=2.30.0", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/vllm#readme"


### PR DESCRIPTION
### Related Issues

- fixes #3451

### Proposed Changes:

The `fastapi<0.137` pin was added in #3450 as a temporary workaround for [vllm-project/vllm#45596](https://github.com/vllm-project/vllm/issues/45596) (`'_IncludedRouter' object has no attribute 'path'` on FastAPI >= 0.137). That bug has been fixed upstream in vllm-project/vllm#45629 and released in **vLLM 0.24.0**, so the workaround is no longer needed.

This removes the temporary pin (a straight inverse of #3450). Since `fastapi` was not a direct dependency before that PR, it is removed from the dependency list entirely rather than left unconstrained. The struck-through `vllm>BUGFIX_VERSION` floor from the issue is intentionally not added.

### How did you test it?

Dependency-metadata change only (no source changes), so it exercises the existing CI test matrix against the now-unpinned FastAPI.

### Notes for the reviewer

Straight inverse of #3450, now that the upstream vLLM fix is released.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I've used a [conventional commit type](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `chore:`