### PR TITLE
fix: fix RagasEvaluator output edge type

### DIFF
--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -106,7 +106,7 @@ class RagasEvaluator:
         data["init_parameters"]["ragas_metrics"] = [_deserialize_metric(m) for m in metrics_data]
         return default_from_dict(cls, data)
 
-    @component.output_types(result=dict[str, dict[str, MetricResult]])
+    @component.output_types(result=dict[str, MetricResult])
     def run(
         self,
         query: str | None = None,
@@ -152,7 +152,7 @@ class RagasEvaluator:
 
         return {"result": results}
 
-    @component.output_types(result=dict[str, dict[str, MetricResult]])
+    @component.output_types(result=dict[str, MetricResult])
     async def run_async(
         self,
         query: str | None = None,


### PR DESCRIPTION
### Related Issues
https://github.com/deepset-ai/haystack-core-integrations/blob/dba2899dc42d1b4a5546cbcd9d76f0c6398574fc/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py#L109-L119

Here, the `result` output type declared by the edge is the same as the method type hint. This is wrong and too nested:
https://github.com/deepset-ai/haystack-core-integrations/blob/dba2899dc42d1b4a5546cbcd9d76f0c6398574fc/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py#L151-L153

This also prevents properly connecting the evaluator to other components if needed

### Proposed Changes:
- fix the output edge type

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
