### PR TITLE
feat: add TavilyWebSearchTool

### DIFF
--- a/integrations/tavily/pydoc/config_docusaurus.yml
+++ b/integrations/tavily/pydoc/config_docusaurus.yml
@@ -2,6 +2,7 @@ loaders:
   - modules:
       - haystack_integrations.components.websearch.tavily.tavily_websearch
       - haystack_integrations.components.fetchers.tavily.tavily_fetcher
+      - haystack_integrations.tools.tavily.websearch_tool
     search_path: [../src]
 processors:
   - type: filter

--- a/integrations/tavily/pyproject.toml
+++ b/integrations/tavily/pyproject.toml
@@ -66,7 +66,7 @@ integration = 'pytest -m "integration" {args:tests}'
 all = 'pytest {args:tests}'
 unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 30 -x -m "not integration" {args:tests}'
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
-types = "mypy -p haystack_integrations.components.websearch.tavily -p haystack_integrations.components.fetchers.tavily {args}"
+types = "mypy -p haystack_integrations.components.websearch.tavily -p haystack_integrations.components.fetchers.tavily -p haystack_integrations.tools.tavily {args}"
 
 [tool.mypy]
 install_types = true

--- a/integrations/tavily/src/haystack_integrations/tools/tavily/__init__.py
+++ b/integrations/tavily/src/haystack_integrations/tools/tavily/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack_integrations.tools.tavily.websearch_tool import TavilyWebSearchTool
+
+__all__ = ["TavilyWebSearchTool"]

--- a/integrations/tavily/src/haystack_integrations/tools/tavily/websearch_tool.py
+++ b/integrations/tavily/src/haystack_integrations/tools/tavily/websearch_tool.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack import Document
+from haystack.core.serialization import generate_qualified_class_name
+from haystack.tools import ComponentTool
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+from haystack_integrations.components.websearch.tavily import TavilyWebSearch
+
+_DEFAULT_DESCRIPTION = (
+    "Search the web. Returns the top results, each with title, exact URL and a content "
+    "snippet. Cite the exact URLs verbatim."
+)
+
+
+def _format_search_results(documents: list[Document]) -> str:
+    """
+    Format the search results as the tool-result string: title + exact URL + snippet.
+
+    :param documents: Documents returned by `TavilyWebSearch`.
+    :returns: Formatted results, or a message when no results were found.
+    """
+    if not documents:
+        return "No results."
+    blocks = []
+    for d in documents:
+        url = d.meta.get("url", "")
+        title = d.meta.get("title", "Untitled")
+        snippet = (d.content or "").strip()
+        blocks.append(f"- {title}\n  URL: {url}\n  {snippet}")
+    return "\n".join(blocks)
+
+
+class TavilyWebSearchTool(ComponentTool):
+    """
+    A tool that searches the web with Tavily.
+
+    Wraps the `TavilyWebSearch` component and formats its results as a string that an LLM can cite.
+    The tool parameters are derived from the component's `run` method, so the LLM can pass a `query` and,
+    optionally, `search_params` overriding the ones set at initialization time.
+
+    ### Usage example
+
+    ```python
+    from haystack.components.agents import Agent
+    from haystack.components.generators.chat import OpenAIChatGenerator
+    from haystack.dataclasses import ChatMessage
+    from haystack_integrations.tools.tavily import TavilyWebSearchTool
+
+    web_search = TavilyWebSearchTool(top_k=5, search_params={"search_depth": "advanced"})
+
+    agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-5-mini"), tools=[web_search])
+
+    result = agent.run(messages=[ChatMessage.from_user("What is Haystack by deepset?")])
+    print(result["last_message"].text)
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: Secret | None = None,
+        top_k: int | None = None,
+        search_params: dict[str, Any] | None = None,
+        name: str = "web_search",
+        description: str = _DEFAULT_DESCRIPTION,
+    ) -> None:
+        """
+        Initialize the TavilyWebSearchTool.
+
+        :param api_key:
+            API key for Tavily. If unset, `TavilyWebSearch` reads the `TAVILY_API_KEY` environment variable.
+        :param top_k:
+            Maximum number of results to return. If unset, the `TavilyWebSearch` default applies.
+        :param search_params:
+            Additional parameters passed to the Tavily search API.
+            See the [Tavily API reference](https://docs.tavily.com/docs/tavily-api/rest_api)
+            for available options. Supported keys include: `search_depth`, `include_answer`,
+            `include_raw_content`, `include_domains`, `exclude_domains`.
+        :param name: Tool name exposed to the LLM.
+        :param description: Tool description exposed to the LLM.
+        """
+        self.api_key = api_key
+        self.top_k = top_k
+        self.search_params = search_params
+
+        component_params: dict[str, Any] = {}
+        if api_key is not None:
+            component_params["api_key"] = api_key
+        if top_k is not None:
+            component_params["top_k"] = top_k
+        if search_params is not None:
+            component_params["search_params"] = search_params
+
+        super().__init__(
+            component=TavilyWebSearch(**component_params),
+            name=name,
+            description=description,
+            outputs_to_string={"source": "documents", "handler": _format_search_results},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the tool to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return {
+            "type": generate_qualified_class_name(type(self)),
+            "data": {
+                "api_key": self.api_key.to_dict() if self.api_key else None,
+                "top_k": self.top_k,
+                "search_params": self.search_params,
+                "name": self.name,
+                "description": self.description,
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TavilyWebSearchTool":
+        """
+        Deserialize the tool from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized tool.
+        """
+        inner_data = data["data"]
+        deserialize_secrets_inplace(inner_data, keys=["api_key"])
+        return cls(**inner_data)

--- a/integrations/tavily/tests/test_tavily_websearch_tool.py
+++ b/integrations/tavily/tests/test_tavily_websearch_tool.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import pytest
+from haystack import Document
+from haystack.utils import Secret
+
+from haystack_integrations.tools.tavily.websearch_tool import TavilyWebSearchTool, _format_search_results
+
+
+class TestFormatSearchResults:
+    def test_format_search_results(self):
+        documents = [
+            Document(content="Example content", meta={"title": "Example Title", "url": "https://example.com"}),
+            Document(content="  Other content  ", meta={"title": "Other Title", "url": "https://other.com"}),
+        ]
+        formatted = _format_search_results(documents)
+        assert formatted == (
+            "- Example Title\n  URL: https://example.com\n  Example content\n"
+            "- Other Title\n  URL: https://other.com\n  Other content"
+        )
+
+    def test_format_search_results_no_documents(self):
+        assert _format_search_results([]) == "No results."
+
+    def test_format_search_results_missing_meta(self):
+        formatted = _format_search_results([Document(content=None)])
+        assert formatted == "- Untitled\n  URL: \n  "
+
+
+class TestTavilyWebSearchTool:
+    @pytest.fixture
+    def search_response(self):
+        return {
+            "results": [
+                {"title": "Example Title", "url": "https://example.com", "content": "Example content", "score": 0.95}
+            ]
+        }
+
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        tool = TavilyWebSearchTool()
+
+        assert tool.api_key is None
+        assert tool.top_k is None
+        assert tool.search_params is None
+        assert tool.name == "web_search"
+        assert "Search the web" in tool.description
+        # the parameters exposed to the LLM are derived from the component's run method
+        assert tool.parameters["required"] == ["query"]
+        assert tool.parameters["properties"]["query"]["type"] == "string"
+        # unset parameters fall back to the component defaults
+        assert tool._component.top_k == 10
+        assert tool._component.api_key.resolve_value() == "test-key"
+        assert tool._component.search_params is None
+
+    def test_init_with_params(self):
+        tool = TavilyWebSearchTool(
+            api_key=Secret.from_token("custom-key"),
+            top_k=5,
+            search_params={"search_depth": "advanced"},
+            name="custom_search",
+            description="Custom description.",
+        )
+
+        assert tool.api_key == Secret.from_token("custom-key")
+        assert tool.top_k == 5
+        assert tool.search_params == {"search_depth": "advanced"}
+        assert tool.name == "custom_search"
+        assert tool.description == "Custom description."
+        assert tool._component.api_key == Secret.from_token("custom-key")
+        assert tool._component.top_k == 5
+        assert tool._component.search_params == {"search_depth": "advanced"}
+
+    def test_to_dict(self):
+        tool = TavilyWebSearchTool(
+            api_key=Secret.from_env_var("TAVILY_API_KEY"),
+            top_k=5,
+            search_params={"search_depth": "advanced"},
+        )
+        data = tool.to_dict()
+
+        assert data["type"] == "haystack_integrations.tools.tavily.websearch_tool.TavilyWebSearchTool"
+        assert data["data"] == {
+            "api_key": {"env_vars": ["TAVILY_API_KEY"], "strict": True, "type": "env_var"},
+            "top_k": 5,
+            "search_params": {"search_depth": "advanced"},
+            "name": "web_search",
+            "description": tool.description,
+        }
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        data = {
+            "type": "haystack_integrations.tools.tavily.websearch_tool.TavilyWebSearchTool",
+            "data": {
+                "api_key": {"env_vars": ["TAVILY_API_KEY"], "strict": True, "type": "env_var"},
+                "top_k": 3,
+                "search_params": {"include_answer": True},
+                "name": "custom_search",
+                "description": "Custom description.",
+            },
+        }
+        tool = TavilyWebSearchTool.from_dict(data)
+
+        assert tool.api_key == Secret.from_env_var("TAVILY_API_KEY")
+        assert tool.top_k == 3
+        assert tool.search_params == {"include_answer": True}
+        assert tool.name == "custom_search"
+        assert tool.description == "Custom description."
+        assert tool._component.top_k == 3
+
+    def test_invoke(self, search_response):
+        tool = TavilyWebSearchTool(api_key=Secret.from_token("test-key"), top_k=5)
+        mock_client = MagicMock()
+        mock_client.search.return_value = search_response
+        tool._component._tavily_client = mock_client
+
+        result = tool.invoke(query="test query")
+
+        assert result["documents"] == [
+            Document(
+                content="Example content",
+                meta={"title": "Example Title", "url": "https://example.com"},
+                score=0.95,
+            )
+        ]
+        mock_client.search.assert_called_once_with(query="test query", max_results=5)
+
+    def test_invoke_outputs_to_string(self, search_response):
+        tool = TavilyWebSearchTool(api_key=Secret.from_token("test-key"))
+        mock_client = MagicMock()
+        mock_client.search.return_value = search_response
+        tool._component._tavily_client = mock_client
+
+        result = tool.invoke(query="test query")
+        message = tool.outputs_to_string["handler"](result[tool.outputs_to_string["source"]])
+
+        assert message == "- Example Title\n  URL: https://example.com\n  Example content"


### PR DESCRIPTION

### Proposed Changes:
- add a ready-made `TavilyWebSearchTool` based on `TavilyWebSearch` component

### How did you test it?
CI, new tests
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
