### PR TITLE
test: fix cohere, amazon_bedrock, mirage, and ollama tests under Haystack 3.0

### DIFF
--- a/integrations/amazon_bedrock/tests/conftest.py
+++ b/integrations/amazon_bedrock/tests/conftest.py
@@ -30,3 +30,13 @@ def mock_aioboto3_session():
 @pytest.fixture()
 def test_files_path():
     return Path(__file__).parent / "test_files"
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -377,6 +377,12 @@ class TestAmazonBedrockChatGenerator:
         pipeline.add_component("generator", generator)
 
         pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
+
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -417,20 +423,6 @@ class TestAmazonBedrockChatGenerator:
                         },
                         "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                         "boto3_config": None,
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_chat_generator.weather",
-                                    "outputs_to_string": None,
-                                    "inputs_from_state": None,
-                                    "outputs_to_state": None,
-                                },
-                            }
-                        ],
                         "guardrail_config": None,
                         "tools_cachepoint_config": None,
                         "system_cachepoint_config": None,
@@ -444,6 +436,10 @@ class TestAmazonBedrockChatGenerator:
             expected_dict.pop("connection_type_validation")
 
         assert pipeline_dict == expected_dict
+
+        # deserializing the serialized pipeline must reproduce the original tool
+        new_pipeline = Pipeline.loads(pipeline.dumps())
+        assert new_pipeline.get_component("generator").tools == [tool]
 
     def test_prepare_request_params_tool_config(self, top_song_tool_config, mock_boto3_session, set_env_variables):
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")

--- a/integrations/cohere/tests/test_chat_generator.py
+++ b/integrations/cohere/tests/test_chat_generator.py
@@ -341,6 +341,11 @@ class TestCohereChatGenerator:
 
         pipeline_dict = pipeline.to_dict()
 
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
+
         expected_dict = {
             "metadata": {},
             "max_runs_per_component": 100,
@@ -356,20 +361,6 @@ class TestCohereChatGenerator:
                         "generation_kwargs": {"temperature": 0.7},
                         "timeout": None,
                         "max_retries": None,
-                        "tools": [
-                            {
-                                "type": "haystack.tools.tool.Tool",
-                                "data": {
-                                    "name": "weather",
-                                    "description": "useful to determine the weather in a given location",
-                                    "parameters": {"city": {"type": "string"}},
-                                    "function": "tests.test_chat_generator.weather",
-                                    "outputs_to_string": tool.outputs_to_string,
-                                    "inputs_from_state": tool.inputs_from_state,
-                                    "outputs_to_state": tool.outputs_to_state,
-                                },
-                            }
-                        ],
                     },
                 }
             },

--- a/integrations/mirage/tests/conftest.py
+++ b/integrations/mirage/tests/conftest.py
@@ -1,18 +1,11 @@
-from pathlib import Path
-
 import pytest
-
-
-@pytest.fixture()
-def test_files_path():
-    return Path(__file__).parent / "test_files"
 
 
 @pytest.fixture(autouse=True)
 def allow_deserialization_of_test_modules(monkeypatch):
     """
     haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
-    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    trusted-module allowlist. Token sources defined in the test modules live outside that
     allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
     """
     monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/ollama/tests/conftest.py
+++ b/integrations/ollama/tests/conftest.py
@@ -6,3 +6,13 @@ import pytest
 @pytest.fixture()
 def test_files_path():
     return Path(__file__).parent / "test_files"
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
+    trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -817,6 +817,11 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
         )
         data = component.to_dict()
 
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # from_dict round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = data["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
+
         expected_dict = {
             "type": "haystack_integrations.components.generators.ollama.chat.chat_generator.OllamaChatGenerator",
             "init_parameters": {
@@ -830,24 +835,6 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
                     "max_tokens": 10,
                     "some_test_param": "test-params",
                 },
-                "tools": [
-                    {
-                        "type": "haystack.tools.tool.Tool",
-                        "data": {
-                            "description": "description",
-                            "function": "builtins.print",
-                            "name": "name",
-                            "parameters": {
-                                "x": {
-                                    "type": "string",
-                                },
-                            },
-                            "outputs_to_string": None,
-                            "inputs_from_state": None,
-                            "outputs_to_state": None,
-                        },
-                    },
-                ],
                 "response_format": {
                     "type": "object",
                     "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
@@ -857,6 +844,10 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
         }
 
         assert data == expected_dict
+
+        # deserializing the serialized component must reproduce the original tool
+        loaded = OllamaChatGenerator.from_dict(component.to_dict())
+        assert loaded.tools == [tool]
 
     def test_to_dict_and_from_dict_preserves_think(self):
         """`think` enables a model's reasoning output and must survive a


### PR DESCRIPTION
### Related Issues

- Fixes deepset-ai/haystack-private#446

After the haystack `v3` branch was merged into haystack `main`, the nightly runs failed for four integrations: [cohere](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28985763970/job/86014401864), [amazon_bedrock](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28985929286/job/86014921799), [mirage](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28986144110/job/86015631413), and [ollama](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/28985200803/job/86012595554). 

### Proposed Changes:

Fixes are similar to what we already did for other integrations in #3533 and #3537.

- **Pinned serialization dicts** (same fix as #3533): the `Tool` serialization format varies across Haystack versions (3.0 adds `Tool.async_function`). Stop pinning the `tools` entry in the expected dict and cover it with a `from_dict`/`Pipeline.loads` round-trip instead:
  - cohere `test_serde_in_pipeline` (the existing `dumps`/`loads` round-trip already covers the tools)
  - amazon_bedrock `test_serde_in_pipeline` (added a `Pipeline.loads` round-trip, which the test previously lacked)
  - ollama `test_to_dict` (added a `from_dict` round-trip)
- **Trusted-module deserialization allowlist** (same fix as #3537): 3.0 refuses to deserialize classes and callables from modules outside its allowlist, which excludes tools/callables/token sources defined in the test modules. Added the autouse conftest fixture setting `HAYSTACK_DESERIALIZATION_ALLOWLIST="tests,test_*"`:
  - cohere (`test_serde_with_mixed_tools_and_toolsets`), amazon_bedrock (`test_from_dict_with_serialized_callable`), ollama (`test_from_dict_with_toolset`), mirage (`test_token_source_serialization_roundtrip`. mirage deserializes token sources via haystack's `import_class_by_name`)

### How did you test it?

ran unit tests for Haystack 2.x and main branch (former v3 branch)

### Notes for the reviewer

Failing ollama tests don't seem related to the PR's changes

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)