### PR TITLE
refactor: align Weaviate closing methods to standard

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/bm25_retriever.py
@@ -92,6 +92,18 @@ class WeaviateBM25Retriever:
 
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/embedding_retriever.py
@@ -98,6 +98,18 @@ class WeaviateEmbeddingRetriever:
 
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/hybrid_retriever.py
+++ b/integrations/weaviate/src/haystack_integrations/components/retrievers/weaviate/hybrid_retriever.py
@@ -115,6 +115,18 @@ class WeaviateHybridRetriever:
 
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -5,6 +5,7 @@
 import base64
 import datetime
 import json
+from contextlib import suppress
 from dataclasses import asdict
 from typing import Any, NoReturn
 
@@ -294,19 +295,21 @@ class WeaviateDocumentStore:
 
     def close(self) -> None:
         """
-        Close the synchronous Weaviate client connection.
+        Release the associated synchronous resources.
         """
-        if self._client:
-            self._client.close()
+        if self._client is not None:
+            with suppress(Exception):
+                self._client.close()
             self._client = None
             self._collection = None
 
     async def close_async(self) -> None:
         """
-        Close the asynchronous Weaviate client connection.
+        Release the associated asynchronous resources.
         """
-        if self._async_client:
-            await self._async_client.close()
+        if self._async_client is not None:
+            with suppress(Exception):
+                await self._async_client.close()
             self._async_client = None
             self._async_collection = None
 

--- a/integrations/weaviate/tests/test_bm25_retriever.py
+++ b/integrations/weaviate/tests/test_bm25_retriever.py
@@ -11,6 +11,16 @@ from haystack_integrations.components.retrievers.weaviate import WeaviateBM25Ret
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 
+def test_close():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    retriever = WeaviateBM25Retriever(document_store=mock_document_store)
+
+    retriever.close()
+
+    mock_document_store.close.assert_called_once_with()
+    assert retriever._document_store is mock_document_store
+
+
 def test_init_default():
     mock_document_store = Mock(spec=WeaviateDocumentStore)
     retriever = WeaviateBM25Retriever(document_store=mock_document_store)

--- a/integrations/weaviate/tests/test_bm25_retriever_async.py
+++ b/integrations/weaviate/tests/test_bm25_retriever_async.py
@@ -11,6 +11,18 @@ from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 
 @pytest.mark.asyncio
+async def test_close_async():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    mock_document_store.close_async = AsyncMock()
+    retriever = WeaviateBM25Retriever(document_store=mock_document_store)
+
+    await retriever.close_async()
+
+    mock_document_store.close_async.assert_awaited_once_with()
+    assert retriever._document_store is mock_document_store
+
+
+@pytest.mark.asyncio
 async def test_run_async_calls_async_retrieval():
     mock_document_store = Mock(spec=WeaviateDocumentStore)
     mock_document_store._bm25_retrieval_async = AsyncMock(return_value=[])

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -196,6 +196,35 @@ async def test_write_documents_async_with_skip_and_fail_policies():
             await ds.write_documents_async(["not-a-doc"], policy=DuplicatePolicy.FAIL)  # type: ignore[list-item]
 
 
+def test_close():
+    document_store = WeaviateDocumentStore()
+    mock_client = MagicMock()
+    document_store._client = mock_client
+    document_store._collection = MagicMock()
+
+    document_store.close()
+
+    mock_client.close.assert_called_once()
+    assert document_store._client is None
+    assert document_store._collection is None
+
+    document_store.close()
+    mock_client.close.assert_called_once()
+
+
+def test_close_is_exception_safe():
+    document_store = WeaviateDocumentStore()
+    mock_client = MagicMock()
+    mock_client.close.side_effect = RuntimeError("boom")
+    document_store._client = mock_client
+    document_store._collection = MagicMock()
+
+    document_store.close()
+
+    assert document_store._client is None
+    assert document_store._collection is None
+
+
 @pytest.mark.integration
 class TestWeaviateDocumentStore(
     DocumentStoreBaseExtendedTests,
@@ -315,7 +344,7 @@ class TestWeaviateDocumentStore(
             {"class": "My_collection", "properties": DOCUMENT_COLLECTION_PROPERTIES}
         )
 
-    def test_close(self, document_store: WeaviateDocumentStore) -> None:
+    def test_close_and_reopen(self, document_store: WeaviateDocumentStore) -> None:
         # Initialise client and collection
         assert document_store.client is not None
         assert document_store.collection is not None

--- a/integrations/weaviate/tests/test_document_store_async.py
+++ b/integrations/weaviate/tests/test_document_store_async.py
@@ -6,6 +6,7 @@ import dataclasses
 import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -33,6 +34,37 @@ from numpy import float32 as np_float32
 
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 from haystack_integrations.document_stores.weaviate.document_store import DOCUMENT_COLLECTION_PROPERTIES
+
+
+@pytest.mark.asyncio
+async def test_close_async():
+    document_store = WeaviateDocumentStore()
+    mock_client = AsyncMock()
+    document_store._async_client = mock_client
+    document_store._async_collection = MagicMock()
+
+    await document_store.close_async()
+
+    mock_client.close.assert_awaited_once()
+    assert document_store._async_client is None
+    assert document_store._async_collection is None
+
+    await document_store.close_async()
+    mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_async_is_exception_safe():
+    document_store = WeaviateDocumentStore()
+    mock_client = AsyncMock()
+    mock_client.close.side_effect = RuntimeError("boom")
+    document_store._async_client = mock_client
+    document_store._async_collection = MagicMock()
+
+    await document_store.close_async()
+
+    assert document_store._async_client is None
+    assert document_store._async_collection is None
 
 
 @pytest.mark.integration
@@ -146,7 +178,7 @@ class TestWeaviateDocumentStoreAsync(
         assert await document_store.count_documents_async() == 3
 
     @pytest.mark.asyncio
-    async def test_close_async(self, document_store: WeaviateDocumentStore) -> None:
+    async def test_close_async_and_reopen(self, document_store: WeaviateDocumentStore) -> None:
         # Initialise client and collection
         assert await document_store.async_client is not None
         assert await document_store.async_collection is not None

--- a/integrations/weaviate/tests/test_embedding_retriever.py
+++ b/integrations/weaviate/tests/test_embedding_retriever.py
@@ -11,6 +11,16 @@ from haystack_integrations.components.retrievers.weaviate import WeaviateEmbeddi
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 
+def test_close():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    retriever = WeaviateEmbeddingRetriever(document_store=mock_document_store)
+
+    retriever.close()
+
+    mock_document_store.close.assert_called_once_with()
+    assert retriever._document_store is mock_document_store
+
+
 def test_init_default():
     mock_document_store = Mock(spec=WeaviateDocumentStore)
     retriever = WeaviateEmbeddingRetriever(document_store=mock_document_store)

--- a/integrations/weaviate/tests/test_embedding_retriever_async.py
+++ b/integrations/weaviate/tests/test_embedding_retriever_async.py
@@ -11,6 +11,18 @@ from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 
 @pytest.mark.asyncio
+async def test_close_async():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    mock_document_store.close_async = AsyncMock()
+    retriever = WeaviateEmbeddingRetriever(document_store=mock_document_store)
+
+    await retriever.close_async()
+
+    mock_document_store.close_async.assert_awaited_once_with()
+    assert retriever._document_store is mock_document_store
+
+
+@pytest.mark.asyncio
 async def test_run_async_calls_async_retrieval():
     mock_document_store = Mock(spec=WeaviateDocumentStore)
     mock_document_store._embedding_retrieval_async = AsyncMock(return_value=[])

--- a/integrations/weaviate/tests/test_hybrid_retriever.py
+++ b/integrations/weaviate/tests/test_hybrid_retriever.py
@@ -11,6 +11,16 @@ from haystack_integrations.components.retrievers.weaviate import WeaviateHybridR
 from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 
+def test_close():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    retriever = WeaviateHybridRetriever(document_store=mock_document_store)
+
+    retriever.close()
+
+    mock_document_store.close.assert_called_once_with()
+    assert retriever._document_store is mock_document_store
+
+
 def test_init_default():
     mock_document_store = Mock(spec=WeaviateDocumentStore)
     retriever = WeaviateHybridRetriever(document_store=mock_document_store)

--- a/integrations/weaviate/tests/test_hybrid_retriever_async.py
+++ b/integrations/weaviate/tests/test_hybrid_retriever_async.py
@@ -11,6 +11,18 @@ from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
 
 
 @pytest.mark.asyncio
+async def test_close_async():
+    mock_document_store = Mock(spec=WeaviateDocumentStore)
+    mock_document_store.close_async = AsyncMock()
+    retriever = WeaviateHybridRetriever(document_store=mock_document_store)
+
+    await retriever.close_async()
+
+    mock_document_store.close_async.assert_awaited_once_with()
+    assert retriever._document_store is mock_document_store
+
+
+@pytest.mark.asyncio
 async def test_run_async_calls_async_retrieval():
     mock_document_store = Mock(spec=WeaviateDocumentStore)
     mock_document_store._hybrid_retrieval_async = AsyncMock(return_value=[])


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628
- In general, I think it's a good idea to align with our standard the few Document Stores that already support closing resources 

### Proposed Changes:
- align Weaviate with what is described in https://github.com/deepset-ai/haystack-core-integrations/issues/1628#issuecomment-5034357021
  - add methods to close retrievers
  -  slightly refactor Document Store closing methods

### How did you test it?
CI, new and refactored tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
