### PR TITLE
feat(stackit): add dimensions parameter to text and document embedders

### DIFF
--- a/integrations/stackit/src/haystack_integrations/components/embedders/stackit/document_embedder.py
+++ b/integrations/stackit/src/haystack_integrations/components/embedders/stackit/document_embedder.py
@@ -51,6 +51,7 @@ class STACKITDocumentEmbedder(OpenAIDocumentEmbedder):
         meta_fields_to_embed: list[str] | None = None,
         embedding_separator: str = "\n",
         *,
+        dimensions: int | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
         http_client_kwargs: dict[str, Any] | None = None,
@@ -78,6 +79,9 @@ class STACKITDocumentEmbedder(OpenAIDocumentEmbedder):
             List of meta fields that should be embedded along with the Document text.
         :param embedding_separator:
             Separator used to concatenate the meta fields to the Document text.
+        :param dimensions:
+            The number of dimensions of the resulting embeddings. Only supported by some models -
+            check the STACKIT model card for the model you are using to see if this parameter is supported.
         :param timeout:
             Timeout for STACKIT client calls. If not set, it defaults to either the `OPENAI_TIMEOUT` environment
             variable, or 30 seconds.
@@ -91,7 +95,7 @@ class STACKITDocumentEmbedder(OpenAIDocumentEmbedder):
         super(STACKITDocumentEmbedder, self).__init__(  # noqa: UP008
             api_key=api_key,
             model=model,
-            dimensions=None,
+            dimensions=dimensions,
             api_base_url=api_base_url,
             organization=None,
             prefix=prefix,
@@ -118,6 +122,7 @@ class STACKITDocumentEmbedder(OpenAIDocumentEmbedder):
         return default_to_dict(
             self,
             model=self.model,
+            dimensions=self.dimensions,
             api_key=self.api_key.to_dict(),
             api_base_url=self.api_base_url,
             prefix=self.prefix,

--- a/integrations/stackit/src/haystack_integrations/components/embedders/stackit/text_embedder.py
+++ b/integrations/stackit/src/haystack_integrations/components/embedders/stackit/text_embedder.py
@@ -39,6 +39,7 @@ class STACKITTextEmbedder(OpenAITextEmbedder):
         prefix: str = "",
         suffix: str = "",
         *,
+        dimensions: int | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
         http_client_kwargs: dict[str, Any] | None = None,
@@ -57,6 +58,9 @@ class STACKITTextEmbedder(OpenAITextEmbedder):
             A string to add to the beginning of each text.
         :param suffix:
             A string to add to the end of each text.
+        :param dimensions:
+            The number of dimensions of the resulting embeddings. Only supported by some models -
+            check the STACKIT model card for the model you are using to see if this parameter is supported.
         :param timeout:
             Timeout for STACKIT client calls. If not set, it defaults to either the `OPENAI_TIMEOUT` environment
             variable, or 30 seconds.
@@ -70,7 +74,7 @@ class STACKITTextEmbedder(OpenAITextEmbedder):
         super(STACKITTextEmbedder, self).__init__(  # noqa: UP008
             api_key=api_key,
             model=model,
-            dimensions=None,
+            dimensions=dimensions,
             api_base_url=api_base_url,
             organization=None,
             prefix=prefix,
@@ -94,6 +98,7 @@ class STACKITTextEmbedder(OpenAITextEmbedder):
             self,
             api_key=self.api_key.to_dict(),
             model=self.model,
+            dimensions=self.dimensions,
             api_base_url=self.api_base_url,
             prefix=self.prefix,
             suffix=self.suffix,

--- a/integrations/stackit/tests/test_stackit_document_embedder.py
+++ b/integrations/stackit/tests/test_stackit_document_embedder.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import os
+from unittest.mock import Mock, patch
 
 import pytest
 from haystack import Document
 from haystack.utils import Secret
+from openai import BadRequestError
 
 from haystack_integrations.components.embedders.stackit.document_embedder import STACKITDocumentEmbedder
 
@@ -24,6 +27,7 @@ class TestSTACKITDocumentEmbedder:
         embedder = STACKITDocumentEmbedder(model="intfloat/e5-mistral-7b-instruct")
         assert embedder.api_key == Secret.from_env_var(["STACKIT_API_KEY"])
         assert embedder.model == "intfloat/e5-mistral-7b-instruct"
+        assert embedder.dimensions is None
         assert embedder.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
         assert embedder.prefix == ""
         assert embedder.suffix == ""
@@ -35,7 +39,8 @@ class TestSTACKITDocumentEmbedder:
     def test_init_with_parameters(self):
         embedder = STACKITDocumentEmbedder(
             api_key=Secret.from_token("test-api-key"),
-            model="intfloat/e5-mistral-7b-instruct",
+            model="Qwen/Qwen3-VL-Embedding-8B",
+            dimensions=1024,
             api_base_url="https://custom-api-base-url.com",
             prefix="START",
             suffix="END",
@@ -45,7 +50,8 @@ class TestSTACKITDocumentEmbedder:
             embedding_separator="-",
         )
         assert embedder.api_key == Secret.from_token("test-api-key")
-        assert embedder.model == "intfloat/e5-mistral-7b-instruct"
+        assert embedder.model == "Qwen/Qwen3-VL-Embedding-8B"
+        assert embedder.dimensions == 1024
         assert embedder.api_base_url == "https://custom-api-base-url.com"
         assert embedder.prefix == "START"
         assert embedder.suffix == "END"
@@ -64,6 +70,7 @@ class TestSTACKITDocumentEmbedder:
             "init_parameters": {
                 "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "intfloat/e5-mistral-7b-instruct",
+                "dimensions": None,
                 "api_base_url": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
                 "prefix": "",
                 "suffix": "",
@@ -81,7 +88,8 @@ class TestSTACKITDocumentEmbedder:
         monkeypatch.setenv("ENV_VAR", "test-secret-key")
         embedder = STACKITDocumentEmbedder(
             api_key=Secret.from_env_var("ENV_VAR", strict=False),
-            model="intfloat/e5-mistral-7b-instruct",
+            model="Qwen/Qwen3-VL-Embedding-8B",
+            dimensions=1024,
             api_base_url="https://custom-api-base-url.com",
             prefix="START",
             suffix="END",
@@ -98,7 +106,8 @@ class TestSTACKITDocumentEmbedder:
             "type": "haystack_integrations.components.embedders.stackit.document_embedder.STACKITDocumentEmbedder",
             "init_parameters": {
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
-                "model": "intfloat/e5-mistral-7b-instruct",
+                "model": "Qwen/Qwen3-VL-Embedding-8B",
+                "dimensions": 1024,
                 "api_base_url": "https://custom-api-base-url.com",
                 "prefix": "START",
                 "suffix": "END",
@@ -119,6 +128,7 @@ class TestSTACKITDocumentEmbedder:
             "init_parameters": {
                 "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "intfloat/e5-mistral-7b-instruct",
+                "dimensions": None,
                 "api_base_url": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
                 "prefix": "",
                 "suffix": "",
@@ -134,6 +144,7 @@ class TestSTACKITDocumentEmbedder:
         embedder = STACKITDocumentEmbedder.from_dict(data)
         assert embedder.api_key == Secret.from_env_var(["STACKIT_API_KEY"])
         assert embedder.model == "intfloat/e5-mistral-7b-instruct"
+        assert embedder.dimensions is None
         assert embedder.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
         assert embedder.prefix == ""
         assert embedder.suffix == ""
@@ -166,6 +177,56 @@ class TestSTACKITDocumentEmbedder:
         for doc in docs_with_embeddings:
             assert isinstance(doc.embedding, list)
             assert isinstance(doc.embedding[0], float)
+
+    @pytest.mark.skipif(
+        not os.environ.get("STACKIT_API_KEY", None),
+        reason="Export an env var called STACKIT_API_KEY containing the STACKIT API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_run_with_dimensions(self):
+        embedder = STACKITDocumentEmbedder(model="Qwen/Qwen3-VL-Embedding-8B", dimensions=256)
+
+        docs = [Document(content="I love cheese")]
+        result = embedder.run(docs)
+        docs_with_embeddings = result["documents"]
+
+        assert len(docs_with_embeddings) == 1
+        assert len(docs_with_embeddings[0].embedding) == 256
+
+    @pytest.mark.skipif(
+        not os.environ.get("STACKIT_API_KEY", None),
+        reason="Export an env var called STACKIT_API_KEY containing the STACKIT API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_run_with_dimensions_unsupported_by_model(self, caplog):
+        # OpenAIDocumentEmbedder defaults to raise_on_failure=False, so a per-batch API error
+        # is logged and the affected documents come back without an embedding, instead of raising.
+        embedder = STACKITDocumentEmbedder(model="intfloat/e5-mistral-7b-instruct", dimensions=256)
+
+        with caplog.at_level(logging.ERROR):
+            result = embedder.run([Document(content="I love cheese")])
+
+        assert result["documents"][0].embedding is None
+        logged_errors = [r.exc for r in caplog.records if isinstance(getattr(r, "exc", None), BadRequestError)]
+        assert len(logged_errors) == 1
+        assert logged_errors[0].status_code == 400
+
+    def test_run_forwards_dimensions_to_client(self):
+        embedder = STACKITDocumentEmbedder(
+            model="Qwen/Qwen3-VL-Embedding-8B",
+            dimensions=1024,
+            api_key=Secret.from_token("test-api-key"),
+        )
+
+        mock_response = Mock()
+        mock_response.data = [Mock(embedding=[0.1, 0.2, 0.3])]
+        mock_response.model = "Qwen/Qwen3-VL-Embedding-8B"
+        mock_response.usage = {"prompt_tokens": 4, "total_tokens": 4}
+
+        with patch.object(embedder.client.embeddings, "create", return_value=mock_response) as mock_create:
+            embedder.run([Document(content="I love cheese")])
+
+        assert mock_create.call_args.kwargs["dimensions"] == 1024
 
     def test_run_wrong_input_format(self):
         embedder = STACKITDocumentEmbedder(

--- a/integrations/stackit/tests/test_stackit_document_embedder.py
+++ b/integrations/stackit/tests/test_stackit_document_embedder.py
@@ -3,12 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from haystack import Document
 from haystack.utils import Secret
-from openai import BadRequestError
 
 from haystack_integrations.components.embedders.stackit.document_embedder import STACKITDocumentEmbedder
 
@@ -207,9 +206,7 @@ class TestSTACKITDocumentEmbedder:
             result = embedder.run([Document(content="I love cheese")])
 
         assert result["documents"][0].embedding is None
-        logged_errors = [r.exc for r in caplog.records if isinstance(getattr(r, "exc", None), BadRequestError)]
-        assert len(logged_errors) == 1
-        assert logged_errors[0].status_code == 400
+        assert "Failed embedding of documents" in caplog.text
 
     def test_run_forwards_dimensions_to_client(self):
         embedder = STACKITDocumentEmbedder(
@@ -223,10 +220,16 @@ class TestSTACKITDocumentEmbedder:
         mock_response.model = "Qwen/Qwen3-VL-Embedding-8B"
         mock_response.usage = {"prompt_tokens": 4, "total_tokens": 4}
 
-        with patch.object(embedder.client.embeddings, "create", return_value=mock_response) as mock_create:
-            embedder.run([Document(content="I love cheese")])
+        # Assign a mock client instead of patching the real one's attributes: depending on the
+        # Haystack version, the OpenAI client is created eagerly in __init__ or lazily in warm_up(),
+        # and warm_up() leaves an already-set client untouched.
+        mock_client = Mock()
+        mock_client.embeddings.create.return_value = mock_response
+        embedder.client = mock_client
 
-        assert mock_create.call_args.kwargs["dimensions"] == 1024
+        embedder.run([Document(content="I love cheese")])
+
+        assert mock_client.embeddings.create.call_args.kwargs["dimensions"] == 1024
 
     def test_run_wrong_input_format(self):
         embedder = STACKITDocumentEmbedder(

--- a/integrations/stackit/tests/test_stackit_text_embedder.py
+++ b/integrations/stackit/tests/test_stackit_text_embedder.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+from unittest.mock import Mock, patch
 
 import pytest
 from haystack.utils import Secret
+from openai import BadRequestError
 
 from haystack_integrations.components.embedders.stackit.text_embedder import STACKITTextEmbedder
 
@@ -24,19 +26,22 @@ class TestSTACKITTextEmbedder:
         assert embedder.api_key == Secret.from_env_var(["STACKIT_API_KEY"])
         assert embedder.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
         assert embedder.model == "intfloat/e5-mistral-7b-instruct"
+        assert embedder.dimensions is None
         assert embedder.prefix == ""
         assert embedder.suffix == ""
 
     def test_init_with_parameters(self):
         embedder = STACKITTextEmbedder(
             api_key=Secret.from_token("test-api-key"),
-            model="intfloat/e5-mistral-7b-instruct",
+            model="Qwen/Qwen3-VL-Embedding-8B",
+            dimensions=1024,
             prefix="START",
             suffix="END",
         )
         assert embedder.api_key == Secret.from_token("test-api-key")
         assert embedder.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
-        assert embedder.model == "intfloat/e5-mistral-7b-instruct"
+        assert embedder.model == "Qwen/Qwen3-VL-Embedding-8B"
+        assert embedder.dimensions == 1024
         assert embedder.prefix == "START"
         assert embedder.suffix == "END"
 
@@ -50,6 +55,7 @@ class TestSTACKITTextEmbedder:
             "init_parameters": {
                 "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "intfloat/e5-mistral-7b-instruct",
+                "dimensions": None,
                 "api_base_url": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
                 "prefix": "",
                 "suffix": "",
@@ -63,7 +69,8 @@ class TestSTACKITTextEmbedder:
         monkeypatch.setenv("ENV_VAR", "test-secret-key")
         embedder = STACKITTextEmbedder(
             api_key=Secret.from_env_var("ENV_VAR", strict=False),
-            model="intfloat/e5-mistral-7b-instruct",
+            model="Qwen/Qwen3-VL-Embedding-8B",
+            dimensions=1024,
             api_base_url="https://custom-api-base-url.com",
             prefix="START",
             suffix="END",
@@ -76,7 +83,8 @@ class TestSTACKITTextEmbedder:
             "type": "haystack_integrations.components.embedders.stackit.text_embedder.STACKITTextEmbedder",
             "init_parameters": {
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
-                "model": "intfloat/e5-mistral-7b-instruct",
+                "model": "Qwen/Qwen3-VL-Embedding-8B",
+                "dimensions": 1024,
                 "api_base_url": "https://custom-api-base-url.com",
                 "prefix": "START",
                 "suffix": "END",
@@ -93,6 +101,7 @@ class TestSTACKITTextEmbedder:
             "init_parameters": {
                 "api_key": {"env_vars": ["STACKIT_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "intfloat/e5-mistral-7b-instruct",
+                "dimensions": None,
                 "api_base_url": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
                 "prefix": "",
                 "suffix": "",
@@ -105,6 +114,7 @@ class TestSTACKITTextEmbedder:
         assert embedder.api_key == Secret.from_env_var(["STACKIT_API_KEY"])
         assert embedder.api_base_url == "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"
         assert embedder.model == "intfloat/e5-mistral-7b-instruct"
+        assert embedder.dimensions is None
         assert embedder.prefix == ""
         assert embedder.suffix == ""
         assert embedder.timeout is None
@@ -121,6 +131,46 @@ class TestSTACKITTextEmbedder:
         text = "The food was delicious"
         result = embedder.run(text)
         assert all(isinstance(x, float) for x in result["embedding"])
+
+    @pytest.mark.skipif(
+        not os.environ.get("STACKIT_API_KEY", None),
+        reason="Export an env var called STACKIT_API_KEY containing the STACKIT API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_run_with_dimensions(self):
+        embedder = STACKITTextEmbedder(model="Qwen/Qwen3-VL-Embedding-8B", dimensions=256)
+        result = embedder.run("The food was delicious")
+
+        assert len(result["embedding"]) == 256
+
+    @pytest.mark.skipif(
+        not os.environ.get("STACKIT_API_KEY", None),
+        reason="Export an env var called STACKIT_API_KEY containing the STACKIT API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_run_with_dimensions_unsupported_by_model(self):
+        embedder = STACKITTextEmbedder(model="intfloat/e5-mistral-7b-instruct", dimensions=256)
+
+        with pytest.raises(BadRequestError) as exc_info:
+            embedder.run("The food was delicious")
+        assert exc_info.value.status_code == 400
+
+    def test_run_forwards_dimensions_to_client(self):
+        embedder = STACKITTextEmbedder(
+            model="Qwen/Qwen3-VL-Embedding-8B",
+            dimensions=1024,
+            api_key=Secret.from_token("test-api-key"),
+        )
+
+        mock_response = Mock()
+        mock_response.data = [Mock(embedding=[0.1, 0.2, 0.3])]
+        mock_response.model = "Qwen/Qwen3-VL-Embedding-8B"
+        mock_response.usage = {"prompt_tokens": 4, "total_tokens": 4}
+
+        with patch.object(embedder.client.embeddings, "create", return_value=mock_response) as mock_create:
+            embedder.run("I love cheese")
+
+        assert mock_create.call_args.kwargs["dimensions"] == 1024
 
     def test_run_wrong_input_format(self):
         embedder = STACKITTextEmbedder(

--- a/integrations/stackit/tests/test_stackit_text_embedder.py
+++ b/integrations/stackit/tests/test_stackit_text_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from haystack.utils import Secret
@@ -167,10 +167,16 @@ class TestSTACKITTextEmbedder:
         mock_response.model = "Qwen/Qwen3-VL-Embedding-8B"
         mock_response.usage = {"prompt_tokens": 4, "total_tokens": 4}
 
-        with patch.object(embedder.client.embeddings, "create", return_value=mock_response) as mock_create:
-            embedder.run("I love cheese")
+        # Assign a mock client instead of patching the real one's attributes: depending on the
+        # Haystack version, the OpenAI client is created eagerly in __init__ or lazily in warm_up(),
+        # and warm_up() leaves an already-set client untouched.
+        mock_client = Mock()
+        mock_client.embeddings.create.return_value = mock_response
+        embedder.client = mock_client
 
-        assert mock_create.call_args.kwargs["dimensions"] == 1024
+        embedder.run("I love cheese")
+
+        assert mock_client.embeddings.create.call_args.kwargs["dimensions"] == 1024
 
     def test_run_wrong_input_format(self):
         embedder = STACKITTextEmbedder(


### PR DESCRIPTION
### Related Issues

- N/A — no related issue, this was identified directly as a missing feature.

### Proposed Changes:

The Qwen embedding model (`Qwen/Qwen3-VL-Embedding-8B`) hosted on STACKIT supports Matryoshka-style variable-dimension embeddings, but `STACKITTextEmbedder` and `STACKITDocumentEmbedder` hardcoded `dimensions=None` when calling the underlying `OpenAITextEmbedder`/`OpenAIDocumentEmbedder`, so there was no way to request a reduced embedding size.

This PR exposes `dimensions` as a keyword-only init parameter on both embedders and forwards it to the parent OpenAI-compatible client, following the same pattern already used for `timeout`/`max_retries`/`http_client_kwargs`. It's added as keyword-only (rather than inserted positionally after `model`) so existing positional-argument usage of these components isn't broken. `to_dict`/`from_dict` were updated so the new parameter round-trips through serialization.

### How did you test it?

- Unit tests: constructor defaults/overrides, `to_dict`/`from_dict` round-trip, and a mocked-client test asserting `dimensions` is actually forwarded to `client.embeddings.create(...)`.
- Integration tests (require `STACKIT_API_KEY`): requesting `dimensions=256` against `Qwen/Qwen3-VL-Embedding-8B` returns embeddings of that length; requesting `dimensions` against a model that doesn't support it (`intfloat/e5-mistral-7b-instruct`) surfaces the API's 400 error, with the two embedders asserting on their differing failure behavior (`STACKITDocumentEmbedder` logs and continues, `STACKITTextEmbedder` raises).
- Ran locally against the real STACKIT API with my own key: `hatch run test:unit`, `hatch run test:integration`, `hatch run test:types` (mypy), `hatch run default:fmt-check` (ruff) — all green.

### Notes for the reviewer

- `dimensions` is keyword-only in both constructors (after the `*`), not inserted positionally after `model`, to avoid a backward-compatibility break for any code calling these components with positional args.
- The integration tests need `STACKIT_API_KEY` to run; they'll be skipped in CI for this fork PR since repo secrets aren't forwarded to `pull_request` runs from forks, but they will run once merged to `main` and in the nightly job.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `feat:`