### PR TITLE
chore: docling - drop the haystack-ai <3.0.0 cap to allow Haystack 3.0

### DIFF
--- a/integrations/docling/pyproject.toml
+++ b/integrations/docling/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.12.0,<3.0.0",
+  "haystack-ai>=2.12.0",
   "docling>=2.32.0,<3.0.0",
   "lxml>=6.0.2",
 ]


### PR DESCRIPTION
### Related Issues
None

### Proposed Changes:
- Relax the `haystack-ai` dependency from `>=2.12.0,<3.0.0` to `>=2.12.0` so `docling-haystack` can be installed together with Haystack 3.0.
- The docling integration was the only one in the monorepo with an upper bound on `haystack-ai`; the cap was inherited from the upstream project's pyproject when the integration was donated in #3066. With #3562 already having removed the reliance on the `haystack.utils.base_serialization` helpers, this pin was the last remaining Haystack 3.0 blocker.

### How did you test it?
Installed Haystack `3.0.0rc0` (current `main` of deepset-ai/haystack) into the docling test env and verified:
- all 37 unit tests pass
- `mypy` passes
- a pipeline containing `DoclingConverter` round-trips through `Pipeline.dumps()`/`Pipeline.loads()` (the `haystack_integrations` namespace is on the v3 deserialization allowlist by default) and `Pipeline.run()` converts a real document end-to-end

Also re-ran `fmt`, `test:types`, and `test:unit` against the released `haystack-ai==2.31.0` to confirm nothing regresses on 2.x.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)