### PR TITLE
chore: Update litellm dependency version in pyproject.toml

### DIFF
--- a/integrations/litellm/pyproject.toml
+++ b/integrations/litellm/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-# litellm 1.82.7 and 1.82.8 were malicious releases and are excluded.
 dependencies = ["haystack-ai>=2.30.0", "litellm>=1.84.0,<2.0"]
 
 [project.urls]

--- a/integrations/litellm/pyproject.toml
+++ b/integrations/litellm/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 # litellm 1.82.7 and 1.82.8 were malicious releases and are excluded.
-dependencies = ["haystack-ai>=2.30.0", "litellm>=1.60.0,<2.0,!=1.82.7,!=1.82.8"]
+dependencies = ["haystack-ai>=2.30.0", "litellm>=1.84.0,<2.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/litellm#readme"


### PR DESCRIPTION
### Related Issues

There is a security advisory regarding litellm pypi package < 1.84.0 https://github.com/advisories/GHSA-4xpc-pv4p-pm3w

SDK usage and thus usage of our Haystack integration is unaffected. Only proxy deployments must patch. Our integration's constraint is litellm>=1.60.0,<2.0 right now, which allows users to upgrade. Most users won't need to. No need for further action on our side.

### Proposed Changes:

- Tighten the litellm dependency constraint so that unpatched versions are excluded

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
