### PR TITLE
feat: add TwelveLabs Marengo multimodal embedders (image/audio/video)

### DIFF
--- a/integrations/twelvelabs/README.md
+++ b/integrations/twelvelabs/README.md
@@ -8,6 +8,38 @@
 
 ---
 
+## Components
+
+TwelveLabs **Marengo** embeds text, images, audio, and video into a single shared vector space, so
+embeddings from any modality are directly comparable — enabling cross-modal retrieval.
+
+- `TwelveLabsTextEmbedder` — embeds a text query.
+- `TwelveLabsDocumentEmbedder` — embeds the text `content` of Documents.
+- `TwelveLabsMultimodalEmbedder` — embeds a single image, audio, or video (local path or URL) into
+  the shared Marengo space; the cross-modal companion to `TwelveLabsTextEmbedder`.
+- `TwelveLabsDocumentMultimodalEmbedder` — embeds the media referenced by each Document
+  (via `meta["file_path"]`) for indexing.
+- `TwelveLabsVideoConverter` — analyzes video with **Pegasus** and converts the result to Documents.
+
+```python
+from haystack import Document
+from haystack_integrations.components.embedders.twelvelabs import (
+    TwelveLabsMultimodalEmbedder,
+    TwelveLabsDocumentMultimodalEmbedder,
+)
+
+# Set the TWELVELABS_API_KEY environment variable
+
+# Embed a single media query (image / audio / video, local path or URL).
+query_embedding = TwelveLabsMultimodalEmbedder().run(source="cat.jpg")["embedding"]
+
+# Embed media Documents for indexing (modality inferred from the file extension).
+docs = [Document(meta={"file_path": "clip.mp4"})]
+docs = TwelveLabsDocumentMultimodalEmbedder().run(documents=docs)["documents"]
+```
+
+---
+
 ## Contributing
 
 Refer to the general [Contribution Guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md).

--- a/integrations/twelvelabs/pydoc/config_docusaurus.yml
+++ b/integrations/twelvelabs/pydoc/config_docusaurus.yml
@@ -2,6 +2,8 @@ loaders:
   - modules:
       - haystack_integrations.components.converters.twelvelabs.video_converter
       - haystack_integrations.components.embedders.twelvelabs.document_embedder
+      - haystack_integrations.components.embedders.twelvelabs.document_multimodal_embedder
+      - haystack_integrations.components.embedders.twelvelabs.multimodal_embedder
       - haystack_integrations.components.embedders.twelvelabs.text_embedder
     search_path: [../src]
 processors:

--- a/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/__init__.py
+++ b/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/__init__.py
@@ -2,6 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from .document_embedder import TwelveLabsDocumentEmbedder
+from .document_multimodal_embedder import TwelveLabsDocumentMultimodalEmbedder
+from .multimodal_embedder import TwelveLabsMultimodalEmbedder
 from .text_embedder import TwelveLabsTextEmbedder
 
-__all__ = ["TwelveLabsDocumentEmbedder", "TwelveLabsTextEmbedder"]
+__all__ = [
+    "TwelveLabsDocumentEmbedder",
+    "TwelveLabsDocumentMultimodalEmbedder",
+    "TwelveLabsMultimodalEmbedder",
+    "TwelveLabsTextEmbedder",
+]

--- a/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/_media_embed.py
+++ b/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/_media_embed.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import asyncio
+import mimetypes
+import time
+from pathlib import Path, PurePath
+from typing import Any
+from urllib.parse import urlparse
+
+from twelvelabs import AsyncTwelveLabs, TwelveLabs
+
+# The modalities Marengo can embed into its shared vector space (text is handled by the
+# dedicated text embedder).
+MODALITIES = ("image", "audio", "video")
+
+# Video embeddings are produced by an asynchronous TwelveLabs task; these bound the poll loop.
+_POLL_INTERVAL = 3.0
+_TASK_TIMEOUT = 1800.0
+# Request a single whole-video embedding (rather than per-clip segments) so this maps to one vector.
+_VIDEO_SCOPE = ["video"]
+
+# Extension -> modality, checked before falling back to the standard-library MIME database.
+_EXTENSION_MODALITY = {
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".png": "image",
+    ".gif": "image",
+    ".webp": "image",
+    ".bmp": "image",
+    ".tif": "image",
+    ".tiff": "image",
+    ".mp3": "audio",
+    ".wav": "audio",
+    ".m4a": "audio",
+    ".flac": "audio",
+    ".ogg": "audio",
+    ".oga": "audio",
+    ".aac": "audio",
+    ".mp4": "video",
+    ".mov": "video",
+    ".webm": "video",
+    ".mkv": "video",
+    ".avi": "video",
+    ".m4v": "video",
+}
+
+
+def _is_url(source: str) -> bool:
+    """Whether `source` is an http(s) URL (as opposed to a local file path)."""
+    return urlparse(source).scheme in ("http", "https")
+
+
+def _local_path(source: str) -> Path:
+    """Resolve a local media path, raising a clear error if it does not exist."""
+    path = Path(source).expanduser()
+    if not path.is_file():
+        msg = f"Media file not found: {source!r}."
+        raise FileNotFoundError(msg)
+    return path
+
+
+def detect_modality(source: str) -> str:
+    """
+    Infer the media modality of a URL or local path.
+
+    :param source: A publicly accessible URL or a local file path.
+    :returns: One of `"image"`, `"audio"` or `"video"`.
+    :raises ValueError: If the modality cannot be inferred from the extension or MIME type.
+    """
+    path = urlparse(source).path if _is_url(source) else source
+    suffix = PurePath(path).suffix.lower()
+    if suffix in _EXTENSION_MODALITY:
+        return _EXTENSION_MODALITY[suffix]
+    mime, _ = mimetypes.guess_type(path)
+    if mime:
+        top_level = mime.split("/", 1)[0]
+        if top_level in MODALITIES:
+            return top_level
+    msg = f"Could not infer the modality of {source!r}. Pass an explicit modality, one of {MODALITIES}."
+    raise ValueError(msg)
+
+
+def _extract_vector(result: Any, model: str, modality: str) -> list[float]:
+    """Pull the first float vector out of an image/audio embedding result."""
+    segments = result.segments if result else None
+    if segments:
+        vector = segments[0].float_
+        if vector:
+            return [float(x) for x in vector]
+    msg = f"TwelveLabs returned no {modality} embedding for model {model!r}."
+    raise RuntimeError(msg)
+
+
+def _extract_video_vector(result: Any, model: str) -> list[float]:
+    """Pull the whole-video float vector out of a retrieved video-embedding task."""
+    embedding = getattr(result, "video_embedding", None)
+    segments = embedding.segments if embedding else None
+    if segments:
+        # Prefer the whole-video segment; fall back to the first segment if scope is absent.
+        chosen = next((s for s in segments if (getattr(s, "embedding_scope", "") or "") == "video"), segments[0])
+        vector = chosen.float_
+        if vector:
+            return [float(x) for x in vector]
+    msg = f"TwelveLabs returned no video embedding for model {model!r}."
+    raise RuntimeError(msg)
+
+
+def embed_media(source: str, modality: str, model: str, api_key: str) -> list[float]:
+    """
+    Embed a single image, audio or video source with Marengo and return its vector.
+
+    Images and audio are embedded synchronously. Video is embedded through the asynchronous
+    TwelveLabs video-embedding task: this submits the task and blocks (polling) until it is ready.
+
+    :param source: A publicly accessible URL or a local file path.
+    :param modality: One of `"image"`, `"audio"` or `"video"`.
+    :param model: The Marengo model name.
+    :param api_key: The TwelveLabs API key.
+    :returns: The embedding vector in Marengo's shared multimodal space.
+    """
+    client = TwelveLabs(api_key=api_key)
+    if modality == "video":
+        return _embed_video(client, source, model)
+    if _is_url(source):
+        params: dict[str, Any] = {f"{modality}_url": source}
+        response = client.embed.create(model_name=model, **params)
+    else:
+        with _local_path(source).open("rb") as handle:
+            params = {f"{modality}_file": handle}
+            response = client.embed.create(model_name=model, **params)
+    return _extract_vector(getattr(response, f"{modality}_embedding"), model, modality)
+
+
+def _embed_video(client: TwelveLabs, source: str, model: str) -> list[float]:
+    task_id = _create_video_task(client, source, model)
+    _await_video_task(client, task_id)
+    result = client.embed.tasks.retrieve(task_id)
+    return _extract_video_vector(result, model)
+
+
+def _create_video_task(client: TwelveLabs, source: str, model: str) -> str:
+    if _is_url(source):
+        task = client.embed.tasks.create(model_name=model, video_url=source, video_embedding_scope=_VIDEO_SCOPE)
+    else:
+        with _local_path(source).open("rb") as handle:
+            task = client.embed.tasks.create(model_name=model, video_file=handle, video_embedding_scope=_VIDEO_SCOPE)
+    task_id = getattr(task, "id", None)
+    if not task_id:
+        msg = "TwelveLabs did not return an id for the video embedding task."
+        raise RuntimeError(msg)
+    return task_id
+
+
+def _await_video_task(client: TwelveLabs, task_id: str) -> None:
+    deadline = time.monotonic() + _TASK_TIMEOUT
+    while True:
+        status = (client.embed.tasks.status(task_id).status or "").lower()
+        if status == "ready":
+            return
+        if status == "failed":
+            msg = f"TwelveLabs video embedding task {task_id} failed."
+            raise RuntimeError(msg)
+        if time.monotonic() >= deadline:
+            msg = f"TwelveLabs video embedding task {task_id} did not finish within {_TASK_TIMEOUT:.0f}s."
+            raise TimeoutError(msg)
+        time.sleep(_POLL_INTERVAL)
+
+
+async def embed_media_async(source: str, modality: str, model: str, api_key: str) -> list[float]:
+    """
+    Asynchronously embed a single image, audio or video source with Marengo.
+
+    See :func:`embed_media` for parameter and return details.
+    """
+    client = AsyncTwelveLabs(api_key=api_key)
+    if modality == "video":
+        return await _embed_video_async(client, source, model)
+    if _is_url(source):
+        params: dict[str, Any] = {f"{modality}_url": source}
+        response = await client.embed.create(model_name=model, **params)
+    else:
+        with _local_path(source).open("rb") as handle:
+            params = {f"{modality}_file": handle}
+            response = await client.embed.create(model_name=model, **params)
+    return _extract_vector(getattr(response, f"{modality}_embedding"), model, modality)
+
+
+async def _embed_video_async(client: AsyncTwelveLabs, source: str, model: str) -> list[float]:
+    task_id = await _create_video_task_async(client, source, model)
+    await _await_video_task_async(client, task_id)
+    result = await client.embed.tasks.retrieve(task_id)
+    return _extract_video_vector(result, model)
+
+
+async def _create_video_task_async(client: AsyncTwelveLabs, source: str, model: str) -> str:
+    if _is_url(source):
+        task = await client.embed.tasks.create(model_name=model, video_url=source, video_embedding_scope=_VIDEO_SCOPE)
+    else:
+        with _local_path(source).open("rb") as handle:
+            task = await client.embed.tasks.create(
+                model_name=model, video_file=handle, video_embedding_scope=_VIDEO_SCOPE
+            )
+    task_id = getattr(task, "id", None)
+    if not task_id:
+        msg = "TwelveLabs did not return an id for the video embedding task."
+        raise RuntimeError(msg)
+    return task_id
+
+
+async def _await_video_task_async(client: AsyncTwelveLabs, task_id: str) -> None:
+    deadline = time.monotonic() + _TASK_TIMEOUT
+    while True:
+        status_response = await client.embed.tasks.status(task_id)
+        status = (status_response.status or "").lower()
+        if status == "ready":
+            return
+        if status == "failed":
+            msg = f"TwelveLabs video embedding task {task_id} failed."
+            raise RuntimeError(msg)
+        if time.monotonic() >= deadline:
+            msg = f"TwelveLabs video embedding task {task_id} did not finish within {_TASK_TIMEOUT:.0f}s."
+            raise TimeoutError(msg)
+        await asyncio.sleep(_POLL_INTERVAL)

--- a/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/document_multimodal_embedder.py
+++ b/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/document_multimodal_embedder.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import asyncio
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from haystack import Document, component, default_from_dict, default_to_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
+from tqdm import tqdm
+
+from ._media_embed import MODALITIES, detect_modality, embed_media, embed_media_async
+
+DEFAULT_MODEL = "marengo3.0"
+
+
+@component
+class TwelveLabsDocumentMultimodalEmbedder:
+    """
+    Embeds the media referenced by Documents using TwelveLabs Marengo.
+
+    Each Document points at an image, audio, or video file (or URL) through its metadata
+    (`meta["file_path"]` by default). This component computes a Marengo embedding for that
+    media and stores it on `Document.embedding`. Because Marengo embeds every modality into
+    one shared space, the resulting embeddings support cross-modal retrieval — for example,
+    search a store of video embeddings with a text query embedded by `TwelveLabsTextEmbedder`.
+
+    This is the media counterpart to `TwelveLabsDocumentEmbedder`, which embeds a Document's
+    text `content`.
+
+    The modality of each Document is inferred from its file extension / MIME type; set
+    `meta["modality"]` (or the field named by `modality_meta_field`) to override it.
+
+    ### Usage example
+
+    ```python
+    from haystack import Document
+    from haystack_integrations.components.embedders.twelvelabs import TwelveLabsDocumentMultimodalEmbedder
+
+    # Set the TWELVELABS_API_KEY environment variable
+    embedder = TwelveLabsDocumentMultimodalEmbedder()
+    docs = [Document(meta={"file_path": "cat.jpg"})]
+    docs = embedder.run(documents=docs)["documents"]
+    print(docs[0].embedding)
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: Secret = Secret.from_env_var("TWELVELABS_API_KEY"),
+        model: str = DEFAULT_MODEL,
+        file_path_meta_field: str = "file_path",
+        root_path: str = "",
+        modality_meta_field: str = "modality",
+        batch_size: int = 32,
+        progress_bar: bool = True,
+    ) -> None:
+        """
+        Create a TwelveLabsDocumentMultimodalEmbedder.
+
+        :param api_key: The TwelveLabs API key. Read from the `TWELVELABS_API_KEY`
+            environment variable by default.
+        :param model: The Marengo model name.
+        :param file_path_meta_field: The metadata field on each Document that holds the media's
+            local file path or URL.
+        :param root_path: An absolute path prepended to each Document's relative `file_path`
+            (ignored for URLs). When set, it also acts as a sandbox: paths that resolve outside
+            `root_path` (via `..` segments or an absolute `file_path`) are rejected.
+        :param modality_meta_field: The metadata field that, when present, overrides the inferred
+            modality (`"image"`, `"audio"` or `"video"`).
+        :param batch_size: Number of Documents per batch; within a batch `run_async` embeds concurrently.
+        :param progress_bar: Whether to show a progress bar while embedding. Can be helpful
+            to disable in production deployments to keep the logs clean.
+        """
+        self.api_key = api_key
+        self.model = model
+        self.file_path_meta_field = file_path_meta_field
+        self.root_path = root_path
+        self.modality_meta_field = modality_meta_field
+        self.batch_size = batch_size
+        self.progress_bar = progress_bar
+
+    def _get_telemetry_data(self) -> dict[str, Any]:
+        """Data sent to Posthog for usage analytics."""
+        return {"model": self.model}
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            api_key=self.api_key.to_dict(),
+            model=self.model,
+            file_path_meta_field=self.file_path_meta_field,
+            root_path=self.root_path,
+            modality_meta_field=self.modality_meta_field,
+            batch_size=self.batch_size,
+            progress_bar=self.progress_bar,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TwelveLabsDocumentMultimodalEmbedder":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        return default_from_dict(cls, data)
+
+    def _validate(self, documents: list[Document]) -> None:
+        if not isinstance(documents, list) or any(not isinstance(d, Document) for d in documents):
+            msg = (
+                "TwelveLabsDocumentMultimodalEmbedder expects a list of Documents. To embed a "
+                "single media source, use the TwelveLabsMultimodalEmbedder."
+            )
+            raise TypeError(msg)
+
+    def _resolve_source(self, document: Document) -> str:
+        source = document.meta.get(self.file_path_meta_field)
+        if not isinstance(source, str) or not source:
+            msg = (
+                f"Document '{document.id}' has no media path in meta['{self.file_path_meta_field}']. "
+                "Populate it with a local file path or a publicly accessible URL."
+            )
+            raise ValueError(msg)
+        if urlparse(source).scheme in ("http", "https"):
+            return source
+        if not self.root_path:
+            return source
+        # Treat root_path as a sandbox: reject anything that resolves outside it
+        # (absolute file_path values or `..` traversal).
+        root = Path(self.root_path).expanduser().resolve()
+        resolved = (root / source).resolve()
+        if not resolved.is_relative_to(root):
+            msg = f"Media path for document '{document.id}' resolves to '{resolved}', outside root_path '{root}'."
+            raise ValueError(msg)
+        return str(resolved)
+
+    def _resolve_modality(self, document: Document, source: str) -> str:
+        override = document.meta.get(self.modality_meta_field)
+        if override is not None and not isinstance(override, str):
+            msg = (
+                f"meta['{self.modality_meta_field}'] for document '{document.id}' must be a string, "
+                f"got {type(override).__name__}."
+            )
+            raise ValueError(msg)
+        resolved = (override or detect_modality(source)).lower()
+        if resolved not in MODALITIES:
+            msg = f"Unsupported modality {override!r} for document '{document.id}'. Expected one of {MODALITIES}."
+            raise ValueError(msg)
+        return resolved
+
+    def _embedded_document(self, document: Document, embedding: list[float], modality: str) -> Document:
+        return replace(
+            document,
+            embedding=embedding,
+            meta={
+                **document.meta,
+                "embedding_source": {"type": modality, "file_path_meta_field": self.file_path_meta_field},
+            },
+        )
+
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    def run(self, documents: list[Document]) -> dict[str, Any]:
+        """
+        Embed the media referenced by a list of Documents.
+
+        :param documents: The Documents to embed. Each must reference its media through
+            `meta[file_path_meta_field]` (a local file path or a URL).
+        :returns: A dictionary with keys:
+            - `documents`: New Documents that are copies of the inputs with `embedding` populated
+              and an `embedding_source` entry added to their metadata.
+            - `meta`: Metadata about the request (the model used).
+        :raises TypeError: If the input is not a list of Documents.
+        :raises ValueError: If a Document has no media path or an unsupported modality.
+        """
+        self._validate(documents)
+        key = self.api_key.resolve_value() or ""
+        embedded: list[Document] = []
+        for document in tqdm(documents, disable=not self.progress_bar, desc="Calculating embeddings"):
+            source = self._resolve_source(document)
+            modality = self._resolve_modality(document, source)
+            embedding = embed_media(source, modality, self.model, key)
+            embedded.append(self._embedded_document(document, embedding, modality))
+        return {"documents": embedded, "meta": {"model": self.model}}
+
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    async def run_async(self, documents: list[Document]) -> dict[str, Any]:
+        """
+        Asynchronously embed the media referenced by a list of Documents.
+
+        Documents within each batch of `batch_size` are embedded concurrently.
+
+        :param documents: The Documents to embed.
+        :returns: A dictionary with keys `documents` (copies with `embedding` populated) and `meta`.
+        :raises TypeError: If the input is not a list of Documents.
+        :raises ValueError: If a Document has no media path or an unsupported modality.
+        """
+        self._validate(documents)
+        key = self.api_key.resolve_value() or ""
+        sources = [self._resolve_source(document) for document in documents]
+        modalities = [
+            self._resolve_modality(document, source) for document, source in zip(documents, sources, strict=True)
+        ]
+        embeddings: list[list[float]] = []
+        for i in tqdm(
+            range(0, len(documents), self.batch_size),
+            disable=not self.progress_bar,
+            desc="Calculating embeddings",
+        ):
+            batch = list(zip(sources[i : i + self.batch_size], modalities[i : i + self.batch_size], strict=True))
+            batch_embeddings = await asyncio.gather(
+                *(embed_media_async(source, modality, self.model, key) for source, modality in batch)
+            )
+            embeddings.extend(batch_embeddings)
+        embedded = [
+            self._embedded_document(document, embedding, modality)
+            for document, embedding, modality in zip(documents, embeddings, modalities, strict=True)
+        ]
+        return {"documents": embedded, "meta": {"model": self.model}}

--- a/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/multimodal_embedder.py
+++ b/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/multimodal_embedder.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+from ._media_embed import MODALITIES, detect_modality, embed_media, embed_media_async
+
+DEFAULT_MODEL = "marengo3.0"
+
+
+@component
+class TwelveLabsMultimodalEmbedder:
+    """
+    Embeds an image, audio, or video into TwelveLabs Marengo's shared multimodal space.
+
+    Marengo embeds text, images, audio, and video into a single vector space, so the vector
+    produced here is directly comparable (cosine similarity) with text embeddings from
+    `TwelveLabsTextEmbedder` and with other media embeddings from the same model — enabling
+    cross-modal retrieval such as text-to-video or image-to-video search. Use this component
+    to embed a single media query before searching a document store populated with Marengo
+    embeddings.
+
+    Images and audio are embedded synchronously; video uses the asynchronous TwelveLabs
+    video-embedding task, which this component submits and then blocks on until it completes.
+
+    ### Usage example
+
+    ```python
+    from haystack_integrations.components.embedders.twelvelabs import TwelveLabsMultimodalEmbedder
+
+    # Set the TWELVELABS_API_KEY environment variable
+    embedder = TwelveLabsMultimodalEmbedder()
+    result = embedder.run(source="https://example.com/cat.jpg")
+    print(result["embedding"])
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: Secret = Secret.from_env_var("TWELVELABS_API_KEY"),
+        model: str = DEFAULT_MODEL,
+    ) -> None:
+        """
+        Create a TwelveLabsMultimodalEmbedder.
+
+        :param api_key: The TwelveLabs API key. Read from the `TWELVELABS_API_KEY`
+            environment variable by default.
+        :param model: The Marengo model name.
+        """
+        self.api_key = api_key
+        self.model = model
+
+    def _get_telemetry_data(self) -> dict[str, Any]:
+        """Data sent to Posthog for usage analytics."""
+        return {"model": self.model}
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return default_to_dict(self, api_key=self.api_key.to_dict(), model=self.model)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TwelveLabsMultimodalEmbedder":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        return default_from_dict(cls, data)
+
+    def _resolve_modality(self, source: str, modality: str | None) -> str:
+        resolved = (modality or detect_modality(source)).lower()
+        if resolved not in MODALITIES:
+            msg = f"Unsupported modality {modality!r}. Expected one of {MODALITIES}."
+            raise ValueError(msg)
+        return resolved
+
+    @component.output_types(embedding=list[float], meta=dict[str, Any])
+    def run(self, source: str, modality: str | None = None) -> dict[str, Any]:
+        """
+        Embed a single media source.
+
+        :param source: A publicly accessible URL or a local file path to an image, audio, or video file.
+        :param modality: Optional explicit modality (`"image"`, `"audio"` or `"video"`). If omitted,
+            it is inferred from the source's file extension / MIME type.
+        :returns: A dictionary with keys:
+            - `embedding`: The embedding vector for the media in Marengo's shared space.
+            - `meta`: Metadata about the request (the model used and the resolved modality).
+        :raises TypeError: If `source` is not a string.
+        :raises ValueError: If the modality is unsupported or cannot be inferred.
+        """
+        if not isinstance(source, str):
+            msg = "TwelveLabsMultimodalEmbedder expects a string source (a URL or a local file path)."
+            raise TypeError(msg)
+        resolved = self._resolve_modality(source, modality)
+        embedding = embed_media(source, resolved, self.model, self.api_key.resolve_value() or "")
+        return {"embedding": embedding, "meta": {"model": self.model, "modality": resolved}}
+
+    @component.output_types(embedding=list[float], meta=dict[str, Any])
+    async def run_async(self, source: str, modality: str | None = None) -> dict[str, Any]:
+        """
+        Asynchronously embed a single media source.
+
+        See `run` for parameter and return details.
+
+        :param source: A publicly accessible URL or a local file path.
+        :param modality: Optional explicit modality; inferred from the source when omitted.
+        :returns: A dictionary with keys `embedding` and `meta`.
+        :raises TypeError: If `source` is not a string.
+        :raises ValueError: If the modality is unsupported or cannot be inferred.
+        """
+        if not isinstance(source, str):
+            msg = "TwelveLabsMultimodalEmbedder expects a string source (a URL or a local file path)."
+            raise TypeError(msg)
+        resolved = self._resolve_modality(source, modality)
+        embedding = await embed_media_async(source, resolved, self.model, self.api_key.resolve_value() or "")
+        return {"embedding": embedding, "meta": {"model": self.model, "modality": resolved}}

--- a/integrations/twelvelabs/tests/test_document_multimodal_embedder.py
+++ b/integrations/twelvelabs/tests/test_document_multimodal_embedder.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from haystack import Document
+from haystack.utils import Secret
+
+from haystack_integrations.components.embedders.twelvelabs import TwelveLabsDocumentMultimodalEmbedder
+
+PATCH_TARGET = "haystack_integrations.components.embedders.twelvelabs.document_multimodal_embedder.embed_media"
+ASYNC_PATCH_TARGET = (
+    "haystack_integrations.components.embedders.twelvelabs.document_multimodal_embedder.embed_media_async"
+)
+
+
+def test_init_defaults(monkeypatch):
+    monkeypatch.setenv("TWELVELABS_API_KEY", "tlk_env")
+    embedder = TwelveLabsDocumentMultimodalEmbedder()
+    assert embedder.model == "marengo3.0"
+    assert embedder.file_path_meta_field == "file_path"
+    assert embedder.root_path == ""
+    assert embedder.modality_meta_field == "modality"
+    assert embedder.batch_size == 32
+    assert embedder.progress_bar is True
+
+
+def test_to_dict_and_from_dict(monkeypatch):
+    monkeypatch.setenv("TWELVELABS_API_KEY", "tlk_env")
+    data = TwelveLabsDocumentMultimodalEmbedder(root_path="/data", file_path_meta_field="path", batch_size=8).to_dict()
+    assert data["type"].endswith("TwelveLabsDocumentMultimodalEmbedder")
+    params = data["init_parameters"]
+    assert params["root_path"] == "/data"
+    assert params["file_path_meta_field"] == "path"
+    assert params["batch_size"] == 8
+    restored = TwelveLabsDocumentMultimodalEmbedder.from_dict(data)
+    assert restored.root_path == "/data"
+    assert restored.file_path_meta_field == "path"
+    assert restored.batch_size == 8
+
+
+def test_run_embeds_documents_and_preserves_originals():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(api_key=Secret.from_token("tlk_test"), progress_bar=False)
+    docs = [Document(meta={"file_path": "cat.jpg"}), Document(meta={"file_path": "clip.mp4"})]
+    with patch(PATCH_TARGET, side_effect=[[0.1] * 4, [0.2] * 4]) as mock_embed:
+        result = embedder.run(documents=docs)
+    out = result["documents"]
+    assert result["meta"] == {"model": "marengo3.0"}
+    assert mock_embed.call_count == 2
+    mock_embed.assert_any_call("cat.jpg", "image", "marengo3.0", "tlk_test")
+    mock_embed.assert_any_call("clip.mp4", "video", "marengo3.0", "tlk_test")
+    assert out[0].embedding == [0.1] * 4
+    assert out[1].embedding == [0.2] * 4
+    assert out[0].meta["embedding_source"] == {"type": "image", "file_path_meta_field": "file_path"}
+    assert out[1].meta["embedding_source"]["type"] == "video"
+    # Originals are not mutated.
+    assert docs[0].embedding is None
+
+
+def test_run_joins_relative_path_with_root_path(tmp_path):
+    root = tmp_path
+    (root / "sub").mkdir()
+    embedder = TwelveLabsDocumentMultimodalEmbedder(
+        api_key=Secret.from_token("tlk_test"), root_path=str(root), progress_bar=False
+    )
+    docs = [Document(meta={"file_path": "sub/cat.jpg"})]
+    with patch(PATCH_TARGET, return_value=[0.1] * 4) as mock_embed:
+        embedder.run(documents=docs)
+    expected = str(root.resolve() / "sub" / "cat.jpg")
+    mock_embed.assert_called_once_with(expected, "image", "marengo3.0", "tlk_test")
+
+
+def test_run_rejects_traversal_outside_root_path():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(
+        api_key=Secret.from_token("tlk_test"), root_path="/data", progress_bar=False
+    )
+    docs = [Document(meta={"file_path": "../../etc/passwd.jpg"})]
+    with patch(PATCH_TARGET, return_value=[0.1] * 4), pytest.raises(ValueError):
+        embedder.run(documents=docs)
+
+
+def test_run_rejects_absolute_path_with_root_path():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(
+        api_key=Secret.from_token("tlk_test"), root_path="/data", progress_bar=False
+    )
+    docs = [Document(meta={"file_path": "/etc/passwd.jpg"})]
+    with patch(PATCH_TARGET, return_value=[0.1] * 4), pytest.raises(ValueError):
+        embedder.run(documents=docs)
+
+
+def test_run_rejects_non_string_modality_meta():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(api_key=Secret.from_token("tlk_test"), progress_bar=False)
+    docs = [Document(meta={"file_path": "cat.jpg", "modality": 123})]
+    with patch(PATCH_TARGET, return_value=[0.1] * 4), pytest.raises(ValueError):
+        embedder.run(documents=docs)
+
+
+def test_run_url_ignores_root_path():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(
+        api_key=Secret.from_token("tlk_test"), root_path="/data", progress_bar=False
+    )
+    docs = [Document(meta={"file_path": "https://ex.com/v.mp4"})]
+    with patch(PATCH_TARGET, return_value=[0.1] * 4) as mock_embed:
+        embedder.run(documents=docs)
+    mock_embed.assert_called_once_with("https://ex.com/v.mp4", "video", "marengo3.0", "tlk_test")
+
+
+def test_run_modality_override_from_meta():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(api_key=Secret.from_token("tlk_test"), progress_bar=False)
+    docs = [Document(meta={"file_path": "https://ex.com/stream", "modality": "audio"})]
+    with patch(PATCH_TARGET, return_value=[0.1] * 4) as mock_embed:
+        embedder.run(documents=docs)
+    mock_embed.assert_called_once_with("https://ex.com/stream", "audio", "marengo3.0", "tlk_test")
+
+
+def test_run_missing_media_path_raises():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(api_key=Secret.from_token("tlk_test"), progress_bar=False)
+    with patch(PATCH_TARGET, return_value=[0.1] * 4), pytest.raises(ValueError):
+        embedder.run(documents=[Document(content="no path here")])
+
+
+def test_run_rejects_non_documents():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(api_key=Secret.from_token("tlk_test"))
+    with pytest.raises(TypeError):
+        embedder.run(documents=["not a document"])
+
+
+@pytest.mark.asyncio
+async def test_run_async_embeds_documents():
+    embedder = TwelveLabsDocumentMultimodalEmbedder(api_key=Secret.from_token("tlk_test"), progress_bar=False)
+    docs = [Document(meta={"file_path": "cat.jpg"}), Document(meta={"file_path": "song.mp3"})]
+    with patch(ASYNC_PATCH_TARGET, new=AsyncMock(side_effect=[[0.1] * 4, [0.2] * 4])) as mock_embed:
+        out = (await embedder.run_async(documents=docs))["documents"]
+    assert mock_embed.await_count == 2
+    assert out[0].embedding == [0.1] * 4
+    assert out[1].embedding == [0.2] * 4
+    assert out[1].meta["embedding_source"]["type"] == "audio"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("TWELVELABS_API_KEY"), reason="TWELVELABS_API_KEY env var not set")
+def test_live_video_document_embedding():
+    sample = Path(__file__).parent / "assets" / "sample_video.mp4"
+    embedder = TwelveLabsDocumentMultimodalEmbedder(progress_bar=False)
+    docs = [Document(meta={"file_path": str(sample)})]
+    out = embedder.run(documents=docs)["documents"]
+    assert isinstance(out[0].embedding, list)
+    assert len(out[0].embedding) > 0
+    assert out[0].meta["embedding_source"]["type"] == "video"

--- a/integrations/twelvelabs/tests/test_media_embed.py
+++ b/integrations/twelvelabs/tests/test_media_embed.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from haystack_integrations.components.embedders.twelvelabs._media_embed import (
+    detect_modality,
+    embed_media,
+    embed_media_async,
+)
+
+MODULE = "haystack_integrations.components.embedders.twelvelabs._media_embed"
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("cat.jpg", "image"),
+        ("/data/photo.PNG", "image"),
+        ("https://ex.com/pic.jpeg?v=1", "image"),
+        ("song.mp3", "audio"),
+        ("clip.wav", "audio"),
+        ("movie.mp4", "video"),
+        ("https://ex.com/v.mov", "video"),
+    ],
+)
+def test_detect_modality(source, expected):
+    assert detect_modality(source) == expected
+
+
+def test_detect_modality_unknown_raises():
+    with pytest.raises(ValueError):
+        detect_modality("mystery.xyz")
+
+
+def _segment(vector, scope=None):
+    seg = MagicMock()
+    seg.float_ = vector
+    seg.embedding_scope = scope
+    return seg
+
+
+def test_embed_media_image_url():
+    with patch(f"{MODULE}.TwelveLabs") as cls:
+        client = cls.return_value
+        response = MagicMock()
+        response.image_embedding.segments = [_segment([0.1, 0.2, 0.3])]
+        client.embed.create.return_value = response
+        out = embed_media("https://ex.com/cat.jpg", "image", "marengo3.0", "tlk")
+    cls.assert_called_once_with(api_key="tlk")
+    client.embed.create.assert_called_once_with(model_name="marengo3.0", image_url="https://ex.com/cat.jpg")
+    assert out == [0.1, 0.2, 0.3]
+
+
+def test_embed_media_audio_local_file(tmp_path):
+    audio = tmp_path / "a.mp3"
+    audio.write_bytes(b"xx")
+    with patch(f"{MODULE}.TwelveLabs") as cls:
+        client = cls.return_value
+        response = MagicMock()
+        response.audio_embedding.segments = [_segment([0.5, 0.6])]
+        client.embed.create.return_value = response
+        out = embed_media(str(audio), "audio", "marengo3.0", "tlk")
+    _, kwargs = client.embed.create.call_args
+    assert kwargs["model_name"] == "marengo3.0"
+    assert "audio_file" in kwargs
+    assert out == [0.5, 0.6]
+
+
+def test_embed_media_video_polls_until_ready():
+    with patch(f"{MODULE}.TwelveLabs") as cls, patch(f"{MODULE}.time.sleep") as sleep:
+        client = cls.return_value
+        client.embed.tasks.create.return_value = MagicMock(id="task-1")
+        client.embed.tasks.status.side_effect = [MagicMock(status="processing"), MagicMock(status="ready")]
+        retrieved = MagicMock()
+        retrieved.video_embedding.segments = [_segment([0.7, 0.8], scope="video")]
+        client.embed.tasks.retrieve.return_value = retrieved
+        out = embed_media("https://ex.com/v.mp4", "video", "marengo3.0", "tlk")
+    client.embed.tasks.create.assert_called_once_with(
+        model_name="marengo3.0", video_url="https://ex.com/v.mp4", video_embedding_scope=["video"]
+    )
+    assert client.embed.tasks.status.call_count == 2
+    client.embed.tasks.retrieve.assert_called_once_with("task-1")
+    sleep.assert_called_once()
+    assert out == [0.7, 0.8]
+
+
+def test_embed_media_video_failed_raises():
+    with patch(f"{MODULE}.TwelveLabs") as cls, patch(f"{MODULE}.time.sleep"):
+        client = cls.return_value
+        client.embed.tasks.create.return_value = MagicMock(id="task-1")
+        client.embed.tasks.status.return_value = MagicMock(status="failed")
+        with pytest.raises(RuntimeError):
+            embed_media("https://ex.com/v.mp4", "video", "marengo3.0", "tlk")
+
+
+def test_embed_media_no_vector_raises():
+    with patch(f"{MODULE}.TwelveLabs") as cls:
+        client = cls.return_value
+        response = MagicMock()
+        response.image_embedding.segments = None
+        client.embed.create.return_value = response
+        with pytest.raises(RuntimeError):
+            embed_media("https://ex.com/cat.jpg", "image", "marengo3.0", "tlk")
+
+
+def test_embed_media_missing_local_file_raises():
+    with patch(f"{MODULE}.TwelveLabs"), pytest.raises(FileNotFoundError):
+        embed_media("/no/such/file.jpg", "image", "marengo3.0", "tlk")
+
+
+@pytest.mark.asyncio
+async def test_embed_media_async_image_url():
+    with patch(f"{MODULE}.AsyncTwelveLabs") as cls:
+        client = cls.return_value
+        response = MagicMock()
+        response.image_embedding.segments = [_segment([0.1, 0.2])]
+        client.embed.create = AsyncMock(return_value=response)
+        out = await embed_media_async("https://ex.com/cat.jpg", "image", "marengo3.0", "tlk")
+    client.embed.create.assert_awaited_once_with(model_name="marengo3.0", image_url="https://ex.com/cat.jpg")
+    assert out == [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_embed_media_async_video_polls_until_ready():
+    with patch(f"{MODULE}.AsyncTwelveLabs") as cls, patch(f"{MODULE}.asyncio.sleep", new=AsyncMock()) as sleep:
+        client = cls.return_value
+        client.embed.tasks.create = AsyncMock(return_value=MagicMock(id="task-1"))
+        client.embed.tasks.status = AsyncMock(side_effect=[MagicMock(status="processing"), MagicMock(status="ready")])
+        retrieved = MagicMock()
+        retrieved.video_embedding.segments = [_segment([0.7, 0.8], scope="video")]
+        client.embed.tasks.retrieve = AsyncMock(return_value=retrieved)
+        out = await embed_media_async("https://ex.com/v.mp4", "video", "marengo3.0", "tlk")
+    client.embed.tasks.create.assert_awaited_once_with(
+        model_name="marengo3.0", video_url="https://ex.com/v.mp4", video_embedding_scope=["video"]
+    )
+    assert client.embed.tasks.status.await_count == 2
+    client.embed.tasks.retrieve.assert_awaited_once_with("task-1")
+    sleep.assert_awaited_once()
+    assert out == [0.7, 0.8]
+
+
+@pytest.mark.asyncio
+async def test_embed_media_async_video_failed_raises():
+    with patch(f"{MODULE}.AsyncTwelveLabs") as cls, patch(f"{MODULE}.asyncio.sleep", new=AsyncMock()):
+        client = cls.return_value
+        client.embed.tasks.create = AsyncMock(return_value=MagicMock(id="task-1"))
+        client.embed.tasks.status = AsyncMock(return_value=MagicMock(status="failed"))
+        with pytest.raises(RuntimeError):
+            await embed_media_async("https://ex.com/v.mp4", "video", "marengo3.0", "tlk")

--- a/integrations/twelvelabs/tests/test_multimodal_embedder.py
+++ b/integrations/twelvelabs/tests/test_multimodal_embedder.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from haystack.utils import Secret
+
+from haystack_integrations.components.embedders.twelvelabs import TwelveLabsMultimodalEmbedder
+
+PATCH_TARGET = "haystack_integrations.components.embedders.twelvelabs.multimodal_embedder.embed_media"
+ASYNC_PATCH_TARGET = "haystack_integrations.components.embedders.twelvelabs.multimodal_embedder.embed_media_async"
+
+
+def test_init_defaults(monkeypatch):
+    monkeypatch.setenv("TWELVELABS_API_KEY", "tlk_env")
+    embedder = TwelveLabsMultimodalEmbedder()
+    assert embedder.model == "marengo3.0"
+    assert embedder.api_key.resolve_value() == "tlk_env"
+
+
+def test_to_dict_and_from_dict(monkeypatch):
+    monkeypatch.setenv("TWELVELABS_API_KEY", "tlk_env")
+    data = TwelveLabsMultimodalEmbedder(model="marengo3.0").to_dict()
+    assert data["type"].endswith("TwelveLabsMultimodalEmbedder")
+    assert data["init_parameters"]["model"] == "marengo3.0"
+    restored = TwelveLabsMultimodalEmbedder.from_dict(data)
+    assert restored.model == "marengo3.0"
+
+
+def test_run_infers_image():
+    embedder = TwelveLabsMultimodalEmbedder(api_key=Secret.from_token("tlk_test"))
+    with patch(PATCH_TARGET, return_value=[0.1] * 8) as mock_embed:
+        result = embedder.run(source="https://ex.com/cat.jpg")
+    mock_embed.assert_called_once_with("https://ex.com/cat.jpg", "image", "marengo3.0", "tlk_test")
+    assert result["embedding"] == [0.1] * 8
+    assert result["meta"] == {"model": "marengo3.0", "modality": "image"}
+
+
+def test_run_explicit_modality_overrides_inference():
+    embedder = TwelveLabsMultimodalEmbedder(api_key=Secret.from_token("tlk_test"))
+    with patch(PATCH_TARGET, return_value=[0.2] * 4) as mock_embed:
+        result = embedder.run(source="https://ex.com/stream", modality="video")
+    mock_embed.assert_called_once_with("https://ex.com/stream", "video", "marengo3.0", "tlk_test")
+    assert result["meta"]["modality"] == "video"
+
+
+def test_run_rejects_non_string_source():
+    embedder = TwelveLabsMultimodalEmbedder(api_key=Secret.from_token("tlk_test"))
+    with pytest.raises(TypeError):
+        embedder.run(source=123)
+
+
+def test_run_uninferrable_modality_raises():
+    embedder = TwelveLabsMultimodalEmbedder(api_key=Secret.from_token("tlk_test"))
+    with pytest.raises(ValueError):
+        embedder.run(source="mystery.xyz")
+
+
+def test_run_bad_explicit_modality_raises():
+    embedder = TwelveLabsMultimodalEmbedder(api_key=Secret.from_token("tlk_test"))
+    with pytest.raises(ValueError):
+        embedder.run(source="cat.jpg", modality="hologram")
+
+
+@pytest.mark.asyncio
+async def test_run_async_infers_audio():
+    embedder = TwelveLabsMultimodalEmbedder(api_key=Secret.from_token("tlk_test"))
+    with patch(ASYNC_PATCH_TARGET, new=AsyncMock(return_value=[0.3] * 8)) as mock_embed:
+        result = await embedder.run_async(source="song.mp3")
+    mock_embed.assert_awaited_once_with("song.mp3", "audio", "marengo3.0", "tlk_test")
+    assert result["embedding"] == [0.3] * 8
+    assert result["meta"]["modality"] == "audio"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("TWELVELABS_API_KEY"), reason="TWELVELABS_API_KEY env var not set")
+def test_live_image_embedding():
+    embedder = TwelveLabsMultimodalEmbedder()
+    result = embedder.run(source="https://upload.wikimedia.org/wikipedia/commons/1/15/Cat_August_2010-4.jpg")
+    assert isinstance(result["embedding"], list)
+    assert len(result["embedding"]) > 0
+    assert result["meta"]["modality"] == "image"


### PR DESCRIPTION
## Description

Follow-up to #3480 (the initial TwelveLabs integration). That PR shipped **text** embeddings
via Marengo (`TwelveLabsTextEmbedder`, `TwelveLabsDocumentEmbedder`) plus the Pegasus
`TwelveLabsVideoConverter`. But Marengo embeds **text, images, audio, and video into one shared
512-dimensional space**, and only the text path was exposed. This PR adds the image/audio/video
embedding capabilities so the shared space can actually be used for cross-modal retrieval.

Modeled on the Voyage integration's multimodal embedder, and kept consistent with the existing
Text/Document embedder pairing in this integration.

## Components added

### `TwelveLabsMultimodalEmbedder`
Embeds a single image, audio, or video (a local file path **or** a public URL) into Marengo's
shared space and returns `{"embedding": [...], "meta": {...}}`. This is the cross-modal query
companion to `TwelveLabsTextEmbedder` — e.g. embed a text query with the text embedder and search
a store of video/image embeddings, or vice-versa. Modality is inferred from the file
extension / MIME type and can be set explicitly via `modality=`.

```python
from haystack_integrations.components.embedders.twelvelabs import TwelveLabsMultimodalEmbedder

embedder = TwelveLabsMultimodalEmbedder()  # reads TWELVELABS_API_KEY
result = embedder.run(source="https://example.com/cat.jpg")
print(len(result["embedding"]))
```

### `TwelveLabsDocumentMultimodalEmbedder`
The indexing counterpart to `TwelveLabsDocumentEmbedder` (which embeds text `content`). It reads
each Document's media path from `meta["file_path"]` (configurable via `file_path_meta_field` /
`root_path`), embeds the media, and writes `Document.embedding` — following the same convention as
the existing `CohereDocumentImageEmbedder` / `JinaDocumentImageEmbedder`. Modality is inferred
per-Document (override with `meta["modality"]`).

```python
from haystack import Document
from haystack_integrations.components.embedders.twelvelabs import TwelveLabsDocumentMultimodalEmbedder

docs = [Document(meta={"file_path": "clip.mp4"})]
docs = TwelveLabsDocumentMultimodalEmbedder().run(documents=docs)["documents"]
```

## Implementation notes

- Images and audio are embedded synchronously via `client.embed.create`.
- Video uses the asynchronous TwelveLabs video-embedding task: the component submits the task,
  polls `embed.tasks.status` until it is `ready`, then retrieves the embedding (whole-video scope).
- Both components provide `run` and `run_async`.
- No new dependency — uses the `twelvelabs` SDK already declared by the integration.

## Tests and quality

- 22 new unit tests (56 total pass); `ruff check`, `ruff format --check`, and `mypy` all clean.
- Gated integration tests (`@pytest.mark.integration`, skipped without `TWELVELABS_API_KEY`) cover
  a live image embedding and a live video-Document embedding.

## Notes for reviewers

- Naming: went with `TwelveLabsMultimodalEmbedder` (query-side) + `TwelveLabsDocumentMultimodalEmbedder`
  (document-side) to mirror the existing `Text` / `Document` pairing and the repo's image-embedder
  convention. Happy to rename or split further if you'd prefer.
- Opening as a **draft** — feedback on scope, naming, and the media-input interface welcome before
  I finalize.
