### PR TITLE
fix: docling stop relying on `haystack.utils.base_serialization` helpers

### DIFF
--- a/integrations/docling/pyproject.toml
+++ b/integrations/docling/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.8.0,<3.0.0",
+  "haystack-ai>=2.12.0,<3.0.0",
   "docling>=2.32.0,<3.0.0",
   "lxml>=6.0.2",
 ]

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -14,7 +14,7 @@ from haystack import Document, component, logging
 from haystack.components.converters.utils import normalize_metadata
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
-from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils import deserialize_component_inplace
 
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
@@ -196,7 +196,7 @@ class DoclingConverter:
         init_params = data.get("init_parameters", {})
 
         if init_params.get("meta_extractor") is not None:
-            deserialize_chatgenerator_inplace(init_params, key="meta_extractor")
+            deserialize_component_inplace(init_params, key="meta_extractor")
 
         return default_from_dict(cls, data)
 

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -14,7 +14,7 @@ from haystack import Document, component, logging
 from haystack.components.converters.utils import normalize_metadata
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
-from haystack.utils import deserialize_component_inplace
+from haystack.utils.deserialization import deserialize_component_inplace
 
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -195,7 +195,13 @@ class DoclingConverter:
         """
         init_params = data.get("init_parameters", {})
 
-        if init_params.get("meta_extractor") is not None:
+        meta_extractor_data = init_params.get("meta_extractor")
+        if meta_extractor_data is not None:
+            if "data" in meta_extractor_data:
+                # Pipelines serialized before this fix wrap the meta extractor as
+                # {"type": ..., "data": {"type": ..., "init_parameters": ...}}; unwrap it here so older
+                # serialized pipelines keep working.
+                init_params["meta_extractor"] = meta_extractor_data["data"]
             deserialize_chatgenerator_inplace(init_params, key="meta_extractor")
 
         return default_from_dict(cls, data)

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -12,9 +12,9 @@ from typing import Any
 from docling_core.types.io import DocumentStream
 from haystack import Document, component, logging
 from haystack.components.converters.utils import normalize_metadata
-from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
-from haystack.utils.base_serialization import deserialize_class_instance, serialize_class_instance
+from haystack.utils import deserialize_chatgenerator_inplace
 
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
@@ -69,12 +69,12 @@ class BaseMetaExtractor(ABC):
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a dictionary."""
-        return {}
+        return default_to_dict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "BaseMetaExtractor":  # noqa: ARG003
+    def from_dict(cls, data: dict[str, Any]) -> "BaseMetaExtractor":
         """Deserialize from a dictionary."""
-        return cls()
+        return default_from_dict(cls, data)
 
 
 class MetaExtractor(BaseMetaExtractor):
@@ -169,7 +169,7 @@ class DoclingConverter:
 
         meta_extractor_data = None
         if self.meta_extractor is not None:
-            meta_extractor_data = serialize_class_instance(self.meta_extractor)
+            meta_extractor_data = component_to_dict(self.meta_extractor, "meta_extractor")
 
         return default_to_dict(
             self,
@@ -195,9 +195,8 @@ class DoclingConverter:
         """
         init_params = data.get("init_parameters", {})
 
-        meta_extractor_data = init_params.get("meta_extractor")
-        if meta_extractor_data is not None:
-            init_params["meta_extractor"] = deserialize_class_instance(meta_extractor_data)
+        if init_params.get("meta_extractor") is not None:
+            deserialize_chatgenerator_inplace(init_params, key="meta_extractor")
 
         return default_from_dict(cls, data)
 

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -14,7 +14,7 @@ from haystack import Document, component, logging
 from haystack.components.converters.utils import normalize_metadata
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
-from haystack.utils.deserialization import deserialize_component_inplace
+from haystack.utils import deserialize_chatgenerator_inplace
 
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
@@ -196,7 +196,7 @@ class DoclingConverter:
         init_params = data.get("init_parameters", {})
 
         if init_params.get("meta_extractor") is not None:
-            deserialize_component_inplace(init_params, key="meta_extractor")
+            deserialize_chatgenerator_inplace(init_params, key="meta_extractor")
 
         return default_from_dict(cls, data)
 

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -233,6 +233,29 @@ def test_component_from_dict_custom_params() -> None:
     assert isinstance(restored.meta_extractor, MetaExtractor)
 
 
+def test_component_from_dict_with_legacy_meta_extractor_format() -> None:
+    # Pipelines serialized before this fix wrap meta_extractor as {"type": ..., "data": {...}}
+    data = {
+        "type": "haystack_integrations.components.converters.docling.converter.DoclingConverter",
+        "init_parameters": {
+            "converter": None,
+            "convert_kwargs": {},
+            "export_type": "markdown",
+            "md_export_kwargs": {"image_placeholder": ""},
+            "chunker": None,
+            "meta_extractor": {
+                "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
+                "data": {
+                    "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
+                    "init_parameters": {},
+                },
+            },
+        },
+    }
+    restored = DoclingConverter.from_dict(data)
+    assert isinstance(restored.meta_extractor, MetaExtractor)
+
+
 def test_component_to_dict_chunker_warns_and_is_dropped() -> None:
     # Pass an explicit tokenizer so HybridChunker doesn't invoke its default factory
     # (get_default_tokenizer), which would download a tokenizer from HuggingFace.

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -179,7 +179,7 @@ def test_component_to_dict_custom_params() -> None:
             "chunker": None,
             "meta_extractor": {
                 "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
-                "data": {},
+                "init_parameters": {},
             },
         },
     }
@@ -219,7 +219,7 @@ def test_component_from_dict_custom_params() -> None:
             "chunker": None,
             "meta_extractor": {
                 "type": "haystack_integrations.components.converters.docling.converter.MetaExtractor",
-                "data": {},
+                "init_parameters": {},
             },
         },
     }


### PR DESCRIPTION
### Related Issues

- related to deepset-ai/haystack#11905

### Proposed Changes:

- Removes DoclingConverter's dependency on serialize_class_instance/deserialize_class_instance (being deleted from haystack-ai as dead code). 
- Now uses component_to_dict/deserialize_chatgenerator_inplace for the meta_extractor field, and BaseMetaExtractor.to_dict/from_dict use default_to_dict/default_from_dict. 
- Bumped minimum haystack-ai to 2.12.0 since deserialize_chatgenerator_inplace isn't available before that.

### How did you test it?

- Updated test_converter.py fixtures; unit tests, ruff, mypy all pass, including lowest-dependency CI.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
