### PR TITLE
test: fix tests for integrations that inherit from the OpenAIChatGenerator

### DIFF
--- a/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
+++ b/integrations/aimlapi/tests/test_aimlapi_chat_generator.py
@@ -900,6 +900,10 @@ class TestChatCompletionChunkConversion:
         assert result.meta["finish_reason"] == "tool_calls"
         assert result.meta["index"] == 0
         assert result.meta["completion_start_time"] is not None
+
+        # Normalize usage details since cache_write_tokens is not always present in the response
+        result.meta["usage"]["prompt_tokens_details"].setdefault("cache_write_tokens", None)
+
         assert result.meta["usage"] == {
             "completion_tokens": 42,
             "prompt_tokens": 55,
@@ -912,6 +916,7 @@ class TestChatCompletionChunkConversion:
             },
             "prompt_tokens_details": {
                 "audio_tokens": None,
+                "cache_write_tokens": None,
                 "cached_tokens": 0,
             },
         }

--- a/integrations/cometapi/tests/test_cometapi_chat_generator.py
+++ b/integrations/cometapi/tests/test_cometapi_chat_generator.py
@@ -824,6 +824,9 @@ class TestChatCompletionChunkConversion:
         if not isinstance(usage["prompt_tokens_details"], dict):
             usage["prompt_tokens_details"] = asdict(usage["prompt_tokens_details"])
 
+        # Normalize usage details since cache_write_tokens is not always present in the response
+        usage["prompt_tokens_details"].setdefault("cache_write_tokens", None)
+
         assert usage == {
             "completion_tokens": 42,
             "prompt_tokens": 55,
@@ -836,6 +839,7 @@ class TestChatCompletionChunkConversion:
             },
             "prompt_tokens_details": {
                 "audio_tokens": None,
+                "cache_write_tokens": None,
                 "cached_tokens": 0,
             },
         }

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -1067,6 +1067,10 @@ class TestChatCompletionChunkConversion:
         assert result.meta["finish_reason"] == "tool_calls"
         assert result.meta["index"] == 0
         assert result.meta["completion_start_time"] is not None
+
+        # Normalize usage details since cache_write_tokens is not always present in the response
+        result.meta["usage"]["prompt_tokens_details"].setdefault("cache_write_tokens", None)
+
         assert result.meta["usage"] == {
             "completion_tokens": 42,
             "prompt_tokens": 55,
@@ -1079,6 +1083,7 @@ class TestChatCompletionChunkConversion:
             },
             "prompt_tokens_details": {
                 "audio_tokens": None,
+                "cache_write_tokens": None,
                 "cached_tokens": 0,
             },
         }

--- a/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
+++ b/integrations/orcarouter/tests/test_orcarouter_chat_generator.py
@@ -840,6 +840,10 @@ class TestChatCompletionChunkConversion:
         assert result.meta["finish_reason"] == "tool_calls"
         assert result.meta["index"] == 0
         assert result.meta["completion_start_time"] is not None
+
+        # Normalize usage details since cache_write_tokens is not always present in the response
+        result.meta["usage"]["prompt_tokens_details"].setdefault("cache_write_tokens", None)
+
         assert result.meta["usage"] == {
             "completion_tokens": 42,
             "prompt_tokens": 55,
@@ -852,6 +856,7 @@ class TestChatCompletionChunkConversion:
             },
             "prompt_tokens_details": {
                 "audio_tokens": None,
+                "cache_write_tokens": None,
                 "cached_tokens": 0,
             },
         }

--- a/integrations/togetherai/tests/test_togetherai_chat_generator.py
+++ b/integrations/togetherai/tests/test_togetherai_chat_generator.py
@@ -1029,6 +1029,10 @@ class TestChatCompletionChunkConversion:
         assert result.meta["finish_reason"] == "tool_calls"
         assert result.meta["index"] == 0
         assert result.meta["completion_start_time"] is not None
+
+        # Normalize usage details since cache_write_tokens is not always present in the response
+        result.meta["usage"]["prompt_tokens_details"].setdefault("cache_write_tokens", None)
+
         assert result.meta["usage"] == {
             "completion_tokens": 42,
             "prompt_tokens": 55,
@@ -1041,6 +1045,7 @@ class TestChatCompletionChunkConversion:
             },
             "prompt_tokens_details": {
                 "audio_tokens": None,
+                "cache_write_tokens": None,
                 "cached_tokens": 0,
             },
         }


### PR DESCRIPTION
### Related Issues

- fixes failing tests:
  - https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29215854996
  - https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29215794301
  - https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29216112569
  - https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29215285474
  - https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29215167352 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update the usage dict comparison to normalize the presence of cache_write_tokens which was introduced in openai's v2.45.0 sdk https://github.com/openai/openai-python/releases#release-v2.45.0 

Tests were updated so that they pass with older versions of the sdk as well

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
