### PR TITLE
fix: pin litellm on dspy integration

### DIFF
--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -22,7 +22,14 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "dspy>=3.1.3", "litellm!=1.82.7,!=1.82.8"]
+dependencies = [
+    "haystack-ai>=2.22.0",
+    "dspy>=3.1.3",
+    # litellm 1.83.8+ ships a Rust extension with no cp314 wheels and caps requires-python at
+    # <3.14, so on Python 3.14 pin to the last pure-Python release. Other versions stay unpinned.
+    "litellm!=1.82.7,!=1.82.8; python_version < '3.14'",
+    "litellm!=1.82.7,!=1.82.8,<1.83.8; python_version >= '3.14'",
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/dspy#readme"


### PR DESCRIPTION
### Related Issues

- fixes failing tests https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29295540511
- related to https://github.com/BerriAI/litellm/issues/26343

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Pin litellm to a compatible python 3.14 version when using python >=3.14

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
