### PR TITLE
feat: expose per-run parameter overrides on DDGSWebSearch

### DIFF
--- a/integrations/ddgs/src/haystack_integrations/components/websearch/ddgs/ddgs_websearch.py
+++ b/integrations/ddgs/src/haystack_integrations/components/websearch/ddgs/ddgs_websearch.py
@@ -75,7 +75,15 @@ class DDGSWebSearch:
         if self._client is None:
             self._client = DDGS()
 
-    def _search(self, query: str) -> dict[str, list[Document] | list[str]]:
+    def _search(
+        self,
+        query: str,
+        top_k: int | None = None,
+        backend: str | None = None,
+        region: str | None = None,
+        safesearch: str | None = None,
+        search_params: dict[str, Any] | None = None,
+    ) -> dict[str, list[Document] | list[str]]:
         """
         Run the blocking ddgs search and normalise the results.
 
@@ -91,12 +99,12 @@ class DDGSWebSearch:
             raise RuntimeError(msg)
 
         params: dict[str, Any] = {
-            "region": self.region,
-            "safesearch": self.safesearch,
-            "backend": self.backend,
-            "max_results": self.top_k,
+            "region": region if region is not None else self.region,
+            "safesearch": safesearch if safesearch is not None else self.safesearch,
+            "backend": backend if backend is not None else self.backend,
+            "max_results": top_k if top_k is not None else self.top_k,
         }
-        params.update(self.search_params)
+        params.update(search_params if search_params is not None else self.search_params)
 
         results = self._client.text(query, **params)
         documents, links = self._parse_response(results)
@@ -109,21 +117,52 @@ class DDGSWebSearch:
         return {"documents": documents, "links": links}
 
     @component.output_types(documents=list[Document], links=list[str])
-    def run(self, query: str) -> dict[str, list[Document] | list[str]]:
+    def run(
+        self,
+        query: str,
+        top_k: int | None = None,
+        backend: str | None = None,
+        region: str | None = None,
+        safesearch: str | None = None,
+        search_params: dict[str, Any] | None = None,
+    ) -> dict[str, list[Document] | list[str]]:
         """
         Use ddgs to search the web.
 
         :param query:
             Search query.
+        :param top_k:
+            Optional per-run override of the maximum number of results. If not provided, the
+            init-time ``top_k`` is used.
+        :param backend:
+            Optional per-run override of the ddgs backends. If not provided, the init-time
+            ``backend`` is used.
+        :param region:
+            Optional per-run override of the region/locale. If not provided, the init-time
+            ``region`` is used.
+        :param safesearch:
+            Optional per-run override of the safe-search level. If not provided, the init-time
+            ``safesearch`` is used.
+        :param search_params:
+            Optional per-run override of the extra ``DDGS().text()`` arguments. If provided, fully
+            replaces the init-time ``search_params``.
         :returns:
             A dictionary with the following keys:
             - ``documents``: List of documents returned by the search backends.
             - ``links``: List of links returned by the search backends.
         """
-        return self._search(query)
+        return self._search(query, top_k, backend, region, safesearch, search_params)
 
     @component.output_types(documents=list[Document], links=list[str])
-    async def run_async(self, query: str) -> dict[str, list[Document] | list[str]]:
+    async def run_async(
+        self,
+        query: str,
+        top_k: int | None = None,
+        backend: str | None = None,
+        region: str | None = None,
+        safesearch: str | None = None,
+        search_params: dict[str, Any] | None = None,
+    ) -> dict[str, list[Document] | list[str]]:
         """
         Asynchronously use ddgs to search the web.
 
@@ -132,10 +171,25 @@ class DDGSWebSearch:
 
         :param query:
             Search query.
+        :param top_k:
+            Optional per-run override of the maximum number of results. If not provided, the
+            init-time ``top_k`` is used.
+        :param backend:
+            Optional per-run override of the ddgs backends. If not provided, the init-time
+            ``backend`` is used.
+        :param region:
+            Optional per-run override of the region/locale. If not provided, the init-time
+            ``region`` is used.
+        :param safesearch:
+            Optional per-run override of the safe-search level. If not provided, the init-time
+            ``safesearch`` is used.
+        :param search_params:
+            Optional per-run override of the extra ``DDGS().text()`` arguments. If provided, fully
+            replaces the init-time ``search_params``.
         :returns:
             A dictionary with ``documents`` and ``links`` keys.
         """
-        return await asyncio.to_thread(self._search, query)
+        return await asyncio.to_thread(self._search, query, top_k, backend, region, safesearch, search_params)
 
     @staticmethod
     def _parse_response(results: list[dict[str, Any]]) -> tuple[list[Document], list[str]]:

--- a/integrations/ddgs/src/haystack_integrations/components/websearch/ddgs/ddgs_websearch.py
+++ b/integrations/ddgs/src/haystack_integrations/components/websearch/ddgs/ddgs_websearch.py
@@ -48,15 +48,15 @@ class DDGSWebSearch:
         :param top_k:
             Maximum number of results to return.
         :param backend:
-            Comma-separated ddgs backends to query, or ``"auto"`` to let ddgs choose
-            (for example ``"duckduckgo, google, brave"``). See the ddgs docs for the full list.
+            Comma-separated ddgs backends to query, or `"auto"` to let ddgs choose
+            (for example `"duckduckgo, google, brave"`). See the ddgs docs for the full list.
         :param region:
-            Region/locale for the search, for example ``"us-en"``, ``"de-de"``, or ``"wt-wt"`` (no region).
+            Region/locale for the search, for example `"us-en"`, `"de-de"`, or `"wt-wt"` (no region).
         :param safesearch:
-            Safe-search level: ``"on"``, ``"moderate"``, or ``"off"``.
+            Safe-search level: `"on"`, `"moderate"`, or `"off"`.
         :param search_params:
-            Additional keyword arguments forwarded to ``DDGS().text()`` (for example ``page`` or
-            ``timelimit``). Values here override ``backend``, ``region``, ``safesearch``, and ``top_k``
+            Additional keyword arguments forwarded to `DDGS().text()` (for example `page` or
+            `timelimit`). Values here override `backend`, `region`, `safesearch`, and `top_k`
             on conflict.
         """
         self.top_k = top_k
@@ -90,7 +90,7 @@ class DDGSWebSearch:
         :param query:
             Search query.
         :returns:
-            A dictionary with ``documents`` and ``links`` keys.
+            A dictionary with `documents` and `links` keys.
         """
         if self._client is None:
             self.warm_up()
@@ -121,6 +121,7 @@ class DDGSWebSearch:
         self,
         query: str,
         top_k: int | None = None,
+        *,
         backend: str | None = None,
         region: str | None = None,
         safesearch: str | None = None,
@@ -133,23 +134,23 @@ class DDGSWebSearch:
             Search query.
         :param top_k:
             Optional per-run override of the maximum number of results. If not provided, the
-            init-time ``top_k`` is used.
+            init-time `top_k` is used.
         :param backend:
             Optional per-run override of the ddgs backends. If not provided, the init-time
-            ``backend`` is used.
+            `backend` is used.
         :param region:
             Optional per-run override of the region/locale. If not provided, the init-time
-            ``region`` is used.
+            `region` is used.
         :param safesearch:
             Optional per-run override of the safe-search level. If not provided, the init-time
-            ``safesearch`` is used.
+            `safesearch` is used.
         :param search_params:
-            Optional per-run override of the extra ``DDGS().text()`` arguments. If provided, fully
-            replaces the init-time ``search_params``.
+            Optional per-run override of the extra `DDGS().text()` arguments. If provided, fully
+            replaces the init-time `search_params`.
         :returns:
             A dictionary with the following keys:
-            - ``documents``: List of documents returned by the search backends.
-            - ``links``: List of links returned by the search backends.
+            - `documents`: List of documents returned by the search backends.
+            - `links`: List of links returned by the search backends.
         """
         return self._search(query, top_k, backend, region, safesearch, search_params)
 
@@ -158,6 +159,7 @@ class DDGSWebSearch:
         self,
         query: str,
         top_k: int | None = None,
+        *,
         backend: str | None = None,
         region: str | None = None,
         safesearch: str | None = None,
@@ -173,21 +175,21 @@ class DDGSWebSearch:
             Search query.
         :param top_k:
             Optional per-run override of the maximum number of results. If not provided, the
-            init-time ``top_k`` is used.
+            init-time `top_k` is used.
         :param backend:
             Optional per-run override of the ddgs backends. If not provided, the init-time
-            ``backend`` is used.
+            `backend` is used.
         :param region:
             Optional per-run override of the region/locale. If not provided, the init-time
-            ``region`` is used.
+            `region` is used.
         :param safesearch:
             Optional per-run override of the safe-search level. If not provided, the init-time
-            ``safesearch`` is used.
+            `safesearch` is used.
         :param search_params:
-            Optional per-run override of the extra ``DDGS().text()`` arguments. If provided, fully
-            replaces the init-time ``search_params``.
+            Optional per-run override of the extra `DDGS().text()` arguments. If provided, fully
+            replaces the init-time `search_params`.
         :returns:
-            A dictionary with ``documents`` and ``links`` keys.
+            A dictionary with `documents` and `links` keys.
         """
         return await asyncio.to_thread(self._search, query, top_k, backend, region, safesearch, search_params)
 
@@ -197,9 +199,9 @@ class DDGSWebSearch:
         Convert ddgs text results into Haystack Documents and links.
 
         :param results:
-            The list of result dictionaries returned by ``DDGS().text()``.
+            The list of result dictionaries returned by `DDGS().text()`.
         :returns:
-            A tuple of ``(documents, links)``.
+            A tuple of `(documents, links)`.
         """
         documents: list[Document] = []
         links: list[str] = []

--- a/integrations/ddgs/tests/test_ddgs_websearch.py
+++ b/integrations/ddgs/tests/test_ddgs_websearch.py
@@ -109,6 +109,25 @@ class TestDDGSWebSearch:
         assert kwargs["region"] == "fr-fr"
         assert kwargs["timelimit"] == "d"
 
+    @patch(DDGS_PATH)
+    def test_run_overrides_params_at_runtime(self, mock_ddgs):
+        mock_ddgs.return_value.text.return_value = []
+        ws = DDGSWebSearch(top_k=10, backend="auto", region="us-en", safesearch="moderate")
+        ws.run(
+            query="q",
+            top_k=3,
+            backend="duckduckgo, brave",
+            region="de-de",
+            safesearch="off",
+            search_params={"timelimit": "w"},
+        )
+        _, kwargs = mock_ddgs.return_value.text.call_args
+        assert kwargs["max_results"] == 3
+        assert kwargs["backend"] == "duckduckgo, brave"
+        assert kwargs["region"] == "de-de"
+        assert kwargs["safesearch"] == "off"
+        assert kwargs["timelimit"] == "w"
+
     @pytest.mark.asyncio
     @patch(DDGS_PATH)
     async def test_run_async(self, mock_ddgs):
@@ -116,6 +135,16 @@ class TestDDGSWebSearch:
         result = await DDGSWebSearch(top_k=2).run_async(query="what is haystack?")
         assert len(result["documents"]) == 2
         assert result["links"] == ["https://haystack.deepset.ai", "https://www.deepset.ai"]
+
+    @pytest.mark.asyncio
+    @patch(DDGS_PATH)
+    async def test_run_async_overrides_params_at_runtime(self, mock_ddgs):
+        mock_ddgs.return_value.text.return_value = []
+        ws = DDGSWebSearch(top_k=10, region="us-en")
+        await ws.run_async(query="q", top_k=3, region="de-de")
+        _, kwargs = mock_ddgs.return_value.text.call_args
+        assert kwargs["max_results"] == 3
+        assert kwargs["region"] == "de-de"
 
     @pytest.mark.integration
     def test_web_search_integration(self):


### PR DESCRIPTION
### Related Issues

Similar to the review comments for the Linkup PR https://github.com/deepset-ai/haystack-core-integrations/pull/3621

### Proposed Changes:
- Allow `DDGSWebSearch.run` and `run_async` to override the init-time `top_k`, `backend`, `region`, `safesearch`, and `search_params` on a per-call basis. 

### How did you test it?
- New tests and ran end-to-end locally

### Notes for the reviewer
I thought about not exposing all parameters but just `top_k` at first. However, I can imagine that the other parameters are useful for users to have in the run method too.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)