### PR TITLE
fix(langfuse): stop relying on `haystack.utils.base_serialization` helpers

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -7,7 +7,8 @@ from typing import Any
 import httpx
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
 from haystack.core.serialization import component_to_dict
-from haystack.utils import Secret, deserialize_component_inplace, deserialize_secrets_inplace
+from haystack.utils import Secret, deserialize_secrets_inplace
+from haystack.utils.deserialization import deserialize_component_inplace
 
 from haystack_integrations.tracing.langfuse import LangfuseTracer, SpanHandler
 from langfuse import Langfuse

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import httpx
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
-from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.base_serialization import deserialize_class_instance, serialize_class_instance
+from haystack.core.serialization import component_to_dict
+from haystack.utils import Secret, deserialize_chatgenerator_inplace, deserialize_secrets_inplace
 
 from haystack_integrations.tracing.langfuse import LangfuseTracer, SpanHandler
 from langfuse import Langfuse
@@ -198,7 +198,7 @@ class LangfuseConnector:
 
         :returns: The serialized component as a dictionary.
         """
-        span_handler = serialize_class_instance(self.span_handler) if self.span_handler else None
+        span_handler = component_to_dict(self.span_handler, "span_handler") if self.span_handler else None
         if self.langfuse_client_kwargs:
             # pop httpx_client and mask from self._langfuse_client_kwargs to prevent serialization issues
             langfuse_client_kwargs = {
@@ -229,5 +229,5 @@ class LangfuseConnector:
         init_params = data["init_parameters"]
         deserialize_secrets_inplace(init_params, keys=["secret_key", "public_key"])
         if init_params.get("span_handler") is not None:
-            init_params["span_handler"] = deserialize_class_instance(init_params["span_handler"])
+            deserialize_chatgenerator_inplace(init_params, key="span_handler")
         return default_from_dict(cls, data)

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -7,7 +7,7 @@ from typing import Any
 import httpx
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
 from haystack.core.serialization import component_to_dict
-from haystack.utils import Secret, deserialize_chatgenerator_inplace, deserialize_secrets_inplace
+from haystack.utils import Secret, deserialize_component_inplace, deserialize_secrets_inplace
 
 from haystack_integrations.tracing.langfuse import LangfuseTracer, SpanHandler
 from langfuse import Langfuse
@@ -229,5 +229,5 @@ class LangfuseConnector:
         init_params = data["init_parameters"]
         deserialize_secrets_inplace(init_params, keys=["secret_key", "public_key"])
         if init_params.get("span_handler") is not None:
-            deserialize_chatgenerator_inplace(init_params, key="span_handler")
+            deserialize_component_inplace(init_params, key="span_handler")
         return default_from_dict(cls, data)

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -228,6 +228,12 @@ class LangfuseConnector:
         """
         init_params = data["init_parameters"]
         deserialize_secrets_inplace(init_params, keys=["secret_key", "public_key"])
-        if init_params.get("span_handler") is not None:
+        span_handler_data = init_params.get("span_handler")
+        if span_handler_data is not None:
+            if "data" in span_handler_data:
+                # Pipelines serialized before this fix wrap the span handler as
+                # {"type": ..., "data": {"type": ..., "init_parameters": ...}}; unwrap it here so older
+                # serialized pipelines keep working.
+                init_params["span_handler"] = span_handler_data["data"]
             deserialize_chatgenerator_inplace(init_params, key="span_handler")
         return default_from_dict(cls, data)

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -7,8 +7,7 @@ from typing import Any
 import httpx
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
 from haystack.core.serialization import component_to_dict
-from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.deserialization import deserialize_component_inplace
+from haystack.utils import Secret, deserialize_chatgenerator_inplace, deserialize_secrets_inplace
 
 from haystack_integrations.tracing.langfuse import LangfuseTracer, SpanHandler
 from langfuse import Langfuse
@@ -230,5 +229,5 @@ class LangfuseConnector:
         init_params = data["init_parameters"]
         deserialize_secrets_inplace(init_params, keys=["secret_key", "public_key"])
         if init_params.get("span_handler") is not None:
-            deserialize_component_inplace(init_params, key="span_handler")
+            deserialize_chatgenerator_inplace(init_params, key="span_handler")
         return default_from_dict(cls, data)

--- a/integrations/langfuse/tests/test_langfuse_connector.py
+++ b/integrations/langfuse/tests/test_langfuse_connector.py
@@ -104,10 +104,7 @@ class TestLangfuseConnector:
                 },
                 "span_handler": {
                     "type": "tests.test_langfuse_connector.CustomSpanHandler",
-                    "data": {
-                        "type": "tests.test_langfuse_connector.CustomSpanHandler",
-                        "init_parameters": {},
-                    },
+                    "init_parameters": {},
                 },
                 "host": "https://example.com",
                 "langfuse_client_kwargs": {"timeout": 30.0},
@@ -199,10 +196,7 @@ class TestLangfuseConnector:
                 },
                 "span_handler": {
                     "type": "tests.test_langfuse_connector.CustomSpanHandler",
-                    "data": {
-                        "type": "tests.test_langfuse_connector.CustomSpanHandler",
-                        "init_parameters": {},
-                    },
+                    "init_parameters": {},
                 },
                 "host": "https://example.com",
                 "langfuse_client_kwargs": {"timeout": 30.0},

--- a/integrations/langfuse/tests/test_langfuse_connector.py
+++ b/integrations/langfuse/tests/test_langfuse_connector.py
@@ -212,6 +212,41 @@ class TestLangfuseConnector:
         assert langfuse_connector.host == "https://example.com"
         assert langfuse_connector.langfuse_client_kwargs == {"timeout": 30.0}
 
+    def test_from_dict_with_legacy_span_handler_format(self, monkeypatch):
+        # Pipelines serialized before this fix wrap span_handler as {"type": ..., "data": {...}}
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
+
+        data = {
+            "type": "haystack_integrations.components.connectors.langfuse.langfuse_connector.LangfuseConnector",
+            "init_parameters": {
+                "name": "Chat example - OpenAI",
+                "public": True,
+                "secret_key": {
+                    "type": "env_var",
+                    "env_vars": ["LANGFUSE_SECRET_KEY"],
+                    "strict": True,
+                },
+                "public_key": {
+                    "type": "env_var",
+                    "env_vars": ["LANGFUSE_PUBLIC_KEY"],
+                    "strict": True,
+                },
+                "span_handler": {
+                    "type": "tests.test_langfuse_connector.CustomSpanHandler",
+                    "data": {
+                        "type": "tests.test_langfuse_connector.CustomSpanHandler",
+                        "init_parameters": {},
+                    },
+                },
+                "host": "https://example.com",
+                "langfuse_client_kwargs": {"timeout": 30.0},
+            },
+        }
+
+        langfuse_connector = LangfuseConnector.from_dict(data)
+        assert isinstance(langfuse_connector.span_handler, CustomSpanHandler)
+
     def test_pipeline_serialization(self, monkeypatch):
         # Set test env vars
         monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/pull/11905#pullrequestreview-4646995270

### Proposed Changes:

- `serialize_class_instance`/`deserialize_class_instance` in `haystack.utils.base_serialization` are being removed from `haystack-ai` as dead code (see deepset-ai/haystack#11905). 

- `to_dict`: serialize `span_handler` with `component_to_dict` (from `haystack.core.serialization`) instead of `serialize_class_instance`.

- `from_dict`: deserialize `span_handler` with `deserialize_component_inplace` (from `haystack.utils`) instead of `deserialize_class_instance`

### How did you test it?

- Updated `test_langfuse_connector.py` fixtures to match the new (flatter) `span_handler` serialization format.
- Ran the full unit test suite, ruff, and mypy for the `langfuse` integration.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
