### PR TITLE
docs: fix FirecrawlCrawler wrong name in docstrings

### DIFF
--- a/integrations/firecrawl/src/haystack_integrations/components/fetchers/firecrawl/firecrawl_crawler.py
+++ b/integrations/firecrawl/src/haystack_integrations/components/fetchers/firecrawl/firecrawl_crawler.py
@@ -27,15 +27,15 @@ class FirecrawlCrawler:
     ### Usage example
 
     ```python
-    from haystack_integrations.components.fetchers.firecrawl import FirecrawlFetcher
+    from haystack_integrations.components.fetchers.firecrawl import FirecrawlCrawler
 
-    fetcher = FirecrawlFetcher(
+    crawler = FirecrawlCrawler(
         api_key=Secret.from_env_var("FIRECRAWL_API_KEY"),
         params={"limit": 5},
     )
-    fetcher.warm_up()
+    crawler.warm_up()
 
-    result = fetcher.run(urls=["https://docs.haystack.deepset.ai/docs/intro"])
+    result = crawler.run(urls=["https://docs.haystack.deepset.ai/docs/intro"])
     documents = result["documents"]
     ```
     """
@@ -46,7 +46,7 @@ class FirecrawlCrawler:
         params: dict[str, Any] | None = None,
     ) -> None:
         """
-        Initialize the FirecrawlFetcher.
+        Initialize the FirecrawlCrawler.
 
         :param api_key:
             API key for Firecrawl.

--- a/integrations/firecrawl/tests/test_firecrawl_crawler.py
+++ b/integrations/firecrawl/tests/test_firecrawl_crawler.py
@@ -61,7 +61,7 @@ class TestFirecrawlCrawler:
             api_key=Secret.from_env_var("FIRECRAWL_API_KEY"),
             params={"limit": 5},
         )
-        data = component_to_dict(fetcher, "FirecrawlFetcher")
+        data = component_to_dict(fetcher, "FirecrawlCrawler")
         assert data["type"] == "haystack_integrations.components.fetchers.firecrawl.firecrawl_crawler.FirecrawlCrawler"
         assert data["init_parameters"]["params"] == {"limit": 5}
         assert "api_key" in data["init_parameters"]
@@ -75,7 +75,7 @@ class TestFirecrawlCrawler:
                 "api_key": {"env_vars": ["FIRECRAWL_API_KEY"], "strict": True, "type": "env_var"},
             },
         }
-        fetcher = component_from_dict(FirecrawlCrawler, data, "FirecrawlFetcher")
+        fetcher = component_from_dict(FirecrawlCrawler, data, "FirecrawlCrawler")
         assert fetcher.params == {"limit": 3}
         assert fetcher.api_key.resolve_value() == "test-key"
 


### PR DESCRIPTION
### Proposed Changes:
- in docstrings, use the correct `FirecrawlCrawler` component name (instead of `FirecrawlFetcher`)
- a few other consistency fixes (not strictly necessary)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
