### PR TITLE
fix(elasticsearch): don't merge same-field ranges under OR

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/filters.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/filters.py
@@ -31,7 +31,10 @@ def _parse_logical_condition(condition: dict[str, Any]) -> dict[str, Any]:
 
     operator = condition["operator"]
     conditions = [_parse_comparison_condition(c) for c in condition["conditions"]]
-    if len(conditions) > 1:
+    # Range merging is only valid when the conditions are AND-combined (AND, and the
+    # inner `must` of NOT). Merging same-field ranges under OR would collapse e.g.
+    # `price < 10 OR price > 100` into a single impossible range, matching nothing.
+    if len(conditions) > 1 and operator != "OR":
         conditions = _normalize_ranges(conditions)
     if operator == "AND":
         return {"bool": {"must": conditions}}

--- a/integrations/elasticsearch/tests/test_filters.py
+++ b/integrations/elasticsearch/tests/test_filters.py
@@ -183,6 +183,27 @@ def test_normalize_filters(filters, expected):
     assert result == expected
 
 
+def test_or_of_ranges_on_same_field_are_not_merged():
+    # `price < 10 OR price > 100` must stay two separate range clauses under `should`.
+    # Merging them into a single {"lt": 10, "gt": 100} range means price < 10 AND
+    # price > 100, which matches no document.
+    filters = {
+        "operator": "OR",
+        "conditions": [
+            {"field": "meta.price", "operator": "<", "value": 10},
+            {"field": "meta.price", "operator": ">", "value": 100},
+        ],
+    }
+    assert _normalize_filters(filters) == {
+        "bool": {
+            "should": [
+                {"range": {"price": {"lt": 10}}},
+                {"range": {"price": {"gt": 100}}},
+            ]
+        }
+    }
+
+
 def test_normalize_filters_invalid_operator():
     with pytest.raises(FilterError):
         _normalize_filters({"operator": "INVALID", "conditions": []})


### PR DESCRIPTION
### The bug

`_parse_logical_condition` calls `_normalize_ranges` for every multi-condition group:

```python
if len(conditions) > 1:
    conditions = _normalize_ranges(conditions)
```

`_normalize_ranges` merges range clauses that act on the same field into a single clause (via `dict.update`). That's correct when the conditions are AND-combined — `price > 10 AND price < 100` should become one `{"gt": 10, "lt": 100}` range. But it also runs for `OR`, where it's wrong:

```python
{
    "operator": "OR",
    "conditions": [
        {"field": "meta.price", "operator": "<", "value": 10},
        {"field": "meta.price", "operator": ">", "value": 100},
    ],
}
```

renders as:

```json
{"bool": {"should": [{"range": {"price": {"lt": 10, "gt": 100}}}]}}
```

A single range clause with both `lt: 10` and `gt: 100` means `price < 10 AND price > 100`, which **matches no document** — even though the user asked for `price < 10 OR price > 100`. The correct output keeps two separate range clauses in `should`.

### The fix

Only merge ranges when the conditions are AND-combined. `AND` and the inner `must` of `NOT` keep merging; `OR` skips it:

```python
if len(conditions) > 1 and operator != "OR":
    conditions = _normalize_ranges(conditions)
```

### Test

Added `test_or_of_ranges_on_same_field_are_not_merged`, which asserts that an OR of two same-field ranges stays two separate `range` clauses. It fails before the change (the ranges collapse into one impossible range) and passes after.

Verified locally: `hatch run test:unit` passes (165 passed), `hatch run fmt` and `hatch run test:types` are clean.

---
*Authored with AI assistance (Claude Code); the change and tests were reviewed and verified locally by me.*
