### PR TITLE
fix(chroma): raise a clear error for id filters with a non-'==' operator

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/filters.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/filters.py
@@ -68,7 +68,7 @@ def _convert_filters(filters: dict[str, Any]) -> ChromaFilter:
             continue
         # if field is "id", it'll be passed to Chroma's ids filter
         elif field == "id":
-            if not value["$eq"]:
+            if "$eq" not in value or not value["$eq"]:
                 msg = f"id filter only supports '==' operator, got {value}"
                 raise ChromaDocumentStoreFilterError(msg)
             ids.append(value["$eq"])

--- a/integrations/chroma/tests/test_filters.py
+++ b/integrations/chroma/tests/test_filters.py
@@ -17,6 +17,13 @@ def test_id_filter_with_empty_value_raises():
         _convert_filters({"field": "id", "operator": "==", "value": ""})
 
 
+def test_id_filter_with_non_eq_operator_raises():
+    # A non-'==' operator produces e.g. {"$in": [...]} (no "$eq" key), which must
+    # surface the friendly ChromaDocumentStoreFilterError, not a raw KeyError('$eq').
+    with pytest.raises(ChromaDocumentStoreFilterError, match="id filter only supports"):
+        _convert_filters({"field": "id", "operator": "in", "value": ["1", "2"]})
+
+
 @pytest.mark.parametrize(
     ("condition", "match"),
     [


### PR DESCRIPTION
### The bug

The `id` branch of `_convert_filters` assumes the operator was always `==`:

```python
elif field == "id":
    if not value["$eq"]:
        msg = f"id filter only supports '==' operator, got {value}"
        raise ChromaDocumentStoreFilterError(msg)
    ids.append(value["$eq"])
```

But any other operator produces a dict without an `$eq` key — e.g. `{"field": "id", "operator": "in", "value": ["1", "2"]}` converts to `{"$in": ["1", "2"]}`. The unguarded `value["$eq"]` then raises a raw `KeyError('$eq')` before the code can raise the friendly `ChromaDocumentStoreFilterError` it was clearly meant to raise (the error message even interpolates the whole `value` to explain the constraint). This is reachable through the public `filter_documents()` / `delete_documents()` APIs with any `id` filter whose operator isn't `==`.

### The fix

Guard the lookup so a missing `$eq` key (any non-`==` operator) falls into the intended error path:

```python
if "$eq" not in value or not value["$eq"]:
```

The empty-`==` case (`value == {"$eq": ""}`) still raises as before.

### Test

Added `test_id_filter_with_non_eq_operator_raises`, mirroring the existing `test_id_filter_with_empty_value_raises`. It fails before the change (raw `KeyError('$eq')` instead of `ChromaDocumentStoreFilterError`) and passes after.

Verified locally: `hatch run test:unit` passes (48 passed), `hatch run fmt` and `hatch run test:types` are clean.

---
*Authored with AI assistance (Claude Code); the change and tests were reviewed and verified locally by me.*
