### PR TITLE
fix: pin litellm on cognee integration

### DIFF
--- a/integrations/cognee/pyproject.toml
+++ b/integrations/cognee/pyproject.toml
@@ -26,6 +26,10 @@ classifiers = [
 dependencies = [
   "haystack-ai>=2.24.0",
   "cognee>=1.0.9",
+  # litellm (pulled in transitively by cognee) ships a Rust extension from 1.83.8+ with no cp314
+  # wheels and caps requires-python at <3.14, so on Python 3.14 constrain to the last pure-Python
+  # release. Other Python versions stay unpinned.
+  "litellm<1.83.8; python_version >= '3.14'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29295643088
- related to https://github.com/BerriAI/litellm/issues/26343

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Pin litellm to a compatible python 3.14 version when using python >=3.14

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
