### PR TITLE
fix: `Qdrant` normalisation of .meta usage in `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -709,6 +709,7 @@ class QdrantDocumentStore:
         unique_values_set: set[Any],
         offset: int,
         limit: int,
+        search_term: str | None = None,
     ) -> bool:
         """Collect unique values from a batch of records. Returns True when len(unique_values) >= offset + limit."""
         for record in records:
@@ -717,6 +718,8 @@ class QdrantDocumentStore:
                 if metadata_field in meta:
                     value = meta[metadata_field]
                     if value is not None:
+                        if search_term is not None and search_term.lower() not in str(value).lower():
+                            continue
                         hashable_value = str(value) if isinstance(value, (list, dict)) else value
                         if hashable_value not in unique_values_set:
                             unique_values_set.add(hashable_value)
@@ -1265,7 +1268,12 @@ class QdrantDocumentStore:
             return dict.fromkeys(metadata_fields, 0)
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, filters: dict[str, Any] | None = None, limit: int = 100, offset: int = 0
+        self,
+        metadata_field: str,
+        filters: dict[str, Any] | None = None,
+        search_term: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
     ) -> list[Any]:
         """
         Returns unique values for a metadata field, with optional filters and offset/limit pagination.
@@ -1275,6 +1283,7 @@ class QdrantDocumentStore:
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
         :param filters: Optional filters to restrict the documents considered.
             For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
+        :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
         :param limit: Maximum number of unique values to return per page. Defaults to 100.
         :param offset: Number of unique values to skip (for pagination). Defaults to 0.
 
@@ -1300,7 +1309,7 @@ class QdrantDocumentStore:
                     with_vectors=False,
                 )
                 if self._process_records_unique_values(
-                    records, field_name, unique_values, unique_values_set, offset, limit
+                    records, field_name, unique_values, unique_values_set, offset, limit, search_term
                 ):
                     break
                 if self._check_stop_scrolling(next_offset):
@@ -1312,7 +1321,12 @@ class QdrantDocumentStore:
             return []
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, filters: dict[str, Any] | None = None, limit: int = 100, offset: int = 0
+        self,
+        metadata_field: str,
+        filters: dict[str, Any] | None = None,
+        search_term: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
     ) -> list[Any]:
         """
         Asynchronously returns unique values for a metadata field, with optional filters and offset/limit pagination.
@@ -1322,6 +1336,7 @@ class QdrantDocumentStore:
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
         :param filters: Optional filters to restrict the documents considered.
             For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
+        :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
         :param limit: Maximum number of unique values to return per page. Defaults to 100.
         :param offset: Number of unique values to skip (for pagination). Defaults to 0.
 
@@ -1347,7 +1362,7 @@ class QdrantDocumentStore:
                     with_vectors=False,
                 )
                 if self._process_records_unique_values(
-                    records, field_name, unique_values, unique_values_set, offset, limit
+                    records, field_name, unique_values, unique_values_set, offset, limit, search_term
                 ):
                     break
                 if self._check_stop_scrolling(next_offset):

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -1283,6 +1283,7 @@ class QdrantDocumentStore:
         self._initialize_client()
         assert self._client is not None
 
+        field_name = _normalize_metadata_field_name(metadata_field)
         qdrant_filter = convert_filters_to_qdrant(filters) if filters else None
         unique_values: list[Any] = []
         unique_values_set: set[Any] = set()
@@ -1299,7 +1300,7 @@ class QdrantDocumentStore:
                     with_vectors=False,
                 )
                 if self._process_records_unique_values(
-                    records, metadata_field, unique_values, unique_values_set, offset, limit
+                    records, field_name, unique_values, unique_values_set, offset, limit
                 ):
                     break
                 if self._check_stop_scrolling(next_offset):
@@ -1329,6 +1330,7 @@ class QdrantDocumentStore:
         await self._initialize_async_client()
         assert self._async_client is not None
 
+        field_name = _normalize_metadata_field_name(metadata_field)
         qdrant_filter = convert_filters_to_qdrant(filters) if filters else None
         unique_values: list[Any] = []
         unique_values_set: set[Any] = set()
@@ -1345,7 +1347,7 @@ class QdrantDocumentStore:
                     with_vectors=False,
                 )
                 if self._process_records_unique_values(
-                    records, metadata_field, unique_values, unique_values_set, offset, limit
+                    records, field_name, unique_values, unique_values_set, offset, limit
                 ):
                     break
                 if self._check_stop_scrolling(next_offset):

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -602,3 +602,18 @@ class TestQdrantDocumentStore(
 
         values = document_store.get_metadata_field_unique_values("meta.category")
         assert set(values) == {"A", "B"}
+
+    def test_get_metadata_field_unique_values_with_search_term(self, document_store: QdrantDocumentStore):
+        """Test that search_term filters unique values by a case-insensitive substring match on the field value."""
+        docs = [
+            Document(content="Doc 1", meta={"category": "Apple"}),
+            Document(content="Doc 2", meta={"category": "Banana"}),
+            Document(content="Doc 3", meta={"category": "Apricot"}),
+        ]
+        document_store.write_documents(docs)
+
+        values = document_store.get_metadata_field_unique_values("category", search_term="ap")
+        assert set(values) == {"Apple", "Apricot"}
+
+        values = document_store.get_metadata_field_unique_values("category", search_term="nonexistent")
+        assert values == []

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -591,3 +591,14 @@ class TestQdrantDocumentStore(
             "category", filters={"field": "meta.status", "operator": "==", "value": "active"}
         )
         assert set(values) == {"A", "B"}
+
+    def test_get_metadata_field_unique_values_with_meta_prefix(self, document_store: QdrantDocumentStore):
+        """Test that a 'meta.'-prefixed field name is normalized before lookup."""
+        docs = [
+            Document(content="Doc 1", meta={"category": "A"}),
+            Document(content="Doc 2", meta={"category": "B"}),
+        ]
+        document_store.write_documents(docs)
+
+        values = document_store.get_metadata_field_unique_values("meta.category")
+        assert set(values) == {"A", "B"}

--- a/integrations/qdrant/tests/test_document_store_async.py
+++ b/integrations/qdrant/tests/test_document_store_async.py
@@ -309,3 +309,29 @@ class TestQdrantDocumentStoreAsync(
         assert len(updated_docs) == 1
         assert updated_docs[0].embedding is not None
         assert len(updated_docs[0].embedding) == 768
+
+    async def test_get_metadata_field_unique_values_with_meta_prefix_async(self, document_store: QdrantDocumentStore):
+        """Test that a 'meta.'-prefixed field name is normalized before lookup."""
+        docs = [
+            Document(content="Doc 1", meta={"category": "A"}),
+            Document(content="Doc 2", meta={"category": "B"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        values = await document_store.get_metadata_field_unique_values_async("meta.category")
+        assert set(values) == {"A", "B"}
+
+    async def test_get_metadata_field_unique_values_with_search_term_async(self, document_store: QdrantDocumentStore):
+        """Test that search_term filters unique values by a case-insensitive substring match on the field value."""
+        docs = [
+            Document(content="Doc 1", meta={"category": "Apple"}),
+            Document(content="Doc 2", meta={"category": "Banana"}),
+            Document(content="Doc 3", meta={"category": "Apricot"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        values = await document_store.get_metadata_field_unique_values_async("category", search_term="ap")
+        assert set(values) == {"Apple", "Apricot"}
+
+        values = await document_store.get_metadata_field_unique_values_async("category", search_term="nonexistent")
+        assert values == []


### PR DESCRIPTION
### Related Issues

- fixes partially https://github.com/deepset-ai/haystack-private/issues/484 

### How did you test it?

- add a new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
