### PR TITLE
fix: `PineCone` normalisation of .meta usage in `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -893,10 +893,11 @@ class PineconeDocumentStore:
         documents: list[Document], metadata_field: str, search_term: str | None, from_: int, size: int
     ) -> tuple[list[str], int]:
         """Helper method to get unique values for a metadata field with search and pagination."""
+        field_name = metadata_field.removeprefix("meta.")
         unique_values: set[str] = set()
         for doc in documents:
-            if doc.meta and metadata_field in doc.meta:
-                value = doc.meta[metadata_field]
+            if doc.meta and field_name in doc.meta:
+                value = doc.meta[field_name]
                 # Handle list values
                 if isinstance(value, list):
                     unique_values.update(str(v) for v in value)

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -339,6 +339,18 @@ def test_get_metadata_field_unique_values_impl_pagination_search_and_lists():
     assert values == ["python"]
 
 
+def test_get_metadata_field_unique_values_impl_strips_meta_prefix():
+    docs = [
+        Document(content="a", meta={"category": "news"}),
+        Document(content="b", meta={"category": "sports"}),
+    ]
+    values, total = PineconeDocumentStore._get_metadata_field_unique_values_impl(
+        docs, "meta.category", search_term=None, from_=0, size=10
+    )
+    assert total == 2
+    assert values == ["news", "sports"]
+
+
 def test_prepare_documents_for_writing_edge_cases(caplog):
     ds = PineconeDocumentStore(api_key=Secret.from_token("fake-api-key"))
 


### PR DESCRIPTION
### Related Issues

- fixes #https://github.com/deepset-ai/haystack-private/issues/477

### Proposed Changes:

- prefix check inside `_get_metadata_field_unique_values_impl()`

### How did you test it?

- added a unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
