### PR TITLE
feat(tavily): add TavilyFetcher component using the Extract API

### DIFF
--- a/integrations/tavily/CHANGELOG.md
+++ b/integrations/tavily/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [unreleased]
-
-### 🚀 Features
-
-- Add TavilyFetcher component using the Tavily Extract API (#3559)
-
 ## [integrations/tavily-v0.2.0] - 2026-07-03
 
 ### 🚀 Features
@@ -16,6 +10,7 @@
 
 - Track test coverage for all integrations (#3065)
 - Tavily - add 2 unit tests (#3222)
+
 
 ## [integrations/tavily-v0.1.0] - 2026-03-27
 

--- a/integrations/tavily/CHANGELOG.md
+++ b/integrations/tavily/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+
+### 🚀 Features
+
+- Add TavilyFetcher component using the Tavily Extract API (#3559)
+
 ## [integrations/tavily-v0.2.0] - 2026-07-03
 
 ### 🚀 Features
@@ -10,7 +16,6 @@
 
 - Track test coverage for all integrations (#3065)
 - Tavily - add 2 unit tests (#3222)
-
 
 ## [integrations/tavily-v0.1.0] - 2026-03-27
 

--- a/integrations/tavily/pydoc/config_docusaurus.yml
+++ b/integrations/tavily/pydoc/config_docusaurus.yml
@@ -1,6 +1,7 @@
 loaders:
   - modules:
       - haystack_integrations.components.websearch.tavily.tavily_websearch
+      - haystack_integrations.components.fetchers.tavily.tavily_fetcher
     search_path: [../src]
 processors:
   - type: filter

--- a/integrations/tavily/pyproject.toml
+++ b/integrations/tavily/pyproject.toml
@@ -66,7 +66,7 @@ integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
-types = "mypy -p haystack_integrations.components.websearch.tavily {args}"
+types = "mypy -p haystack_integrations.components.websearch.tavily -p haystack_integrations.components.fetchers.tavily {args}"
 
 [tool.mypy]
 install_types = true

--- a/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/__init__.py
+++ b/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack_integrations.components.fetchers.tavily.tavily_fetcher import TavilyFetcher
+
+__all__ = ["TavilyFetcher"]

--- a/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
+++ b/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Literal
+
+from haystack import Document, component, logging
+from haystack.utils import Secret
+
+from tavily import AsyncTavilyClient, TavilyClient
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class TavilyFetcher:
+    """
+    A component that uses the Tavily Extract API to fetch and extract content from URLs as Haystack Documents.
+
+    This component wraps the Tavily Extract API, which retrieves and parses web page content from
+    one or more specified URLs. Unlike web search, it fetches content directly from the given URLs
+    rather than discovering them via a query.
+
+    Tavily is an AI-powered search and extraction API optimized for LLM applications. You need a Tavily
+    API key from [tavily.com](https://tavily.com).
+
+    ### Usage example
+
+    ```python
+    from haystack_integrations.components.fetchers.tavily import TavilyFetcher
+    from haystack.utils import Secret
+
+    fetcher = TavilyFetcher(
+        api_key=Secret.from_env_var("TAVILY_API_KEY"),
+        extract_depth="basic",
+    )
+    result = fetcher.run(urls=["https://haystack.deepset.ai"])
+    documents = result["documents"]
+    meta = result["meta"]
+    ```
+    """
+
+    def __init__(
+        self,
+        api_key: Secret = Secret.from_env_var("TAVILY_API_KEY"),
+        extract_depth: Literal["basic", "advanced"] = "basic",
+        include_images: bool = False,
+        extract_params: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Initialize the TavilyFetcher component.
+
+        :param api_key:
+            API key for Tavily. Defaults to the `TAVILY_API_KEY` environment variable.
+        :param extract_depth:
+            Extraction depth: `"basic"` (fast, lower cost) or `"advanced"` (more data including
+            tables, higher latency and cost). Defaults to `"basic"`.
+        :param include_images:
+            If `True`, extracted image URLs are included in each Document's metadata under
+            the `"images"` key. Defaults to `False`.
+        :param extract_params:
+            Additional parameters passed to the Tavily Extract API, such as `format`,
+            `include_favicon`, `query`, or `chunks_per_source`.
+            See the [Tavily Extract API reference](https://docs.tavily.com/documentation/api-reference/endpoint/extract)
+            for available options.
+        """
+        self.api_key = api_key
+        self.extract_depth = extract_depth
+        self.include_images = include_images
+        self.extract_params = extract_params
+        self._tavily_client: TavilyClient | None = None
+        self._async_tavily_client: AsyncTavilyClient | None = None
+
+    def warm_up(self) -> None:
+        """
+        Initialize the Tavily sync and async clients.
+
+        Called automatically on first use. Can be called explicitly to avoid cold-start latency.
+        """
+        if self._tavily_client is None:
+            self._tavily_client = TavilyClient(api_key=self.api_key.resolve_value())
+        if self._async_tavily_client is None:
+            self._async_tavily_client = AsyncTavilyClient(api_key=self.api_key.resolve_value())
+
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    def run(
+        self,
+        urls: list[str],
+        extract_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Fetch and extract content from the given URLs using the Tavily Extract API.
+
+        :param urls:
+            List of URLs to extract content from. Maximum 20 URLs per request.
+        :param extract_params:
+            Optional per-run override of extract parameters.
+            If provided, fully replaces the init-time `extract_params`.
+        :returns: A dictionary with:
+            - `documents`: List of Documents containing extracted page content.
+              Each Document's `meta` includes `"url"` and, if `include_images` is True, `"images"`.
+            - `meta`: Request-level metadata containing `"response_time"`, `"usage"`,
+              `"request_id"`, and `"failed_results"` for URLs that could not be processed.
+        """
+        if self._tavily_client is None:
+            self.warm_up()
+        if self._tavily_client is None:
+            msg = "TavilyFetcher client failed to initialize."
+            raise RuntimeError(msg)
+
+        params = (extract_params if extract_params is not None else self.extract_params or {}).copy()
+        response = self._tavily_client.extract(
+            urls=urls,
+            extract_depth=self.extract_depth,
+            include_images=self.include_images,
+            **params,
+        )
+        return self._parse_response(response)
+
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    async def run_async(
+        self,
+        urls: list[str],
+        extract_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Asynchronously fetch and extract content from the given URLs using the Tavily Extract API.
+
+        :param urls:
+            List of URLs to extract content from. Maximum 20 URLs per request.
+        :param extract_params:
+            Optional per-run override of extract parameters.
+            If provided, fully replaces the init-time `extract_params`.
+        :returns: A dictionary with:
+            - `documents`: List of Documents containing extracted page content.
+              Each Document's `meta` includes `"url"` and, if `include_images` is True, `"images"`.
+            - `meta`: Request-level metadata containing `"response_time"`, `"usage"`,
+              `"request_id"`, and `"failed_results"` for URLs that could not be processed.
+        """
+        if self._async_tavily_client is None:
+            self.warm_up()
+        if self._async_tavily_client is None:
+            msg = "TavilyFetcher async client failed to initialize."
+            raise RuntimeError(msg)
+
+        params = (extract_params if extract_params is not None else self.extract_params or {}).copy()
+        response = await self._async_tavily_client.extract(
+            urls=urls,
+            extract_depth=self.extract_depth,
+            include_images=self.include_images,
+            **params,
+        )
+        return self._parse_response(response)
+
+    def _parse_response(self, response: dict[str, Any]) -> dict[str, Any]:
+        """
+        Convert a Tavily Extract response into Haystack Documents and request metadata.
+
+        :param response: Raw Tavily Extract API response dictionary.
+        :returns: Dictionary with `documents` and `meta` keys.
+        """
+        documents: list[Document] = []
+
+        for result in response.get("results", []):
+            url = result.get("url", "")
+            content = result.get("raw_content", "")
+            doc_meta: dict[str, Any] = {"url": url}
+            if self.include_images:
+                doc_meta["images"] = result.get("images", [])
+            documents.append(Document(content=content, meta=doc_meta))
+
+        meta: dict[str, Any] = {
+            "response_time": response.get("response_time"),
+            "usage": response.get("usage"),
+            "request_id": response.get("request_id"),
+            "failed_results": response.get("failed_results", []),
+        }
+
+        return {"documents": documents, "meta": meta}

--- a/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
+++ b/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
@@ -43,6 +43,7 @@ class TavilyFetcher:
     def __init__(
         self,
         api_key: Secret = Secret.from_env_var("TAVILY_API_KEY"),
+        *,
         extract_depth: Literal["basic", "advanced"] = "basic",
         include_images: bool = False,
         extract_params: dict[str, Any] | None = None,
@@ -78,9 +79,9 @@ class TavilyFetcher:
         Called automatically on first use. Can be called explicitly to avoid cold-start latency.
         """
         if self._tavily_client is None:
-            self._tavily_client = TavilyClient(api_key=self.api_key.resolve_value())
+            self._tavily_client = TavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
         if self._async_tavily_client is None:
-            self._async_tavily_client = AsyncTavilyClient(api_key=self.api_key.resolve_value())
+            self._async_tavily_client = AsyncTavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
 
     @component.output_types(documents=list[Document], meta=dict[str, Any])
     def run(
@@ -104,12 +105,9 @@ class TavilyFetcher:
         """
         if self._tavily_client is None:
             self.warm_up()
-        if self._tavily_client is None:
-            msg = "TavilyFetcher client failed to initialize."
-            raise RuntimeError(msg)
 
         params = (extract_params if extract_params is not None else self.extract_params or {}).copy()
-        response = self._tavily_client.extract(
+        response = self._tavily_client.extract(  # type: ignore[union-attr]
             urls=urls,
             extract_depth=self.extract_depth,
             include_images=self.include_images,
@@ -139,12 +137,9 @@ class TavilyFetcher:
         """
         if self._async_tavily_client is None:
             self.warm_up()
-        if self._async_tavily_client is None:
-            msg = "TavilyFetcher async client failed to initialize."
-            raise RuntimeError(msg)
 
         params = (extract_params if extract_params is not None else self.extract_params or {}).copy()
-        response = await self._async_tavily_client.extract(
+        response = await self._async_tavily_client.extract(  # type: ignore[union-attr]
             urls=urls,
             extract_depth=self.extract_depth,
             include_images=self.include_images,

--- a/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
+++ b/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
@@ -19,7 +19,7 @@ class TavilyFetcher:
 
     This component wraps the Tavily Extract API, which retrieves and parses web page content from
     one or more specified URLs. Unlike web search, it fetches content directly from the given URLs
-    rather than discovering them via a query.
+    rather than discovering them via a query. PDF URLs are also supported for extraction.
 
     Tavily is an AI-powered search and extraction API optimized for LLM applications. You need a Tavily
     API key from [tavily.com](https://tavily.com).

--- a/integrations/tavily/tests/test_tavily_fetcher.py
+++ b/integrations/tavily/tests/test_tavily_fetcher.py
@@ -224,13 +224,7 @@ class TestTavilyFetcher:
             mock_cls.return_value.extract.return_value = extract_response
             fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
             fetcher.run(urls=["https://example.com"])
-            mock_cls.assert_called_once_with(api_key="test-key")
-
-    def test_run_raises_runtime_error_when_warm_up_fails(self, monkeypatch):
-        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
-        monkeypatch.setattr(fetcher, "warm_up", lambda: None)
-        with pytest.raises(RuntimeError, match="TavilyFetcher client failed to initialize"):
-            fetcher.run(urls=["https://example.com"])
+            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
 
     @pytest.mark.asyncio
     async def test_run_async(self, mock_async_client):
@@ -252,14 +246,7 @@ class TestTavilyFetcher:
             mock_cls.return_value.extract = AsyncMock(return_value=extract_response)
             fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
             await fetcher.run_async(urls=["https://example.com"])
-            mock_cls.assert_called_once_with(api_key="test-key")
-
-    @pytest.mark.asyncio
-    async def test_run_async_raises_runtime_error_when_warm_up_fails(self, monkeypatch):
-        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
-        monkeypatch.setattr(fetcher, "warm_up", lambda: None)
-        with pytest.raises(RuntimeError, match="TavilyFetcher async client failed to initialize"):
-            await fetcher.run_async(urls=["https://example.com"])
+            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
 
     @pytest.mark.asyncio
     async def test_run_async_raises_on_error(self, mock_async_client):

--- a/integrations/tavily/tests/test_tavily_fetcher.py
+++ b/integrations/tavily/tests/test_tavily_fetcher.py
@@ -269,6 +269,22 @@ class TestTavilyFetcher:
         assert isinstance(result["documents"][0], Document)
         assert result["documents"][0].content
         assert result["meta"]["response_time"] is not None
+        assert result["meta"]["usage"] is not None
+
+    @pytest.mark.skipif(
+        not os.environ.get("TAVILY_API_KEY"),
+        reason="Export TAVILY_API_KEY to run integration tests.",
+    )
+    @pytest.mark.integration
+    def test_run_integration_pdf(self):
+        # Attention Is All You Need — stable public arXiv PDF
+        fetcher = TavilyFetcher(api_key=Secret.from_env_var("TAVILY_API_KEY"))
+        result = fetcher.run(urls=["https://arxiv.org/pdf/1706.03762"])
+        assert len(result["documents"]) > 0
+        assert isinstance(result["documents"][0], Document)
+        assert result["documents"][0].content
+        assert result["meta"]["response_time"] is not None
+        assert result["meta"]["usage"] is not None
 
     @pytest.mark.skipif(
         not os.environ.get("TAVILY_API_KEY"),
@@ -281,3 +297,4 @@ class TestTavilyFetcher:
         result = await fetcher.run_async(urls=["https://haystack.deepset.ai"])
         assert len(result["documents"]) > 0
         assert result["meta"]["response_time"] is not None
+        assert result["meta"]["usage"] is not None

--- a/integrations/tavily/tests/test_tavily_fetcher.py
+++ b/integrations/tavily/tests/test_tavily_fetcher.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from haystack import Document
+from haystack.core.serialization import component_from_dict, component_to_dict
+from haystack.utils import Secret
+
+from haystack_integrations.components.fetchers.tavily import TavilyFetcher
+
+
+class TestTavilyFetcher:
+    @pytest.fixture
+    def extract_response(self):
+        return {
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "raw_content": "Example page content",
+                    "images": ["https://example.com/image.png"],
+                }
+            ],
+            "failed_results": [],
+            "response_time": 1.23,
+            "usage": {"credits": 1},
+            "request_id": "req-abc123",
+        }
+
+    @pytest.fixture
+    def mock_client(self, extract_response):
+        client = MagicMock()
+        client.extract.return_value = extract_response
+        return client
+
+    @pytest.fixture
+    def mock_async_client(self, extract_response):
+        client = MagicMock()
+        client.extract = AsyncMock(return_value=extract_response)
+        return client
+
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        fetcher = TavilyFetcher()
+        assert fetcher.extract_depth == "basic"
+        assert fetcher.include_images is False
+        assert fetcher.extract_params is None
+        assert fetcher.api_key.resolve_value() == "test-key"
+
+    def test_init_with_params(self):
+        fetcher = TavilyFetcher(
+            api_key=Secret.from_token("custom-key"),
+            extract_depth="advanced",
+            include_images=True,
+            extract_params={"format": "text"},
+        )
+        assert fetcher.extract_depth == "advanced"
+        assert fetcher.include_images is True
+        assert fetcher.extract_params == {"format": "text"}
+
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        fetcher = TavilyFetcher(extract_depth="advanced", extract_params={"format": "text"})
+        data = component_to_dict(fetcher, "TavilyFetcher")
+        assert data["type"] == "haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyFetcher"
+        assert data["init_parameters"]["extract_depth"] == "advanced"
+        assert data["init_parameters"]["extract_params"] == {"format": "text"}
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        data = {
+            "type": "haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyFetcher",
+            "init_parameters": {
+                "extract_depth": "advanced",
+                "include_images": True,
+                "extract_params": {"format": "text"},
+                "api_key": {"env_vars": ["TAVILY_API_KEY"], "strict": True, "type": "env_var"},
+            },
+        }
+        fetcher = component_from_dict(TavilyFetcher, data, "TavilyFetcher")
+        assert fetcher.extract_depth == "advanced"
+        assert fetcher.include_images is True
+        assert fetcher.extract_params == {"format": "text"}
+
+    def test_run_returns_documents_and_meta(self, mock_client):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._tavily_client = mock_client
+
+        result = fetcher.run(urls=["https://example.com"])
+
+        assert len(result["documents"]) == 1
+        doc = result["documents"][0]
+        assert isinstance(doc, Document)
+        assert doc.content == "Example page content"
+        assert doc.meta["url"] == "https://example.com"
+        assert "images" not in doc.meta  # include_images=False by default
+
+        meta = result["meta"]
+        assert meta["response_time"] == 1.23
+        assert meta["usage"] == {"credits": 1}
+        assert meta["request_id"] == "req-abc123"
+        assert meta["failed_results"] == []
+
+    def test_run_includes_images_when_enabled(self, mock_client):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"), include_images=True)
+        fetcher._tavily_client = mock_client
+
+        result = fetcher.run(urls=["https://example.com"])
+
+        assert result["documents"][0].meta["images"] == ["https://example.com/image.png"]
+
+    def test_run_passes_extract_depth(self, mock_client):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"), extract_depth="advanced")
+        fetcher._tavily_client = mock_client
+
+        fetcher.run(urls=["https://example.com"])
+
+        mock_client.extract.assert_called_once_with(
+            urls=["https://example.com"],
+            extract_depth="advanced",
+            include_images=False,
+        )
+
+    def test_run_passes_init_extract_params(self, mock_client):
+        fetcher = TavilyFetcher(
+            api_key=Secret.from_token("test-key"),
+            extract_params={"format": "text"},
+        )
+        fetcher._tavily_client = mock_client
+
+        fetcher.run(urls=["https://example.com"])
+
+        mock_client.extract.assert_called_once_with(
+            urls=["https://example.com"],
+            extract_depth="basic",
+            include_images=False,
+            format="text",
+        )
+
+    def test_run_overrides_extract_params_at_runtime(self, mock_client):
+        fetcher = TavilyFetcher(
+            api_key=Secret.from_token("test-key"),
+            extract_params={"format": "text"},
+        )
+        fetcher._tavily_client = mock_client
+
+        fetcher.run(urls=["https://example.com"], extract_params={"format": "markdown", "include_favicon": True})
+
+        mock_client.extract.assert_called_once_with(
+            urls=["https://example.com"],
+            extract_depth="basic",
+            include_images=False,
+            format="markdown",
+            include_favicon=True,
+        )
+
+    def test_run_multiple_urls(self, mock_client):
+        mock_client.extract.return_value = {
+            "results": [
+                {"url": "https://a.com", "raw_content": "Content A"},
+                {"url": "https://b.com", "raw_content": "Content B"},
+            ],
+            "failed_results": [],
+            "response_time": 2.0,
+            "usage": None,
+            "request_id": None,
+        }
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._tavily_client = mock_client
+
+        result = fetcher.run(urls=["https://a.com", "https://b.com"])
+
+        assert len(result["documents"]) == 2
+        assert result["documents"][0].meta["url"] == "https://a.com"
+        assert result["documents"][1].meta["url"] == "https://b.com"
+
+    def test_run_with_failed_results_in_meta(self, mock_client):
+        mock_client.extract.return_value = {
+            "results": [],
+            "failed_results": [{"url": "https://broken.com", "error": "Connection refused"}],
+            "response_time": 0.5,
+            "usage": None,
+            "request_id": "req-xyz",
+        }
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._tavily_client = mock_client
+
+        result = fetcher.run(urls=["https://broken.com"])
+
+        assert result["documents"] == []
+        assert result["meta"]["failed_results"] == [{"url": "https://broken.com", "error": "Connection refused"}]
+
+    def test_run_empty_results(self, mock_client):
+        mock_client.extract.return_value = {
+            "results": [],
+            "failed_results": [],
+            "response_time": 0.1,
+            "usage": None,
+            "request_id": None,
+        }
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._tavily_client = mock_client
+
+        result = fetcher.run(urls=["https://example.com"])
+
+        assert result["documents"] == []
+
+    def test_warm_up_initializes_clients(self):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        assert fetcher._tavily_client is None
+        assert fetcher._async_tavily_client is None
+        fetcher.warm_up()
+        assert fetcher._tavily_client is not None
+        assert fetcher._async_tavily_client is not None
+
+    def test_run_triggers_warm_up(self, extract_response):
+        with (
+            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient") as mock_cls,
+            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient"),
+        ):
+            mock_cls.return_value.extract.return_value = extract_response
+            fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+            fetcher.run(urls=["https://example.com"])
+            mock_cls.assert_called_once_with(api_key="test-key")
+
+    def test_run_raises_runtime_error_when_warm_up_fails(self, monkeypatch):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        monkeypatch.setattr(fetcher, "warm_up", lambda: None)
+        with pytest.raises(RuntimeError, match="TavilyFetcher client failed to initialize"):
+            fetcher.run(urls=["https://example.com"])
+
+    @pytest.mark.asyncio
+    async def test_run_async(self, mock_async_client):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._async_tavily_client = mock_async_client
+
+        result = await fetcher.run_async(urls=["https://example.com"])
+
+        assert len(result["documents"]) == 1
+        assert result["documents"][0].content == "Example page content"
+        mock_async_client.extract.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_triggers_warm_up(self, extract_response):
+        with (
+            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient"),
+            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient") as mock_cls,
+        ):
+            mock_cls.return_value.extract = AsyncMock(return_value=extract_response)
+            fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+            await fetcher.run_async(urls=["https://example.com"])
+            mock_cls.assert_called_once_with(api_key="test-key")
+
+    @pytest.mark.asyncio
+    async def test_run_async_raises_runtime_error_when_warm_up_fails(self, monkeypatch):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        monkeypatch.setattr(fetcher, "warm_up", lambda: None)
+        with pytest.raises(RuntimeError, match="TavilyFetcher async client failed to initialize"):
+            await fetcher.run_async(urls=["https://example.com"])
+
+    @pytest.mark.asyncio
+    async def test_run_async_raises_on_error(self, mock_async_client):
+        mock_async_client.extract = AsyncMock(side_effect=Exception("API error"))
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._async_tavily_client = mock_async_client
+
+        with pytest.raises(Exception, match="API error"):
+            await fetcher.run_async(urls=["https://example.com"])
+
+    @pytest.mark.skipif(
+        not os.environ.get("TAVILY_API_KEY"),
+        reason="Export TAVILY_API_KEY to run integration tests.",
+    )
+    @pytest.mark.integration
+    def test_run_integration(self):
+        fetcher = TavilyFetcher(api_key=Secret.from_env_var("TAVILY_API_KEY"))
+        result = fetcher.run(urls=["https://haystack.deepset.ai"])
+        assert len(result["documents"]) > 0
+        assert isinstance(result["documents"][0], Document)
+        assert result["documents"][0].content
+        assert result["meta"]["response_time"] is not None
+
+    @pytest.mark.skipif(
+        not os.environ.get("TAVILY_API_KEY"),
+        reason="Export TAVILY_API_KEY to run integration tests.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_run_async_integration(self):
+        fetcher = TavilyFetcher(api_key=Secret.from_env_var("TAVILY_API_KEY"))
+        result = await fetcher.run_async(urls=["https://haystack.deepset.ai"])
+        assert len(result["documents"]) > 0
+        assert result["meta"]["response_time"] is not None

--- a/integrations/tavily/tests/test_tavily_fetcher.py
+++ b/integrations/tavily/tests/test_tavily_fetcher.py
@@ -269,7 +269,6 @@ class TestTavilyFetcher:
         assert isinstance(result["documents"][0], Document)
         assert result["documents"][0].content
         assert result["meta"]["response_time"] is not None
-        assert result["meta"]["usage"] is not None
 
     @pytest.mark.skipif(
         not os.environ.get("TAVILY_API_KEY"),
@@ -284,7 +283,6 @@ class TestTavilyFetcher:
         assert isinstance(result["documents"][0], Document)
         assert result["documents"][0].content
         assert result["meta"]["response_time"] is not None
-        assert result["meta"]["usage"] is not None
 
     @pytest.mark.skipif(
         not os.environ.get("TAVILY_API_KEY"),
@@ -297,4 +295,3 @@ class TestTavilyFetcher:
         result = await fetcher.run_async(urls=["https://haystack.deepset.ai"])
         assert len(result["documents"]) > 0
         assert result["meta"]["response_time"] is not None
-        assert result["meta"]["usage"] is not None


### PR DESCRIPTION
### Related Issues

- closes #3559

### Proposed Changes

Adds `TavilyFetcher`, a new component under `components/fetchers/tavily/` that calls the [Tavily Extract API](https://docs.tavily.com/documentation/api-reference/endpoint/extract) to fetch and extract web page content from given URLs, returning results as Haystack `Document` objects.

```python
fetcher = TavilyFetcher(api_key=Secret.from_env_var("TAVILY_API_KEY"))
result = fetcher.run(urls=["https://haystack.deepset.ai"])
```

- Both sync (`run`) and async (`run_async`) supported
- `extract_depth`: `"basic"` (default) or `"advanced"`
- `include_images`: optionally include image URLs in Document metadata
- `extract_params`: pass-through for extra API params (`format`, `query`, `chunks_per_source`, etc.)
- `meta` output: `response_time`, `usage`, `request_id`, `failed_results`

### How did you test it?

19 unit tests (mocked) + 2 integration tests run against the real Tavily Extract API all pass.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `feat:`