### PR TITLE
fix: `ChromaDocumentStore` match `search_term` against metadata field value, not content

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -356,7 +356,8 @@ class ChromaDocumentStore:
 
         :param result: The full GetResult from a Chroma collection get operation.
         :param field_name: The metadata field name to collect unique values for.
-        :param search_term: Optional search term to filter documents by content.
+        :param search_term: Optional search term to filter by, matched as a case-insensitive
+            substring against the value of `field_name`.
         :param from_: The offset to start returning values from.
         :param size: The maximum number of unique values to return.
         :returns: A tuple of the paginated unique values list and the total count.
@@ -367,13 +368,15 @@ class ChromaDocumentStore:
             return [], 0
 
         if search_term:
-            documents = result.get("documents")
-            if documents is None:
-                documents = []
-            filtered_metadatas = [
-                metadatas[i] for i in range(len(documents)) if documents[i] and search_term in documents[i]
+            search_term_lower = search_term.lower()
+            metadatas = [
+                meta
+                for meta in metadatas
+                if meta
+                and field_name in meta
+                and meta.get(field_name) is not None
+                and search_term_lower in str(meta.get(field_name)).lower()
             ]
-            metadatas = filtered_metadatas
 
         if not metadatas:
             return [], 0
@@ -1294,12 +1297,12 @@ class ChromaDocumentStore:
         size: int = 10,
     ) -> tuple[list[str], int]:
         """
-        Return unique metadata field values, optionally filtered by a content search term, with pagination.
+        Return unique metadata field values, optionally filtered by a search term, with pagination.
 
         :param metadata_field: The metadata field to get unique values for.
             Can include or omit the "meta." prefix.
-        :param search_term: Optional search term to filter documents by matching
-            in the content field.
+        :param search_term: Optional search term to filter values, matched as a
+            case-insensitive substring against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
         :returns: A tuple containing list of unique values and total count of unique values.
@@ -1309,11 +1312,7 @@ class ChromaDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        kwargs: dict[str, Any] = {"include": ["metadatas"]}
-        if search_term:
-            kwargs["include"] = ["metadatas", "documents"]
-
-        result = self._collection.get(**kwargs)
+        result = self._collection.get(include=["metadatas"])
         return self._compute_field_unique_values(result, field_name, search_term, from_, size)
 
     async def get_metadata_field_unique_values_async(
@@ -1324,14 +1323,14 @@ class ChromaDocumentStore:
         size: int = 10,
     ) -> tuple[list[str], int]:
         """
-        Asynchronously return unique metadata field values, optionally filtered by content, with pagination.
+        Asynchronously return unique metadata field values, optionally filtered by a search term, with pagination.
 
         Asynchronous methods are only supported for HTTP connections.
 
         :param metadata_field: The metadata field to get unique values for.
             Can include or omit the "meta." prefix.
-        :param search_term: Optional search term to filter documents by matching
-            in the content field.
+        :param search_term: Optional search term to filter values, matched as a
+            case-insensitive substring against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
         :returns: A tuple containing list of unique values and total count of unique values.
@@ -1341,11 +1340,7 @@ class ChromaDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        kwargs: dict[str, Any] = {"include": ["metadatas"]}
-        if search_term:
-            kwargs["include"] = ["metadatas", "documents"]
-
-        result = await self._async_collection.get(**kwargs)
+        result = await self._async_collection.get(include=["metadatas"])
         return self._compute_field_unique_values(result, field_name, search_term, from_, size)
 
     @classmethod

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -207,24 +207,6 @@ class TestDocumentStoreUnit:
         assert values == []
         assert total == 0
 
-    def test_compute_field_unique_values_search_term_matches_field_value_case_insensitive(self):
-        result = {"ids": ["1", "2"], "metadatas": [{"cat": "Alpha"}, {"cat": "Beta"}]}
-        values, total = ChromaDocumentStore._compute_field_unique_values(result, "cat", "alpha", 0, 10)
-        assert values == ["Alpha"]
-        assert total == 1
-
-    def test_compute_field_unique_values_search_term_ignores_documents(self):
-        """search_term must match the metadata field's value, not the document content,
-        even if a "documents" key happens to be present in the result."""
-        result = {
-            "ids": ["1", "2"],
-            "documents": ["absent in content", "no match here"],
-            "metadatas": [{"cat": "A"}, {"cat": "absent-value"}],
-        }
-        values, total = ChromaDocumentStore._compute_field_unique_values(result, "cat", "absent", 0, 10)
-        assert values == ["absent-value"]
-        assert total == 1
-
     def test_filter_metadata_discards_unsupported_types(self, caplog):
         meta = {"ok": "x", "also_ok": None, "bad": {"nested": 1}, "worse": object()}
         with caplog.at_level(logging.WARNING):

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -196,15 +196,34 @@ class TestDocumentStoreUnit:
     @pytest.mark.parametrize(
         "result",
         [
-            {"ids": ["1"], "documents": None, "metadatas": [{"cat": "A"}]},
-            {"ids": ["1"], "documents": ["hello world"], "metadatas": [{"cat": "A"}]},
+            {"ids": ["1"], "metadatas": [{"cat": "A"}]},
+            {"ids": ["1"], "metadatas": [None]},
+            {"ids": ["1"], "metadatas": [{"other": "A"}]},
         ],
-        ids=["documents_none", "no_matches"],
+        ids=["no_match", "metadata_none", "field_missing"],
     )
     def test_compute_field_unique_values_with_search_term_edge_cases(self, result):
         values, total = ChromaDocumentStore._compute_field_unique_values(result, "cat", "absent", 0, 10)
         assert values == []
         assert total == 0
+
+    def test_compute_field_unique_values_search_term_matches_field_value_case_insensitive(self):
+        result = {"ids": ["1", "2"], "metadatas": [{"cat": "Alpha"}, {"cat": "Beta"}]}
+        values, total = ChromaDocumentStore._compute_field_unique_values(result, "cat", "alpha", 0, 10)
+        assert values == ["Alpha"]
+        assert total == 1
+
+    def test_compute_field_unique_values_search_term_ignores_documents(self):
+        """search_term must match the metadata field's value, not the document content,
+        even if a "documents" key happens to be present in the result."""
+        result = {
+            "ids": ["1", "2"],
+            "documents": ["absent in content", "no match here"],
+            "metadatas": [{"cat": "A"}, {"cat": "absent-value"}],
+        }
+        values, total = ChromaDocumentStore._compute_field_unique_values(result, "cat", "absent", 0, 10)
+        assert values == ["absent-value"]
+        assert total == 1
 
     def test_filter_metadata_discards_unsupported_types(self, caplog):
         meta = {"ok": "x", "also_ok": None, "bad": {"nested": 1}, "worse": object()}
@@ -741,12 +760,61 @@ class TestMetadataOperations:
         assert sorted(all_values) == ["A", "B", "C"]
 
     def test_get_metadata_field_unique_values_with_search_term(self, populated_store):
-        """Test getting unique values filtered by search term"""
-        # Search for documents containing "Doc 1"
+        """Test getting unique values filtered by search term.
+
+        The search term is matched against the metadata field's own value, not document
+        content. "Doc 1" is content for one document (category "A"), but it is not a
+        substring of any "category" value, so no values should match.
+        """
         values, total = populated_store.get_metadata_field_unique_values(
             "category", search_term="Doc 1", from_=0, size=10
         )
-        assert values == ["A"]  # Only Doc 1 has category A
+        assert values == []
+        assert total == 0
+
+    def test_get_metadata_field_unique_values_search_term_matches_field_value(self, populated_store):
+        """Search term matches when it's a case-insensitive substring of the field's value."""
+        values, total = populated_store.get_metadata_field_unique_values(
+            "status", search_term="ACT", from_=0, size=10
+        )
+        # "ACT" is a substring of both "active" and "inactive" (case-insensitive)
+        assert sorted(values) == ["active", "inactive"]
+        assert total == 2
+
+        values, total = populated_store.get_metadata_field_unique_values(
+            "status", search_term="ina", from_=0, size=10
+        )
+        assert values == ["inactive"]
+        assert total == 1
+
+    def test_get_metadata_field_unique_values_search_term_excludes_content_only_match(self, document_store):
+        """A search term present only in document content (not in the metadata field value)
+        must not match, proving search_term no longer filters on content."""
+        docs = [
+            Document(content="unique-marker-xyz", meta={"category": "A"}),
+            Document(content="plain content", meta={"category": "B"}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total = document_store.get_metadata_field_unique_values(
+            "category", search_term="unique-marker-xyz", from_=0, size=10
+        )
+        assert values == []
+        assert total == 0
+
+    def test_get_metadata_field_unique_values_search_term_matches_field_value_not_content(self, document_store):
+        """A search term present in the metadata field's value but absent from the content
+        must match, proving search_term filters on the metadata field's value."""
+        docs = [
+            Document(content="Nothing special here", meta={"category": "special-value"}),
+            Document(content="Nothing special here either", meta={"category": "other"}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total = document_store.get_metadata_field_unique_values(
+            "category", search_term="SPECIAL", from_=0, size=10
+        )
+        assert values == ["special-value"]
         assert total == 1
 
     def test_get_metadata_field_unique_values_field_normalization(self, populated_store):

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -774,16 +774,12 @@ class TestMetadataOperations:
 
     def test_get_metadata_field_unique_values_search_term_matches_field_value(self, populated_store):
         """Search term matches when it's a case-insensitive substring of the field's value."""
-        values, total = populated_store.get_metadata_field_unique_values(
-            "status", search_term="ACT", from_=0, size=10
-        )
+        values, total = populated_store.get_metadata_field_unique_values("status", search_term="ACT", from_=0, size=10)
         # "ACT" is a substring of both "active" and "inactive" (case-insensitive)
         assert sorted(values) == ["active", "inactive"]
         assert total == 2
 
-        values, total = populated_store.get_metadata_field_unique_values(
-            "status", search_term="ina", from_=0, size=10
-        )
+        values, total = populated_store.get_metadata_field_unique_values("status", search_term="ina", from_=0, size=10)
         assert values == ["inactive"]
         assert total == 1
 

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -215,3 +215,37 @@ class TestDocumentStoreAsync(
         )
         assert values == []
         assert total == 0
+
+    async def test_get_metadata_field_unique_values_async_search_term_excludes_content_only_match(
+        self, document_store: ChromaDocumentStore
+    ):
+        """A search term present only in document content (not in the metadata field value)
+        must not match, proving search_term no longer filters on content."""
+        docs = [
+            Document(content="unique-marker-xyz", meta={"category": "A"}),
+            Document(content="plain content", meta={"category": "B"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        values, total = await document_store.get_metadata_field_unique_values_async(
+            "category", search_term="unique-marker-xyz", from_=0, size=10
+        )
+        assert values == []
+        assert total == 0
+
+    async def test_get_metadata_field_unique_values_async_search_term_matches_field_value(
+        self, document_store: ChromaDocumentStore
+    ):
+        """A search term present in the metadata field's value but absent from the content
+        must match, proving search_term filters on the metadata field's value (case-insensitively)."""
+        docs = [
+            Document(content="Nothing special here", meta={"category": "special-value"}),
+            Document(content="Nothing special here either", meta={"category": "other"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        values, total = await document_store.get_metadata_field_unique_values_async(
+            "category", search_term="SPECIAL", from_=0, size=10
+        )
+        assert values == ["special-value"]
+        assert total == 1


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/478

### Proposed Changes:

- match search_term against metadata field value, not content both in sync and async

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
