### PR TITLE
refactor: align Valkey closing methods to standard

### DIFF
--- a/integrations/valkey/src/haystack_integrations/components/retrievers/valkey/embedding_retriever.py
+++ b/integrations/valkey/src/haystack_integrations/components/retrievers/valkey/embedding_retriever.py
@@ -121,6 +121,18 @@ class ValkeyEmbeddingRetriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self.document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import json
 import struct
+from contextlib import suppress
 from dataclasses import replace
 from typing import Any, ClassVar, Literal
 
@@ -282,24 +283,22 @@ class ValkeyDocumentStore(DocumentStore):
             raise ValkeyDocumentStoreError(msg) from e
 
     def close(self) -> None:
-        """Close the synchronous Valkey client connection."""
-        if self._client:
-            try:
+        """
+        Release the associated synchronous resources.
+        """
+        if self._client is not None:
+            with suppress(Exception):
                 self._client.close()
-            except Exception as e:
-                logger.error("Failed to close Valkey client: {error}", error=e)
-                pass
-        self._client = None
+            self._client = None
 
     async def close_async(self) -> None:
-        """Close the asynchronous Valkey client connection."""
-        if self._async_client:
-            try:
+        """
+        Release the associated asynchronous resources.
+        """
+        if self._async_client is not None:
+            with suppress(Exception):
                 await self._async_client.close()
-            except Exception as e:
-                logger.error("Failed to close Valkey client: {error}", error=e)
-                pass
-        self._async_client = None
+            self._async_client = None
 
     def _has_index(self) -> bool:
         client = self._get_connection()

--- a/integrations/valkey/tests/test_document_store.py
+++ b/integrations/valkey/tests/test_document_store.py
@@ -102,6 +102,16 @@ class TestValkeyDocumentStore(
         """Filterable docs with 3-dim embeddings (Valkey store uses embedding_dim=3)."""
         return _filterable_docs_embedding_dim_3()
 
+    def test_close_and_reopen(self, document_store):
+        assert document_store.count_documents() == 0
+        assert document_store._client is not None
+
+        document_store.close()
+        assert document_store._client is None
+
+        assert document_store.count_documents() == 0
+        assert document_store._client is not None
+
     def test_write_documents(self, document_store):
         """Test default write_documents() behavior (OVERWRITE by default)."""
         docs = [Document(id="1", content="test doc 1")]
@@ -1246,12 +1256,21 @@ class TestValkeyDocumentStoreErrorPaths:
             with pytest.raises(ValkeyDocumentStoreError, match="Failed to connect to Valkey"):
                 unit_store._get_connection()
 
-    def test_close_swallows_client_exception(self, unit_store, caplog):
+    def test_close(self, unit_store):
+        mock_client = MagicMock()
+        unit_store._client = mock_client
+        unit_store.close()
+        mock_client.close.assert_called_once()
+        assert unit_store._client is None
+
+        unit_store.close()
+        mock_client.close.assert_called_once()
+
+    def test_close_is_exception_safe(self, unit_store):
         unit_store._client = MagicMock()
         unit_store._client.close.side_effect = RuntimeError("close boom")
         unit_store.close()
         assert unit_store._client is None
-        assert "Failed to close Valkey client" in caplog.text
 
     def test_count_documents_returns_zero_when_no_index(self, unit_store):
         unit_store._client = MagicMock()

--- a/integrations/valkey/tests/test_document_store_async.py
+++ b/integrations/valkey/tests/test_document_store_async.py
@@ -5,6 +5,7 @@
 # ruff: noqa: S110
 
 import uuid
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -23,6 +24,33 @@ from haystack.testing.document_store_async import (
 )
 
 from haystack_integrations.document_stores.valkey import ValkeyDocumentStore
+
+
+@pytest.mark.asyncio
+async def test_close_async():
+    store = ValkeyDocumentStore(index_name="unit_test", embedding_dim=3, metadata_fields={"category": str})
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+
+    await store.close_async()
+
+    mock_client.close.assert_awaited_once()
+    assert store._async_client is None
+
+    await store.close_async()
+    mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_async_is_exception_safe():
+    store = ValkeyDocumentStore(index_name="unit_test", embedding_dim=3, metadata_fields={"category": str})
+    mock_client = AsyncMock()
+    mock_client.close.side_effect = RuntimeError("close boom")
+    store._async_client = mock_client
+
+    await store.close_async()
+
+    assert store._async_client is None
 
 
 @pytest.mark.integration
@@ -67,6 +95,17 @@ class TestValkeyDocumentStoreAsync(
             await document_store._async_client.flushdb()
         except Exception:
             pass
+
+    @pytest.mark.asyncio
+    async def test_close_async_and_reopen(self, document_store):
+        assert await document_store.count_documents_async() == 0
+        assert document_store._async_client is not None
+
+        await document_store.close_async()
+        assert document_store._async_client is None
+
+        assert await document_store.count_documents_async() == 0
+        assert document_store._async_client is not None
 
     # --- Override for mixin bug: test_count_not_empty_async is missing `self` in DeleteByFilterAsyncTest ---
 

--- a/integrations/valkey/tests/test_embedding_retriever.py
+++ b/integrations/valkey/tests/test_embedding_retriever.py
@@ -68,6 +68,26 @@ class TestValkeyEmbeddingRetrieverUnit:
         with pytest.raises(ValueError, match="document_store must be an instance of ValkeyDocumentStore"):
             ValkeyEmbeddingRetriever(document_store="not_a_store")
 
+    def test_close(self):
+        mock_store = Mock(spec=ValkeyDocumentStore)
+        retriever = ValkeyEmbeddingRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once_with()
+        assert retriever.document_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        mock_store = Mock(spec=ValkeyDocumentStore)
+        mock_store.close_async = AsyncMock()
+        retriever = ValkeyEmbeddingRetriever(document_store=mock_store)
+
+        await retriever.close_async()
+
+        mock_store.close_async.assert_awaited_once_with()
+        assert retriever.document_store is mock_store
+
     def test_to_dict(self, mock_store):
         retriever = ValkeyEmbeddingRetriever(
             document_store=mock_store,


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628
- In general, I think it's a good idea to align with our standard the few Document Stores that already support closing resources 

### Proposed Changes:
- align Valkey with what is described in https://github.com/deepset-ai/haystack-core-integrations/issues/1628#issuecomment-5034357021
  - add methods to close retrievers
  -  slightly refactor Document Store closing methods

### How did you test it?
CI, new and refactored tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
