### PR TITLE
fix(valkey): report accurate written count when async batch writes partially fail

### DIFF
--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -705,12 +705,18 @@ class ValkeyDocumentStore(DocumentStore):
         written_count = 0
         for i in range(0, len(documents), self._batch_size):
             batch = documents[i : i + self._batch_size]
-            try:
-                await asyncio.gather(*[write_single_doc(doc) for doc in batch])
-                written_count += len(batch)
-            except Exception as e:
-                msg = f"Failed to write batch starting at index {i}: {e}"
-                raise ValkeyDocumentStoreError(msg) from e
+            results = await asyncio.gather(*[write_single_doc(doc) for doc in batch], return_exceptions=True)
+            for result in results:
+                if not isinstance(result, BaseException):
+                    written_count += 1
+
+            for doc, result in zip(batch, results, strict=True):
+                if isinstance(result, BaseException):
+                    msg = (
+                        f"Failed to write document {doc.id}: {result}. "
+                        f"{written_count} document(s) were written before this failure."
+                    )
+                    raise ValkeyDocumentStoreError(msg) from result
 
         return written_count
 

--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -697,10 +697,10 @@ class ValkeyDocumentStore(DocumentStore):
         client = await self._get_connection_async()
         await self._create_index_async()
 
-        def write_single_doc(doc: Document) -> Any:
+        async def write_single_doc(doc: Document) -> Any:
             doc_dict = self._prepare_document_dict(doc)
             key = f"{self._index_name}:{doc.id}"
-            return glide_json.set(client, key, "$", json.dumps(doc_dict))
+            return await glide_json.set(client, key, "$", json.dumps(doc_dict))
 
         written_count = 0
         for i in range(0, len(documents), self._batch_size):

--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -709,13 +709,16 @@ class ValkeyDocumentStore(DocumentStore):
                 if not isinstance(result, BaseException):
                     written_count += 1
 
-            for doc, result in zip(batch, results, strict=True):
-                if isinstance(result, BaseException):
-                    msg = (
-                        f"Failed to write document {doc.id}: {result}. "
-                        f"{written_count} document(s) were written before this failure."
-                    )
-                    raise ValkeyDocumentStoreError(msg) from result
+            failures = [
+                (doc, result) for doc, result in zip(batch, results, strict=True) if isinstance(result, BaseException)
+            ]
+            if failures:
+                ids = ", ".join(doc.id for doc, _ in failures)
+                msg = (
+                    f"Failed to write document(s) {ids}: {failures[0][1]}. "
+                    f"{written_count} document(s) were written before this failure."
+                )
+                raise ValkeyDocumentStoreError(msg) from failures[0][1]
 
         return written_count
 

--- a/integrations/valkey/tests/test_document_store.py
+++ b/integrations/valkey/tests/test_document_store.py
@@ -1294,6 +1294,41 @@ class TestValkeyDocumentStoreErrorPaths:
         assert seen_keys == [f"async_failure:{doc.id}" for doc in documents[:4]]
 
     @pytest.mark.asyncio
+    async def test_write_documents_async_reports_multiple_failures_in_same_batch(self):
+        store = ValkeyDocumentStore(index_name="async_multiple_failures", embedding_dim=3, batch_size=3)
+        documents = [Document(id=f"doc-{i}", content=f"document {i}", embedding=[0.1, 0.2, 0.3]) for i in range(7)]
+        seen_keys = []
+        failing_keys = {
+            f"async_multiple_failures:{documents[3].id}",
+            f"async_multiple_failures:{documents[4].id}",
+        }
+        first_failure = RuntimeError("first write failed")
+        second_failure = RuntimeError("write failed")
+
+        async def fake_set(_client, key, _path, _value):
+            seen_keys.append(key)
+            if key == f"async_multiple_failures:{documents[3].id}":
+                raise first_failure
+            if key in failing_keys:
+                raise second_failure
+            return "OK"
+
+        with (
+            patch.object(store, "_get_connection_async", AsyncMock(return_value=MagicMock())),
+            patch.object(store, "_create_index_async", AsyncMock()),
+            patch.object(ds_module.glide_json, "set", fake_set),
+            pytest.raises(ValkeyDocumentStoreError) as exc_info,
+        ):
+            await store.write_documents_async(documents)
+
+        error = exc_info.value
+        assert documents[3].id in str(error)
+        assert documents[4].id in str(error)
+        assert "4 document(s) were written" in str(error)
+        assert error.__cause__ is first_failure
+        assert seen_keys == [f"async_multiple_failures:{doc.id}" for doc in documents[:6]]
+
+    @pytest.mark.asyncio
     async def test_write_documents_async_reports_successful_sibling_in_first_batch(self):
         store = ValkeyDocumentStore(index_name="async_first_batch_failure", embedding_dim=3, batch_size=2)
         documents = [Document(id=f"doc-{i}", content=f"document {i}", embedding=[0.1, 0.2, 0.3]) for i in range(2)]

--- a/integrations/valkey/tests/test_document_store.py
+++ b/integrations/valkey/tests/test_document_store.py
@@ -1306,6 +1306,33 @@ class TestValkeyDocumentStoreErrorPaths:
         assert "1 document(s) were written" in str(exc_info.value)
         assert documents[0].id in str(exc_info.value)
 
+    @pytest.mark.asyncio
+    async def test_write_documents_async_wraps_document_preparation_errors(self):
+        store = ValkeyDocumentStore(
+            index_name="async_prepare_failure", embedding_dim=3, batch_size=2, metadata_fields={"category": str}
+        )
+        documents = [
+            Document(id="doc-0", content="document 0", embedding=[0.1, 0.2, 0.3], meta={"category": "news"}),
+            Document(id="doc-1", content="document 1", embedding=[0.1, 0.2, 0.3], meta={"category": 123}),
+        ]
+        seen_keys = []
+
+        async def fake_set(_client, key, _path, _value):
+            seen_keys.append(key)
+            return "OK"
+
+        with (
+            patch.object(store, "_get_connection_async", AsyncMock(return_value=MagicMock())),
+            patch.object(store, "_create_index_async", AsyncMock()),
+            patch.object(ds_module.glide_json, "set", fake_set),
+            pytest.raises(ValkeyDocumentStoreError) as exc_info,
+        ):
+            await store.write_documents_async(documents)
+
+        assert "1 document(s) were written" in str(exc_info.value)
+        assert documents[1].id in str(exc_info.value)
+        assert seen_keys == [f"async_prepare_failure:{documents[0].id}"]
+
     @pytest.mark.parametrize("cluster_mode", [False, True])
     def test_get_connection_wraps_create_errors(self, unit_store, cluster_mode):
         unit_store._cluster_mode = cluster_mode

--- a/integrations/valkey/tests/test_document_store.py
+++ b/integrations/valkey/tests/test_document_store.py
@@ -6,7 +6,7 @@
 
 import struct
 from dataclasses import replace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from glide_shared.commands.server_modules.ft_options.ft_create_options import DistanceMetricType
@@ -1237,6 +1237,75 @@ def unit_store():
 
 
 class TestValkeyDocumentStoreErrorPaths:
+    @pytest.mark.asyncio
+    async def test_write_documents_async_returns_count_across_multiple_batches(self):
+        store = ValkeyDocumentStore(index_name="async_success", embedding_dim=3, batch_size=2)
+        documents = [Document(id=f"doc-{i}", content=f"document {i}", embedding=[0.1, 0.2, 0.3]) for i in range(5)]
+        seen_keys = []
+
+        async def fake_set(_client, key, _path, _value):
+            seen_keys.append(key)
+            return "OK"
+
+        with (
+            patch.object(store, "_get_connection_async", AsyncMock(return_value=MagicMock())),
+            patch.object(store, "_create_index_async", AsyncMock()),
+            patch.object(ds_module.glide_json, "set", fake_set),
+        ):
+            written_count = await store.write_documents_async(documents)
+
+        assert written_count == len(documents)
+        assert seen_keys == [f"async_success:{doc.id}" for doc in documents]
+
+    @pytest.mark.asyncio
+    async def test_write_documents_async_reports_partial_success_in_failing_batch(self):
+        store = ValkeyDocumentStore(index_name="async_failure", embedding_dim=3, batch_size=2)
+        documents = [Document(id=f"doc-{i}", content=f"document {i}", embedding=[0.1, 0.2, 0.3]) for i in range(6)]
+        seen_keys = []
+        failing_key = f"async_failure:{documents[2].id}"
+
+        async def fake_set(_client, key, _path, _value):
+            seen_keys.append(key)
+            if key == failing_key:
+                msg = "write failed"
+                raise RuntimeError(msg)
+            return "OK"
+
+        with (
+            patch.object(store, "_get_connection_async", AsyncMock(return_value=MagicMock())),
+            patch.object(store, "_create_index_async", AsyncMock()),
+            patch.object(ds_module.glide_json, "set", fake_set),
+            pytest.raises(ValkeyDocumentStoreError) as exc_info,
+        ):
+            await store.write_documents_async(documents)
+
+        assert "3 document(s) were written" in str(exc_info.value)
+        assert documents[2].id in str(exc_info.value)
+        assert seen_keys == [f"async_failure:{doc.id}" for doc in documents[:4]]
+
+    @pytest.mark.asyncio
+    async def test_write_documents_async_reports_successful_sibling_in_first_batch(self):
+        store = ValkeyDocumentStore(index_name="async_first_batch_failure", embedding_dim=3, batch_size=2)
+        documents = [Document(id=f"doc-{i}", content=f"document {i}", embedding=[0.1, 0.2, 0.3]) for i in range(2)]
+        failing_key = f"async_first_batch_failure:{documents[0].id}"
+
+        async def fake_set(_client, key, _path, _value):
+            if key == failing_key:
+                msg = "write failed"
+                raise RuntimeError(msg)
+            return "OK"
+
+        with (
+            patch.object(store, "_get_connection_async", AsyncMock(return_value=MagicMock())),
+            patch.object(store, "_create_index_async", AsyncMock()),
+            patch.object(ds_module.glide_json, "set", fake_set),
+            pytest.raises(ValkeyDocumentStoreError) as exc_info,
+        ):
+            await store.write_documents_async(documents)
+
+        assert "1 document(s) were written" in str(exc_info.value)
+        assert documents[0].id in str(exc_info.value)
+
     @pytest.mark.parametrize("cluster_mode", [False, True])
     def test_get_connection_wraps_create_errors(self, unit_store, cluster_mode):
         unit_store._cluster_mode = cluster_mode


### PR DESCRIPTION
### Related Issues

- fixes #3579

### Proposed Changes:

`write_documents_async` counted writes per batch. When one document in a
batch failed, the siblings that were already written were not counted, and
the error message said nothing was written. That is not true, because each
`glide_json.set` call is durable on its own.

Now the batch is gathered with `return_exceptions=True`, successes are
counted per document, and the error message reports the real number of
written documents. Batches after a failure are not started.

The second commit makes `write_single_doc` async, so errors from
`_prepare_document_dict` (for example invalid metadata) go through the
same per-document accounting and are wrapped in `ValkeyDocumentStoreError`,
the same way the sync path wraps them.

### How did you test it?

Four new unit tests (mocked glide client, no live Valkey needed):
all-success count, failure in a middle batch, failure in the first batch
with a successful sibling, and a document preparation error. Full run:
`hatch run test:unit` (116 passed), `hatch run test:types`,
`hatch run fmt` — all clean.

### Notes for the reviewer

The error message now also says how many documents were written before
the failure, for example: "3 document(s) were written before this failure."

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`