### PR TITLE
test: fix retry mechanism for installing libreoffice on windows

### DIFF
--- a/.github/workflows/libreoffice.yml
+++ b/.github/workflows/libreoffice.yml
@@ -92,9 +92,17 @@ jobs:
           timeout_minutes: 4
           max_attempts: 3
           shell: pwsh
+          # Only the install is retried. The PATH append below must not be part of this block:
+          # its exit code would mask a failed choco install and the action would never retry.
           command: |
             choco install libreoffice-fresh -y
-            echo "C:\Program Files\LibreOffice\program" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Add LibreOffice to PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          echo "C:\Program Files\LibreOffice\program" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install LibreOffice headless (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29215387725/job/86710167536

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update the retry block in the github workflow to trigger correctly. In the linked failing tests above you can see the install was never retried. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
