### PR TITLE
test: refactor Anthropic test suite

### DIFF
--- a/integrations/anthropic/tests/conftest.py
+++ b/integrations/anthropic/tests/conftest.py
@@ -26,6 +26,7 @@ def tools():
     )
     return [tool]
 
+
 def _canonical_completion() -> Message:
     return Message(
         id="foo",
@@ -75,6 +76,6 @@ def mock_chat_completion_extended_thinking():
         yield mock_chat_completion_create
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_files_path():
     return Path(__file__).parent / "test_files"

--- a/integrations/anthropic/tests/conftest.py
+++ b/integrations/anthropic/tests/conftest.py
@@ -1,34 +1,63 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from anthropic.types import Message
+from anthropic.types import Message, TextBlockParam, Usage
+from haystack.dataclasses import ChatMessage
+from haystack.tools import Tool
+
+
+@pytest.fixture
+def chat_messages():
+    return [
+        ChatMessage.from_system("\nYou are a helpful assistant, be super brief in your responses."),
+        ChatMessage.from_user("What's the capital of France?"),
+    ]
+
+
+@pytest.fixture
+def tools():
+    tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+    tool = Tool(
+        name="weather",
+        description="useful to determine the weather in a given location",
+        parameters=tool_parameters,
+        function=lambda x: x,
+    )
+    return [tool]
+
+def _canonical_completion() -> Message:
+    return Message(
+        id="foo",
+        type="message",
+        model="claude-sonnet-4-5",
+        role="assistant",
+        content=[TextBlockParam(type="text", text="Hello! I'm Claude.")],
+        stop_reason="end_turn",
+        usage=Usage(input_tokens=57, output_tokens=40),
+    )
 
 
 @pytest.fixture
 def mock_chat_completion():
-    """
-    Mock the OpenAI API completion response and reuse it for tests
-    """
-    with patch("anthropic.resources.messages.Messages.create") as mock_chat_completion_create:
-        completion = Message(
-            id="foo",
-            content=[{"type": "text", "text": "Hello, world!"}],
-            model="claude-sonnet-4-5",
-            role="assistant",
-            type="message",
-            usage={"input_tokens": 57, "output_tokens": 40},
-        )
+    """Mock the synchronous Anthropic Messages.create and return the canonical reply."""
+    with patch("anthropic.resources.messages.Messages.create") as mock_anthropic:
+        mock_anthropic.return_value = _canonical_completion()
+        yield mock_anthropic
 
-        mock_chat_completion_create.return_value = completion
-        yield mock_chat_completion_create
+
+@pytest.fixture
+async def mock_anthropic_completion_async():
+    """Mock the asynchronous Anthropic AsyncMessages.create and return the canonical reply."""
+    with patch("anthropic.resources.messages.AsyncMessages.create") as mock_anthropic:
+        # Make the mock return an awaitable
+        mock_anthropic.return_value = AsyncMock(return_value=_canonical_completion())()
+        yield mock_anthropic
 
 
 @pytest.fixture
 def mock_chat_completion_extended_thinking():
-    """
-    Mock the OpenAI API completion response and reuse it for tests
-    """
+    """Mock the Anthropic Messages.create with an extended-thinking reply."""
     with patch("anthropic.resources.messages.Messages.create") as mock_chat_completion_create:
         completion = Message(
             id="foo",

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -4,15 +4,10 @@
 
 import json
 import os
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock
 
 import anthropic
 import pytest
-from anthropic.types import (
-    Message,
-    TextBlockParam,
-    Usage,
-)
 from haystack import Pipeline
 from haystack.components.agents import Agent
 from haystack.components.generators.utils import print_streaming_chunk
@@ -45,6 +40,20 @@ def population(city: str) -> str:
     return f"The population of {city} is 2.2 million"
 
 
+class StreamingCollector:
+    """Callable streaming callback that records chunks so live tests can assert on streaming behavior."""
+
+    def __init__(self):
+        self.responses = ""
+        self.counter = 0
+
+    def __call__(self, chunk: StreamingChunk) -> None:
+        self.counter += 1
+        self.responses += chunk.content if chunk.content else ""
+        assert chunk.component_info is not None
+        assert chunk.component_info.type.endswith("chat_generator.AnthropicChatGenerator")
+
+
 @pytest.fixture
 def tool_with_no_parameters():
     tool = Tool(
@@ -56,42 +65,7 @@ def tool_with_no_parameters():
     return tool
 
 
-@pytest.fixture
-def tools():
-    tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
-    tool = Tool(
-        name="weather",
-        description="useful to determine the weather in a given location",
-        parameters=tool_parameters,
-        function=lambda x: x,
-    )
-    return [tool]
-
-
-@pytest.fixture
-def chat_messages():
-    return [
-        ChatMessage.from_user("What's the capital of France"),
-    ]
-
-
-@pytest.fixture
-def mock_anthropic_completion():
-    with patch("anthropic.resources.messages.Messages.create") as mock_anthropic:
-        completion = Message(
-            id="foo",
-            type="message",
-            model="claude-sonnet-4-5",
-            role="assistant",
-            content=[TextBlockParam(type="text", text="Hello! I'm Claude.")],
-            stop_reason="end_turn",
-            usage={"input_tokens": 10, "output_tokens": 20},
-        )
-        mock_anthropic.return_value = completion
-        yield mock_anthropic
-
-
-class TestAnthropicChatGenerator:
+class TestInit:
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = AnthropicChatGenerator.SUPPORTED_MODELS
@@ -110,6 +84,25 @@ class TestAnthropicChatGenerator:
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.tools is None
+
+    def test_init_with_parameters(self, monkeypatch):
+        """
+        Test that the AnthropicChatGenerator component initializes with parameters.
+        """
+        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=lambda x: x)
+
+        component = AnthropicChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            model="claude-sonnet-4-5",
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+            tools=[tool],
+        )
+        assert component.client.api_key == "test-api-key"
+        assert component.model == "claude-sonnet-4-5"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.tools == [tool]
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         """
@@ -137,44 +130,8 @@ class TestAnthropicChatGenerator:
         with pytest.raises(ValueError, match="Duplicate tool names"):
             component._prepare_request_params([ChatMessage.from_user("hi")])
 
-    def test_init_with_parameters(self, monkeypatch):
-        """
-        Test that the AnthropicChatGenerator component initializes with parameters.
-        """
-        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=lambda x: x)
 
-        monkeypatch.setenv("OPENAI_TIMEOUT", "100")
-        monkeypatch.setenv("OPENAI_MAX_RETRIES", "10")
-        component = AnthropicChatGenerator(
-            api_key=Secret.from_token("test-api-key"),
-            model="claude-sonnet-4-5",
-            streaming_callback=print_streaming_chunk,
-            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-            tools=[tool],
-        )
-        assert component.client.api_key == "test-api-key"
-        assert component.model == "claude-sonnet-4-5"
-        assert component.streaming_callback is print_streaming_chunk
-        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
-        assert component.tools == [tool]
-
-    def test_init_with_parameters_and_env_vars(self, monkeypatch):
-        """
-        Test that the AnthropicChatGenerator component initializes with parameters and env vars.
-        """
-        monkeypatch.setenv("OPENAI_TIMEOUT", "100")
-        monkeypatch.setenv("OPENAI_MAX_RETRIES", "10")
-        component = AnthropicChatGenerator(
-            model="claude-sonnet-4-5",
-            api_key=Secret.from_token("test-api-key"),
-            streaming_callback=print_streaming_chunk,
-            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
-        )
-        assert component.client.api_key == "test-api-key"
-        assert component.model == "claude-sonnet-4-5"
-        assert component.streaming_callback is print_streaming_chunk
-        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
-
+class TestSerialization:
     def test_to_dict_default(self, monkeypatch):
         """
         Test that the AnthropicChatGenerator component can be serialized to a dictionary.
@@ -298,34 +255,86 @@ class TestAnthropicChatGenerator:
         with pytest.raises(ValueError):
             AnthropicChatGenerator.from_dict(data)
 
-    def test_run(self, chat_messages, mock_chat_completion):
+    def test_serde_in_pipeline(self):
+        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
+
+        generator = AnthropicChatGenerator(
+            api_key=Secret.from_env_var("ANTHROPIC_API_KEY", strict=False),
+            model="claude-sonnet-4-5",
+            generation_kwargs={"temperature": 0.6},
+            tools=[tool],
+        )
+
+        pipeline = Pipeline()
+        pipeline.add_component("generator", generator)
+
+        pipeline_dict = pipeline.to_dict()
+
+        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
+        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
+        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
+        assert len(tools_entries) == 1
+        type_ = "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator"
+
+        expected_dict = {
+            "metadata": {},
+            "max_runs_per_component": 100,
+            "connection_type_validation": True,
+            "components": {
+                "generator": {
+                    "type": type_,
+                    "init_parameters": {
+                        "api_key": {"type": "env_var", "env_vars": ["ANTHROPIC_API_KEY"], "strict": False},
+                        "model": "claude-sonnet-4-5",
+                        "generation_kwargs": {"temperature": 0.6},
+                        "ignore_tools_thinking_messages": True,
+                        "streaming_callback": None,
+                        "anthropic_server_tools": None,
+                        "timeout": None,
+                        "max_retries": None,
+                    },
+                }
+            },
+            "connections": [],
+        }
+
+        if not hasattr(pipeline, "_connection_type_validation"):
+            expected_dict.pop("connection_type_validation")
+
+        assert pipeline_dict == expected_dict
+
+        pipeline_yaml = pipeline.dumps()
+
+        new_pipeline = Pipeline.loads(pipeline_yaml)
+        assert new_pipeline == pipeline
+
+
+class TestRun:
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            pytest.param([ChatMessage.from_user("What's the capital of France?")], id="list"),
+            pytest.param("What's the capital of France?", id="string"),
+        ],
+    )
+    def test_run(self, mock_chat_completion, messages):
         component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        response = component.run(chat_messages)
+        result = component.run(messages)
 
-        # check that the component returns the correct ChatMessage response
-        assert isinstance(response, dict)
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) == 1
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-
-    def test_run_with_string_input(self, mock_anthropic_completion):
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        result = component.run("What's the capital of France?")
-
-        # Check that the backend received exactly one user message
-        _, kwargs = mock_anthropic_completion.call_args
+        # both a message list and a bare string must reach the backend as a single user message
+        _, kwargs = mock_chat_completion.call_args
         assert len(kwargs["messages"]) == 1
         assert kwargs["messages"][0]["role"] == "user"
         assert kwargs["messages"][0]["content"][0]["type"] == "text"
         assert kwargs["messages"][0]["content"][0]["text"] == "What's the capital of France?"
 
-        # Check that the result contains exactly one ChatMessage
+        # the result contains exactly one ChatMessage reply
+        assert isinstance(result, dict)
         assert isinstance(result["replies"], list)
         assert len(result["replies"]) == 1
         assert isinstance(result["replies"][0], ChatMessage)
 
-    def test_run_with_params(self, chat_messages, mock_anthropic_completion):
+    def test_run_with_params(self, chat_messages, mock_chat_completion):
         """
         Test that the AnthropicChatGenerator component can run with parameters.
         """
@@ -335,7 +344,7 @@ class TestAnthropicChatGenerator:
         response = component.run(chat_messages)
 
         # Check that the component calls the Anthropic API with the correct parameters
-        _, kwargs = mock_anthropic_completion.call_args
+        _, kwargs = mock_chat_completion.call_args
         assert kwargs["max_tokens"] == 10
         assert kwargs["temperature"] == 0.5
 
@@ -349,23 +358,18 @@ class TestAnthropicChatGenerator:
         assert response["replies"][0].meta["model"] == "claude-sonnet-4-5"
         assert response["replies"][0].meta["finish_reason"] == "stop"
 
-    def test_run_with_output_config(self, chat_messages, mock_anthropic_completion):
-        """
-        Test that output_config is passed to the Anthropic API.
-        """
-        output_config = {"effort": "medium"}
-        component = AnthropicChatGenerator(
-            api_key=Secret.from_token("test-api-key"),
-            generation_kwargs={"max_tokens": 10, "output_config": output_config},
-        )
-        component.run(chat_messages)
-
-        _, kwargs = mock_anthropic_completion.call_args
-        assert kwargs["output_config"] == output_config
-
     @pytest.mark.parametrize(
         "generation_kwargs,expected_kwargs",
         [
+            (
+                # a raw output_config is forwarded to the Anthropic API unchanged
+                {
+                    "output_config": {"effort": "medium"},
+                },
+                {
+                    "output_config": {"effort": "medium"},
+                },
+            ),
             (
                 {
                     "parallel_tool_use": False,
@@ -439,7 +443,7 @@ class TestAnthropicChatGenerator:
         ],
     )
     def test_run_with_flattened_generation_kwargs(
-        self, chat_messages, mock_anthropic_completion, generation_kwargs, expected_kwargs
+        self, chat_messages, mock_chat_completion, generation_kwargs, expected_kwargs
     ):
         """
         Test that the AnthropicChatGenerator component can run with parameters.
@@ -451,11 +455,13 @@ class TestAnthropicChatGenerator:
         component.run(chat_messages)
 
         # Check that the component calls the Anthropic API with the correct parameters
-        actual_kwargs = mock_anthropic_completion.call_args.kwargs
+        actual_kwargs = mock_chat_completion.call_args.kwargs
         assert actual_kwargs.get("tool_choice") == expected_kwargs.get("tool_choice")
         assert actual_kwargs.get("thinking") == expected_kwargs.get("thinking")
         assert actual_kwargs.get("output_config") == expected_kwargs.get("output_config")
 
+
+class TestAnthropicServerTools:
     def test_init_with_anthropic_server_tools(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
         server_tools = [{"type": "web_search_20250305"}]
@@ -475,180 +481,27 @@ class TestAnthropicChatGenerator:
         component = AnthropicChatGenerator.from_dict(data)
         assert component.anthropic_server_tools == [{"type": "web_search_20250305"}]
 
-    def test_run_with_anthropic_server_tools(self, chat_messages, mock_anthropic_completion):
+    def test_run_with_anthropic_server_tools(self, chat_messages, mock_chat_completion):
         server_tools = [{"type": "web_search_20250305"}]
         component = AnthropicChatGenerator(
             api_key=Secret.from_token("test-api-key"), anthropic_server_tools=server_tools
         )
         component.run(messages=chat_messages)
-        _, kwargs = mock_anthropic_completion.call_args
+        _, kwargs = mock_chat_completion.call_args
         assert kwargs["tools"] == server_tools
 
-    def test_run_with_tools_and_anthropic_server_tools(self, chat_messages, mock_anthropic_completion, tools):
+    def test_run_with_tools_and_anthropic_server_tools(self, chat_messages, mock_chat_completion, tools):
         server_tools = [{"type": "web_search_20250305"}]
         component = AnthropicChatGenerator(
             api_key=Secret.from_token("test-api-key"), tools=tools, anthropic_server_tools=server_tools
         )
         component.run(messages=chat_messages)
-        _, kwargs = mock_anthropic_completion.call_args
+        _, kwargs = mock_chat_completion.call_args
         assert len(kwargs["tools"]) == 2
         assert kwargs["tools"][-1] == {"type": "web_search_20250305"}
 
-    def test_serde_in_pipeline(self):
-        tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
 
-        generator = AnthropicChatGenerator(
-            api_key=Secret.from_env_var("ANTHROPIC_API_KEY", strict=False),
-            model="claude-sonnet-4-5",
-            generation_kwargs={"temperature": 0.6},
-            tools=[tool],
-        )
-
-        pipeline = Pipeline()
-        pipeline.add_component("generator", generator)
-
-        pipeline_dict = pipeline.to_dict()
-
-        # the Tool serialization format is owned by haystack-ai and varies across its versions; the
-        # dumps/loads round-trip below covers the tools, so exclude them from the pinned-dict comparison
-        tools_entries = pipeline_dict["components"]["generator"]["init_parameters"].pop("tools")
-        assert len(tools_entries) == 1
-        type_ = "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator"
-
-        expected_dict = {
-            "metadata": {},
-            "max_runs_per_component": 100,
-            "connection_type_validation": True,
-            "components": {
-                "generator": {
-                    "type": type_,
-                    "init_parameters": {
-                        "api_key": {"type": "env_var", "env_vars": ["ANTHROPIC_API_KEY"], "strict": False},
-                        "model": "claude-sonnet-4-5",
-                        "generation_kwargs": {"temperature": 0.6},
-                        "ignore_tools_thinking_messages": True,
-                        "streaming_callback": None,
-                        "anthropic_server_tools": None,
-                        "timeout": None,
-                        "max_retries": None,
-                    },
-                }
-            },
-            "connections": [],
-        }
-
-        if not hasattr(pipeline, "_connection_type_validation"):
-            expected_dict.pop("connection_type_validation")
-
-        assert pipeline_dict == expected_dict
-
-        pipeline_yaml = pipeline.dumps()
-
-        new_pipeline = Pipeline.loads(pipeline_yaml)
-        assert new_pipeline == pipeline
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run(self):
-        """
-        Integration test that the AnthropicChatGenerator component can run with default parameters.
-        """
-        component = AnthropicChatGenerator()
-        results = component.run(messages=[ChatMessage.from_user("What's the capital of France?")])
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-        assert "claude-sonnet-4-5" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_wrong_model(self, chat_messages):
-        component = AnthropicChatGenerator(model="something-obviously-wrong")
-        with pytest.raises(anthropic.NotFoundError):
-            component.run(chat_messages)
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_streaming(self):
-        """
-        Integration test that the AnthropicChatGenerator component can run with streaming.
-        """
-
-        class Callback:
-            def __init__(self):
-                self.responses = ""
-                self.counter = 0
-
-            def __call__(self, chunk: StreamingChunk) -> None:
-                self.counter += 1
-                self.responses += chunk.content if chunk.content else ""
-                assert chunk.component_info is not None
-                assert chunk.component_info.type.endswith("chat_generator.AnthropicChatGenerator")
-
-        callback = Callback()
-
-        component = AnthropicChatGenerator(streaming_callback=callback, timeout=30.0, max_retries=1)
-        results = component.run([ChatMessage.from_user("What's the capital of France?")])
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-
-        assert "claude-sonnet-4-5" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-        assert callback.counter > 1
-        assert "Paris" in callback.responses
-        assert "input_tokens" in message.meta["usage"]
-        assert "output_tokens" in message.meta["usage"]
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_tools(self, tools):
-        """
-        Integration test that the AnthropicChatGenerator component can run with tools.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = AnthropicChatGenerator(tools=tools)
-        results = component.run(messages=initial_messages)
-
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.id is not None
-        assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
-        assert message.meta["finish_reason"] == "tool_calls"
-        assert "completion_tokens" in message.meta["usage"]
-
-        new_messages = [
-            *initial_messages,
-            message,
-            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-        ]
-        # the model tends to make tool calls if provided with tools, so we don't pass them here
-        results = component.run(new_messages, generation_kwargs={"max_tokens": 50})
-
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
-
+class TestMixedToolsAndToolsets:
     def test_init_with_mixed_tools_and_toolsets(self, monkeypatch):
         """Test initialization with a mixed list of Tools and Toolsets."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
@@ -665,6 +518,17 @@ class TestAnthropicChatGenerator:
         assert generator.tools == [tool1, toolset1, tool3]
         assert isinstance(generator.tools, list)
         assert len(generator.tools) == 3
+
+    def test_init_with_duplicate_tools_in_mixed_list(self, monkeypatch):
+        """Test that initialization fails with duplicate tool names in mixed Tools and Toolsets."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+
+        tool1 = Tool(name="duplicate", description="First", parameters={}, function=lambda: None)
+        tool2 = Tool(name="duplicate", description="Second", parameters={}, function=lambda: None)
+        toolset1 = Toolset([tool2])
+
+        with pytest.raises(ValueError, match="duplicate"):
+            AnthropicChatGenerator(tools=[tool1, toolset1])
 
     def test_serde_with_mixed_tools_and_toolsets(self, monkeypatch):
         """Test serialization/deserialization with mixed Tools and Toolsets."""
@@ -692,7 +556,7 @@ class TestAnthropicChatGenerator:
         assert restored.tools[0].name == "tool1"
         assert next(iter(restored.tools[1])).name == "tool2"
 
-    def test_run_with_mixed_tools_and_toolsets(self, chat_messages, mock_anthropic_completion, monkeypatch):
+    def test_run_with_mixed_tools_and_toolsets(self, chat_messages, mock_chat_completion, monkeypatch):
         """Test that the run method works with mixed Tools and Toolsets."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
 
@@ -712,144 +576,194 @@ class TestAnthropicChatGenerator:
         assert len(response["replies"]) == 1
 
         # Check that the component called the Anthropic API with the correct tools
-        _, kwargs = mock_anthropic_completion.call_args
+        _, kwargs = mock_chat_completion.call_args
         assert "tools" in kwargs
         assert len(kwargs["tools"]) == 2
         assert kwargs["tools"][0]["name"] == "tool1"
         assert kwargs["tools"][1]["name"] == "tool2"
 
-    def test_init_with_duplicate_tools_in_mixed_list(self, monkeypatch):
-        """Test that initialization fails with duplicate tool names in mixed Tools and Toolsets."""
+
+class TestPromptCaching:
+    def test_prompt_caching_enabled(self, monkeypatch):
+        """
+        Test that the generation_kwargs extra_headers are correctly passed to the Anthropic API when prompt
+        caching is enabled
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+        component = AnthropicChatGenerator(
+            generation_kwargs={"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}}
+        )
+        assert component.generation_kwargs.get("extra_headers", {}).get("anthropic-beta") == "prompt-caching-2024-07-31"
+
+    def test_to_dict_with_prompt_caching(self, monkeypatch):
+        """
+        Test that the generation_kwargs extra_headers are correctly serialized to a dictionary
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+        component = AnthropicChatGenerator(
+            generation_kwargs={"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}}
+        )
+        data = component.to_dict()
+        assert (
+            data["init_parameters"]["generation_kwargs"]["extra_headers"]["anthropic-beta"]
+            == "prompt-caching-2024-07-31"
+        )
+
+    def test_from_dict_with_prompt_caching(self, monkeypatch):
+        """
+        Test that the generation_kwargs extra_headers are correctly deserialized from a dictionary
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+        data = {
+            "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
+            "init_parameters": {
+                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
+                "model": "claude-sonnet-4-5",
+                "generation_kwargs": {"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}},
+            },
+        }
+        component = AnthropicChatGenerator.from_dict(data)
+        assert component.generation_kwargs["extra_headers"]["anthropic-beta"] == "prompt-caching-2024-07-31"
+
+    @pytest.mark.parametrize("enable_caching", [True, False])
+    def test_run_with_prompt_caching(self, monkeypatch, mock_chat_completion, enable_caching):
+        """
+        Test that the generation_kwargs extra_headers are correctly passed to the Anthropic API in both cases of
+        prompt caching being enabled or not
+        """
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
 
-        tool1 = Tool(name="duplicate", description="First", parameters={}, function=lambda: None)
-        tool2 = Tool(name="duplicate", description="Second", parameters={}, function=lambda: None)
-        toolset1 = Toolset([tool2])
+        generation_kwargs = {"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}} if enable_caching else {}
+        component = AnthropicChatGenerator(generation_kwargs=generation_kwargs)
 
-        with pytest.raises(ValueError, match="duplicate"):
-            AnthropicChatGenerator(tools=[tool1, toolset1])
+        messages = [ChatMessage.from_system("System message"), ChatMessage.from_user("User message")]
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_toolset(self):
-        """
-        Integration test that the AnthropicChatGenerator component can run with a Toolset.
-        """
+        component.run(messages)
 
-        def weather_function(city: str) -> str:
-            """Get weather information for a city."""
-            weather_data = {"Paris": "22°C, sunny", "London": "15°C, rainy", "Tokyo": "18°C, cloudy"}
-            return weather_data.get(city, "Weather data not available")
+        # Check that the Anthropic API was called with the correct headers
+        _, kwargs = mock_chat_completion.call_args
+        headers = kwargs.get("extra_headers", {})
+        if enable_caching:
+            assert "anthropic-beta" in headers
+        else:
+            assert "anthropic-beta" not in headers
 
-        def echo_function(text: str) -> str:
-            """Echo a text."""
-            return text
+    def test_cache_control_forwarded_for_all_block_types(self, monkeypatch, mock_chat_completion):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+        component = AnthropicChatGenerator()
 
-        # Create tools
-        weather_tool = Tool(
-            name="weather",
-            description="Get weather information for a city",
-            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
-            function=weather_function,
+        sys_msg = ChatMessage.from_system("sys")
+        sys_msg._meta["cache_control"] = {"type": "ephemeral"}
+
+        usr_msg = ChatMessage.from_user(
+            "doc chunk",
+            meta={"cache_control": {"type": "ephemeral"}},
         )
 
-        echo_tool = Tool(
-            name="echo",
-            description="Echo a text",
-            parameters={"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
-            function=echo_function,
+        tool_call = ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})
+        asst_msg = ChatMessage.from_assistant(
+            tool_calls=[tool_call],
+            meta={"cache_control": {"type": "ephemeral"}},
         )
 
-        # Create Toolset
-        toolset = Toolset([weather_tool, echo_tool])
-
-        # Test with weather query
-        initial_messages = [ChatMessage.from_user("What's the weather like in Tokyo?")]
-        component = AnthropicChatGenerator(tools=toolset)
-        results = component.run(messages=initial_messages)
-
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.id is not None
-        assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Tokyo"}
-        assert message.meta["finish_reason"] == "tool_calls"
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_tools_streaming(self, tools):
-        """
-        Integration test that the AnthropicChatGenerator component can run with tools and streaming.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = AnthropicChatGenerator(
-            tools=tools, streaming_callback=print_streaming_chunk, generation_kwargs={"max_tokens": 11000}
+        tool_res = ChatMessage.from_tool(
+            origin=tool_call,
+            tool_result="sunny",
+            meta={"cache_control": {"type": "ephemeral"}},
         )
-        results = component.run(messages=initial_messages)
 
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
+        component.run([sys_msg, usr_msg, asst_msg, tool_res])
 
-        # now we have the tool call
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.id is not None
-        assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
-        assert message.meta["finish_reason"] == "tool_calls"
-        assert "output_tokens" in message.meta["usage"]
-        assert "input_tokens" in message.meta["usage"]
+        _, kwargs = mock_chat_completion.call_args
 
-        new_messages = [
-            *initial_messages,
-            message,
-            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-        ]
-        results = component.run(new_messages)
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
+        for blk in kwargs["system"]:
+            assert blk.get("cache_control") == {"type": "ephemeral"}
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
+        assert all("cache_control" not in msg for msg in kwargs["messages"])
+
+        for msg in kwargs["messages"]:
+            for cblk in msg["content"]:
+                assert cblk.get("cache_control") == {"type": "ephemeral"}
+
+    @pytest.mark.parametrize(
+        "beta_header",
+        [
+            "featureA,extended-cache-ttl-2025-04-11",
+            "featureA , featureB , new-fancy-stuff",
+        ],
     )
-    @pytest.mark.integration
-    def test_live_run_with_tools_streaming_and_reasoning(self, tools):
-        """
-        Integration test that the AnthropicChatGenerator component can run with tools and streaming.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = AnthropicChatGenerator(
-            tools=tools,
-            streaming_callback=print_streaming_chunk,
-            generation_kwargs={
-                "thinking": {"type": "enabled", "budget_tokens": 10000},
-                "max_tokens": 11000,
+    def test_extra_headers_pass_through(self, monkeypatch, mock_chat_completion, beta_header):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+
+        component = AnthropicChatGenerator(generation_kwargs={"extra_headers": {"anthropic-beta": beta_header}})
+        component.run([ChatMessage.from_user("ping")])
+
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["extra_headers"]["anthropic-beta"] == beta_header
+
+    def test_convert_messages_attaches_cache_control(self):
+        user = ChatMessage.from_user(
+            "hello",
+            meta={
+                "cache_control": {
+                    "type": "ephemeral",
+                }
             },
         )
+        sys = ChatMessage.from_system("hi", meta={"cache_control": {"type": "ephemeral", "example_key": "example_val"}})
+        sys_blocks, non_sys = _convert_messages_to_anthropic_format([sys, user])
+
+        assert sys_blocks[0]["cache_control"] == {"type": "ephemeral", "example_key": "example_val"}
+        assert non_sys[0]["content"][0]["cache_control"]["type"] == "ephemeral"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set")
+class TestIntegration:
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_live_run(self, streaming):
+        """
+        Integration test that the AnthropicChatGenerator component can run with default parameters,
+        with and without streaming.
+        """
+        callback = StreamingCollector() if streaming else None
+        component = AnthropicChatGenerator(streaming_callback=callback, timeout=30.0, max_retries=1)
+        results = component.run(messages=[ChatMessage.from_user("What's the capital of France?")])
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "claude-sonnet-4-5" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+        if streaming:
+            assert callback.counter > 1
+            assert "Paris" in callback.responses
+            assert "input_tokens" in message.meta["usage"]
+            assert "output_tokens" in message.meta["usage"]
+
+    def test_live_run_wrong_model(self, chat_messages):
+        component = AnthropicChatGenerator(model="something-obviously-wrong")
+        with pytest.raises(anthropic.NotFoundError):
+            component.run(chat_messages)
+
+    @pytest.mark.parametrize("tools_as_toolset", [False, True], ids=["list", "toolset"])
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_live_run_with_tools(self, tools, streaming, tools_as_toolset):
+        """
+        Integration test that the AnthropicChatGenerator component can run with tools passed either as a plain
+        list or wrapped in a Toolset, with and without streaming.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator(
+            tools=Toolset(tools) if tools_as_toolset else tools,
+            streaming_callback=print_streaming_chunk if streaming else None,
+            generation_kwargs={"max_tokens": 11000} if streaming else {},
+        )
         results = component.run(messages=initial_messages)
 
         assert len(results["replies"]) == 1
         message = results["replies"][0]
 
-        # this is Anthropic thinking message prior to tool call
-        assert message.reasoning.reasoning_text
-
-        # now we have the tool call
         assert message.tool_calls
         tool_call = message.tool_call
         assert isinstance(tool_call, ToolCall)
@@ -857,64 +771,26 @@ class TestAnthropicChatGenerator:
         assert tool_call.tool_name == "weather"
         assert tool_call.arguments == {"city": "Paris"}
         assert message.meta["finish_reason"] == "tool_calls"
-        assert "output_tokens" in message.meta["usage"]
-        assert "input_tokens" in message.meta["usage"]
+        if streaming:
+            assert "output_tokens" in message.meta["usage"]
+            assert "input_tokens" in message.meta["usage"]
+        else:
+            assert "completion_tokens" in message.meta["usage"]
 
         new_messages = [
             *initial_messages,
             message,
             ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
         ]
-        results = component.run(new_messages)
+        # the model tends to make tool calls if provided with tools, so we don't pass them here
+        results = component.run(new_messages, generation_kwargs={"max_tokens": 50})
+
         assert len(results["replies"]) == 1
         final_message = results["replies"][0]
         assert not final_message.tool_calls
         assert len(final_message.text) > 0
         assert "paris" in final_message.text.lower()
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_tool_with_no_args_streaming(self, tool_with_no_parameters):
-        """
-        Integration test that the AnthropicChatGenerator component can run with a tool that has no arguments and
-        streaming.
-        """
-        initial_messages = [ChatMessage.from_user("Print Hello World using the print hello world tool.")]
-        component = AnthropicChatGenerator(tools=[tool_with_no_parameters], streaming_callback=print_streaming_chunk)
-        results = component.run(messages=initial_messages)
-
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        # now we have the tool call
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.id is not None
-        assert tool_call.tool_name == "hello_world"
-        assert tool_call.arguments == {}
-        assert message.meta["finish_reason"] == "tool_calls"
-
-        new_messages = [
-            *initial_messages,
-            message,
-            ChatMessage.from_tool(tool_result="Hello World!", origin=tool_call),
-        ]
-        results = component.run(new_messages)
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "hello" in final_message.text.lower()
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
     def test_live_run_with_parallel_tools(self, tools):
         """
         Integration test that the AnthropicChatGenerator component can run with parallel tools.
@@ -968,11 +844,39 @@ class TestAnthropicChatGenerator:
         assert "12°" in message.text
         assert message.meta["finish_reason"] == "stop"
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
+    def test_live_run_with_tool_with_no_args_streaming(self, tool_with_no_parameters):
+        """
+        Integration test that the AnthropicChatGenerator component can run with a tool that has no arguments and
+        streaming.
+        """
+        initial_messages = [ChatMessage.from_user("Print Hello World using the print hello world tool.")]
+        component = AnthropicChatGenerator(tools=[tool_with_no_parameters], streaming_callback=print_streaming_chunk)
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        # now we have the tool call
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.id is not None
+        assert tool_call.tool_name == "hello_world"
+        assert tool_call.arguments == {}
+        assert message.meta["finish_reason"] == "tool_calls"
+
+        new_messages = [
+            *initial_messages,
+            message,
+            ChatMessage.from_tool(tool_result="Hello World!", origin=tool_call),
+        ]
+        results = component.run(new_messages)
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "hello" in final_message.text.lower()
+
     def test_live_run_with_mixed_tools(self):
         """
         Integration test that verifies AnthropicChatGenerator works with mixed Tool and Toolset.
@@ -1068,230 +972,7 @@ class TestAnthropicChatGenerator:
         assert "paris" in final_message.text.lower()
         assert "berlin" in final_message.text.lower()
 
-    def test_prompt_caching_enabled(self, monkeypatch):
-        """
-        Test that the generation_kwargs extra_headers are correctly passed to the Anthropic API when prompt
-        caching is enabled
-        """
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        component = AnthropicChatGenerator(
-            generation_kwargs={"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}}
-        )
-        assert component.generation_kwargs.get("extra_headers", {}).get("anthropic-beta") == "prompt-caching-2024-07-31"
-
-    def test_prompt_caching_cache_control_without_extra_headers(self, monkeypatch, mock_chat_completion, caplog):
-        """
-        Test that the cache_control is removed from the messages when prompt caching is not enabled via extra_headers
-        This is to avoid Anthropic errors when prompt caching is not enabled
-        """
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        component = AnthropicChatGenerator()
-
-        messages = [ChatMessage.from_system("System message"), ChatMessage.from_user("User message")]
-
-        # Add cache_control to messages
-        for msg in messages:
-            msg._meta["cache_control"] = {"type": "ephemeral"}
-
-        # Invoke run with messages
-        component.run(messages)
-
-        # Check caplog for the warning message that should have been logged
-        assert not any("Prompt caching is not enabled" in record.message for record in caplog.records)
-        # Check that the Anthropic API was called without cache_control in messages so that it does not raise an error
-        _, kwargs = mock_chat_completion.call_args
-        for msg in kwargs["messages"]:
-            assert "cache_control" not in msg
-
-    @pytest.mark.parametrize("enable_caching", [True, False])
-    def test_run_with_prompt_caching(self, monkeypatch, mock_chat_completion, enable_caching):
-        """
-        Test that the generation_kwargs extra_headers are correctly passed to the Anthropic API in both cases of
-        prompt caching being enabled or not
-        """
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-
-        generation_kwargs = {"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}} if enable_caching else {}
-        component = AnthropicChatGenerator(generation_kwargs=generation_kwargs)
-
-        messages = [ChatMessage.from_system("System message"), ChatMessage.from_user("User message")]
-
-        component.run(messages)
-
-        # Check that the Anthropic API was called with the correct headers
-        _, kwargs = mock_chat_completion.call_args
-        headers = kwargs.get("extra_headers", {})
-        if enable_caching:
-            assert "anthropic-beta" in headers
-        else:
-            assert "anthropic-beta" not in headers
-
-    def test_to_dict_with_prompt_caching(self, monkeypatch):
-        """
-        Test that the generation_kwargs extra_headers are correctly serialized to a dictionary
-        """
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        component = AnthropicChatGenerator(
-            generation_kwargs={"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}}
-        )
-        data = component.to_dict()
-        assert (
-            data["init_parameters"]["generation_kwargs"]["extra_headers"]["anthropic-beta"]
-            == "prompt-caching-2024-07-31"
-        )
-
-    def test_from_dict_with_prompt_caching(self, monkeypatch):
-        """
-        Test that the generation_kwargs extra_headers are correctly deserialized from a dictionary
-        """
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        data = {
-            "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "strict": True, "type": "env_var"},
-                "model": "claude-sonnet-4-5",
-                "generation_kwargs": {"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}},
-            },
-        }
-        component = AnthropicChatGenerator.from_dict(data)
-        assert component.generation_kwargs["extra_headers"]["anthropic-beta"] == "prompt-caching-2024-07-31"
-
-    def test_cache_control_forwarded_for_all_block_types(self, monkeypatch, mock_chat_completion):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        component = AnthropicChatGenerator()
-
-        sys_msg = ChatMessage.from_system("sys")
-        sys_msg._meta["cache_control"] = {"type": "ephemeral"}
-
-        usr_msg = ChatMessage.from_user(
-            "doc chunk",
-            meta={"cache_control": {"type": "ephemeral"}},
-        )
-
-        tool_call = ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})
-        asst_msg = ChatMessage.from_assistant(
-            tool_calls=[tool_call],
-            meta={"cache_control": {"type": "ephemeral"}},
-        )
-
-        tool_res = ChatMessage.from_tool(
-            origin=tool_call,
-            tool_result="sunny",
-            meta={"cache_control": {"type": "ephemeral"}},
-        )
-
-        component.run([sys_msg, usr_msg, asst_msg, tool_res])
-
-        _, kwargs = mock_chat_completion.call_args
-
-        for blk in kwargs["system"]:
-            assert blk.get("cache_control") == {"type": "ephemeral"}
-
-        assert all("cache_control" not in msg for msg in kwargs["messages"])
-
-        for msg in kwargs["messages"]:
-            for cblk in msg["content"]:
-                assert cblk.get("cache_control") == {"type": "ephemeral"}
-
-    @pytest.mark.parametrize(
-        "beta_header",
-        [
-            "featureA,extended-cache-ttl-2025-04-11",
-            "featureA , featureB , new-fancy-stuff",
-        ],
-    )
-    def test_extra_headers_pass_through(self, monkeypatch, mock_chat_completion, beta_header):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-
-        component = AnthropicChatGenerator(generation_kwargs={"extra_headers": {"anthropic-beta": beta_header}})
-        component.run([ChatMessage.from_user("ping")])
-
-        _, kwargs = mock_chat_completion.call_args
-        assert kwargs["extra_headers"]["anthropic-beta"] == beta_header
-
-    def test_convert_messages_attaches_cache_control(self):
-        user = ChatMessage.from_user(
-            "hello",
-            meta={
-                "cache_control": {
-                    "type": "ephemeral",
-                }
-            },
-        )
-        sys = ChatMessage.from_system("hi", meta={"cache_control": {"type": "ephemeral", "example_key": "example_val"}})
-        sys_blocks, non_sys = _convert_messages_to_anthropic_format([sys, user])
-
-        assert sys_blocks[0]["cache_control"] == {"type": "ephemeral", "example_key": "example_val"}
-        assert non_sys[0]["content"][0]["cache_control"]["type"] == "ephemeral"
-
-    @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY", None), reason="ANTHROPIC_API_KEY not set")
-    @pytest.mark.integration
-    @pytest.mark.parametrize("cache_enabled", [True, False])
-    def test_prompt_caching_live_run(self, cache_enabled):
-        generation_kwargs = {"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}} if cache_enabled else {}
-
-        claude_llm = AnthropicChatGenerator(
-            api_key=Secret.from_env_var("ANTHROPIC_API_KEY"), generation_kwargs=generation_kwargs
-        )
-
-        # see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-limitations
-        system_message = ChatMessage.from_system("This is the cached, here we make it at least 1024 tokens long." * 70)
-        if cache_enabled:
-            system_message._meta["cache_control"] = {"type": "ephemeral"}
-
-        messages = [system_message, ChatMessage.from_user("What's in cached content?")]
-        result = claude_llm.run(messages)
-
-        assert "replies" in result
-        assert len(result["replies"]) == 1
-        token_usage = result["replies"][0].meta.get("usage")
-
-        if cache_enabled:
-            # either we created cache or we read it (depends on how you execute this integration test)
-            assert (
-                token_usage.get("cache_creation_input_tokens") > 1024
-                or token_usage.get("cache_read_input_tokens") > 1024
-            )
-        else:
-            assert token_usage["cache_creation_input_tokens"] == 0
-            assert token_usage["cache_read_input_tokens"] == 0
-
-    @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set")
-    @pytest.mark.integration
-    @pytest.mark.parametrize("cache_enabled", [True, False])
-    def test_prompt_caching_live_run_with_user_message(self, cache_enabled):
-        claude_llm = AnthropicChatGenerator(
-            api_key=Secret.from_env_var("ANTHROPIC_API_KEY"),
-        )
-
-        system_message = ChatMessage.from_system("Hello from system. Just a generic instruction.")
-
-        user_message = ChatMessage.from_user("This is a user message that should be long enough to cache. " * 100)
-        if cache_enabled:
-            user_message._meta["cache_control"] = {"type": "ephemeral"}
-
-        messages = [system_message, user_message]
-        result = claude_llm.run(messages)
-
-        assert "replies" in result
-        assert len(result["replies"]) == 1
-        token_usage = result["replies"][0].meta.get("usage")
-
-        if cache_enabled:
-            assert (
-                token_usage.get("cache_creation_input_tokens", 0) > 1024
-                or token_usage.get("cache_read_input_tokens", 0) > 1024
-            ), f"Unexpected usage stats: {token_usage}"
-        else:
-            assert token_usage.get("cache_creation_input_tokens", 0) == 0
-            assert token_usage.get("cache_read_input_tokens", 0) == 0
-
     @pytest.mark.parametrize("streaming_callback", [None, Mock()])
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
     def test_live_run_with_reasoning(self, streaming_callback):
         chat_generator = AnthropicChatGenerator(
             model="claude-sonnet-4-5",
@@ -1318,11 +999,91 @@ class TestAnthropicChatGenerator:
         if streaming_callback:
             streaming_callback.assert_called()
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic token to run this test.",
-    )
+    def test_live_run_with_tools_streaming_and_reasoning(self, tools):
+        """
+        Integration test that the AnthropicChatGenerator component can run with tools and streaming.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator(
+            tools=tools,
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={
+                "thinking": {"type": "enabled", "budget_tokens": 10000},
+                "max_tokens": 11000,
+            },
+        )
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        # this is Anthropic thinking message prior to tool call
+        assert message.reasoning.reasoning_text
+
+        # now we have the tool call
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.id is not None
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"
+        assert "output_tokens" in message.meta["usage"]
+        assert "input_tokens" in message.meta["usage"]
+
+        new_messages = [
+            *initial_messages,
+            message,
+            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+        ]
+        results = component.run(new_messages)
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
+
+    @pytest.mark.parametrize("cache_enabled", [True, False])
+    @pytest.mark.parametrize("cache_location", ["system", "user"])
+    def test_prompt_caching_live_run(self, cache_enabled, cache_location):
+        """
+        Prompt caching works whether the cache_control marker sits on the system or the user message.
+        """
+        generation_kwargs = {"extra_headers": {"anthropic-beta": "prompt-caching-2024-07-31"}} if cache_enabled else {}
+
+        claude_llm = AnthropicChatGenerator(
+            api_key=Secret.from_env_var("ANTHROPIC_API_KEY"), generation_kwargs=generation_kwargs
+        )
+
+        # see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-limitations
+        if cache_location == "system":
+            cached_message = ChatMessage.from_system(
+                "This is the cached, here we make it at least 1024 tokens long." * 70
+            )
+            messages = [cached_message, ChatMessage.from_user("What's in cached content?")]
+        else:
+            cached_message = ChatMessage.from_user("This is a user message that should be long enough to cache. " * 100)
+            messages = [ChatMessage.from_system("Hello from system. Just a generic instruction."), cached_message]
+
+        if cache_enabled:
+            cached_message._meta["cache_control"] = {"type": "ephemeral"}
+
+        result = claude_llm.run(messages)
+
+        assert "replies" in result
+        assert len(result["replies"]) == 1
+        token_usage = result["replies"][0].meta.get("usage")
+
+        if cache_enabled:
+            # either we created cache or we read it (depends on how you execute this integration test)
+            assert (
+                token_usage.get("cache_creation_input_tokens", 0) > 1024
+                or token_usage.get("cache_read_input_tokens", 0) > 1024
+            ), f"Unexpected usage stats: {token_usage}"
+        else:
+            assert token_usage.get("cache_creation_input_tokens", 0) == 0
+            assert token_usage.get("cache_read_input_tokens", 0) == 0
+
     def test_live_run_multimodal(self, test_files_path):
         """Integration test for multimodal functionality with real API."""
         image_path = test_files_path / "apple.jpg"
@@ -1341,11 +1102,6 @@ class TestAnthropicChatGenerator:
         assert len(message.text) > 0
         assert any(word in message.text.lower() for word in ["apple", "fruit", "red"])
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic token to run this test.",
-    )
     def test_live_run_with_file_content(self, test_files_path):
         pdf_path = test_files_path / "sample_pdf_3.pdf"
 
@@ -1358,7 +1114,6 @@ class TestAnthropicChatGenerator:
                 content_parts=[file_content, "Is this document a paper about LLMs? Respond with 'yes' or 'no' only."]
             )
         ]
-
         generator = AnthropicChatGenerator(model="claude-haiku-4-5")
         results = generator.run(chat_messages)
 
@@ -1370,11 +1125,6 @@ class TestAnthropicChatGenerator:
         assert message.text
         assert "no" in message.text.lower()
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
     def test_live_run_with_json_structured_output(self):
         """
         Integration test that the AnthropicChatGenerator component returns valid JSON
@@ -1418,39 +1168,6 @@ class TestAnthropicChatGenerator:
         assert "enterprise" in parsed["plan_interest"].lower()
         assert parsed["demo_requested"] is True
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic token to run this test.",
-    )
-    def test_live_run_agent_with_images_in_tool_result(self, test_files_path):
-        def retrieve_image():
-            return [
-                TextContent("Here is the retrieved image."),
-                ImageContent.from_file_path(test_files_path / "apple.jpg", size=(100, 100)),
-            ]
-
-        image_retriever_tool = create_tool_from_function(
-            name="retrieve_image", description="Tool to retrieve an image", function=retrieve_image
-        )
-        image_retriever_tool.outputs_to_string = {"raw_result": True}
-
-        agent = Agent(
-            chat_generator=AnthropicChatGenerator(model="claude-haiku-4-5"),
-            system_prompt="You are an Agent that can retrieve images and describe them.",
-            tools=[image_retriever_tool],
-        )
-
-        user_message = ChatMessage.from_user("Retrieve the image and describe it in max 5 words.")
-        result = agent.run(messages=[user_message])
-
-        assert "apple" in result["last_message"].text.lower()
-
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
     @pytest.mark.parametrize("streaming", [False, True])
     def test_live_run_with_anthropic_server_tools(self, streaming):
         """The web search runs on Anthropic's side: it must never surface as a tool call to invoke."""
@@ -1478,11 +1195,29 @@ class TestAnthropicChatGenerator:
         _, non_system = _convert_messages_to_anthropic_format([message])
         assert non_system[0]["content"] == raw_content
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
+    def test_live_run_agent_with_images_in_tool_result(self, test_files_path):
+        def retrieve_image():
+            return [
+                TextContent("Here is the retrieved image."),
+                ImageContent.from_file_path(test_files_path / "apple.jpg", size=(100, 100)),
+            ]
+
+        image_retriever_tool = create_tool_from_function(
+            name="retrieve_image", description="Tool to retrieve an image", function=retrieve_image
+        )
+        image_retriever_tool.outputs_to_string = {"raw_result": True}
+
+        agent = Agent(
+            chat_generator=AnthropicChatGenerator(model="claude-haiku-4-5"),
+            system_prompt="You are an Agent that can retrieve images and describe them.",
+            tools=[image_retriever_tool],
+        )
+
+        user_message = ChatMessage.from_user("Retrieve the image and describe it in max 5 words.")
+        result = agent.run(messages=[user_message])
+
+        assert "apple" in result["last_message"].text.lower()
+
     @pytest.mark.parametrize("streaming", [False, True])
     def test_live_run_agent_with_local_and_anthropic_server_tools(self, streaming):
         """An Agent must invoke only the client-side tool, while the server tool runs remotely."""
@@ -1533,200 +1268,3 @@ class TestAnthropicChatGenerator:
             for m in result["messages"]
         )
         assert searched
-
-
-class TestAnthropicChatGeneratorAsync:
-    @pytest.fixture
-    async def mock_anthropic_completion_async(self):
-        with patch("anthropic.resources.messages.AsyncMessages.create") as mock_anthropic:
-            completion = Message(
-                id="foo",
-                type="message",
-                model="claude-sonnet-4-5",
-                role="assistant",
-                content=[TextBlockParam(type="text", text="Hello! I'm Claude.")],
-                stop_reason="end_turn",
-                usage=Usage(input_tokens=10, output_tokens=20),
-            )
-            # Make the mock return an awaitable
-            mock_anthropic.return_value = AsyncMock(return_value=completion)()
-            yield mock_anthropic
-
-    @pytest.fixture
-    async def mock_anthropic_completion_async_with_tool(self):
-        with patch("anthropic.resources.messages.AsyncMessages.create") as mock_anthropic:
-            completion = Message(
-                id="foo",
-                type="message",
-                model="claude-sonnet-4-5",
-                role="assistant",
-                content=[
-                    TextBlockParam(type="text", text="Let me check the weather for you."),
-                    {"type": "tool_use", "id": "tool_123", "name": "weather", "input": {"city": "Paris"}},
-                ],
-                stop_reason="tool_use",
-                usage=Usage(input_tokens=10, output_tokens=20),
-            )
-            # Make the mock return an awaitable
-            mock_anthropic.return_value = AsyncMock(return_value=completion)()
-            yield mock_anthropic
-
-    @pytest.mark.asyncio
-    async def test_run_async(self, chat_messages, mock_anthropic_completion_async, monkeypatch):
-        """
-        Test that the async run method of AnthropicChatGenerator works correctly.
-        """
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
-        component = AnthropicChatGenerator()
-        response = await component.run_async(chat_messages)
-
-        # check that the component returns the correct ChatMessage response
-        assert isinstance(response, dict)
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) == 1
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-
-    @pytest.mark.asyncio
-    async def test_run_async_with_string_input(self, mock_anthropic_completion_async):
-        """
-        Test that the async run method of AnthropicChatGenerator works with string input.
-        """
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        result = await component.run_async("What's the capital of France?")
-
-        # Check that the backend received exactly one user message
-        _, kwargs = mock_anthropic_completion_async.call_args
-        assert len(kwargs["messages"]) == 1
-        assert kwargs["messages"][0]["role"] == "user"
-        assert kwargs["messages"][0]["content"][0]["type"] == "text"
-        assert kwargs["messages"][0]["content"][0]["text"] == "What's the capital of France?"
-
-        # Check that the result contains exactly one ChatMessage
-        assert isinstance(result["replies"], list)
-        assert len(result["replies"]) == 1
-        assert isinstance(result["replies"][0], ChatMessage)
-
-    @pytest.mark.asyncio
-    async def test_run_async_with_params(self, chat_messages, mock_anthropic_completion_async):
-        """
-        Test that the async run method of AnthropicChatGenerator works with parameters.
-        """
-        component = AnthropicChatGenerator(
-            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
-        )
-        response = await component.run_async(chat_messages)
-
-        # Check that the component calls the Anthropic API with the correct parameters
-        _, kwargs = mock_anthropic_completion_async.call_args
-        assert kwargs["max_tokens"] == 10
-        assert kwargs["temperature"] == 0.5
-
-        # Check that the component returns the correct response
-        assert isinstance(response, dict)
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) == 1
-        assert isinstance(response["replies"][0], ChatMessage)
-        assert "Hello! I'm Claude." in response["replies"][0].text
-        assert response["replies"][0].meta["model"] == "claude-sonnet-4-5"
-        assert response["replies"][0].meta["finish_reason"] == "stop"
-        assert "completion_tokens" in response["replies"][0].meta["usage"]
-
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    async def test_live_run_async(self):
-        """
-        Integration test that the async run method of AnthropicChatGenerator works with default parameters.
-        """
-        component = AnthropicChatGenerator()
-        results = await component.run_async(messages=[ChatMessage.from_user("What's the capital of France?")])
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-        assert "claude-sonnet-4-5" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-        assert "completion_tokens" in message.meta["usage"]
-
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    async def test_live_run_async_with_streaming(self):
-        """
-        Test that the async run method of AnthropicChatGenerator works with streaming.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = AnthropicChatGenerator()  # No streaming callback during initialization
-
-        counter = 0
-        responses = ""
-
-        # Create a callback that's compatible with async operations
-        async def callback(chunk: StreamingChunk) -> None:
-            nonlocal counter
-            nonlocal responses
-            counter += 1
-            responses += chunk.content if chunk.content else ""
-            assert chunk.component_info is not None
-            assert chunk.component_info.type.endswith("chat_generator.AnthropicChatGenerator")
-
-        # Run the async streaming test
-        results = await component.run_async(messages=initial_messages, streaming_callback=callback)
-
-        # Verify the results
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-        assert "paris" in message.text.lower()
-        assert "claude-sonnet-4-5" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-        assert "input_tokens" in message.meta["usage"]
-        assert "output_tokens" in message.meta["usage"]
-
-        # Verify streaming behavior
-        assert counter > 1  # Should have received multiple chunks
-        assert "paris" in responses.lower()  # Should have received the response in chunks
-
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_API_KEY", None),
-        reason="Export an env var called ANTHROPIC_API_KEY containing the Anthropic API key to run this test.",
-    )
-    @pytest.mark.integration
-    async def test_live_run_async_with_tools(self, tools):
-        """
-        Integration test that the async run method works with tools.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = AnthropicChatGenerator(tools=tools)
-        results = await component.run_async(messages=initial_messages)
-
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.id is not None
-        assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
-        assert message.meta["finish_reason"] == "tool_calls"
-
-        new_messages = [
-            *initial_messages,
-            message,
-            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-        ]
-        results = await component.run_async(new_messages)
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
-        assert "completion_tokens" in final_message.meta["usage"]

--- a/integrations/anthropic/tests/test_chat_generator_async.py
+++ b/integrations/anthropic/tests/test_chat_generator_async.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+from haystack.dataclasses import (
+    ChatMessage,
+    StreamingChunk,
+    ToolCall,
+)
+from haystack.utils.auth import Secret
+
+from haystack_integrations.components.generators.anthropic.chat.chat_generator import (
+    AnthropicChatGenerator,
+)
+
+
+class TestUnit:
+    @pytest.mark.asyncio
+    async def test_run_async(self, chat_messages, mock_anthropic_completion_async, monkeypatch):
+        """
+        Test that the async run method of AnthropicChatGenerator works correctly.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
+        component = AnthropicChatGenerator()
+        response = await component.run_async(chat_messages)
+
+        # check that the component returns the correct ChatMessage response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_string_input(self, mock_anthropic_completion_async):
+        """
+        Test that the async run method of AnthropicChatGenerator works with string input.
+        """
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        result = await component.run_async("What's the capital of France?")
+
+        # Check that the backend received exactly one user message
+        _, kwargs = mock_anthropic_completion_async.call_args
+        assert len(kwargs["messages"]) == 1
+        assert kwargs["messages"][0]["role"] == "user"
+        assert kwargs["messages"][0]["content"][0]["type"] == "text"
+        assert kwargs["messages"][0]["content"][0]["text"] == "What's the capital of France?"
+
+        # Check that the result contains exactly one ChatMessage
+        assert isinstance(result["replies"], list)
+        assert len(result["replies"]) == 1
+        assert isinstance(result["replies"][0], ChatMessage)
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_params(self, chat_messages, mock_anthropic_completion_async):
+        """
+        Test that the async run method of AnthropicChatGenerator works with parameters.
+        """
+        component = AnthropicChatGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
+        )
+        response = await component.run_async(chat_messages)
+
+        # Check that the component calls the Anthropic API with the correct parameters
+        _, kwargs = mock_anthropic_completion_async.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.5
+
+        # Check that the component returns the correct response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert isinstance(response["replies"][0], ChatMessage)
+        assert "Hello! I'm Claude." in response["replies"][0].text
+        assert response["replies"][0].meta["model"] == "claude-sonnet-4-5"
+        assert response["replies"][0].meta["finish_reason"] == "stop"
+        assert "completion_tokens" in response["replies"][0].meta["usage"]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set")
+class TestIntegration:
+    @pytest.mark.asyncio
+    async def test_live_run_async(self):
+        """
+        Integration test that the async run method of AnthropicChatGenerator works with default parameters.
+        """
+        component = AnthropicChatGenerator()
+        results = await component.run_async(messages=[ChatMessage.from_user("What's the capital of France?")])
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "claude-sonnet-4-5" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+        assert "completion_tokens" in message.meta["usage"]
+
+    @pytest.mark.asyncio
+    async def test_live_run_async_with_streaming(self):
+        """
+        Test that the async run method of AnthropicChatGenerator works with streaming.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator()  # No streaming callback during initialization
+
+        counter = 0
+        responses = ""
+
+        # Create a callback that's compatible with async operations
+        async def callback(chunk: StreamingChunk) -> None:
+            nonlocal counter
+            nonlocal responses
+            counter += 1
+            responses += chunk.content if chunk.content else ""
+            assert chunk.component_info is not None
+            assert chunk.component_info.type.endswith("chat_generator.AnthropicChatGenerator")
+
+        # Run the async streaming test
+        results = await component.run_async(messages=initial_messages, streaming_callback=callback)
+
+        # Verify the results
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+        assert "paris" in message.text.lower()
+        assert "claude-sonnet-4-5" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+        assert "input_tokens" in message.meta["usage"]
+        assert "output_tokens" in message.meta["usage"]
+
+        # Verify streaming behavior
+        assert counter > 1  # Should have received multiple chunks
+        assert "paris" in responses.lower()  # Should have received the response in chunks
+
+    @pytest.mark.asyncio
+    async def test_live_run_async_with_tools(self, tools):
+        """
+        Integration test that the async run method works with tools.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = AnthropicChatGenerator(tools=tools)
+        results = await component.run_async(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.id is not None
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"
+
+        new_messages = [
+            *initial_messages,
+            message,
+            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+        ]
+        results = await component.run_async(new_messages)
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
+        assert "completion_tokens" in final_message.meta["usage"]

--- a/integrations/anthropic/tests/test_chat_generator_async.py
+++ b/integrations/anthropic/tests/test_chat_generator_async.py
@@ -18,7 +18,6 @@ from haystack_integrations.components.generators.anthropic.chat.chat_generator i
 
 
 class TestUnit:
-    @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_anthropic_completion_async, monkeypatch):
         """
         Test that the async run method of AnthropicChatGenerator works correctly.
@@ -34,7 +33,6 @@ class TestUnit:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.asyncio
     async def test_run_async_with_string_input(self, mock_anthropic_completion_async):
         """
         Test that the async run method of AnthropicChatGenerator works with string input.
@@ -54,7 +52,6 @@ class TestUnit:
         assert len(result["replies"]) == 1
         assert isinstance(result["replies"][0], ChatMessage)
 
-    @pytest.mark.asyncio
     async def test_run_async_with_params(self, chat_messages, mock_anthropic_completion_async):
         """
         Test that the async run method of AnthropicChatGenerator works with parameters.
@@ -84,7 +81,6 @@ class TestUnit:
 @pytest.mark.integration
 @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set")
 class TestIntegration:
-    @pytest.mark.asyncio
     async def test_live_run_async(self):
         """
         Integration test that the async run method of AnthropicChatGenerator works with default parameters.
@@ -98,7 +94,6 @@ class TestIntegration:
         assert message.meta["finish_reason"] == "stop"
         assert "completion_tokens" in message.meta["usage"]
 
-    @pytest.mark.asyncio
     async def test_live_run_async_with_streaming(self):
         """
         Test that the async run method of AnthropicChatGenerator works with streaming.
@@ -134,7 +129,6 @@ class TestIntegration:
         assert counter > 1  # Should have received multiple chunks
         assert "paris" in responses.lower()  # Should have received the response in chunks
 
-    @pytest.mark.asyncio
     async def test_live_run_async_with_tools(self, tools):
         """
         Integration test that the async run method works with tools.

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -10,14 +10,6 @@ from haystack.dataclasses import ChatMessage, ChatRole
 from haystack_integrations.components.generators.anthropic import AnthropicFoundryChatGenerator
 
 
-@pytest.fixture
-def chat_messages():
-    return [
-        ChatMessage.from_system("\nYou are a helpful assistant, be super brief in your responses."),
-        ChatMessage.from_user("What's the capital of France?"),
-    ]
-
-
 class TestAnthropicFoundryChatGenerator:
     def test_supported_models(self):
         assert isinstance(AnthropicFoundryChatGenerator.SUPPORTED_MODELS, list)

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -1,16 +1,14 @@
 import os
-from unittest.mock import AsyncMock, patch
 
 import anthropic
 import pytest
-from anthropic.types import Message
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, ChatRole
 
 from haystack_integrations.components.generators.anthropic import AnthropicFoundryChatGenerator
 
 
-class TestAnthropicFoundryChatGenerator:
+class TestUnit:
     def test_supported_models(self):
         assert isinstance(AnthropicFoundryChatGenerator.SUPPORTED_MODELS, list)
         assert len(AnthropicFoundryChatGenerator.SUPPORTED_MODELS) > 0
@@ -213,11 +211,21 @@ class TestAnthropicFoundryChatGenerator:
         assert "replies" in response
         assert all(isinstance(reply, ChatMessage) for reply in response["replies"])
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_FOUNDRY_API_KEY") or not os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
-        reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
-    )
-    @pytest.mark.integration
+    async def test_run_async_triggers_warm_up(self, mock_anthropic_completion_async, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
+        component = AnthropicFoundryChatGenerator(resource="my-resource")
+        assert not component._is_warmed_up
+        response = await component.run_async([ChatMessage.from_user("hi")])
+        assert component._is_warmed_up
+        assert "replies" in response
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_FOUNDRY_API_KEY") or not os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
+    reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
+)
+class TestIntegration:
     def test_live_run_wrong_model(self, chat_messages):
         component = AnthropicFoundryChatGenerator(
             model="something-obviously-wrong",
@@ -226,11 +234,6 @@ class TestAnthropicFoundryChatGenerator:
         with pytest.raises(anthropic.NotFoundError):
             component.run(chat_messages)
 
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_FOUNDRY_API_KEY") or not os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
-        reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
-    )
-    @pytest.mark.integration
     def test_live_run(self, chat_messages):
         client = AnthropicFoundryChatGenerator(
             resource=os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"), model="claude-sonnet-4-5"
@@ -249,37 +252,6 @@ class TestAnthropicFoundryChatGenerator:
         assert "paris" in first_reply.text.lower()
         assert first_reply.meta
 
-    # Anthropic messages API is similar for AnthropicFoundry and Anthropic endpoint;
-    # remaining tests are skipped as they are already tested in AnthropicChatGenerator.
-
-
-class TestAnthropicFoundryChatGeneratorAsync:
-    @pytest.mark.asyncio
-    async def test_run_async_triggers_warm_up(self, mock_chat_completion, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
-        component = AnthropicFoundryChatGenerator(resource="my-resource")
-        assert not component._is_warmed_up
-        completion = Message(
-            id="foo",
-            content=[{"type": "text", "text": "Hello!"}],
-            model="claude-sonnet-4-5",
-            role="assistant",
-            type="message",
-            usage={"input_tokens": 10, "output_tokens": 5},
-        )
-        with patch(
-            "anthropic.resources.messages.AsyncMessages.create", new_callable=AsyncMock, return_value=completion
-        ):
-            response = await component.run_async([ChatMessage.from_user("hi")])
-        assert component._is_warmed_up
-        assert "replies" in response
-
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("ANTHROPIC_FOUNDRY_API_KEY") or not os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
-        reason="Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_RESOURCE env variables to run this test.",
-    )
-    @pytest.mark.integration
     async def test_live_run_async(self):
         component = AnthropicFoundryChatGenerator(
             resource=os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE"),
@@ -290,6 +262,3 @@ class TestAnthropicFoundryChatGeneratorAsync:
         message: ChatMessage = results["replies"][0]
         assert "Paris" in message.text
         assert message.meta["finish_reason"] == "end_turn"
-
-    # Anthropic messages API is similar for AnthropicFoundry and Anthropic endpoint;
-    # remaining tests are skipped as they are already tested in AnthropicChatGenerator.

--- a/integrations/anthropic/tests/test_utils.py
+++ b/integrations/anthropic/tests/test_utils.py
@@ -62,7 +62,7 @@ CITATION = {
 }
 
 
-class TestUtils:
+class TestConvertChatCompletionToChatMessage:
     def test_convert_chat_completion_to_chat_message(self, mock_chat_completion):
         """
         Test converting Anthropic chat completion to ChatMessage
@@ -70,7 +70,7 @@ class TestUtils:
         chat_completion = mock_chat_completion.return_value
 
         chat_message = _convert_chat_completion_to_chat_message(chat_completion, ignore_tools_thinking_messages=True)
-        assert chat_message.text == "Hello, world!"
+        assert chat_message.text == "Hello! I'm Claude."
         assert chat_message.role == "assistant"
         assert chat_message.meta["model"] == "claude-sonnet-4-5"
         assert "usage" in chat_message.meta
@@ -116,6 +116,72 @@ class TestUtils:
         # only server tools should save raw content
         assert "raw_content_for_server_tools" not in chat_message.meta
 
+    def test_convert_chat_completion_with_server_tools_keeps_raw_content(self):
+        chat_completion = Message(
+            id="msg_01",
+            content=[
+                ServerToolUseBlock(
+                    id="srvtoolu_1", input={"query": "haystack"}, name="web_search", type="server_tool_use"
+                ),
+                WebSearchToolResultBlock(
+                    tool_use_id="srvtoolu_1",
+                    type="web_search_tool_result",
+                    content=[
+                        WebSearchResultBlock(
+                            encrypted_content="ENCRYPTED_PAYLOAD",
+                            title="Haystack",
+                            url="https://haystack.deepset.ai",
+                            type="web_search_result",
+                            page_age=None,
+                        )
+                    ],
+                ),
+                TextBlock(citations=None, text="Haystack is a framework.", type="text"),
+            ],
+            model="claude-sonnet-4-5",
+            role="assistant",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            type="message",
+            usage=Usage(input_tokens=10, output_tokens=5),
+        )
+
+        message = _convert_chat_completion_to_chat_message(chat_completion, ignore_tools_thinking_messages=True)
+
+        assert message.text == "Haystack is a framework."
+        assert message.tool_calls == []
+
+        raw = message.meta["raw_content_for_server_tools"]
+        assert [b["type"] for b in raw] == ["server_tool_use", "web_search_tool_result", "text"]
+        assert raw[1]["content"][0]["encrypted_content"] == "ENCRYPTED_PAYLOAD"
+
+    def test_convert_chat_completion_with_citations(self):
+        chat_completion = Message(
+            id="msg_03",
+            content=[
+                ServerToolUseBlock(id="srvtoolu_1", input={}, name="web_search", type="server_tool_use"),
+                WebSearchToolResultBlock(tool_use_id="srvtoolu_1", type="web_search_tool_result", content=[]),
+                TextBlock(citations=[CITATION], text="Haystack is a framework.", type="text"),
+                # text blocks without citations must not contribute
+                TextBlock(citations=None, text=" It is open source.", type="text"),
+            ],
+            model="claude-sonnet-4-5",
+            role="assistant",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            type="message",
+            usage=Usage(input_tokens=10, output_tokens=5),
+        )
+
+        message = _convert_chat_completion_to_chat_message(chat_completion, ignore_tools_thinking_messages=True)
+        assert message.meta["citations"] == [CITATION]
+
+        # editing them must not corrupt the encrypted_index of the blocks replayed on the next turn
+        message.meta["citations"][0]["encrypted_index"] = "TAMPERED"
+        assert message.meta["raw_content_for_server_tools"][2]["citations"][0]["encrypted_index"] == "ENCRYPTED_INDEX"
+
+
+class TestConvertAnthropicChunkToStreamingChunk:
     def test_convert_anthropic_completion_chunks_with_multiple_tool_calls_and_reasoning_to_streaming_chunks(self):
         """
         Test converting Anthropic stream events with tools to Haystack StreamingChunks
@@ -437,144 +503,6 @@ class TestUtils:
         assert usage["output_tokens"] == 77
         assert usage["server_tool_use"] is None
 
-    def test_has_server_tool_blocks(self):
-        """Result blocks are matched by suffix; a client-side `tool_result` must not match."""
-        assert _has_server_tool_blocks([{"type": "server_tool_use", "name": "web_search"}])
-        assert _has_server_tool_blocks([{"type": "web_search_tool_result"}])
-        assert _has_server_tool_blocks([{"type": "bash_code_execution_tool_result"}])
-        assert _has_server_tool_blocks([{"type": "text"}, {"type": "web_fetch_tool_result"}])
-
-        assert not _has_server_tool_blocks([{"type": "text"}])
-        assert not _has_server_tool_blocks([{"type": "tool_use", "name": "calculator"}])
-        assert not _has_server_tool_blocks([{"type": "tool_result", "tool_use_id": "toolu_1"}])
-        assert not _has_server_tool_blocks([])
-
-    def test_convert_chat_completion_with_server_tools_keeps_raw_content(self):
-        chat_completion = Message(
-            id="msg_01",
-            content=[
-                ServerToolUseBlock(
-                    id="srvtoolu_1", input={"query": "haystack"}, name="web_search", type="server_tool_use"
-                ),
-                WebSearchToolResultBlock(
-                    tool_use_id="srvtoolu_1",
-                    type="web_search_tool_result",
-                    content=[
-                        WebSearchResultBlock(
-                            encrypted_content="ENCRYPTED_PAYLOAD",
-                            title="Haystack",
-                            url="https://haystack.deepset.ai",
-                            type="web_search_result",
-                            page_age=None,
-                        )
-                    ],
-                ),
-                TextBlock(citations=None, text="Haystack is a framework.", type="text"),
-            ],
-            model="claude-sonnet-4-5",
-            role="assistant",
-            stop_reason="end_turn",
-            stop_sequence=None,
-            type="message",
-            usage=Usage(input_tokens=10, output_tokens=5),
-        )
-
-        message = _convert_chat_completion_to_chat_message(chat_completion, ignore_tools_thinking_messages=True)
-
-        assert message.text == "Haystack is a framework."
-        assert message.tool_calls == []
-
-        raw = message.meta["raw_content_for_server_tools"]
-        assert [b["type"] for b in raw] == ["server_tool_use", "web_search_tool_result", "text"]
-        assert raw[1]["content"][0]["encrypted_content"] == "ENCRYPTED_PAYLOAD"
-
-    def test_convert_chat_completion_with_citations(self):
-        chat_completion = Message(
-            id="msg_03",
-            content=[
-                ServerToolUseBlock(id="srvtoolu_1", input={}, name="web_search", type="server_tool_use"),
-                WebSearchToolResultBlock(tool_use_id="srvtoolu_1", type="web_search_tool_result", content=[]),
-                TextBlock(citations=[CITATION], text="Haystack is a framework.", type="text"),
-                # text blocks without citations must not contribute
-                TextBlock(citations=None, text=" It is open source.", type="text"),
-            ],
-            model="claude-sonnet-4-5",
-            role="assistant",
-            stop_reason="end_turn",
-            stop_sequence=None,
-            type="message",
-            usage=Usage(input_tokens=10, output_tokens=5),
-        )
-
-        message = _convert_chat_completion_to_chat_message(chat_completion, ignore_tools_thinking_messages=True)
-        assert message.meta["citations"] == [CITATION]
-
-        # editing them must not corrupt the encrypted_index of the blocks replayed on the next turn
-        message.meta["citations"][0]["encrypted_index"] = "TAMPERED"
-        assert message.meta["raw_content_for_server_tools"][2]["citations"][0]["encrypted_index"] == "ENCRYPTED_INDEX"
-
-    def test_convert_messages_to_anthropic_format_replays_server_tool_content(self):
-        raw_blocks = [
-            {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "haystack"}},
-            {
-                "type": "web_search_tool_result",
-                "tool_use_id": "srvtoolu_1",
-                "content": [
-                    {
-                        "type": "web_search_result",
-                        "url": "https://haystack.deepset.ai",
-                        "title": "Haystack",
-                        "encrypted_content": "ENCRYPTED_PAYLOAD",
-                    }
-                ],
-            },
-            {
-                "type": "text",
-                "text": "Haystack is a framework.",
-                "citations": [
-                    {
-                        "type": "web_search_result_location",
-                        "url": "https://haystack.deepset.ai",
-                        "title": "Haystack",
-                        "encrypted_index": "ENCRYPTED_INDEX",
-                        "cited_text": "Haystack is an AI orchestration framework",
-                    }
-                ],
-            },
-        ]
-        assistant = ChatMessage.from_assistant(
-            text="Haystack is a framework.",
-            meta={"raw_content_for_server_tools": raw_blocks},
-        )
-
-        _, non_system = _convert_messages_to_anthropic_format([ChatMessage.from_user("hi"), assistant])
-
-        assert non_system[1]["role"] == "assistant"
-        replayed = non_system[1]["content"]
-        assert replayed == raw_blocks
-
-        # the encrypted fields Anthropic requires back both survive
-        assert replayed[1]["content"][0]["encrypted_content"] == "ENCRYPTED_PAYLOAD"
-        assert replayed[2]["citations"][0]["encrypted_index"] == "ENCRYPTED_INDEX"
-
-    def test_convert_messages_to_anthropic_format_replay_does_not_duplicate_tool_calls(self):
-        """The raw blocks already hold the tool_use block; it must not be appended twice."""
-        raw_blocks = [
-            {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {}},
-            {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_1", "content": []},
-            {"type": "tool_use", "id": "toolu_1", "name": "calculator", "input": {"x": 1}},
-        ]
-        assistant = ChatMessage.from_assistant(
-            text="",
-            tool_calls=[ToolCall(tool_name="calculator", arguments={"x": 1}, id="toolu_1")],
-            meta={"raw_content_for_server_tools": raw_blocks},
-        )
-
-        _, non_system = _convert_messages_to_anthropic_format([assistant])
-        replayed = non_system[0]["content"]
-
-        assert [b["type"] for b in replayed].count("tool_use") == 1
-
     def test_accumulate_raw_content_blocks_from_stream(self):
         component_info = ComponentInfo(name="test", type="test")
         raw_chunks = [
@@ -724,6 +652,8 @@ class TestUtils:
         # the server tool's streamed query is kept for replay, not surfaced as a tool call
         assert message.meta["raw_content_for_server_tools"][0]["input"] == {"query": "Haystack"}
 
+
+class TestConvertStreamingChunksToChatMessage:
     def test_convert_streaming_chunks_to_chat_message_with_multiple_tool_calls(self):
         """
         Test converting streaming chunks to a chat message with tool calls
@@ -993,33 +923,69 @@ class TestUtils:
         assert message._meta["finish_reason"] == "tool_calls"
         assert message._meta["usage"] == {"output_tokens": 40}
 
-    def test_convert_image_content_to_anthropic_format_with_unsupported_mime_type(self):
-        """Test that an ImageContent with unsupported mime type raises ValueError."""
-        base64_image = (
-            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+
+class TestConvertMessagesToAnthropicFormat:
+    def test_convert_messages_to_anthropic_format_replays_server_tool_content(self):
+        raw_blocks = [
+            {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "haystack"}},
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_1",
+                "content": [
+                    {
+                        "type": "web_search_result",
+                        "url": "https://haystack.deepset.ai",
+                        "title": "Haystack",
+                        "encrypted_content": "ENCRYPTED_PAYLOAD",
+                    }
+                ],
+            },
+            {
+                "type": "text",
+                "text": "Haystack is a framework.",
+                "citations": [
+                    {
+                        "type": "web_search_result_location",
+                        "url": "https://haystack.deepset.ai",
+                        "title": "Haystack",
+                        "encrypted_index": "ENCRYPTED_INDEX",
+                        "cited_text": "Haystack is an AI orchestration framework",
+                    }
+                ],
+            },
+        ]
+        assistant = ChatMessage.from_assistant(
+            text="Haystack is a framework.",
+            meta={"raw_content_for_server_tools": raw_blocks},
         )
-        image_content = ImageContent(base64_image=base64_image, mime_type="image/bmp")  # Unsupported format
 
-        with pytest.raises(ValueError, match="Unsupported image format: image/bmp"):
-            _convert_image_content_to_anthropic_format(image_content)
+        _, non_system = _convert_messages_to_anthropic_format([ChatMessage.from_user("hi"), assistant])
 
-    def test_convert_image_content_to_anthropic_format_with_none_mime_type(self):
-        """Test that an ImageContent with None mime type raises ValueError."""
-        base64_image = (
-            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        assert non_system[1]["role"] == "assistant"
+        replayed = non_system[1]["content"]
+        assert replayed == raw_blocks
+
+        # the encrypted fields Anthropic requires back both survive
+        assert replayed[1]["content"][0]["encrypted_content"] == "ENCRYPTED_PAYLOAD"
+        assert replayed[2]["citations"][0]["encrypted_index"] == "ENCRYPTED_INDEX"
+
+    def test_convert_messages_to_anthropic_format_replay_does_not_duplicate_tool_calls(self):
+        """The raw blocks already hold the tool_use block; it must not be appended twice."""
+        raw_blocks = [
+            {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {}},
+            {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_1", "content": []},
+            {"type": "tool_use", "id": "toolu_1", "name": "calculator", "input": {"x": 1}},
+        ]
+        assistant = ChatMessage.from_assistant(
+            text="",
+            tool_calls=[ToolCall(tool_name="calculator", arguments={"x": 1}, id="toolu_1")],
+            meta={"raw_content_for_server_tools": raw_blocks},
         )
-        # validation=False skips the mime_type guessing in __post_init__, keeping it None
-        image_content = ImageContent(base64_image=base64_image, mime_type=None, validation=False)
 
-        with pytest.raises(ValueError, match="Unsupported image format: None"):
-            _convert_image_content_to_anthropic_format(image_content)
+        _, non_system = _convert_messages_to_anthropic_format([assistant])
+        replayed = non_system[0]["content"]
 
-    def test_convert_file_content_to_anthropic_format_with_unsupported_mime_type(self):
-        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
-        file_content = FileContent(base64_data=base64_data, mime_type="image/png")
-
-        with pytest.raises(ValueError, match="Unsupported file format: image/png"):
-            _convert_file_content_to_anthropic_format(file_content)
+        assert [b["type"] for b in replayed].count("tool_use") == 1
 
     def test_convert_message_to_anthropic_format_from_system(self):
         messages = [ChatMessage.from_system("You are good assistant")]
@@ -1285,6 +1251,54 @@ class TestUtils:
         with pytest.raises(ValueError, match="File content is only supported for user messages"):
             _convert_messages_to_anthropic_format([message])
 
+
+class TestConvertImageContentToAnthropicFormat:
+    def test_convert_image_content_to_anthropic_format_with_unsupported_mime_type(self):
+        """Test that an ImageContent with unsupported mime type raises ValueError."""
+        base64_image = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        )
+        image_content = ImageContent(base64_image=base64_image, mime_type="image/bmp")  # Unsupported format
+
+        with pytest.raises(ValueError, match="Unsupported image format: image/bmp"):
+            _convert_image_content_to_anthropic_format(image_content)
+
+    def test_convert_image_content_to_anthropic_format_with_none_mime_type(self):
+        """Test that an ImageContent with None mime type raises ValueError."""
+        base64_image = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        )
+        # validation=False skips the mime_type guessing in __post_init__, keeping it None
+        image_content = ImageContent(base64_image=base64_image, mime_type=None, validation=False)
+
+        with pytest.raises(ValueError, match="Unsupported image format: None"):
+            _convert_image_content_to_anthropic_format(image_content)
+
+
+class TestConvertFileContentToAnthropicFormat:
+    def test_convert_file_content_to_anthropic_format_with_unsupported_mime_type(self):
+        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        file_content = FileContent(base64_data=base64_data, mime_type="image/png")
+
+        with pytest.raises(ValueError, match="Unsupported file format: image/png"):
+            _convert_file_content_to_anthropic_format(file_content)
+
+
+class TestHasServerToolBlocks:
+    def test_has_server_tool_blocks(self):
+        """Result blocks are matched by suffix; a client-side `tool_result` must not match."""
+        assert _has_server_tool_blocks([{"type": "server_tool_use", "name": "web_search"}])
+        assert _has_server_tool_blocks([{"type": "web_search_tool_result"}])
+        assert _has_server_tool_blocks([{"type": "bash_code_execution_tool_result"}])
+        assert _has_server_tool_blocks([{"type": "text"}, {"type": "web_fetch_tool_result"}])
+
+        assert not _has_server_tool_blocks([{"type": "text"}])
+        assert not _has_server_tool_blocks([{"type": "tool_use", "name": "calculator"}])
+        assert not _has_server_tool_blocks([{"type": "tool_result", "tool_use_id": "toolu_1"}])
+        assert not _has_server_tool_blocks([])
+
+
+class TestFinalizeReasoningGroup:
     def test_finalize_reasoning_group_with_thinking_text(self):
         """Test that _finalize_reasoning_group appends a reasoning_text entry."""
         formatted: list = []

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -8,7 +8,7 @@ from haystack.dataclasses import ChatMessage, ChatRole
 from haystack_integrations.components.generators.anthropic import AnthropicVertexChatGenerator
 
 
-class TestAnthropicVertexChatGenerator:
+class TestUnit:
     def test_supported_models(self):
         """SUPPORTED_MODELS is a non-empty list of strings."""
         assert isinstance(AnthropicVertexChatGenerator.SUPPORTED_MODELS, list)
@@ -152,11 +152,13 @@ class TestAnthropicVertexChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.skipif(
-        not (os.environ.get("REGION", None) or os.environ.get("PROJECT_ID", None)),
-        reason="Authenticate with GCP and set env variables REGION and PROJECT_ID to run this test.",
-    )
-    @pytest.mark.integration
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not (os.environ.get("REGION", None) and os.environ.get("PROJECT_ID", None)),
+    reason="Authenticate with GCP and set env variables REGION and PROJECT_ID to run this test.",
+)
+class TestIntegration:
     def test_live_run_wrong_model(self, chat_messages):
         component = AnthropicVertexChatGenerator(
             model="something-obviously-wrong", region=os.environ.get("REGION"), project_id=os.environ.get("PROJECT_ID")
@@ -164,11 +166,6 @@ class TestAnthropicVertexChatGenerator:
         with pytest.raises(anthropic.NotFoundError):
             component.run(chat_messages)
 
-    @pytest.mark.skipif(
-        not (os.environ.get("REGION", None) or os.environ.get("PROJECT_ID", None)),
-        reason="Authenticate with GCP and set env variables REGION and PROJECT_ID to run this test.",
-    )
-    @pytest.mark.integration
     def test_default_inference_params(self, chat_messages):
         client = AnthropicVertexChatGenerator(
             region=os.environ.get("REGION"), project_id=os.environ.get("PROJECT_ID"), model="claude-sonnet-4@20250514"
@@ -187,17 +184,6 @@ class TestAnthropicVertexChatGenerator:
         assert "paris" in first_reply.text.lower(), "First reply does not contain 'paris'"
         assert first_reply.meta, "First reply has no metadata"
 
-    # Anthropic messages API is similar for AnthropicVertex and Anthropic endpoint,
-    # remaining tests are skipped for AnthropicVertexChatGenerator as they are already tested in AnthropicChatGenerator.
-
-
-class TestAnthropicVertexChatGeneratorAsync:
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not (os.environ.get("REGION", None) or os.environ.get("PROJECT_ID", None)),
-        reason="Authenticate with GCP and set env variables REGION and PROJECT_ID to run this test.",
-    )
-    @pytest.mark.integration
     async def test_live_run_async(self):
         """
         Integration test that the async run method of AnthropicVertexChatGenerator works correctly
@@ -213,6 +199,3 @@ class TestAnthropicVertexChatGeneratorAsync:
         assert "Paris" in message.text
         assert "claude-sonnet-4-5" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
-
-    # Anthropic messages API is similar for AnthropicVertex and Anthropic endpoint,
-    # remaining tests are skipped for AnthropicVertexChatGenerator as they are already tested in AnthropicChatGenerator.

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -8,14 +8,6 @@ from haystack.dataclasses import ChatMessage, ChatRole
 from haystack_integrations.components.generators.anthropic import AnthropicVertexChatGenerator
 
 
-@pytest.fixture
-def chat_messages():
-    return [
-        ChatMessage.from_system("\\nYou are a helpful assistant, be super brief in your responses."),
-        ChatMessage.from_user("What's the capital of France?"),
-    ]
-
-
 class TestAnthropicVertexChatGenerator:
     def test_supported_models(self):
         """SUPPORTED_MODELS is a non-empty list of strings."""


### PR DESCRIPTION
### Related Issues

- When I recently worked on the Anthropic integration, I realized that the test suite is big and messy

### Proposed Changes:
- mostly work on `test_chat_generator.py`
  - split into sync and async files
  - reorganize the modules into focused test classes
  - parametrize and deduplicate some tests
- extract general fixtures
- clean up

### How did you test it?
CI

### Notes for the reviewer
I realize the PR can be hard to review. In general, I did not remove meaningful tests but mostly moved stuff around.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
