### PR TITLE
feat: Opensearch - add methods to close resources

### DIFF
--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/bm25_retriever.py
@@ -157,6 +157,18 @@ class OpenSearchBM25Retriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     def _prepare_bm25_args(
         self,
         *,

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/embedding_retriever.py
@@ -163,6 +163,18 @@ class OpenSearchEmbeddingRetriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(data["init_parameters"]["filter_policy"])
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/metadata_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/metadata_retriever.py
@@ -181,6 +181,18 @@ class OpenSearchMetadataRetriever:
         )
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     @component.output_types(metadata=list[dict[str, Any]])
     def run(
         self,

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/open_search_hybrid_retriever.py
@@ -357,3 +357,15 @@ class OpenSearchHybridRetriever:
             data["init_parameters"]["join_mode"] = join_mode
 
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self.document_store.close_async()

--- a/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/sql_retriever.py
+++ b/integrations/opensearch/src/haystack_integrations/components/retrievers/opensearch/sql_retriever.py
@@ -80,6 +80,18 @@ class OpenSearchSQLRetriever:
         )
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self._document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self._document_store.close_async()
+
     @component.output_types(result=dict[str, Any])
     def run(
         self,

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -5,6 +5,7 @@
 # ruff: noqa: FBT001, FBT002   boolean-type-hint-positional-argument and boolean-default-value-positional-argument
 
 from collections.abc import Generator, Mapping
+from contextlib import suppress
 from dataclasses import replace
 from math import exp
 from typing import Any, Literal
@@ -320,6 +321,24 @@ class OpenSearchDocumentStore:
                 **self._kwargs,
             )
             await self._ensure_index_exists_async()
+
+    def close(self) -> None:
+        """
+        Release the associated synchronous resources.
+        """
+        if self._client is not None:
+            with suppress(Exception):
+                self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """
+        Release the associated asynchronous resources.
+        """
+        if self._async_client is not None:
+            with suppress(Exception):
+                await self._async_client.close()
+            self._async_client = None
 
     @staticmethod
     def _extract_nested_fields_from_mapping(mapping_properties: dict[str, Any]) -> set[str]:

--- a/integrations/opensearch/tests/test_bm25_retriever.py
+++ b/integrations/opensearch/tests/test_bm25_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from haystack.dataclasses import Document
@@ -157,6 +157,28 @@ def test_from_dict_not_defaults(_mock_opensearch_client):
     assert retriever._filter_policy == FilterPolicy.REPLACE
     assert retriever._custom_query == {"some": "custom query"}
     assert retriever._raise_on_failure is True
+
+
+def test_close():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    retriever = OpenSearchBM25Retriever(document_store=mock_store)
+
+    retriever.close()
+
+    mock_store.close.assert_called_once_with()
+    assert retriever._document_store is mock_store
+
+
+@pytest.mark.asyncio
+async def test_close_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store.close_async = AsyncMock()
+    retriever = OpenSearchBM25Retriever(document_store=mock_store)
+
+    await retriever.close_async()
+
+    mock_store.close_async.assert_awaited_once_with()
+    assert retriever._document_store is mock_store
 
 
 def test_run():

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -752,6 +752,31 @@ async def test_delete_all_documents_async_recreate_works_for_concrete_index(_moc
     mock_client.indices.create.assert_called_once()
 
 
+def test_close():
+    store = OpenSearchDocumentStore(hosts="testhost", http_auth=("a", "b"))
+    mock_client = MagicMock()
+    store._client = mock_client
+
+    store.close()
+
+    mock_client.close.assert_called_once()
+    assert store._client is None
+
+    store.close()
+    mock_client.close.assert_called_once()
+
+
+def test_close_is_exception_safe():
+    store = OpenSearchDocumentStore(hosts="testhost", http_auth=("a", "b"))
+    mock_client = MagicMock()
+    mock_client.close.side_effect = RuntimeError("boom")
+    store._client = mock_client
+
+    store.close()
+
+    assert store._client is None
+
+
 @pytest.mark.integration
 class TestDocumentStore(
     OpenSearchDocumentStoreTestMixin,
@@ -770,6 +795,16 @@ class TestDocumentStore(
     def document_store(self, document_store):
         """Override base class fixture to provide OpenSearch document store."""
         yield document_store
+
+    def test_close_and_reopen(self, document_store: OpenSearchDocumentStore):
+        assert document_store.count_documents() == 0
+        assert document_store._client is not None
+
+        document_store.close()
+        assert document_store._client is None
+
+        assert document_store.count_documents() == 0
+        assert document_store._client is not None
 
     def test_write_documents(self, document_store: OpenSearchDocumentStore):
         docs = [Document(id="1")]

--- a/integrations/opensearch/tests/test_document_store_async.py
+++ b/integrations/opensearch/tests/test_document_store_async.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from unittest.mock import AsyncMock
+
 import pytest
 from haystack.dataclasses import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
@@ -26,6 +28,33 @@ from haystack_integrations.document_stores.opensearch.document_store import Open
 from tests.test_document_store_common import OpenSearchDocumentStoreTestMixin
 
 
+@pytest.mark.asyncio
+async def test_close_async():
+    store = OpenSearchDocumentStore(hosts="testhost", http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+
+    await store.close_async()
+
+    mock_client.close.assert_awaited_once()
+    assert store._async_client is None
+
+    await store.close_async()
+    mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_async_is_exception_safe():
+    store = OpenSearchDocumentStore(hosts="testhost", http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    mock_client.close.side_effect = RuntimeError("boom")
+    store._async_client = mock_client
+
+    await store.close_async()
+
+    assert store._async_client is None
+
+
 @pytest.mark.integration
 class TestDocumentStoreAsync(
     OpenSearchDocumentStoreTestMixin,
@@ -42,6 +71,17 @@ class TestDocumentStoreAsync(
     GetMetadataFieldMinMaxAsyncTest,
     GetMetadataFieldUniqueValuesAsyncTest,
 ):
+    @pytest.mark.asyncio
+    async def test_close_async_and_reopen(self, document_store: OpenSearchDocumentStore):
+        assert await document_store.count_documents_async() == 0
+        assert document_store._async_client is not None
+
+        await document_store.close_async()
+        assert document_store._async_client is None
+
+        assert await document_store.count_documents_async() == 0
+        assert document_store._async_client is not None
+
     @pytest.mark.asyncio
     async def test_write_documents_async(self, document_store: OpenSearchDocumentStore):
         docs = [Document(id="1")]

--- a/integrations/opensearch/tests/test_embedding_retriever.py
+++ b/integrations/opensearch/tests/test_embedding_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from haystack.dataclasses import Document
@@ -137,6 +137,28 @@ def test_from_dict(_mock_opensearch_client):
     }
     retriever = OpenSearchEmbeddingRetriever.from_dict(data)
     assert retriever._filter_policy == FilterPolicy.REPLACE
+
+
+def test_close():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store)
+
+    retriever.close()
+
+    mock_store.close.assert_called_once_with()
+    assert retriever._document_store is mock_store
+
+
+@pytest.mark.asyncio
+async def test_close_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store.close_async = AsyncMock()
+    retriever = OpenSearchEmbeddingRetriever(document_store=mock_store)
+
+    await retriever.close_async()
+
+    mock_store.close_async.assert_awaited_once_with()
+    assert retriever._document_store is mock_store
 
 
 def test_run():

--- a/integrations/opensearch/tests/test_metadata_retriever.py
+++ b/integrations/opensearch/tests/test_metadata_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from haystack.dataclasses import Document
@@ -117,6 +117,28 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever_from_dict._prefix_length == 1
     assert retriever_from_dict._max_expansions == 50
     assert retriever_from_dict._jaccard_n == 5
+
+
+def test_close():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    retriever = OpenSearchMetadataRetriever(document_store=mock_store, metadata_fields=["category"])
+
+    retriever.close()
+
+    mock_store.close.assert_called_once_with()
+    assert retriever._document_store is mock_store
+
+
+@pytest.mark.asyncio
+async def test_close_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store.close_async = AsyncMock()
+    retriever = OpenSearchMetadataRetriever(document_store=mock_store, metadata_fields=["category"])
+
+    await retriever.close_async()
+
+    mock_store.close_async.assert_awaited_once_with()
+    assert retriever._document_store is mock_store
 
 
 def test_run_with_runtime_document_store():

--- a/integrations/opensearch/tests/test_open_search_hybrid_retriever.py
+++ b/integrations/opensearch/tests/test_open_search_hybrid_retriever.py
@@ -4,7 +4,7 @@
 
 from copy import deepcopy
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from haystack import Document, Pipeline
@@ -139,6 +139,26 @@ class TestOpenSearchHybridRetriever:
         del data["init_parameters"]["join_mode"]
         hybrid = OpenSearchHybridRetriever.from_dict(data)
         assert isinstance(hybrid, OpenSearchHybridRetriever)
+
+    def test_close(self, mock_embedder):
+        mock_store = Mock(spec=OpenSearchDocumentStore)
+        retriever = OpenSearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once_with()
+        assert retriever.document_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_close_async(self, mock_embedder):
+        mock_store = Mock(spec=OpenSearchDocumentStore)
+        mock_store.close_async = AsyncMock()
+        retriever = OpenSearchHybridRetriever(document_store=mock_store, embedder=mock_embedder)
+
+        await retriever.close_async()
+
+        mock_store.close_async.assert_awaited_once_with()
+        assert retriever.document_store is mock_store
 
     def test_run(self, mock_embedder):
         # mocked document store

--- a/integrations/opensearch/tests/test_sql_retriever.py
+++ b/integrations/opensearch/tests/test_sql_retriever.py
@@ -50,6 +50,28 @@ def test_from_dict(_mock_opensearch_client):
     assert retriever_from_dict._raise_on_failure is True
 
 
+def test_close():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    retriever = OpenSearchSQLRetriever(document_store=mock_store)
+
+    retriever.close()
+
+    mock_store.close.assert_called_once_with()
+    assert retriever._document_store is mock_store
+
+
+@pytest.mark.asyncio
+async def test_close_async():
+    mock_store = Mock(spec=OpenSearchDocumentStore)
+    mock_store.close_async = AsyncMock()
+    retriever = OpenSearchSQLRetriever(document_store=mock_store)
+
+    await retriever.close_async()
+
+    mock_store.close_async.assert_awaited_once_with()
+    assert retriever._document_store is mock_store
+
+
 @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
 def test_query_sql_uses_positional_args(_mock_opensearch_class):
     """Verify perform_request is called with positional method/url args (ddtrace compatibility)."""


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- add closing methods to Document Store and retrievers as described in the issue

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
