### PR TITLE
fix: `Oracle` match `search_term` against metadata field value only, drop content match

### DIFF
--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
@@ -773,7 +773,7 @@ class OracleDocumentStore:
 
         :param metadata_field: Metadata field name. May be prefixed with ``"meta."``
             (e.g. ``"meta.lang"`` or ``"lang"``).
-        :param search_term: Optional substring filter applied to both the document text and the field value.
+        :param search_term: Optional substring filter applied to the metadata field's own value.
         :param from_: Zero-based offset for pagination. Defaults to ``0``.
         :param size: Maximum number of values to return. When ``None`` all values from ``from_`` onward
             are returned.
@@ -786,7 +786,7 @@ class OracleDocumentStore:
         base_sql = f"FROM {self.table_name} WHERE JSON_VALUE(metadata, '$.{field_path}') IS NOT NULL"
         params: dict[str, Any] = {}
         if search_term:
-            base_sql += f" AND (text LIKE :search OR JSON_VALUE(metadata, '$.{field_path}') LIKE :search)"
+            base_sql += f" AND JSON_VALUE(metadata, '$.{field_path}') LIKE :search"
             params["search"] = f"%{search_term}%"
 
         sql_count = f"SELECT COUNT(DISTINCT JSON_VALUE(metadata, '$.{field_path}')) {base_sql}"
@@ -841,7 +841,7 @@ class OracleDocumentStore:
 
         :param metadata_field: Metadata field name. May be prefixed with ``"meta."``
             (e.g. ``"meta.lang"`` or ``"lang"``).
-        :param search_term: Optional substring filter applied to both the document text and the field value.
+        :param search_term: Optional substring filter applied to the metadata field's own value.
         :param from_: Zero-based offset for pagination. Defaults to ``0``.
         :param size: Maximum number of values to return. When ``None`` all values from ``from_`` onward
             are returned.

--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
@@ -766,17 +766,17 @@ class OracleDocumentStore:
             return {"min": _try_parse_number(row[0]), "max": _try_parse_number(row[1])}
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = None
+        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = 10
     ) -> tuple[list[str], int]:
         """
         Return a paginated list of distinct values for a metadata field, plus the total distinct count.
 
         :param metadata_field: Metadata field name. May be prefixed with ``"meta."``
             (e.g. ``"meta.lang"`` or ``"lang"``).
-        :param search_term: Optional substring filter applied to the metadata field's own value.
+        :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
         :param from_: Zero-based offset for pagination. Defaults to ``0``.
-        :param size: Maximum number of values to return. When ``None`` all values from ``from_`` onward
-            are returned.
+        :param size: Maximum number of values to return. Defaults to ``10``. When ``None`` all values
+            from ``from_`` onward are returned.
         :returns: A tuple ``(values, total)`` where ``values`` is the paginated list of distinct field
             values as strings and ``total`` is the overall distinct count (before pagination).
         :raises ValueError: If ``metadata_field`` contains characters outside ``[A-Za-z0-9_.]``.
@@ -786,7 +786,7 @@ class OracleDocumentStore:
         base_sql = f"FROM {self.table_name} WHERE JSON_VALUE(metadata, '$.{field_path}') IS NOT NULL"
         params: dict[str, Any] = {}
         if search_term:
-            base_sql += f" AND JSON_VALUE(metadata, '$.{field_path}') LIKE :search"
+            base_sql += f" AND UPPER(JSON_VALUE(metadata, '$.{field_path}')) LIKE UPPER(:search)"
             params["search"] = f"%{search_term}%"
 
         sql_count = f"SELECT COUNT(DISTINCT JSON_VALUE(metadata, '$.{field_path}')) {base_sql}"
@@ -834,17 +834,17 @@ class OracleDocumentStore:
         return await asyncio.to_thread(self.get_metadata_field_min_max, metadata_field)
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = None
+        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = 10
     ) -> tuple[list[str], int]:
         """
         Asynchronously returns a paginated list of distinct values for a metadata field, plus the total count.
 
         :param metadata_field: Metadata field name. May be prefixed with ``"meta."``
             (e.g. ``"meta.lang"`` or ``"lang"``).
-        :param search_term: Optional substring filter applied to the metadata field's own value.
+        :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
         :param from_: Zero-based offset for pagination. Defaults to ``0``.
-        :param size: Maximum number of values to return. When ``None`` all values from ``from_`` onward
-            are returned.
+        :param size: Maximum number of values to return. Defaults to ``10``. When ``None`` all values
+            from ``from_`` onward are returned.
         :returns: A tuple ``(values, total)`` where ``values`` is the paginated list of distinct field
             values as strings and ``total`` is the overall distinct count (before pagination).
         :raises ValueError: If ``metadata_field`` contains characters outside ``[A-Za-z0-9_.]``.

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -59,22 +59,10 @@ def test_get_metadata_field_unique_values_search_term_filters_value_only(patched
     vals_sql, vals_params = cursor.execute.call_args_list[1][0]
 
     for sql in (count_sql, vals_sql):
-        assert "text LIKE" not in sql
-        assert "JSON_VALUE(metadata, '$.category') LIKE :search" in sql
+        assert "UPPER(JSON_VALUE(metadata, '$.category')) LIKE UPPER(:search)" in sql
 
     assert count_params["search"] == "%bar%"
     assert vals_params["search"] == "%bar%"
-
-
-def test_get_metadata_field_unique_values_no_search_term_no_like_clause(patched_store, mock_pool):
-    _, _, cursor = mock_pool
-    cursor.fetchone.return_value = (0,)
-    cursor.fetchall.return_value = []
-
-    patched_store.get_metadata_field_unique_values("category")
-
-    sql = cursor.execute.call_args_list[0][0][0]
-    assert "LIKE" not in sql
 
 
 @pytest.mark.integration
@@ -353,6 +341,16 @@ class TestOracleDocumentStore(
         # Q001: content contains "apple" but its category value ("dessert") does not -> excluded.
         # Q002: category value ("apple-tart") contains "apple", content does not -> still included.
         assert values == ["apple-tart"]
+        assert total == 1
+
+    def test_get_metadata_field_unique_values_search_term_case_insensitive(self, document_store):
+        document_store.write_documents(
+            [
+                _doc(_uid("Q003"), content="n/a", meta={"category": "Apple-Tart"}),
+            ]
+        )
+        values, total = document_store.get_metadata_field_unique_values("category", search_term="APPLE")
+        assert values == ["Apple-Tart"]
         assert total == 1
 
 

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -47,6 +47,36 @@ def _uid(suffix: str = "") -> str:
     return f"{base}{suffix.upper():>4}"[:32]
 
 
+def test_get_metadata_field_unique_values_search_term_filters_value_only(patched_store, mock_pool):
+    """search_term must filter on the metadata field's own JSON value, not on document text."""
+    _, _, cursor = mock_pool
+    cursor.fetchone.return_value = (1,)
+    cursor.fetchall.return_value = [("bar",)]
+
+    patched_store.get_metadata_field_unique_values("category", search_term="bar")
+
+    count_sql, count_params = cursor.execute.call_args_list[0][0]
+    vals_sql, vals_params = cursor.execute.call_args_list[1][0]
+
+    for sql in (count_sql, vals_sql):
+        assert "text LIKE" not in sql
+        assert "JSON_VALUE(metadata, '$.category') LIKE :search" in sql
+
+    assert count_params["search"] == "%bar%"
+    assert vals_params["search"] == "%bar%"
+
+
+def test_get_metadata_field_unique_values_no_search_term_no_like_clause(patched_store, mock_pool):
+    _, _, cursor = mock_pool
+    cursor.fetchone.return_value = (0,)
+    cursor.fetchall.return_value = []
+
+    patched_store.get_metadata_field_unique_values("category")
+
+    sql = cursor.execute.call_args_list[0][0][0]
+    assert "LIKE" not in sql
+
+
 @pytest.mark.integration
 class TestOracleDocumentStore(
     DocumentStoreBaseTests,
@@ -310,6 +340,20 @@ class TestOracleDocumentStore(
     def test_create_table_idempotent(self, document_store):
         """Calling _ensure_table() a second time must not raise."""
         document_store._ensure_table()
+
+    def test_get_metadata_field_unique_values_search_term_matches_value_not_content(self, document_store):
+        """search_term filters on the metadata field's own value; document content is not considered."""
+        document_store.write_documents(
+            [
+                _doc(_uid("Q001"), content="this text mentions apple", meta={"category": "dessert"}),
+                _doc(_uid("Q002"), content="unrelated content", meta={"category": "apple-tart"}),
+            ]
+        )
+        values, total = document_store.get_metadata_field_unique_values("category", search_term="apple")
+        # Q001: content contains "apple" but its category value ("dessert") does not -> excluded.
+        # Q002: category value ("apple-tart") contains "apple", content does not -> still included.
+        assert values == ["apple-tart"]
+        assert total == 1
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/481

### Proposed Changes:

- match metadata value only

### How did you test it?

- added unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
