### PR TITLE
docs: fix wrong class references in Fastembed sparse embedder messages and docstrings

### DIFF
--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_document_embedder.py
@@ -71,7 +71,7 @@ class FastembedSparseDocumentEmbedder:
         model_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
-        Create an FastembedDocumentEmbedder component.
+        Create a FastembedSparseDocumentEmbedder component.
 
         :param model: Local path or name of the model in Hugging Face's model hub,
             such as `prithivida/Splade_PP_en_v1`.
@@ -162,7 +162,7 @@ class FastembedSparseDocumentEmbedder:
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = (
                 "FastembedSparseDocumentEmbedder expects a list of Documents as input. "
-                "In case you want to embed a list of strings, please use the FastembedTextEmbedder."
+                "In case you want to embed a list of strings, please use the FastembedSparseTextEmbedder."
             )
             raise TypeError(msg)
 

--- a/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
+++ b/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/fastembed_sparse_text_embedder.py
@@ -107,13 +107,13 @@ class FastembedSparseTextEmbedder:
 
         :param text: A string to embed.
         :returns: A dictionary with the following keys:
-            - `embedding`: A list of floats representing the embedding of the input text.
+            - `sparse_embedding`: The `SparseEmbedding` of the input text.
         :raises TypeError: If the input is not a string.
         """
         if not isinstance(text, str):
             msg = (
                 "FastembedSparseTextEmbedder expects a string as input. "
-                "In case you want to embed a list of Documents, please use the FastembedDocumentEmbedder."
+                "In case you want to embed a list of Documents, please use the FastembedSparseDocumentEmbedder."
             )
             raise TypeError(msg)
 


### PR DESCRIPTION
### Related Issues

- fixes #3609 

### Proposed Changes:

  The sparse embedders reference the dense embedder classes in four user-facing strings (two `TypeError` messages and two docstrings). This corrects them to reference the sparse classes. Behavior is unchanged.

### How did you test it?

Unit tests, lint and format checks.

### Notes for the reviewer

N/A

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings (docstrings updated; string-only change, covered by existing tests)
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
