### PR TITLE
fix(microsoft_sharepoint,google_drive): cancel and drain in-flight fetches when one fails

### DIFF
--- a/integrations/google_drive/src/haystack_integrations/common/google_drive/utils.py
+++ b/integrations/google_drive/src/haystack_integrations/common/google_drive/utils.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+from typing import TypeVar
+
 import httpx
 from haystack import logging
 from haystack.utils import Secret
@@ -18,10 +21,29 @@ from .errors import GoogleDriveConfigError, GoogleDriveRequestError
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+
 DEFAULT_API_BASE_URL = "https://www.googleapis.com/drive/v3"
 _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 # Fallback backoff when a throttled response carries no `Retry-After` header: 1s, 2s, 4s, ...
 _EXPONENTIAL_BACKOFF = wait_exponential()
+
+
+async def _gather_tasks_with_cancel(tasks: list[asyncio.Task[T]]) -> list[T]:
+    """
+    Wait for all tasks, cancelling and draining unfinished siblings if one fails.
+
+    :param tasks: Tasks to wait for.
+    :returns:
+        The task results in input order.
+    """
+    try:
+        return await asyncio.gather(*tasks)
+    except Exception:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
 
 def resolve_access_token(access_token: str | Secret) -> str:

--- a/integrations/google_drive/src/haystack_integrations/common/google_drive/utils.py
+++ b/integrations/google_drive/src/haystack_integrations/common/google_drive/utils.py
@@ -39,7 +39,7 @@ async def _gather_tasks_with_cancel(tasks: list[asyncio.Task[T]]) -> list[T]:
     """
     try:
         return await asyncio.gather(*tasks)
-    except Exception:
+    except BaseException:
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)

--- a/integrations/google_drive/src/haystack_integrations/components/fetchers/google_drive/fetcher.py
+++ b/integrations/google_drive/src/haystack_integrations/components/fetchers/google_drive/fetcher.py
@@ -14,6 +14,7 @@ from haystack.utils import Secret
 from haystack_integrations.common.google_drive.errors import GoogleDriveConfigError, GoogleDriveRequestError
 from haystack_integrations.common.google_drive.utils import (
     DEFAULT_API_BASE_URL,
+    _gather_tasks_with_cancel,
     build_async_retrying,
     build_retrying,
     resolve_access_token,
@@ -197,7 +198,8 @@ class GoogleDriveFetcher:
                 return await self._process_async(client, token, file_id, hints)
 
         async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-            results = await asyncio.gather(*(fetch_one(client, file_id, hints) for file_id, hints in resolved))
+            tasks = [asyncio.create_task(fetch_one(client, file_id, hints)) for file_id, hints in resolved]
+            results = await _gather_tasks_with_cancel(tasks)
 
         return {"streams": [stream for stream in results if stream is not None]}
 

--- a/integrations/google_drive/tests/test_fetcher.py
+++ b/integrations/google_drive/tests/test_fetcher.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 import os
 from unittest.mock import AsyncMock, patch
 
@@ -358,6 +359,50 @@ class TestPipeline:
 
 @pytest.mark.asyncio
 class TestRunAsync:
+    async def test_failure_cancels_and_drains_siblings(self):
+        fetcher = GoogleDriveFetcher(max_retries=0)
+        slow_started = asyncio.Event()
+        slow_cancelled = False
+        current_task = asyncio.current_task()
+        tasks_before = asyncio.all_tasks() - {current_task}
+
+        async def get(url, *_args, **_kwargs):
+            nonlocal slow_cancelled
+            if "SLOW" in url:
+                slow_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    slow_cancelled = True
+                    raise
+            await slow_started.wait()
+            msg = "failed"
+            raise httpx.ReadError(msg)
+
+        targets = [_drive_doc(file_id="SLOW"), _drive_doc(file_id="FAILING")]
+        with patch.object(httpx.AsyncClient, "get", AsyncMock(side_effect=get)):
+            with pytest.raises(httpx.ReadError):
+                await fetcher.run_async(access_token="tok", targets=targets)
+
+        assert slow_cancelled is True
+        assert asyncio.all_tasks() - {current_task} == tasks_before
+
+    async def test_raise_on_failure_false_skips_failed_files(self):
+        fetcher = GoogleDriveFetcher(max_retries=0, raise_on_failure=False)
+
+        async def get(url, *_args, **_kwargs):
+            if "MISSING" in url:
+                msg = "failed"
+                raise httpx.ReadError(msg)
+            return _binary(content=b"ok")
+
+        targets = [_drive_doc(file_id="MISSING"), _drive_doc(file_id="OK")]
+        with patch.object(httpx.AsyncClient, "get", AsyncMock(side_effect=get)):
+            streams = (await fetcher.run_async(access_token="tok", targets=targets))["streams"]
+
+        assert len(streams) == 1
+        assert streams[0].data == b"ok"
+
     async def test_downloads_binary(self):
         fetcher = GoogleDriveFetcher()
         get = AsyncMock(return_value=_binary(content=b"async-bytes"))

--- a/integrations/microsoft_sharepoint/src/haystack_integrations/common/microsoft_sharepoint/utils.py
+++ b/integrations/microsoft_sharepoint/src/haystack_integrations/common/microsoft_sharepoint/utils.py
@@ -39,7 +39,7 @@ async def _gather_tasks_with_cancel(tasks: list[asyncio.Task[T]]) -> list[T]:
     """
     try:
         return await asyncio.gather(*tasks)
-    except Exception:
+    except BaseException:
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)

--- a/integrations/microsoft_sharepoint/src/haystack_integrations/common/microsoft_sharepoint/utils.py
+++ b/integrations/microsoft_sharepoint/src/haystack_integrations/common/microsoft_sharepoint/utils.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+from typing import TypeVar
+
 import httpx
 from haystack import logging
 from haystack.utils import Secret
@@ -18,10 +21,29 @@ from .errors import SharePointConfigError, SharePointRequestError
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+
 DEFAULT_GRAPH_URL = "https://graph.microsoft.com/v1.0"
 _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 # Fallback backoff when a throttled response carries no `Retry-After` header: 1s, 2s, 4s, ...
 _EXPONENTIAL_BACKOFF = wait_exponential()
+
+
+async def _gather_tasks_with_cancel(tasks: list[asyncio.Task[T]]) -> list[T]:
+    """
+    Wait for all tasks, cancelling and draining unfinished siblings if one fails.
+
+    :param tasks: Tasks to wait for.
+    :returns:
+        The task results in input order.
+    """
+    try:
+        return await asyncio.gather(*tasks)
+    except Exception:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
 
 def resolve_access_token(access_token: str | Secret) -> str:

--- a/integrations/microsoft_sharepoint/src/haystack_integrations/components/fetchers/microsoft_sharepoint/fetcher.py
+++ b/integrations/microsoft_sharepoint/src/haystack_integrations/components/fetchers/microsoft_sharepoint/fetcher.py
@@ -18,6 +18,7 @@ from haystack.utils import Secret
 from haystack_integrations.common.microsoft_sharepoint.errors import SharePointConfigError, SharePointRequestError
 from haystack_integrations.common.microsoft_sharepoint.utils import (
     DEFAULT_GRAPH_URL,
+    _gather_tasks_with_cancel,
     build_async_retrying,
     build_retrying,
     resolve_access_token,
@@ -193,7 +194,8 @@ class MSSharePointFetcher:
                 return await self._process_async(client, token, url, hints)
 
         async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-            results = await asyncio.gather(*(fetch_one(client, url, hints) for url, hints in resolved))
+            tasks = [asyncio.create_task(fetch_one(client, url, hints)) for url, hints in resolved]
+            results = await _gather_tasks_with_cancel(tasks)
 
         return {"streams": [stream for stream in results if stream is not None]}
 

--- a/integrations/microsoft_sharepoint/tests/test_fetcher.py
+++ b/integrations/microsoft_sharepoint/tests/test_fetcher.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 import base64
 import json
 import os
@@ -458,6 +459,60 @@ class TestPipeline:
 
 @pytest.mark.asyncio
 class TestRunAsync:
+    async def test_failure_cancels_and_drains_siblings(self):
+        fetcher = MSSharePointFetcher(max_retries=0)
+        slow_started = asyncio.Event()
+        slow_cancelled = False
+        current_task = asyncio.current_task()
+        tasks_before = asyncio.all_tasks() - {current_task}
+        slow_url = "https://host/slow.docx"
+        slow_marker = _encode_share_url(slow_url)
+
+        async def get(url, *_args, **_kwargs):
+            nonlocal slow_cancelled
+            if slow_marker in url:
+                slow_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    slow_cancelled = True
+                    raise
+            await slow_started.wait()
+            msg = "failed"
+            raise httpx.ReadError(msg)
+
+        targets = [
+            _drive_item_document(url=slow_url),
+            _drive_item_document(url="https://host/failing.docx"),
+        ]
+        with patch.object(httpx.AsyncClient, "get", AsyncMock(side_effect=get)):
+            with pytest.raises(httpx.ReadError):
+                await fetcher.run_async(access_token="tok", targets=targets)
+
+        assert slow_cancelled is True
+        assert asyncio.all_tasks() - {current_task} == tasks_before
+
+    async def test_raise_on_failure_false_skips_failed_items(self):
+        fetcher = MSSharePointFetcher(max_retries=0, raise_on_failure=False)
+        missing_url = "https://host/missing.docx"
+        missing_marker = _encode_share_url(missing_url)
+
+        async def get(url, *_args, **_kwargs):
+            if missing_marker in url:
+                msg = "failed"
+                raise httpx.ReadError(msg)
+            return _binary_response(content=b"ok")
+
+        targets = [
+            _drive_item_document(url=missing_url),
+            _drive_item_document(url="https://host/healthy.docx"),
+        ]
+        with patch.object(httpx.AsyncClient, "get", AsyncMock(side_effect=get)):
+            streams = (await fetcher.run_async(access_token="tok", targets=targets))["streams"]
+
+        assert len(streams) == 1
+        assert streams[0].data == b"ok"
+
     async def test_downloads_drive_item(self):
         fetcher = MSSharePointFetcher()
         get = AsyncMock(return_value=_binary_response(content=b"async-bytes"))


### PR DESCRIPTION
### Related Issues

- fixes #3577

### Proposed Changes:

In both fetchers, `run_async` shares one `httpx.AsyncClient` between all
downloads. When one download failed, the exception left the `async with`
block and closed the client while other downloads were still using it. So
one bad file could break healthy fetches too, and tasks were left orphaned.

Now the tasks are created explicitly, and a small helper cancels and
awaits the remaining tasks before the exception is re-raised, while the
client is still open. Same idea as deepset-ai/haystack#11967.
`raise_on_failure=False` behavior is unchanged.

The second commit catches `BaseException` in the helper, so the drain also
runs when `run_async` itself is cancelled (for example by a caller timeout).

### How did you test it?

New unit test in each integration: one slow download and one failing
download share the client; the test checks the slow one gets cancelled
cleanly and no orphaned tasks remain. The new tests fail on the old code.
Full runs in both integrations: `hatch run test:unit` (80 + 90 passed),
`hatch run test:types`, `hatch run fmt` — all clean.

### Notes for the reviewer

The helper is duplicated in both integrations because each package is
self-contained. Happy to move it to a shared place if you prefer.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`