### PR TITLE
refactor: align AlloyDB closing methods to standard

### DIFF
--- a/integrations/alloydb/src/haystack_integrations/components/retrievers/alloydb/embedding_retriever.py
+++ b/integrations/alloydb/src/haystack_integrations/components/retrievers/alloydb/embedding_retriever.py
@@ -117,3 +117,9 @@ class AlloyDBEmbeddingRetriever:
         if filter_policy := data["init_parameters"].get("filter_policy"):
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()

--- a/integrations/alloydb/src/haystack_integrations/components/retrievers/alloydb/keyword_retriever.py
+++ b/integrations/alloydb/src/haystack_integrations/components/retrievers/alloydb/keyword_retriever.py
@@ -102,3 +102,9 @@ class AlloyDBKeywordRetriever:
         if filter_policy := data["init_parameters"].get("filter_policy"):
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()

--- a/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/document_store.py
+++ b/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/document_store.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import suppress
 from typing import Any, Literal, overload
 
 from haystack import default_from_dict, default_to_dict, logging
@@ -256,35 +257,21 @@ class AlloyDBDocumentStore(DocumentStore):
 
     def close(self) -> None:
         """
-        Closes the database connection and the AlloyDB connector.
-
-        Call this when you are done using the document store to release resources.
-        For long-lived applications the connector runs a background refresh thread;
-        calling `close()` ensures that thread is stopped cleanly.
+        Release the associated synchronous resources.
         """
         if self._connection is not None:
-            try:
+            with suppress(Exception):
                 self._connection.close()
-            except Exception:  # noqa: S110
-                pass
             self._connection = None
             self._cursor = None
             self._dict_cursor = None
 
         if self._connector is not None:
-            try:
+            with suppress(Exception):
                 self._connector.close()
-            except Exception:  # noqa: S110
-                pass
             self._connector = None
 
         self._table_initialized = False
-
-    def __del__(self) -> None:
-        """
-        Closes the connector when the object is garbage collected.
-        """
-        self.close()
 
     @staticmethod
     def _connection_is_valid(connection: Connection) -> bool:

--- a/integrations/alloydb/tests/test_document_store.py
+++ b/integrations/alloydb/tests/test_document_store.py
@@ -43,6 +43,16 @@ class TestDocumentStore(
     GetMetadataFieldMinMaxTest,
     GetMetadataFieldUniqueValuesTest,
 ):
+    def test_close_and_reopen(self, document_store: AlloyDBDocumentStore):
+        assert document_store.count_documents() == 0
+        assert document_store._connection is not None
+
+        document_store.close()
+        assert document_store._connection is None
+
+        assert document_store.count_documents() == 0
+        assert document_store._connection is not None
+
     def test_get_metadata_fields_info_empty_collection(self, document_store: AlloyDBDocumentStore):
         """Returns empty dict when the store has no documents."""
         assert document_store.count_documents() == 0
@@ -229,10 +239,31 @@ def test_normalize_metadata_field_name_rejects_invalid_characters():
         AlloyDBDocumentStore._normalize_metadata_field_name("field; DROP TABLE")
 
 
-def test_close_is_idempotent(mock_store):
-    """Calling close() multiple times should not raise."""
+def test_close(mock_store):
+    mock_connection = Mock(spec=Connection)
+    mock_store._connection = mock_connection
+    mock_store._cursor = Mock(spec=Cursor)
+    mock_store._dict_cursor = Mock(spec=Cursor)
+
     mock_store.close()
+
+    mock_connection.close.assert_called_once()
+    assert mock_store._connection is None
+    assert mock_store._cursor is None
+    assert mock_store._dict_cursor is None
+
     mock_store.close()
+    mock_connection.close.assert_called_once()
+
+
+def test_close_is_exception_safe(mock_store):
+    mock_connection = Mock(spec=Connection)
+    mock_connection.close.side_effect = RuntimeError("boom")
+    mock_store._connection = mock_connection
+
+    mock_store.close()
+
+    assert mock_store._connection is None
 
 
 def test_init_is_lazy(monkeypatch):

--- a/integrations/alloydb/tests/test_retrievers.py
+++ b/integrations/alloydb/tests/test_retrievers.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import Mock
+
 import pytest
 from haystack.dataclasses import Document
 from haystack.utils.auth import EnvVarSecret
@@ -33,6 +35,15 @@ class TestEmbeddingRetriever:
     def test_init_raises_with_wrong_store(self):
         with pytest.raises(ValueError, match="document_store must be an instance of AlloyDBDocumentStore"):
             AlloyDBEmbeddingRetriever(document_store="not_a_store")
+
+    def test_close(self):
+        mock_store = Mock(spec=AlloyDBDocumentStore)
+        retriever = AlloyDBEmbeddingRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once_with()
+        assert retriever.document_store is mock_store
 
     def test_to_dict(self, mock_store):
         retriever = AlloyDBEmbeddingRetriever(
@@ -132,6 +143,15 @@ class TestKeywordRetriever:
         assert retriever.document_store == mock_store
         assert retriever.filters == {}
         assert retriever.top_k == 10
+
+    def test_close(self):
+        mock_store = Mock(spec=AlloyDBDocumentStore)
+        retriever = AlloyDBKeywordRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once_with()
+        assert retriever.document_store is mock_store
 
     def test_init(self, mock_store):
         retriever = AlloyDBKeywordRetriever(


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628
- In general, I think it's a good idea to align with our standard the few Document Stores that already support closing resources 

### Proposed Changes:
- align AlloyDB with what is described in https://github.com/deepset-ai/haystack-core-integrations/issues/1628#issuecomment-5034357021 (this Document Store has only sync methods)
  - add methods to close retrievers
  -  slightly refactor Document Store closing methods

### How did you test it?
CI, new and refactored tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
