### PR TITLE
fix(pgvector): parenthesize `not in` clause so it does not escape an AND filter

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -229,7 +229,7 @@ def _not_in(field: Composable, value: Any) -> tuple[Composed, list]:
     if not isinstance(value, list):
         msg = f"{field}'s value must be a list when using 'not in' comparator in Pinecone"
         raise FilterError(msg)
-    return SQL("{} IS NULL OR {} != ALL(%s)").format(field, field), [value]
+    return SQL("({} IS NULL OR {} != ALL(%s))").format(field, field), [value]
 
 
 def _in(field: Composable, value: Any) -> tuple[Composed, list]:

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -228,11 +228,30 @@ def test_logical_condition_nested():
         "("
         "(meta->>'domain' IS DISTINCT FROM %s OR meta->>'chapter' = ANY(%s))"
         " AND "
-        "((meta->>'number')::integer >= %s OR meta->>'author' IS NULL OR meta->>'author' != ALL(%s))"
+        "((meta->>'number')::integer >= %s OR (meta->>'author' IS NULL OR meta->>'author' != ALL(%s)))"
         ")"
     )
     assert _render(query) == expected_sql
     assert values == ["science", [["intro", "conclusion"]], 90, [["John", "Jane"]]]
+
+
+def test_logical_condition_not_in_is_parenthesized_when_and_combined():
+    # `not in` renders an internal `OR` (`IS NULL OR != ALL`). Without surrounding
+    # parentheses that `OR` escapes an enclosing `AND` (AND binds tighter than OR in
+    # SQL), so an AND-combined `not in` would wrongly match documents.
+    condition = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.number", "operator": "==", "value": 5},
+            {"field": "meta.author", "operator": "not in", "value": ["John", "Jane"]},
+        ],
+    }
+    query, values = _parse_logical_condition(condition)
+    assert isinstance(query, Composed)
+
+    expected_sql = "((meta->>'number')::integer = %s AND (meta->>'author' IS NULL OR meta->>'author' != ALL(%s)))"
+    assert _render(query) == expected_sql
+    assert values == [5, [["John", "Jane"]]]
 
 
 def test_convert_filters_to_where_clause_and_params():


### PR DESCRIPTION
### The bug

In the pgvector filter translation, `_not_in` renders:

```python
return SQL("{} IS NULL OR {} != ALL(%s)").format(field, field), [value]
```

with no surrounding parentheses. `not in` is the only comparison operator that produces an internal `OR`. When `_parse_logical_condition` joins sibling conditions with ` AND `, that ungrouped `OR` escapes the `AND` scope, because in SQL `AND` binds tighter than `OR`.

So this filter:

```python
{
    "operator": "AND",
    "conditions": [
        {"field": "meta.x", "operator": "==", "value": 5},
        {"field": "meta.author", "operator": "not in", "value": ["John", "Jane"]},
    ],
}
```

renders as:

```sql
WHERE ((meta->>'x')::integer = %s AND meta->>'author' IS NULL OR meta->>'author' != ALL(%s))
```

which SQL parses as `(x = 5 AND author IS NULL) OR (author != ALL(...))`. A document with `x = 999, author = 'Bob'` **wrongly matches** — the `not in` branch is OR'd against the entire rest of the `AND`, instead of being one required conjunct. The intended semantics are `x = 5 AND author not-in-list`.

This stayed hidden because the existing `test_logical_condition_nested` only nests `not in` under an `OR` (where the missing parentheses are harmless), and the base filter tests only AND-combine `==`.

### The fix

Wrap the expression in parentheses so the internal `OR` stays grouped:

```python
return SQL("({} IS NULL OR {} != ALL(%s))").format(field, field), [value]
```

### Tests

- Added `test_logical_condition_not_in_is_parenthesized_when_and_combined`, which AND-combines `not in` with another condition and asserts the `not in` clause is parenthesized. It fails before the change (the `OR` escapes the `AND`) and passes after.
- Updated `test_logical_condition_nested`'s expected SQL to include the now-parenthesized `not in` clause (semantically unchanged — it was already inside an `OR`).

Verified locally: `hatch run test:unit` passes (71 passed), `hatch run fmt` and `hatch run test:types` are clean.

---
*Authored with AI assistance (Claude Code); the change and tests were reviewed and verified locally by me.*
