### PR TITLE
refactor: Elasticsearch - split sync/async paths

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -164,7 +164,8 @@ class ElasticsearchDocumentStore:
             self._ingest_pipeline = None
         self._custom_mapping = custom_mapping
         self._kwargs = kwargs
-        self._initialized = False
+        self._headers = self._kwargs.pop("headers", {})
+        self._headers["user-agent"] = f"haystack-py-ds/{haystack_version}"
 
         if self._sparse_vector_field and self._sparse_vector_field in SPECIAL_FIELDS:
             msg = f"sparse_vector_field '{self._sparse_vector_field}' conflicts with a reserved field name."
@@ -204,44 +205,34 @@ class ElasticsearchDocumentStore:
             if self._sparse_vector_field:
                 self._default_mappings["properties"][self._sparse_vector_field] = {"type": "sparse_vector"}
 
+    def _create_async_client(self) -> AsyncElasticsearch:
+        return AsyncElasticsearch(self._hosts, api_key=self._handle_auth(), headers=self._headers, **self._kwargs)
+
     def _ensure_initialized(self) -> None:
         """
-        Ensures both sync and async clients are initialized and the index exists.
+        Ensures the synchronous client is initialized and the index exists.
         """
-        if not self._initialized:
-            headers = self._kwargs.pop("headers", {})
-            headers["user-agent"] = f"haystack-py-ds/{haystack_version}"
-
-            api_key = self._handle_auth()
-
-            # Initialize both sync and async clients
+        if self._client is None:
             self._client = Elasticsearch(
-                self._hosts,
-                api_key=api_key,
-                headers=headers,
-                **self._kwargs,
+                self._hosts, api_key=self._handle_auth(), headers=self._headers, **self._kwargs
             )
-            self._async_client = AsyncElasticsearch(
-                self._hosts,
-                api_key=api_key,
-                headers=headers,
-                **self._kwargs,
-            )
-
             # Check client connection, this will raise if not connected
             self._client.info()
-
-            if self._custom_mapping:
-                mappings = self._custom_mapping
-            else:
-                # Configure mapping for the embedding field if none is provided
-                mappings = self._default_mappings
-
-            # Create the index if it doesn't exist
+            mappings = self._custom_mapping if self._custom_mapping else self._default_mappings
             if not self._client.indices.exists(index=self._index):
                 self._client.indices.create(index=self._index, mappings=mappings)
 
-            self._initialized = True
+    async def _ensure_initialized_async(self) -> None:
+        """
+        Ensures the asynchronous client is initialized and the index exists.
+        """
+        if self._async_client is None:
+            self._async_client = self._create_async_client()
+            # Check client connection, this will raise if not connected
+            await self._async_client.info()
+            mappings = self._custom_mapping if self._custom_mapping else self._default_mappings
+            if not await self._async_client.indices.exists(index=self._index):
+                await self._async_client.indices.create(index=self._index, mappings=mappings)
 
     def _handle_auth(self) -> str | tuple[str, str] | None:
         """
@@ -300,10 +291,10 @@ class ElasticsearchDocumentStore:
     @property
     def async_client(self) -> AsyncElasticsearch:
         """
-        Returns the asynchronous Elasticsearch client, initializing it if necessary.
+        Returns the asynchronous Elasticsearch client, constructing it if necessary.
         """
-        self._ensure_initialized()
-        assert self._async_client is not None
+        if self._async_client is None:
+            self._async_client = self._create_async_client()
         return self._async_client
 
     def to_dict(self) -> dict[str, Any]:
@@ -361,7 +352,7 @@ class ElasticsearchDocumentStore:
 
         :returns: Number of documents in the document store.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
         result = await self._async_client.count(index=self._index)  # type: ignore
         return result["count"]
 
@@ -468,7 +459,7 @@ class ElasticsearchDocumentStore:
             msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
             raise ValueError(msg)
 
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
         query = {"bool": {"filter": _normalize_filters(filters)}} if filters else None
         documents = await self._search_documents_async(query=query)
         return documents
@@ -765,7 +756,7 @@ class ElasticsearchDocumentStore:
         :raises DocumentStoreError: If an error occurs while writing the documents to the document store.
         :returns: Number of documents written to the document store.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         if len(documents) > 0:
             if not isinstance(documents[0], Document):
@@ -873,7 +864,7 @@ class ElasticsearchDocumentStore:
             - `"wait_for"`: Wait for the next refresh cycle (default, ensures read-your-writes consistency).
             For more details, see the [Elasticsearch refresh documentation](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/refresh-parameter).
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         await helpers.async_bulk(
             client=self.async_client,
@@ -931,7 +922,7 @@ class ElasticsearchDocumentStore:
             completes. If False, no refresh is performed. For more details, see the
             [Elasticsearch delete_by_query refresh documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query#operation-delete-by-query-refresh).
         """
-        self._ensure_initialized()  # ensures _async_client is not None
+        await self._ensure_initialized_async()  # ensures _async_client is not None
 
         try:
             if recreate_index:
@@ -1008,7 +999,7 @@ class ElasticsearchDocumentStore:
             [Elasticsearch refresh documentation](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/refresh-parameter).
         :returns: The number of documents deleted.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         try:
             normalized_filters = _normalize_filters(filters)
@@ -1072,7 +1063,7 @@ class ElasticsearchDocumentStore:
             [Elasticsearch update_by_query refresh documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update-by-query#operation-update-by-query-refresh).
         :returns: The number of documents updated.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         try:
             normalized_filters = _normalize_filters(filters)
@@ -1172,7 +1163,7 @@ class ElasticsearchDocumentStore:
         :returns: List of Documents that match the query
         :raises ValueError: If query_embedding is empty
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         if not query:
             msg = "query must be a non empty string"
@@ -1270,7 +1261,7 @@ class ElasticsearchDocumentStore:
         :returns: List of Documents most similar to query_embedding
         :raises ValueError: If query_embedding is empty
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         if not query_embedding:
             msg = "query_embedding must be a non-empty list of floats"
@@ -1334,7 +1325,7 @@ class ElasticsearchDocumentStore:
         :returns: List of Documents most similar to query_sparse_embedding.
         :raises ValueError: If sparse retrieval is not configured or the query sparse embedding is empty.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
         search_body = self._create_sparse_retrieval_body(
             query_sparse_embedding=query_sparse_embedding,
             filters=filters,
@@ -1384,7 +1375,7 @@ class ElasticsearchDocumentStore:
         :param top_k: Maximum number of documents to return.
         :returns: List of Documents most similar to the inference query.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
         search_body = self._create_sparse_retrieval_inference_body(
             query=query,
             inference_id=inference_id,
@@ -1527,7 +1518,7 @@ class ElasticsearchDocumentStore:
         :param rank_constant: RRF rank constant.
         :returns: List of Documents ranked by RRF score.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
         body = self._create_hybrid_retrieval_inference_body(
             query=query,
             inference_id=inference_id,
@@ -1561,7 +1552,7 @@ class ElasticsearchDocumentStore:
             For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
         :returns: The number of documents that match the filters.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         normalized_filters = _normalize_filters(filters)
         body = {"query": {"bool": {"filter": normalized_filters}}}
@@ -1679,7 +1670,7 @@ class ElasticsearchDocumentStore:
                   documents.
         :raises ValueError: If any of the requested fields don't exist in the index mapping.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         # use index mapping to get all fields
         mapping = await self.async_client.indices.get_mapping(index=self._index)
@@ -1763,7 +1754,7 @@ class ElasticsearchDocumentStore:
 
         :returns: The information about the fields in the index.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         mapping = await self.async_client.indices.get_mapping(index=self._index)
         index_mapping = mapping[self._index]["mappings"]["properties"]
@@ -1822,7 +1813,7 @@ class ElasticsearchDocumentStore:
         :returns: A dictionary with the keys "min" and "max", where each value is the minimum or maximum value of the
                   metadata field across all documents.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         field_name = _normalize_metadata_field_name(metadata_field)
         body = self._build_min_max_query_body(field_name)
@@ -1921,7 +1912,7 @@ class ElasticsearchDocumentStore:
             The after_key is None when there are no more results. Use it in the `after` parameter
             for the next page.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
@@ -2008,7 +1999,7 @@ class ElasticsearchDocumentStore:
         :param fetch_size: Optional number of results to fetch per page.
         :returns: The raw JSON response from Elasticsearch SQL API.
         """
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
         assert self._async_client is not None
 
         try:

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -372,63 +372,48 @@ def test_api_key_validation_only_api_key_id_raises_error(_mock_elasticsearch_cli
         es.client()
 
 
+_API_KEY_INIT_CASES = [
+    (
+        {"api_key": Secret.from_token("test_api_key"), "api_key_id": Secret.from_token("test_api_key_id")},
+        ("test_api_key_id", "test_api_key"),
+    ),
+    ({"api_key": "test_api_key"}, "test_api_key"),
+]
+
+
+@pytest.mark.parametrize(
+    "api_key_kwargs, expected_api_key", _API_KEY_INIT_CASES, ids=["api_key_and_id", "api_key_only"]
+)
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.AsyncElasticsearch")
-def test_client_initialization_with_api_key_tuple(_mock_async_es, _mock_es):
-    api_key = Secret.from_token("test_api_key")
-    api_key_id = Secret.from_token("test_api_key_id")
-
-    # Mock the client.info() call to avoid actual connection
+def test_sync_client_initialization_passes_api_key(_mock_async_es, _mock_es, api_key_kwargs, expected_api_key):
+    # Mock the client.info() call to avoid an actual connection
     mock_client = Mock()
     mock_client.info.return_value = {"version": {"number": "8.0.0"}}
     _mock_es.return_value = mock_client
 
-    document_store = ElasticsearchDocumentStore(hosts="https://localhost:9200", api_key=api_key, api_key_id=api_key_id)
+    _ = ElasticsearchDocumentStore(hosts="https://localhost:9200", **api_key_kwargs).client
 
-    # Access both clients to trigger their initialization
-    _ = document_store.client
-    _ = document_store.async_client
-
-    # Check that Elasticsearch was called with the correct api_key tuple
     _mock_es.assert_called_once()
-    call_args = _mock_es.call_args
-    assert call_args[0][0] == "https://localhost:9200"  # hosts
-    assert call_args[1]["api_key"] == ("test_api_key_id", "test_api_key")
-
-    # Check that AsyncElasticsearch was called with the same api_key tuple
-    _mock_async_es.assert_called_once()
-    async_call_args = _mock_async_es.call_args
-    assert async_call_args[0][0] == "https://localhost:9200"  # hosts
-    assert async_call_args[1]["api_key"] == ("test_api_key_id", "test_api_key")
+    assert _mock_es.call_args[0][0] == "https://localhost:9200"  # hosts
+    assert _mock_es.call_args[1]["api_key"] == expected_api_key
+    # Accessing the sync client must not construct the async client
+    _mock_async_es.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "api_key_kwargs, expected_api_key", _API_KEY_INIT_CASES, ids=["api_key_and_id", "api_key_only"]
+)
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.AsyncElasticsearch")
-def test_client_initialization_with_api_key_string(_mock_async_es, _mock_es):
-    api_key = "test_api_key"
+def test_async_client_initialization_passes_api_key(_mock_async_es, _mock_es, api_key_kwargs, expected_api_key):
+    _ = ElasticsearchDocumentStore(hosts="https://localhost:9200", **api_key_kwargs).async_client
 
-    # Mock the client.info() call to avoid actual connection
-    mock_client = Mock()
-    mock_client.info.return_value = {"version": {"number": "8.0.0"}}
-    _mock_es.return_value = mock_client
-
-    document_store = ElasticsearchDocumentStore(hosts="testhost", api_key=api_key)
-
-    # Access both clients to trigger their (now independent) initialization
-    _ = document_store.client
-    _ = document_store.async_client
-
-    # Check that Elasticsearch was called with the correct api_key string
-    _mock_es.assert_called_once()
-    call_args = _mock_es.call_args
-    assert call_args[0][0] == "testhost"  # hosts
-    assert call_args[1]["api_key"] == "test_api_key"
-
-    # Check that AsyncElasticsearch was called with the same api_key string
     _mock_async_es.assert_called_once()
-    async_call_args = _mock_async_es.call_args
-    assert async_call_args[0][0] == "testhost"  # hosts
-    assert async_call_args[1]["api_key"] == "test_api_key"
+    assert _mock_async_es.call_args[0][0] == "https://localhost:9200"  # hosts
+    assert _mock_async_es.call_args[1]["api_key"] == expected_api_key
+    # Accessing the async client must not construct the sync client
+    _mock_es.assert_not_called()
 
 
 @patch("haystack_integrations.document_stores.elasticsearch.document_store.Elasticsearch")

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -385,8 +385,9 @@ def test_client_initialization_with_api_key_tuple(_mock_async_es, _mock_es):
 
     document_store = ElasticsearchDocumentStore(hosts="https://localhost:9200", api_key=api_key, api_key_id=api_key_id)
 
-    # Access client to trigger initialization
+    # Access both clients to trigger their initialization
     _ = document_store.client
+    _ = document_store.async_client
 
     # Check that Elasticsearch was called with the correct api_key tuple
     _mock_es.assert_called_once()
@@ -413,8 +414,9 @@ def test_client_initialization_with_api_key_string(_mock_async_es, _mock_es):
 
     document_store = ElasticsearchDocumentStore(hosts="testhost", api_key=api_key)
 
-    # Access client to trigger initialization
+    # Access both clients to trigger their (now independent) initialization
     _ = document_store.client
+    _ = document_store.async_client
 
     # Check that Elasticsearch was called with the correct api_key string
     _mock_es.assert_called_once()
@@ -614,7 +616,7 @@ def test_sparse_vector_retrieval_builds_query_with_filters():
 @pytest.mark.asyncio
 async def test_sparse_vector_retrieval_async_builds_query_without_filters():
     store = ElasticsearchDocumentStore(hosts="some hosts", sparse_vector_field="sparse_vec")
-    store._initialized = True
+    store._async_client = AsyncMock()
     store._search_documents_async = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
     await store._sparse_vector_retrieval_async(
@@ -637,7 +639,7 @@ async def test_sparse_vector_retrieval_async_builds_query_without_filters():
 @pytest.mark.asyncio
 async def test_sparse_vector_retrieval_inference_async_builds_query_without_filters():
     store = ElasticsearchDocumentStore(hosts="some hosts", sparse_vector_field="sparse_vec")
-    store._initialized = True
+    store._async_client = AsyncMock()
     store._search_documents_async = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
     await store._sparse_vector_retrieval_inference_async(
@@ -661,7 +663,7 @@ async def test_sparse_vector_retrieval_inference_async_builds_query_without_filt
 @pytest.mark.asyncio
 async def test_sparse_vector_retrieval_inference_async_builds_query_with_filters():
     store = ElasticsearchDocumentStore(hosts="some hosts", sparse_vector_field="sparse_vec")
-    store._initialized = True
+    store._async_client = AsyncMock()
     store._search_documents_async = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
     await store._sparse_vector_retrieval_inference_async(
@@ -687,7 +689,7 @@ async def test_sparse_vector_retrieval_inference_async_builds_query_with_filters
 @pytest.mark.asyncio
 async def test_sparse_vector_retrieval_async_builds_query_with_filters():
     store = ElasticsearchDocumentStore(hosts="some hosts", sparse_vector_field="sparse_vec")
-    store._initialized = True
+    store._async_client = AsyncMock()
     store._search_documents_async = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
     await store._sparse_vector_retrieval_async(
@@ -1372,7 +1374,7 @@ def test_hybrid_retrieval_inference_raises_on_empty_query():
 @pytest.mark.asyncio
 async def test_hybrid_retrieval_inference_async_builds_body_without_filters():
     store = ElasticsearchDocumentStore(hosts="some hosts", sparse_vector_field="sparse_vec")
-    store._initialized = True
+    store._async_client = AsyncMock()
     store._search_documents_async = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
     await store._hybrid_retrieval_inference_async(query="Find Berlin", inference_id="ELSER", top_k=3)
@@ -1391,7 +1393,7 @@ async def test_hybrid_retrieval_inference_async_builds_body_without_filters():
 @pytest.mark.asyncio
 async def test_hybrid_retrieval_inference_async_builds_body_with_filters():
     store = ElasticsearchDocumentStore(hosts="some hosts", sparse_vector_field="sparse_vec")
-    store._initialized = True
+    store._async_client = AsyncMock()
     store._search_documents_async = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
     await store._hybrid_retrieval_inference_async(

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -162,7 +162,6 @@ class OpenSearchDocumentStore:
         # the document store is instantiated.
         self._client: OpenSearch | None = None
         self._async_client: AsyncOpenSearch | None = None
-        self._initialized = False
 
     def _get_default_mappings(self) -> dict[str, Any]:
         default_mappings: dict[str, Any] = {
@@ -303,8 +302,6 @@ class OpenSearchDocumentStore:
                 timeout=self._timeout,
                 **self._kwargs,
             )
-            self._initialized = True
-
             self._ensure_index_exists()
 
     async def _ensure_initialized_async(self) -> None:
@@ -322,7 +319,6 @@ class OpenSearchDocumentStore:
                 connection_class=AsyncHttpConnection,
                 **self._kwargs,
             )
-            self._initialized = True
             await self._ensure_index_exists_async()
 
     @staticmethod

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -497,7 +497,6 @@ def test_wildcard_nested_fields_detected_on_write(mock_bulk, _mock_opensearch_cl
     mock_bulk.return_value = (2, [])
     store = OpenSearchDocumentStore(hosts="testhost", nested_fields="*")
     store._client = MagicMock()
-    store._initialized = True
 
     docs = [
         Document(
@@ -526,7 +525,6 @@ def test_wildcard_nested_fields_incremental_detection(mock_bulk, _mock_opensearc
     mock_bulk.return_value = (1, [])
     store = OpenSearchDocumentStore(hosts="testhost", nested_fields="*")
     store._client = MagicMock()
-    store._initialized = True
 
     # First batch: detects "refs"
     store.write_documents([Document(content="d1", meta={"refs": [{"law": "bgb"}]})])
@@ -545,7 +543,6 @@ def test_explicit_nested_fields_no_detection_on_write(mock_bulk, _mock_opensearc
     mock_bulk.return_value = (1, [])
     store = OpenSearchDocumentStore(hosts="testhost", nested_fields=["refs"])
     store._client = MagicMock()
-    store._initialized = True
 
     store.write_documents([Document(content="d1", meta={"tags": [{"name": "x"}]})])
 


### PR DESCRIPTION
### Related Issues

Elasticsearch is the only remaining Document Store where we mix sync and async clients creation.
This will be problematic once we implement the approach described in https://github.com/deepset-ai/haystack-core-integrations/issues/1628#issuecomment-5034357021
 
### Proposed Changes:
- Elasticsearch: create the 2 clients separately and adapt the code
- minor change in Opensearch: remove the `self._initialized` field from the document store, which is unused but partly hides the fact that sync and async handling is separate

### How did you test it?
CI, adapt existing tests a bit

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
