### PR TITLE
fix: `ElasticSearch` match `search_term` against metadata field value, not content

### DIFF
--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import re
 
 # ruff: noqa: FBT002, FBT001    boolean-type-hint-positional-argument and boolean-default-value-positional-argument
 # ruff: noqa: B008              function-call-in-default-argument
@@ -1888,10 +1887,21 @@ class ElasticsearchDocumentStore:
         }
         if search_term:
             # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
-            # standalone `terms` aggregations), so the substring match on the field's own value is applied
-            # as a query-level filter instead. Case-sensitive: there is no normalizer-based case-insensitivity
-            # infrastructure elsewhere in this document store to hook into.
-            body["query"] = {"regexp": {field_name: f".*{re.escape(search_term)}.*"}}
+            # standalone `terms` aggregations), and a `regexp` query only works on keyword/text fields, not
+            # numeric ones. A doc-value script query works uniformly across field types by stringifying the
+            # field's value, matching the case-sensitive substring semantics documented above.
+            body["query"] = {
+                "script": {
+                    "script": {
+                        "source": (
+                            "def v = doc[params.field]; "
+                            "if (v.size() == 0) { return false; } "
+                            "return v.value.toString().contains(params.term)"
+                        ),
+                        "params": {"field": field_name, "term": search_term},
+                    }
+                }
+            }
 
         result = self.client.search(index=self._index, body=body)
         aggregations = result.get("aggregations", {})
@@ -1956,10 +1966,21 @@ class ElasticsearchDocumentStore:
         }
         if search_term:
             # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
-            # standalone `terms` aggregations), so the substring match on the field's own value is applied
-            # as a query-level filter instead. Case-sensitive: there is no normalizer-based case-insensitivity
-            # infrastructure elsewhere in this document store to hook into.
-            body["query"] = {"regexp": {field_name: f".*{re.escape(search_term)}.*"}}
+            # standalone `terms` aggregations), and a `regexp` query only works on keyword/text fields, not
+            # numeric ones. A doc-value script query works uniformly across field types by stringifying the
+            # field's value, matching the case-sensitive substring semantics documented above.
+            body["query"] = {
+                "script": {
+                    "script": {
+                        "source": (
+                            "def v = doc[params.field]; "
+                            "if (v.size() == 0) { return false; } "
+                            "return v.value.toString().contains(params.term)"
+                        ),
+                        "params": {"field": field_name, "term": search_term},
+                    }
+                }
+            }
 
         result = await self.async_client.search(index=self._index, body=body)
         aggregations = result.get("aggregations", {})

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1919,9 +1919,9 @@ class ElasticsearchDocumentStore:
         after: dict[str, Any] | None = None,
     ) -> tuple[list[str], dict[str, Any] | None]:
         """
-        Asynchronously returns unique values for a metadata field, optionally filtered by a substring match on the
-        field's value.
+        Asynchronously returns unique values for a metadata field.
 
+        Optionally filtered by a substring match on the field's own value.
         Uses composite aggregations for proper pagination beyond 10k results.
 
         See: https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-composite-aggregation

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1937,7 +1937,7 @@ class ElasticsearchDocumentStore:
 
         :param metadata_field: The metadata field to get unique values for.
         :param search_term: Optional term to filter the returned values by, matching as a case-insensitive substring
-            of the metadata field's own value (not the document content).
+            of the metadata field's own value.
         :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import re
 
 # ruff: noqa: FBT002, FBT001    boolean-type-hint-positional-argument and boolean-default-value-positional-argument
 # ruff: noqa: B008              function-call-in-default-argument
@@ -1849,14 +1850,15 @@ class ElasticsearchDocumentStore:
         after: dict[str, Any] | None = None,
     ) -> tuple[list[str], dict[str, Any] | None]:
         """
-        Returns unique values for a metadata field, optionally filtered by a search term in the content.
+        Returns unique values for a metadata field, optionally filtered by a substring match on the field's value.
 
         Uses composite aggregations for proper pagination beyond 10k results.
 
         See: https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-composite-aggregation
 
         :param metadata_field: The metadata field to get unique values for.
-        :param search_term: Optional search term to filter documents by matching in the content field.
+        :param search_term: Optional term to filter the returned values by, matching as a case-sensitive substring
+            of the metadata field's own value (not the document content).
         :param size: The number of unique values to return per page. Defaults to 10000.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.
@@ -1868,22 +1870,23 @@ class ElasticsearchDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        # filter by search_term if provided
-        query: dict[str, Any] = {"match_all": {}}
+        # Build the terms source for the composite aggregation. When a search_term is provided, use the
+        # composite aggregation's `include` regex to filter bucket keys directly by the metadata field's
+        # own value (case-sensitive substring match; there is no normalizer-based case-insensitivity
+        # infrastructure elsewhere in this document store to hook into).
+        terms_source: dict[str, Any] = {"field": field_name}
         if search_term:
-            # Use match_phrase for exact phrase matching to avoid tokenization issues
-            query = {"match_phrase": {"content": search_term}}
+            terms_source["include"] = f".*{re.escape(search_term)}.*"
 
         # Build composite aggregation for proper pagination
         composite_agg: dict[str, Any] = {
             "size": size,
-            "sources": [{field_name: {"terms": {"field": field_name}}}],
+            "sources": [{field_name: {"terms": terms_source}}],
         }
         if after is not None:
             composite_agg["after"] = after
 
         body = {
-            "query": query,
             "aggs": {
                 "unique_values": {
                     "composite": composite_agg,
@@ -1916,14 +1919,16 @@ class ElasticsearchDocumentStore:
         after: dict[str, Any] | None = None,
     ) -> tuple[list[str], dict[str, Any] | None]:
         """
-        Asynchronously returns unique values for a metadata field, optionally filtered by a search term in the content.
+        Asynchronously returns unique values for a metadata field, optionally filtered by a substring match on the
+        field's value.
 
         Uses composite aggregations for proper pagination beyond 10k results.
 
         See: https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-composite-aggregation
 
         :param metadata_field: The metadata field to get unique values for.
-        :param search_term: Optional search term to filter documents by matching in the content field.
+        :param search_term: Optional term to filter the returned values by, matching as a case-sensitive substring
+            of the metadata field's own value (not the document content).
         :param size: The number of unique values to return per page. Defaults to 10000.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.
@@ -1935,22 +1940,23 @@ class ElasticsearchDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        # filter by search_term if provided
-        query: dict[str, Any] = {"match_all": {}}
+        # Build the terms source for the composite aggregation. When a search_term is provided, use the
+        # composite aggregation's `include` regex to filter bucket keys directly by the metadata field's
+        # own value (case-sensitive substring match; there is no normalizer-based case-insensitivity
+        # infrastructure elsewhere in this document store to hook into).
+        terms_source: dict[str, Any] = {"field": field_name}
         if search_term:
-            # Use match_phrase for exact phrase matching to avoid tokenization issues
-            query = {"match_phrase": {"content": search_term}}
+            terms_source["include"] = f".*{re.escape(search_term)}.*"
 
         # Build composite aggregation for proper pagination
         composite_agg: dict[str, Any] = {
             "size": size,
-            "sources": [{field_name: {"terms": {"field": field_name}}}],
+            "sources": [{field_name: {"terms": terms_source}}],
         }
         if after is not None:
             composite_agg["after"] = after
 
         body = {
-            "query": query,
             "aggs": {
                 "unique_values": {
                     "composite": composite_agg,

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1857,7 +1857,9 @@ class ElasticsearchDocumentStore:
 
         :param metadata_field: The metadata field to get unique values for.
         :param search_term: Optional term to filter the returned values by, matching as a case-insensitive substring
-            of the metadata field's own value.
+            of the metadata field's own value (not the document content). NOTE: The matching is done with a server-side
+            script to accomplish the substring matching on the value of the field and this operation is quite expensive
+            for a large corpus.
         :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1856,7 +1856,7 @@ class ElasticsearchDocumentStore:
         See: https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-composite-aggregation
 
         :param metadata_field: The metadata field to get unique values for.
-        :param search_term: Optional term to filter the returned values by, matching as a case-sensitive substring
+        :param search_term: Optional term to filter the returned values by, matching as a case-insensitive substring
             of the metadata field's own value (not the document content).
         :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
@@ -1889,16 +1889,17 @@ class ElasticsearchDocumentStore:
             # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
             # standalone `terms` aggregations), and a `regexp` query only works on keyword/text fields, not
             # numeric ones. A doc-value script query works uniformly across field types by stringifying the
-            # field's value, matching the case-sensitive substring semantics documented above.
+            # field's value, matching the case-insensitive substring semantics documented above. The term is
+            # lower-cased once here rather than per-document in the script.
             body["query"] = {
                 "script": {
                     "script": {
                         "source": (
                             "def v = doc[params.field]; "
                             "if (v.size() == 0) { return false; } "
-                            "return v.value.toString().contains(params.term)"
+                            "return v.value.toString().toLowerCase().contains(params.term)"
                         ),
-                        "params": {"field": field_name, "term": search_term},
+                        "params": {"field": field_name, "term": search_term.lower()},
                     }
                 }
             }
@@ -1935,7 +1936,7 @@ class ElasticsearchDocumentStore:
         See: https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-composite-aggregation
 
         :param metadata_field: The metadata field to get unique values for.
-        :param search_term: Optional term to filter the returned values by, matching as a case-sensitive substring
+        :param search_term: Optional term to filter the returned values by, matching as a case-insensitive substring
             of the metadata field's own value (not the document content).
         :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
@@ -1968,16 +1969,17 @@ class ElasticsearchDocumentStore:
             # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
             # standalone `terms` aggregations), and a `regexp` query only works on keyword/text fields, not
             # numeric ones. A doc-value script query works uniformly across field types by stringifying the
-            # field's value, matching the case-sensitive substring semantics documented above.
+            # field's value, matching the case-insensitive substring semantics documented above. The term is
+            # lower-cased once here rather than per-document in the script.
             body["query"] = {
                 "script": {
                     "script": {
                         "source": (
                             "def v = doc[params.field]; "
                             "if (v.size() == 0) { return false; } "
-                            "return v.value.toString().contains(params.term)"
+                            "return v.value.toString().toLowerCase().contains(params.term)"
                         ),
-                        "params": {"field": field_name, "term": search_term},
+                        "params": {"field": field_name, "term": search_term.lower()},
                     }
                 }
             }

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1857,7 +1857,7 @@ class ElasticsearchDocumentStore:
 
         :param metadata_field: The metadata field to get unique values for.
         :param search_term: Optional term to filter the returned values by, matching as a case-insensitive substring
-            of the metadata field's own value (not the document content).
+            of the metadata field's own value.
         :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1870,23 +1870,15 @@ class ElasticsearchDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        # Build the terms source for the composite aggregation. When a search_term is provided, use the
-        # composite aggregation's `include` regex to filter bucket keys directly by the metadata field's
-        # own value (case-sensitive substring match; there is no normalizer-based case-insensitivity
-        # infrastructure elsewhere in this document store to hook into).
-        terms_source: dict[str, Any] = {"field": field_name}
-        if search_term:
-            terms_source["include"] = f".*{re.escape(search_term)}.*"
-
         # Build composite aggregation for proper pagination
         composite_agg: dict[str, Any] = {
             "size": size,
-            "sources": [{field_name: {"terms": terms_source}}],
+            "sources": [{field_name: {"terms": {"field": field_name}}}],
         }
         if after is not None:
             composite_agg["after"] = after
 
-        body = {
+        body: dict[str, Any] = {
             "aggs": {
                 "unique_values": {
                     "composite": composite_agg,
@@ -1894,6 +1886,12 @@ class ElasticsearchDocumentStore:
             },
             "size": 0,  # we only need aggregations, not documents
         }
+        if search_term:
+            # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
+            # standalone `terms` aggregations), so the substring match on the field's own value is applied
+            # as a query-level filter instead. Case-sensitive: there is no normalizer-based case-insensitivity
+            # infrastructure elsewhere in this document store to hook into.
+            body["query"] = {"regexp": {field_name: f".*{re.escape(search_term)}.*"}}
 
         result = self.client.search(index=self._index, body=body)
         aggregations = result.get("aggregations", {})
@@ -1940,23 +1938,15 @@ class ElasticsearchDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        # Build the terms source for the composite aggregation. When a search_term is provided, use the
-        # composite aggregation's `include` regex to filter bucket keys directly by the metadata field's
-        # own value (case-sensitive substring match; there is no normalizer-based case-insensitivity
-        # infrastructure elsewhere in this document store to hook into).
-        terms_source: dict[str, Any] = {"field": field_name}
-        if search_term:
-            terms_source["include"] = f".*{re.escape(search_term)}.*"
-
         # Build composite aggregation for proper pagination
         composite_agg: dict[str, Any] = {
             "size": size,
-            "sources": [{field_name: {"terms": terms_source}}],
+            "sources": [{field_name: {"terms": {"field": field_name}}}],
         }
         if after is not None:
             composite_agg["after"] = after
 
-        body = {
+        body: dict[str, Any] = {
             "aggs": {
                 "unique_values": {
                     "composite": composite_agg,
@@ -1964,6 +1954,12 @@ class ElasticsearchDocumentStore:
             },
             "size": 0,  # we only need aggregations, not documents
         }
+        if search_term:
+            # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
+            # standalone `terms` aggregations), so the substring match on the field's own value is applied
+            # as a query-level filter instead. Case-sensitive: there is no normalizer-based case-insensitivity
+            # infrastructure elsewhere in this document store to hook into.
+            body["query"] = {"regexp": {field_name: f".*{re.escape(search_term)}.*"}}
 
         result = await self.async_client.search(index=self._index, body=body)
         aggregations = result.get("aggregations", {})

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1937,7 +1937,9 @@ class ElasticsearchDocumentStore:
 
         :param metadata_field: The metadata field to get unique values for.
         :param search_term: Optional term to filter the returned values by, matching as a case-insensitive substring
-            of the metadata field's own value.
+            of the metadata field's own value (not the document content). NOTE: The matching is done with a server-side
+            script to accomplish the substring matching on the value of the field and this operation is quite expensive
+            for a large corpus.
         :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.

--- a/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
+++ b/integrations/elasticsearch/src/haystack_integrations/document_stores/elasticsearch/document_store.py
@@ -1845,7 +1845,7 @@ class ElasticsearchDocumentStore:
         self,
         metadata_field: str,
         search_term: str | None = None,
-        size: int | None = 10000,
+        size: int | None = 10,
         after: dict[str, Any] | None = None,
     ) -> tuple[list[str], dict[str, Any] | None]:
         """
@@ -1858,7 +1858,7 @@ class ElasticsearchDocumentStore:
         :param metadata_field: The metadata field to get unique values for.
         :param search_term: Optional term to filter the returned values by, matching as a case-sensitive substring
             of the metadata field's own value (not the document content).
-        :param size: The number of unique values to return per page. Defaults to 10000.
+        :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.
         :returns: A tuple containing (list of unique values, after_key for pagination).
@@ -1923,7 +1923,7 @@ class ElasticsearchDocumentStore:
         self,
         metadata_field: str,
         search_term: str | None = None,
-        size: int | None = 10000,
+        size: int | None = 10,
         after: dict[str, Any] | None = None,
     ) -> tuple[list[str], dict[str, Any] | None]:
         """
@@ -1937,7 +1937,7 @@ class ElasticsearchDocumentStore:
         :param metadata_field: The metadata field to get unique values for.
         :param search_term: Optional term to filter the returned values by, matching as a case-sensitive substring
             of the metadata field's own value (not the document content).
-        :param size: The number of unique values to return per page. Defaults to 10000.
+        :param size: The number of unique values to return per page. Defaults to 10.
         :param after: Optional pagination key from the previous response. Use None for the first page.
             For subsequent pages, pass the `after_key` from the previous response.
         :returns: A tuple containing (list of unique values, after_key for pagination).

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -1331,6 +1331,19 @@ class TestDocumentStore(
         unique_values, _ = document_store.get_metadata_field_unique_values("meta.category", "Python", 10)
 
         assert unique_values == ["Python-based"]
+
+    def test_get_metadata_field_unique_values_search_term_case_insensitive(
+        self, document_store: ElasticsearchDocumentStore
+    ):
+        docs = [
+            Document(content="n/a", meta={"category": "Python-based"}),
+            Document(content="n/a", meta={"category": "Java-based"}),
+        ]
+        document_store.write_documents(docs)
+
+        unique_values, _ = document_store.get_metadata_field_unique_values("meta.category", "PYTHON", 10)
+
+        assert unique_values == ["Python-based"]
         assert "Backend" not in unique_values
 
     def test_query_sql(self, document_store: ElasticsearchDocumentStore):

--- a/integrations/elasticsearch/tests/test_document_store.py
+++ b/integrations/elasticsearch/tests/test_document_store.py
@@ -1290,13 +1290,13 @@ class TestDocumentStore(
         # Should have no more results
         assert after_key_page2 is None
 
-        # Test with search term - filter by content matching "Python"
-        unique_values_filtered, _ = document_store.get_metadata_field_unique_values("meta.category", "Python", 10)
-        assert set(unique_values_filtered) == {"A"}  # Only category A has documents with "Python" in content
+        # Test with search term - substring match against the target field's own value (not the content)
+        # "Java" is a substring of both "Java" and "JavaScript"
+        unique_languages_filtered, _ = document_store.get_metadata_field_unique_values("meta.language", "Java", 10)
+        assert set(unique_languages_filtered) == {"Java", "JavaScript"}
 
-        # Test with search term - filter by content matching "Java"
-        unique_values_java, _ = document_store.get_metadata_field_unique_values("meta.category", "Java", 10)
-        assert set(unique_values_java) == {"B"}  # Only category B has documents with "Java" in content
+        unique_languages_python, _ = document_store.get_metadata_field_unique_values("meta.language", "Python", 10)
+        assert set(unique_languages_python) == {"Python"}
 
         # Test with integer values
         int_docs = [
@@ -1309,9 +1309,29 @@ class TestDocumentStore(
         unique_priorities, _ = document_store.get_metadata_field_unique_values("meta.priority", None, 10)
         assert set(unique_priorities) == {"1", "2", "3"}
 
-        # Test with search term on integer field
-        unique_priorities_filtered, _ = document_store.get_metadata_field_unique_values("meta.priority", "Doc 1", 10)
+        # Test with search term on integer field - substring match against the field's own (stringified) value
+        unique_priorities_filtered, _ = document_store.get_metadata_field_unique_values("meta.priority", "1", 10)
         assert set(unique_priorities_filtered) == {"1"}
+
+    def test_get_metadata_field_unique_values_search_term_matches_field_value_not_content(
+        self, document_store: ElasticsearchDocumentStore
+    ):
+        """
+        `search_term` must filter by substring match on the metadata field's own value, not by matching
+        against the document's `content`.
+        """
+        docs = [
+            # "Python" appears in the content but NOT in the category value -> must be EXCLUDED
+            Document(content="Python programming guide", meta={"category": "Backend"}),
+            # "Python" appears in the category value but NOT in the content -> must be INCLUDED
+            Document(content="General purpose scripting language", meta={"category": "Python-based"}),
+        ]
+        document_store.write_documents(docs)
+
+        unique_values, _ = document_store.get_metadata_field_unique_values("meta.category", "Python", 10)
+
+        assert unique_values == ["Python-based"]
+        assert "Backend" not in unique_values
 
     def test_query_sql(self, document_store: ElasticsearchDocumentStore):
         docs = [

--- a/integrations/elasticsearch/tests/test_document_store_async.py
+++ b/integrations/elasticsearch/tests/test_document_store_async.py
@@ -364,3 +364,24 @@ class TestElasticsearchDocumentStoreAsync(
         invalid_query = "SELECT * FROM non_existent_index"
         with pytest.raises(DocumentStoreError, match="Failed to execute SQL query"):
             await document_store._query_sql_async(invalid_query)
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_field_unique_values_async_search_term_matches_field_value_not_content(
+        self, document_store: ElasticsearchDocumentStore
+    ):
+        """
+        `search_term` must filter by substring match on the metadata field's own value, not by matching
+        against the document's `content`.
+        """
+        docs = [
+            # "Python" appears in the content but NOT in the category value -> must be EXCLUDED
+            Document(content="Python programming guide", meta={"category": "Backend"}),
+            # "Python" appears in the category value but NOT in the content -> must be INCLUDED
+            Document(content="General purpose scripting language", meta={"category": "Python-based"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        unique_values, _ = await document_store.get_metadata_field_unique_values_async("meta.category", "Python", 10)
+
+        assert unique_values == ["Python-based"]
+        assert "Backend" not in unique_values


### PR DESCRIPTION
### Related Issues

- fixes partially https://github.com/deepset-ai/haystack-private/issues/488

### Proposed Changes:

- search_term now matches the metadata field value

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
