### PR TITLE
fix(docling): stringify binary_hash in document metadata

### DIFF
--- a/integrations/docling/CHANGELOG.md
+++ b/integrations/docling/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- *(docling)* [**breaking**] Store `dl_meta.origin.binary_hash` as a string so values above signed 64-bit range index correctly (#3604)
+
+
 ## [integrations/docling-v1.3.0] - 2026-07-16
 
 ### 🧹 Chores

--- a/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
+++ b/integrations/docling/src/haystack_integrations/components/converters/docling/converter.py
@@ -23,6 +23,25 @@ from docling.document_converter import DocumentConverter
 logger = logging.getLogger(__name__)
 
 
+def _stringify_binary_hash(value: Any) -> Any:
+    """
+    Convert Docling ``binary_hash`` values to strings.
+
+    ``binary_hash`` is an unsigned 64-bit integer. Document stores that map numeric
+    metadata to signed 64-bit integers (for example OpenSearch ``long``) reject values
+    greater than ``2**63 - 1``. Storing the hash as a string avoids that failure while
+    preserving the full value.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (str(item) if key == "binary_hash" and item is not None else _stringify_binary_hash(item))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_stringify_binary_hash(item) for item in value]
+    return value
+
+
 def _bytestream_to_document_stream(source: ByteStream) -> DocumentStream:
     """
     Build a `DocumentStream` from a Haystack `ByteStream`.
@@ -82,7 +101,7 @@ class MetaExtractor(BaseMetaExtractor):
 
     def extract_chunk_meta(self, chunk: BaseChunk) -> dict[str, Any]:
         """Extract chunk meta."""
-        meta: dict[str, Any] = {"dl_meta": chunk.export_json_dict()}
+        meta: dict[str, Any] = {"dl_meta": _stringify_binary_hash(chunk.export_json_dict())}
         doc_items = getattr(chunk.meta, "doc_items", [])
         page_nos = {prov.page_no for item in doc_items for prov in getattr(item, "prov", [])}
         if page_nos:
@@ -91,7 +110,10 @@ class MetaExtractor(BaseMetaExtractor):
 
     def extract_dl_doc_meta(self, dl_doc: DoclingDocument) -> dict[str, Any]:
         """Extract Docling document meta."""
-        return {"dl_meta": {"origin": dl_doc.origin.model_dump(exclude_none=True)}} if dl_doc.origin else {}
+        if not dl_doc.origin:
+            return {}
+        origin = _stringify_binary_hash(dl_doc.origin.model_dump(exclude_none=True))
+        return {"dl_meta": {"origin": origin}}
 
 
 @component

--- a/integrations/docling/tests/test_converter.py
+++ b/integrations/docling/tests/test_converter.py
@@ -18,7 +18,10 @@ from haystack_integrations.components.converters.docling import (
     ExportType,
     MetaExtractor,
 )
-from haystack_integrations.components.converters.docling.converter import _bytestream_to_document_stream
+from haystack_integrations.components.converters.docling.converter import (
+    _bytestream_to_document_stream,
+    _stringify_binary_hash,
+)
 
 
 def test_run_doc_chunks_minimal() -> None:
@@ -557,6 +560,40 @@ class TestMetaExtractor:
         assert result == {"dl_meta": {"origin": {"filename": "foo.pdf", "mimetype": "application/pdf"}}}
         dl_doc.origin.model_dump.assert_called_once_with(exclude_none=True)
 
+    def test_extract_dl_doc_meta_stringifies_oversized_binary_hash(self) -> None:
+        # Values above 2**63 - 1 are valid uint64 hashes but break OpenSearch `long` fields.
+        oversized_hash = 9768961288489567249
+        dl_doc = MagicMock()
+        dl_doc.origin.model_dump.return_value = {
+            "filename": "foo.pdf",
+            "mimetype": "application/pdf",
+            "binary_hash": oversized_hash,
+        }
+
+        result = MetaExtractor().extract_dl_doc_meta(dl_doc=dl_doc)
+
+        assert result == {
+            "dl_meta": {
+                "origin": {
+                    "filename": "foo.pdf",
+                    "mimetype": "application/pdf",
+                    "binary_hash": str(oversized_hash),
+                }
+            }
+        }
+        assert isinstance(result["dl_meta"]["origin"]["binary_hash"], str)
+
+    def test_extract_chunk_meta_stringifies_nested_binary_hash(self) -> None:
+        oversized_hash = 9768961288489567249
+        chunk = MagicMock()
+        chunk.export_json_dict.return_value = {"origin": {"binary_hash": oversized_hash, "filename": "bar.pdf"}}
+        chunk.meta.doc_items = []
+
+        result = MetaExtractor().extract_chunk_meta(chunk=chunk)
+
+        assert result == {"dl_meta": {"origin": {"binary_hash": str(oversized_hash), "filename": "bar.pdf"}}}
+        assert isinstance(result["dl_meta"]["origin"]["binary_hash"], str)
+
     def test_extract_dl_doc_meta_without_origin(self) -> None:
         dl_doc = MagicMock()
         dl_doc.origin = None
@@ -564,6 +601,22 @@ class TestMetaExtractor:
         result = MetaExtractor().extract_dl_doc_meta(dl_doc=dl_doc)
 
         assert result == {}
+
+
+def test_stringify_binary_hash_recursively() -> None:
+    payload = {
+        "origin": {"binary_hash": 9768961288489567249, "filename": "a.pdf"},
+        "items": [{"binary_hash": 1}, {"other": 2}],
+        "binary_hash": None,
+    }
+
+    result = _stringify_binary_hash(payload)
+
+    assert result == {
+        "origin": {"binary_hash": "9768961288489567249", "filename": "a.pdf"},
+        "items": [{"binary_hash": "1"}, {"other": 2}],
+        "binary_hash": None,
+    }
 
 
 def test_run_without_sources_or_paths_raises_value_error() -> None:


### PR DESCRIPTION
### Related Issues

- fixes #3604

### Proposed Changes:

`DoclingConverter` / `MetaExtractor` previously copied Docling's `origin.binary_hash` into Haystack document metadata as an integer. That value is an unsigned 64-bit hash, so values greater than `2**63 - 1` break document stores that map numeric metadata to signed 64-bit types (e.g. OpenSearch `long`).

Following the maintainer suggestion on #3604, `binary_hash` is now always stored as a string. The conversion is applied recursively in both `extract_dl_doc_meta` and `extract_chunk_meta`, so nested occurrences from chunk JSON are covered as well.

This is a **breaking** metadata-type change for callers that assumed `binary_hash` was an `int`.

### How did you test it?

- Added unit tests for oversized `binary_hash` in document and chunk metadata paths
- Added a recursive helper test covering nested dicts/lists and `None`
- Ran: `pytest tests/test_converter.py::TestMetaExtractor tests/test_converter.py::test_stringify_binary_hash_recursively` (8 passed)
- `ruff check` on the touched files

### Notes for the reviewer

- Approach matches @julian-risch's guidance on #3604 (`binary_hash: str` + major release of the integration).
- Version bump / release tagging left to maintainers (hatch-vcs tag-driven). CHANGELOG Unreleased entry marks the change as breaking.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

Made with [Cursor](https://cursor.com)