### PR TITLE
fix(opensearch): don't merge same-field ranges under OR

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/filters.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/filters.py
@@ -93,7 +93,7 @@ def _group_nested_conditions(
                 inner.append(_parse_logical_condition(c, nested_fields=None))
             else:
                 inner.append(_parse_comparison_condition(c, nested_fields))
-        if len(inner) > 1:
+        if len(inner) > 1 and operator != "OR":
             inner = _normalize_ranges(inner)
         if len(inner) == 1:
             conditions.append({"nested": {"path": path, "query": inner[0]}})
@@ -120,7 +120,10 @@ def _parse_logical_condition(condition: dict[str, Any], nested_fields: set[str] 
     else:
         conditions = [_parse_comparison_condition(c, nested_fields) for c in condition["conditions"]]
 
-    if len(conditions) > 1:
+    # Range merging is only valid when the conditions are AND-combined (AND, and the
+    # inner `must` of NOT). Merging same-field ranges under OR would collapse e.g.
+    # `price < 10 OR price > 100` into a single impossible range, matching nothing.
+    if len(conditions) > 1 and operator != "OR":
         conditions = _normalize_ranges(conditions)
     if operator == "AND":
         return {"bool": {"must": conditions}}

--- a/integrations/opensearch/tests/test_filters.py
+++ b/integrations/opensearch/tests/test_filters.py
@@ -500,6 +500,59 @@ def test_normalize_ranges():
     ]
 
 
+def test_or_of_ranges_on_same_field_are_not_merged():
+    # `price < 10 OR price > 100` must stay two separate range clauses under `should`.
+    # Merging them into a single {"lt": 10, "gt": 100} range means price < 10 AND
+    # price > 100, which matches no document.
+    filters = {
+        "operator": "OR",
+        "conditions": [
+            {"field": "meta.price", "operator": "<", "value": 10},
+            {"field": "meta.price", "operator": ">", "value": 100},
+        ],
+    }
+    assert normalize_filters(filters) == {
+        "bool": {
+            "should": [
+                {"range": {"price": {"lt": 10}}},
+                {"range": {"price": {"gt": 100}}},
+            ]
+        }
+    }
+
+
+def test_or_of_ranges_on_same_nested_field_are_not_merged():
+    # Same range-merge bug inside a nested-field logical group: an OR of two ranges on
+    # the same nested sub-field must stay two separate range clauses, not collapse into
+    # a single impossible range.
+    filters = {
+        "operator": "OR",
+        "conditions": [
+            {"field": "meta.refs.score", "operator": "<", "value": 10},
+            {"field": "meta.refs.score", "operator": ">", "value": 100},
+        ],
+    }
+    assert normalize_filters(filters, nested_fields={"refs"}) == {
+        "bool": {
+            "should": [
+                {
+                    "nested": {
+                        "path": "refs",
+                        "query": {
+                            "bool": {
+                                "should": [
+                                    {"range": {"refs.score": {"lt": 10}}},
+                                    {"range": {"refs.score": {"gt": 100}}},
+                                ]
+                            }
+                        },
+                    }
+                }
+            ]
+        }
+    }
+
+
 @pytest.mark.parametrize("filters, nested_fields, expected", nested_filters_data)
 def test_normalize_filters_with_nested_fields(filters, nested_fields, expected):
     result = normalize_filters(filters, nested_fields=nested_fields)


### PR DESCRIPTION
### The bug

Both the top-level `_parse_logical_condition` and the nested-field grouping call `_normalize_ranges` for every multi-condition group:

```python
if len(conditions) > 1:
    conditions = _normalize_ranges(conditions)
```

`_normalize_ranges` merges range clauses on the same field into one (via `dict.update`). That's correct for AND — `price > 10 AND price < 100` should become one `{"gt": 10, "lt": 100}` range. But it also runs for `OR`, where it's wrong:

```python
{
    "operator": "OR",
    "conditions": [
        {"field": "meta.price", "operator": "<", "value": 10},
        {"field": "meta.price", "operator": ">", "value": 100},
    ],
}
```

renders as:

```json
{"bool": {"should": [{"range": {"price": {"lt": 10, "gt": 100}}}]}}
```

A single range clause with both `lt: 10` and `gt: 100` means `price < 10 AND price > 100`, which **matches no document** — even though the user asked for `price < 10 OR price > 100`. The same collapse happens inside nested-field groups (`_group_nested_conditions`), dropping a bound of an OR of ranges on a nested sub-field.

This is a sibling of the pgvector/elasticsearch range handling; the correct output keeps two separate range clauses in `should`.

### The fix

Only merge ranges when the conditions are AND-combined, at both sites (top level and nested groups). `AND` and the inner `must` of `NOT` keep merging; `OR` skips it:

```python
if len(conditions) > 1 and operator != "OR":
    conditions = _normalize_ranges(conditions)
```

### Tests

Added two regression tests:
- `test_or_of_ranges_on_same_field_are_not_merged` — top-level OR of two same-field ranges stays two separate `range` clauses.
- `test_or_of_ranges_on_same_nested_field_are_not_merged` — same, inside a nested-field group.

Both fail before the change (ranges collapse into one impossible range) and pass after. I verified each fix site is load-bearing (reverting the nested guard alone makes the nested test fail).

Verified locally: `hatch run test:unit` passes (167 passed), `hatch run fmt` and `hatch run test:types` are clean.

---
*Authored with AI assistance (Claude Code); the change and tests were reviewed and verified locally by me.*
