### PR TITLE
fix: JinaRanker - add missing output edge

### DIFF
--- a/integrations/jina/pyproject.toml
+++ b/integrations/jina/pyproject.toml
@@ -72,7 +72,8 @@ unit-cov-retry = 'pytest --cov=haystack_integrations --reruns 3 --reruns-delay 3
 integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append --reruns 3 --reruns-delay 30 -x -m "integration" {args:tests}'
 
 types = """mypy -p haystack_integrations.components.connectors.jina \
--p haystack_integrations.components.embedders.jina {args}"""
+-p haystack_integrations.components.embedders.jina \
+-p haystack_integrations.components.rankers.jina {args}"""
 
 [tool.mypy]
 install_types = true

--- a/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
+++ b/integrations/jina/src/haystack_integrations/components/rankers/jina/ranker.py
@@ -158,14 +158,14 @@ class JinaRanker:
 
         return {"documents": ranked_docs, "meta": {"model": resp["model"], "usage": resp["usage"]}}
 
-    @component.output_types(documents=list[Document])
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
     def run(
         self,
         query: str,
         documents: list[Document],
         top_k: int | None = None,
         score_threshold: float | None = None,
-    ) -> dict[str, list[Document]]:
+    ) -> dict[str, Any]:
         """
         Returns a list of Documents ranked by their similarity to the given query.
 
@@ -180,6 +180,7 @@ class JinaRanker:
         :returns:
             A dictionary with the following keys:
             - `documents`: List of Documents most similar to the given query in descending order of similarity.
+            - `meta`: A dictionary with metadata about the request, including the model used and usage information.
 
         :raises ValueError:
             If `top_k` is not > 0.
@@ -195,14 +196,14 @@ class JinaRanker:
 
         return self._parse_response(resp, documents, top_k, score_threshold)
 
-    @component.output_types(documents=list[Document])
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
     async def run_async(
         self,
         query: str,
         documents: list[Document],
         top_k: int | None = None,
         score_threshold: float | None = None,
-    ) -> dict[str, list[Document]]:
+    ) -> dict[str, Any]:
         """
         Asynchronously returns a list of Documents ranked by their similarity to the given query.
 
@@ -220,6 +221,7 @@ class JinaRanker:
         :returns:
             A dictionary with the following keys:
             - `documents`: List of Documents most similar to the given query in descending order of similarity.
+            - `meta`: A dictionary with metadata about the request, including the model used and usage information.
 
         :raises ValueError:
             If `top_k` is not > 0.


### PR DESCRIPTION
## Proposed Changes:
-  add missing output edge to `JinaRanker`
- add py.typed on Jina `rankers` directory and run type checking

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
