### PR TITLE
feat(google_genai): add google_server_tools to GoogleGenAIChatGenerator

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -201,6 +201,7 @@ class GoogleGenAIChatGenerator:
         safety_settings: list[dict[str, Any]] | None = None,
         streaming_callback: StreamingCallbackT | None = None,
         tools: ToolsType | None = None,
+        google_server_tools: list[dict[str, Any]] | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
     ) -> None:
@@ -236,6 +237,10 @@ class GoogleGenAIChatGenerator:
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
             Each tool should have a unique name.
+        :param google_server_tools: A list of Google server-side (built-in) tools passed directly to the API.
+            Use this for native Google tools such as `{"google_search": {}}` or `{"code_execution": {}}`.
+            Each entry must be a dict that matches the `google.genai.types.Tool` schema.
+            These are merged with any Haystack tools at request time.
         :param timeout:
             Timeout for Google GenAI client calls. If not set, it defaults to the default set by the Google GenAI
             client.
@@ -263,6 +268,7 @@ class GoogleGenAIChatGenerator:
         self._safety_settings = safety_settings or []
         self._streaming_callback = streaming_callback
         self._tools = tools
+        self._google_server_tools = google_server_tools
         self._timeout = timeout
         self._max_retries = max_retries
 
@@ -291,6 +297,7 @@ class GoogleGenAIChatGenerator:
             safety_settings=self._safety_settings,
             streaming_callback=callback_name,
             tools=serialized_tools,
+            google_server_tools=self._google_server_tools,
             timeout=self._timeout,
             max_retries=self._max_retries,
         )
@@ -448,9 +455,12 @@ class GoogleGenAIChatGenerator:
             if safety_settings:
                 config_params["safety_settings"] = safety_settings
 
-            # Add tools if provided
-            if tools:
-                config_params["tools"] = _convert_tools_to_google_genai_format(tools)
+            # Merge Haystack tools and Google server-side built-in tools
+            all_tools = _convert_tools_to_google_genai_format(tools) if tools else []
+            if self._google_server_tools:
+                all_tools = all_tools + [types.Tool.model_validate(t) for t in self._google_server_tools]
+            if all_tools:
+                config_params["tools"] = all_tools
 
             config = types.GenerateContentConfig(**config_params) if config_params else None
 
@@ -559,9 +569,12 @@ class GoogleGenAIChatGenerator:
             if safety_settings:
                 config_params["safety_settings"] = safety_settings
 
-            # Add tools if provided
-            if tools:
-                config_params["tools"] = _convert_tools_to_google_genai_format(tools)
+            # Merge Haystack tools and Google server-side built-in tools
+            all_tools = _convert_tools_to_google_genai_format(tools) if tools else []
+            if self._google_server_tools:
+                all_tools = all_tools + [types.Tool.model_validate(t) for t in self._google_server_tools]
+            if all_tools:
+                config_params["tools"] = all_tools
 
             config = types.GenerateContentConfig(**config_params) if config_params else None
 

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -238,9 +238,28 @@ class GoogleGenAIChatGenerator:
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
             Each tool should have a unique name.
         :param google_server_tools: A list of Google server-side (built-in) tools passed directly to the API.
-            Use this for native Google tools such as `{"google_search": {}}` or `{"code_execution": {}}`.
-            Each entry must be a dict that matches the `google.genai.types.Tool` schema.
-            These are merged with any Haystack tools at request time.
+            Each entry must be a dict matching the ``google.genai.types.Tool`` schema. The dict keys correspond
+            to the built-in tool type and the values are their configuration dicts (often empty ``{}``).
+            These are merged with any Haystack ``tools`` at request time.
+
+            Supported built-in tools:
+
+            - ``{"google_search": {}}`` — enables real-time Google Search grounding
+            - ``{"code_execution": {}}`` — enables Python code execution in a sandbox
+            - ``{"url_context": {}}`` — enables fetching and using URL content in context
+
+            Example::
+
+                from haystack.dataclasses import ChatMessage
+                from haystack_integrations.components.generators.google_genai import GoogleGenAIChatGenerator
+
+                chat_generator = GoogleGenAIChatGenerator(
+                    google_server_tools=[{"google_search": {}}, {"code_execution": {}}]
+                )
+                response = chat_generator.run([ChatMessage.from_user("What happened in AI today?")])
+
+            For the full list of built-in tools and their parameters, see:
+            https://ai.google.dev/gemini-api/docs/tools#built-in-tools
         :param timeout:
             Timeout for Google GenAI client calls. If not set, it defaults to the default set by the Google GenAI
             client.

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -238,17 +238,20 @@ class GoogleGenAIChatGenerator:
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
             Each tool should have a unique name.
         :param google_server_tools: A list of Google server-side (built-in) tools passed directly to the API.
-            Each entry must be a dict matching the ``google.genai.types.Tool`` schema. The dict keys correspond
-            to the built-in tool type and the values are their configuration dicts (often empty ``{}``).
-            These are merged with any Haystack ``tools`` at request time.
+            Each entry is a dict whose single key is the built-in tool name and whose value is its configuration
+            dict (empty ``{}`` when the tool takes no parameters). At request time each dict is parsed by
+            ``google.genai.types.Tool.model_validate``, which maps dict keys directly to ``Tool`` fields, so
+            any built-in tool accepted by the API — including ones with nested configuration — can be expressed
+            this way. These built-in tools are merged with any Haystack ``tools`` at request time.
 
             Supported built-in tools:
 
             - ``{"google_search": {}}`` — enables real-time Google Search grounding
             - ``{"code_execution": {}}`` — enables Python code execution in a sandbox
             - ``{"url_context": {}}`` — enables fetching and using URL content in context
+            - ``{"google_search_retrieval": {...}}`` — grounding with configurable dynamic retrieval threshold
 
-            Example::
+            Example (simple, no parameters)::
 
                 from haystack.dataclasses import ChatMessage
                 from haystack_integrations.components.generators.google_genai import GoogleGenAIChatGenerator
@@ -257,6 +260,21 @@ class GoogleGenAIChatGenerator:
                     google_server_tools=[{"google_search": {}}, {"code_execution": {}}]
                 )
                 response = chat_generator.run([ChatMessage.from_user("What happened in AI today?")])
+
+            Example (with parameters — dynamic retrieval threshold)::
+
+                chat_generator = GoogleGenAIChatGenerator(
+                    google_server_tools=[
+                        {
+                            "google_search_retrieval": {
+                                "dynamic_retrieval_config": {
+                                    "mode": "MODE_DYNAMIC",
+                                    "dynamic_threshold": 0.7,
+                                }
+                            }
+                        }
+                    ]
+                )
 
             For the full list of built-in tools and their parameters, see:
             https://ai.google.dev/gemini-api/docs/tools#built-in-tools
@@ -477,6 +495,10 @@ class GoogleGenAIChatGenerator:
             # Merge Haystack tools and Google server-side built-in tools
             all_tools = _convert_tools_to_google_genai_format(tools) if tools else []
             if self._google_server_tools:
+                # model_validate maps each dict onto types.Tool fields
+                # (e.g. {"google_search": {}} → Tool(google_search=GoogleSearch())),
+                # letting callers pass any built-in tool, including ones with
+                # nested configuration, without enumerating them explicitly.
                 all_tools = all_tools + [types.Tool.model_validate(t) for t in self._google_server_tools]
             if all_tools:
                 config_params["tools"] = all_tools
@@ -591,6 +613,10 @@ class GoogleGenAIChatGenerator:
             # Merge Haystack tools and Google server-side built-in tools
             all_tools = _convert_tools_to_google_genai_format(tools) if tools else []
             if self._google_server_tools:
+                # model_validate maps each dict onto types.Tool fields
+                # (e.g. {"google_search": {}} → Tool(google_search=GoogleSearch())),
+                # letting callers pass any built-in tool, including ones with
+                # nested configuration, without enumerating them explicitly.
                 all_tools = all_tools + [types.Tool.model_validate(t) for t in self._google_server_tools]
             if all_tools:
                 config_params["tools"] = all_tools

--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -253,6 +253,33 @@ class TestGoogleGenAIChatGeneratorInitSerDe:
         assert restored._tools[0].name == "tool1"
         assert len(restored._tools[1]) == 1
 
+    def test_init_with_google_server_tools(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        assert component._google_server_tools == [server_tool]
+
+    def test_to_dict_with_google_server_tools(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        data = component.to_dict()
+        assert data["init_parameters"]["google_server_tools"] == [server_tool]
+
+    def test_from_dict_with_google_server_tools(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        data = component.to_dict()
+        restored = GoogleGenAIChatGenerator.from_dict(data)
+        assert restored._google_server_tools == [server_tool]
+
+    def test_to_dict_default_google_server_tools_is_none(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        component = GoogleGenAIChatGenerator()
+        data = component.to_dict()
+        assert data["init_parameters"]["google_server_tools"] is None
+
     def test_to_dict_with_response_format_pydantic(self, monkeypatch):
         """Test that to_dict serializes a Pydantic response_format to a JSON schema dict."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
@@ -298,33 +325,6 @@ class TestGoogleGenAIChatGeneratorInitSerDe:
         restored = GoogleGenAIChatGenerator.from_dict(data)
         assert restored._generation_kwargs["response_format"] == schema
         assert restored._generation_kwargs["temperature"] == 0.5
-
-    def test_init_with_google_server_tools(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
-        server_tool = {"google_search": {}}
-        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
-        assert component._google_server_tools == [server_tool]
-
-    def test_to_dict_with_google_server_tools(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
-        server_tool = {"google_search": {}}
-        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
-        data = component.to_dict()
-        assert data["init_parameters"]["google_server_tools"] == [server_tool]
-
-    def test_from_dict_with_google_server_tools(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
-        server_tool = {"google_search": {}}
-        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
-        data = component.to_dict()
-        restored = GoogleGenAIChatGenerator.from_dict(data)
-        assert restored._google_server_tools == [server_tool]
-
-    def test_to_dict_default_google_server_tools_is_none(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
-        component = GoogleGenAIChatGenerator()
-        data = component.to_dict()
-        assert data["init_parameters"]["google_server_tools"] is None
 
 
 class TestGoogleGenAIChatGeneratorRun:
@@ -780,6 +780,19 @@ class TestGoogleGenAIChatGeneratorInference:
         assert final_message.text and "paris" in final_message.text.lower() and "berlin" in final_message.text.lower()
         # Check that the response mentions both temperature readings
         assert "22" in final_message.text and "15" in final_message.text
+
+    def test_live_run_with_google_server_tools(self):
+        """
+        Integration test that google_server_tools (Google Search) is accepted by the API and produces a response.
+        """
+        component = GoogleGenAIChatGenerator(google_server_tools=[{"google_search": {}}])
+        results = component.run([ChatMessage.from_user("What is the capital of France?")])
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+        assert message.text
+        assert message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
 
     def test_live_run_with_thinking(self):
         """

--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -299,6 +299,33 @@ class TestGoogleGenAIChatGeneratorInitSerDe:
         assert restored._generation_kwargs["response_format"] == schema
         assert restored._generation_kwargs["temperature"] == 0.5
 
+    def test_init_with_google_server_tools(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        assert component._google_server_tools == [server_tool]
+
+    def test_to_dict_with_google_server_tools(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        data = component.to_dict()
+        assert data["init_parameters"]["google_server_tools"] == [server_tool]
+
+    def test_from_dict_with_google_server_tools(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        data = component.to_dict()
+        restored = GoogleGenAIChatGenerator.from_dict(data)
+        assert restored._google_server_tools == [server_tool]
+
+    def test_to_dict_default_google_server_tools_is_none(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        component = GoogleGenAIChatGenerator()
+        data = component.to_dict()
+        assert data["init_parameters"]["google_server_tools"] is None
+
 
 class TestGoogleGenAIChatGeneratorRun:
     def test_run_non_streaming(self, monkeypatch, mock_response):
@@ -364,6 +391,34 @@ class TestGoogleGenAIChatGeneratorRun:
         call_kwargs = component._client.models.generate_content.call_args
         config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
         assert config.tools is not None
+
+    def test_run_with_google_server_tools(self, monkeypatch, mock_response):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        component._client.models.generate_content = Mock(return_value=mock_response)
+
+        component.run([ChatMessage.from_user("Search for AI news")])
+
+        call_kwargs = component._client.models.generate_content.call_args
+        config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+        assert config.tools is not None
+        assert len(config.tools) == 1
+
+    def test_run_merges_haystack_and_google_server_tools(self, monkeypatch, mock_response, tools):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {"google_search": {}}
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        component._client.models.generate_content = Mock(return_value=mock_response)
+
+        component.run([ChatMessage.from_user("Search for AI news")], tools=tools)
+
+        call_kwargs = component._client.models.generate_content.call_args
+        config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+        assert config.tools is not None
+        # _convert_tools_to_google_genai_format bundles all function declarations into one Tool object,
+        # plus one Tool object for google_search
+        assert len(config.tools) == 2
 
     def test_run_with_safety_settings(self, monkeypatch, mock_response):
         monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")

--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -280,6 +280,22 @@ class TestGoogleGenAIChatGeneratorInitSerDe:
         data = component.to_dict()
         assert data["init_parameters"]["google_server_tools"] is None
 
+    def test_init_with_google_search_retrieval_with_params(self, monkeypatch):
+        """google_search_retrieval accepts nested configuration via the same dict syntax."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        server_tool = {
+            "google_search_retrieval": {
+                "dynamic_retrieval_config": {
+                    "mode": "MODE_DYNAMIC",
+                    "dynamic_threshold": 0.7,
+                }
+            }
+        }
+        component = GoogleGenAIChatGenerator(google_server_tools=[server_tool])
+        assert component._google_server_tools == [server_tool]
+        data = component.to_dict()
+        assert data["init_parameters"]["google_server_tools"] == [server_tool]
+
     def test_to_dict_with_response_format_pydantic(self, monkeypatch):
         """Test that to_dict serializes a Pydantic response_format to a JSON schema dict."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")


### PR DESCRIPTION
## Summary

- Adds `google_server_tools: list[dict[str, Any]] | None = None` parameter to `GoogleGenAIChatGenerator.__init__`
- Enables users to pass Google's built-in server-side tools (e.g. `google_search`, `code_execution`) to the Gemini API
- Server tools are merged with Haystack `Tool`/`Toolset` at request time and passed in `GenerateContentConfig.tools`
- Serializes/deserializes cleanly via `to_dict()` / `from_dict()`

## Motivation

Google's Gemini API supports built-in tools that are not Haystack `Tool` objects and cannot be expressed as function declarations. For example:

```python
from google.genai import types
# Native Google search tool
types.Tool(google_search=types.GoogleSearch())

# Code execution tool
types.Tool(code_execution=types.ToolCodeExecution())
```

Currently there is no way to pass these through `GoogleGenAIChatGenerator` because the `tools` parameter only accepts `ToolsType` (Haystack Tools/Toolsets). This PR adds `google_server_tools` to fill that gap.

**Usage:**

```python
generator = GoogleGenAIChatGenerator(
    model="gemini-2.5-flash",
    google_server_tools=[{"google_search": {}}],
)
```

Or combined with Haystack tools:

```python
generator = GoogleGenAIChatGenerator(
    model="gemini-2.5-flash",
    tools=[my_haystack_tool],
    google_server_tools=[{"google_search": {}}, {"code_execution": {}}],
)
```

## Relation to existing work

Follows the same pattern as `anthropic_server_tools` introduced in #3386 for `AnthropicChatGenerator`.

## Test plan

- [ ] `test_init_with_google_server_tools` — verifies `_google_server_tools` is stored on init
- [ ] `test_to_dict_with_google_server_tools` — verifies serialization round-trip
- [ ] `test_from_dict_with_google_server_tools` — verifies deserialization round-trip
- [ ] `test_to_dict_default_google_server_tools_is_none` — verifies default is `None`
- [ ] `test_run_with_google_server_tools` — verifies native tool is passed to `GenerateContentConfig`
- [ ] `test_run_merges_haystack_and_google_server_tools` — verifies Haystack + native tools are merged