### PR TITLE
fix(pgvector): NO_VALUE sentinel collides with the literal string 'no_value'

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -48,7 +48,7 @@ def _convert_filters_to_where_clause_and_params(
         query, values = _parse_logical_condition(filters)
 
     where_clause = SQL(f" {operator} ") + query
-    params = tuple(value for value in values if value != NO_VALUE)
+    params = tuple(value for value in values if value is not NO_VALUE)
 
     return where_clause, params
 

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -20,7 +20,7 @@ PYTHON_TYPES_TO_PG_TYPES = {
     bool: "boolean",
 }
 
-NO_VALUE = "no_value"
+NO_VALUE = object()  # unique sentinel; can never equal a user-supplied filter value
 
 
 def _validate_filters(filters: dict[str, Any] | None = None) -> None:

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -265,6 +265,18 @@ def test_convert_filters_to_where_clause_and_params_handle_null():
     assert params == ("intro",)
 
 
+def test_convert_filters_to_where_clause_and_params_value_equal_to_no_value_sentinel():
+    """A legitimate equality filter whose value is the literal string the internal
+    NO_VALUE sentinel used to be ("no_value") must not be dropped from params --
+    the query still has a placeholder for it."""
+    filters = {"field": "meta.tag", "operator": "==", "value": "no_value"}
+    where_clause, params = _convert_filters_to_where_clause_and_params(filters)
+
+    expected_sql = " WHERE meta->>'tag' = %s"
+    assert _render(where_clause) == expected_sql
+    assert params == ("no_value",)
+
+
 def test_validate_filters():
     filters = {"field": "meta.number", "operator": "==", "value": 100}
     _validate_filters(filters)


### PR DESCRIPTION
### The bug

`NO_VALUE` is the string `"no_value"`, used internally to mark a param slot as "already handled inline (e.g. `IS NULL`), don't add this to the params list":

```python
NO_VALUE = "no_value"
```

`_convert_filters_to_where_clause_and_params` filters params by equality against this sentinel (`value != NO_VALUE`). So a legitimate equality filter whose value happens to be the literal string `"no_value"` gets its param silently dropped too:

```python
filters = {"field": "meta.tag", "operator": "==", "value": "no_value"}
where_clause, params = _convert_filters_to_where_clause_and_params(filters)
# where_clause still has one `%s` placeholder for the value
# params == ()  <- but the placeholder has no matching param!
```

That placeholder/param-count mismatch raises `psycopg.ProgrammingError` at `execute()` time — a valid, unremarkable filter value crashes the query.

### The fix

Make `NO_VALUE` a unique `object()` sentinel instead of a string, so it can never collide with a real user-supplied value:

```python
NO_VALUE = object()  # unique sentinel; can never equal a user-supplied filter value
```

Identity/`!=` comparison still works exactly the same for the internal use (only 3 reference sites: definition, the filter, and the `IS NULL` branch that returns it).

### Testing

Added `test_convert_filters_to_where_clause_and_params_value_equal_to_no_value_sentinel`, asserting `params == ("no_value",)` for the equality filter above. Confirmed it fails against the pre-fix code (`params == ()`, the mismatch) and passes after.

- `hatch run test:unit tests/test_filters.py` — 13/13 passed.
- `hatch run ruff check`/`ruff format --check` on the changed files — clean.
- `hatch run test:types` — no issues.

### AI disclosure

Developed with AI assistance (Claude Code), which located the sentinel-collision pattern while auditing `filters.py` for defects. I reviewed the diff, independently reproduced the placeholder/param mismatch and the fix by executing both against the actual function, and ran the tests/linters/type-checker myself before opening this PR.