### PR TITLE
test: install ffmpeg into CI env of vllm

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -79,6 +79,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install hatch --uploaded-prior-to=P1D
 
+      - name: Install FFmpeg
+        run: |
+          # Recent vLLM imports torchcodec at startup, which needs FFmpeg's shared libraries
+          # (libavutil.so.*); without them `vllm serve` crashes on import and never binds its port.
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
       - name: Install vLLM (CPU)
         run: |
           # vLLM on PyPI is GPU-only and requires CUDA, so it won't run on CPU-only systems.


### PR DESCRIPTION
### Related Issues

- fixes failing vllm tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29215287148/job/86709884422

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Recent versions of vLLM import `torchcodec` which requires `ffmpeg` to be installed in the env so we install it in the github workflow before starting up vLLM

Looks to have been added in version 0.25.0 https://github.com/vllm-project/vllm/releases/tag/v0.25.0

> Video: TorchCodec added as a video decoding backend (https://github.com/vllm-project/vllm/pull/46609).

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
