### PR TITLE
fix: `PGVectorDocumentStore` match `search_term` against metadata field value, not content

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -1909,7 +1909,8 @@ class PgvectorDocumentStore:
         Builds SQL queries for getting unique metadata field values.
 
         :param normalized_field: The normalized metadata field name.
-        :param search_term: Optional search term to filter documents by content.
+        :param search_term: Optional search term to filter unique values by a case-insensitive substring match
+            against the metadata field's own value.
         :param from_: The offset for pagination (0-based).
         :param size: The number of unique values to return.
         :returns: A tuple containing (count_query, select_query, params).
@@ -1925,11 +1926,9 @@ class PgvectorDocumentStore:
 
         params: tuple = ()
         if search_term:
-            # Use full-text search with word boundaries (similar to keyword retrieval)
-            sql_where += SQL(" AND to_tsvector({language}, content) @@ plainto_tsquery({language}, %s)").format(
-                language=SQLLiteral(self.language)
-            )
-            params = (search_term,)
+            # Case-insensitive substring match against the metadata field's own value.
+            sql_where += SQL(" AND meta->>{} ILIKE %s").format(field_literal)
+            params = (f"%{search_term}%",)
 
         # count query
         sql_count = SQL("SELECT COUNT(DISTINCT meta->>{} ) AS total").format(field_literal)
@@ -1965,8 +1964,8 @@ class PgvectorDocumentStore:
         Returns unique values for a given metadata field, optionally filtered by a search term.
 
         :param metadata_field: The name of the metadata field. Can include or omit the "meta." prefix.
-        :param search_term: Optional search term to filter documents by content before extracting unique values.
-            If None, all documents are considered.
+        :param search_term: Optional search term to filter unique values by a case-insensitive substring
+            match against the metadata field's own value. If None, all values are considered.
         :param from_: The offset for pagination (0-based).
         :param size: The number of unique values to return.
         :returns: A tuple containing:
@@ -2003,8 +2002,8 @@ class PgvectorDocumentStore:
         Asynchronously returns unique values for a given metadata field, optionally filtered by a search term.
 
         :param metadata_field: The name of the metadata field. Can include or omit the "meta." prefix.
-        :param search_term: Optional search term to filter documents by content before extracting unique values.
-            If None, all documents are considered.
+        :param search_term: Optional search term to filter unique values by a case-insensitive substring
+            match against the metadata field's own value. If None, all values are considered.
         :param from_: The offset for pagination (0-based).
         :param size: The number of unique values to return.
         :returns: A tuple containing:

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -1958,7 +1958,7 @@ class PgvectorDocumentStore:
         return unique_values, total_count
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None, from_: int, size: int
+        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
     ) -> tuple[list[str], int]:
         """
         Returns unique values for a given metadata field, optionally filtered by a search term.
@@ -1996,7 +1996,7 @@ class PgvectorDocumentStore:
         return PgvectorDocumentStore._process_unique_values_result(count_result, records)
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, search_term: str | None, from_: int, size: int
+        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
     ) -> tuple[list[str], int]:
         """
         Asynchronously returns unique values for a given metadata field, optionally filtered by a search term.

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -241,49 +241,6 @@ def test_count_unique_metadata_by_filter_rejects_empty_fields(mock_store):
         mock_store.count_unique_metadata_by_filter(filters={}, metadata_fields=[])
 
 
-def test_build_unique_values_queries_without_search_term(mock_store):
-    sql_count, sql_query, params = mock_store._build_unique_values_queries("category", None, 0, 10)
-
-    # no search term -> no additional WHERE clause and no params, and crucially no reference
-    # to content/full-text-search at all
-    count_repr = repr(sql_count)
-    query_repr = repr(sql_query)
-    assert "ILIKE" not in count_repr
-    assert "ILIKE" not in query_repr
-    assert "content" not in count_repr
-    assert "content" not in query_repr
-    assert "tsvector" not in count_repr
-    assert "tsvector" not in query_repr
-    assert params == ()
-
-
-def test_build_unique_values_queries_with_search_term_matches_field_value_not_content(mock_store):
-    sql_count, sql_query, params = mock_store._build_unique_values_queries("category", "python", 0, 10)
-
-    count_repr = repr(sql_count)
-    query_repr = repr(sql_query)
-
-    # search_term must be translated into a case-insensitive substring (ILIKE) match against the
-    # metadata field's own value (meta->>'category'), not a full-text search against `content`.
-    assert "ILIKE" in count_repr
-    assert "ILIKE" in query_repr
-    assert "content" not in count_repr
-    assert "content" not in query_repr
-    assert "tsvector" not in count_repr
-    assert "tsvector" not in query_repr
-    assert "plainto_tsquery" not in count_repr
-    assert "plainto_tsquery" not in query_repr
-
-    # the field name must still be passed as a safely-escaped SQL literal (consistent with the
-    # rest of the WHERE clause), never interpolated raw into the query string.
-    assert "Literal('category')" in query_repr
-
-    # the search term itself must be a bound parameter (%s), not interpolated into the SQL text,
-    # and must be wrapped for substring matching.
-    assert "ILIKE %s" in query_repr
-    assert params == ("%python%",)
-
-
 def test_check_and_build_embedding_retrieval_query_rejects_invalid_vector_function(mock_store):
     with pytest.raises(ValueError, match="vector_function must be one of"):
         mock_store._check_and_build_embedding_retrieval_query(
@@ -741,3 +698,35 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
     )
     assert set(unique_priorities_filtered) == {"1"}
     assert total_priorities_filtered == 1
+
+
+@pytest.mark.integration
+def test_get_metadata_field_unique_values_no_search_term(document_store: PgvectorDocumentStore):
+    docs = [
+        Document(content="mentions tsvector and content in the body", meta={"category": "A"}),
+        Document(content="another document", meta={"category": "B"}),
+    ]
+    document_store.write_documents(docs)
+
+    values, total = document_store.get_metadata_field_unique_values("meta.category")
+
+    assert set(values) == {"A", "B"}
+    assert total == 2
+
+
+@pytest.mark.integration
+def test_get_metadata_field_unique_values_search_term_matches_field_value_not_content(
+    document_store: PgvectorDocumentStore,
+):
+    docs = [
+        # "python" appears in the content but NOT in the category value -> must be EXCLUDED
+        Document(content="Python programming guide", meta={"category": "Backend"}),
+        # "python" appears in the category value but NOT in the content -> must be INCLUDED
+        Document(content="General purpose scripting language", meta={"category": "Python-based"}),
+    ]
+    document_store.write_documents(docs)
+
+    values, total = document_store.get_metadata_field_unique_values("meta.category", search_term="python")
+
+    assert values == ["Python-based"]
+    assert total == 1

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -663,10 +663,7 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
     assert len(unique_values_search_empty) == 0
     assert total_search_empty == 1
 
-    # Test that search_term matches metadata VALUE, not content: a document whose content contains
-    # the search term but whose target metadata field value does not must be EXCLUDED, while a
-    # document whose metadata field value contains the search term but whose content does not
-    # must be INCLUDED.
+    # Test that search_term matches metadata VALUE, not content
     content_vs_metadata_docs = [
         Document(content="This document mentions Python explicitly", meta={"topic": "cooking"}),
         Document(content="Unrelated content about recipes", meta={"topic": "python-tutorial"}),
@@ -674,8 +671,6 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
     document_store.write_documents(content_vs_metadata_docs)
 
     unique_topics, total_topics = document_store.get_metadata_field_unique_values("meta.topic", "python", 0, 10)
-    # "cooking" doc's content contains "Python" but its topic value doesn't -> excluded
-    # "python-tutorial" doc's topic value contains "python" but its content doesn't -> included
     assert set(unique_topics) == {"python-tutorial"}
     assert total_topics == 1
 

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -241,6 +241,49 @@ def test_count_unique_metadata_by_filter_rejects_empty_fields(mock_store):
         mock_store.count_unique_metadata_by_filter(filters={}, metadata_fields=[])
 
 
+def test_build_unique_values_queries_without_search_term(mock_store):
+    sql_count, sql_query, params = mock_store._build_unique_values_queries("category", None, 0, 10)
+
+    # no search term -> no additional WHERE clause and no params, and crucially no reference
+    # to content/full-text-search at all
+    count_repr = repr(sql_count)
+    query_repr = repr(sql_query)
+    assert "ILIKE" not in count_repr
+    assert "ILIKE" not in query_repr
+    assert "content" not in count_repr
+    assert "content" not in query_repr
+    assert "tsvector" not in count_repr
+    assert "tsvector" not in query_repr
+    assert params == ()
+
+
+def test_build_unique_values_queries_with_search_term_matches_field_value_not_content(mock_store):
+    sql_count, sql_query, params = mock_store._build_unique_values_queries("category", "python", 0, 10)
+
+    count_repr = repr(sql_count)
+    query_repr = repr(sql_query)
+
+    # search_term must be translated into a case-insensitive substring (ILIKE) match against the
+    # metadata field's own value (meta->>'category'), not a full-text search against `content`.
+    assert "ILIKE" in count_repr
+    assert "ILIKE" in query_repr
+    assert "content" not in count_repr
+    assert "content" not in query_repr
+    assert "tsvector" not in count_repr
+    assert "tsvector" not in query_repr
+    assert "plainto_tsquery" not in count_repr
+    assert "plainto_tsquery" not in query_repr
+
+    # the field name must still be passed as a safely-escaped SQL literal (consistent with the
+    # rest of the WHERE clause), never interpolated raw into the query string.
+    assert "Literal('category')" in query_repr
+
+    # the search term itself must be a bound parameter (%s), not interpolated into the SQL text,
+    # and must be wrapped for substring matching.
+    assert "ILIKE %s" in query_repr
+    assert params == ("%python%",)
+
+
 def test_check_and_build_embedding_retrieval_query_rejects_invalid_vector_function(mock_store):
     with pytest.raises(ValueError, match="vector_function must be one of"):
         mock_store._check_and_build_embedding_retrieval_query(
@@ -623,17 +666,32 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
     # All three pages should be different
     assert len(set(unique_values_single1 + unique_values_single2 + unique_values_single3)) == 3
 
-    # Test with search term - filter by content matching "Python"
+    # Test with search term - case-insensitive substring match against the metadata field's OWN value
+    # (not against document content).
     unique_values_filtered, total_filtered = document_store.get_metadata_field_unique_values(
-        "meta.category", "Python", 0, 10
+        "meta.language", "Python", 0, 10
     )
-    assert set(unique_values_filtered) == {"A"}  # Only category A has documents with "Python" in content
+    assert set(unique_values_filtered) == {"Python"}
     assert total_filtered == 1
 
-    # Test with search term - filter by content matching "Java"
-    unique_values_java, total_java = document_store.get_metadata_field_unique_values("meta.category", "Java", 0, 10)
-    assert set(unique_values_java) == {"B"}  # Only category B has documents with "Java" in content
-    assert total_java == 1
+    # Case-insensitivity: lowercase search term should still match "Python"
+    unique_values_lower, total_lower = document_store.get_metadata_field_unique_values(
+        "meta.language", "python", 0, 10
+    )
+    assert set(unique_values_lower) == {"Python"}
+    assert total_lower == 1
+
+    # Substring matching: "Java" is a substring of both "Java" and "JavaScript"
+    unique_values_java, total_java = document_store.get_metadata_field_unique_values("meta.language", "Java", 0, 10)
+    assert set(unique_values_java) == {"Java", "JavaScript"}
+    assert total_java == 2
+
+    # Substring matching in the middle/end of a value
+    unique_values_script, total_script = document_store.get_metadata_field_unique_values(
+        "meta.language", "Script", 0, 10
+    )
+    assert set(unique_values_script) == {"JavaScript"}
+    assert total_script == 1
 
     # Test pagination with search term
     unique_values_search_page1, total_search = document_store.get_metadata_field_unique_values(
@@ -650,6 +708,22 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
     assert len(unique_values_search_empty) == 0
     assert total_search_empty == 1
 
+    # Test that search_term matches metadata VALUE, not content: a document whose content contains
+    # the search term but whose target metadata field value does not must be EXCLUDED, while a
+    # document whose metadata field value contains the search term but whose content does not
+    # must be INCLUDED.
+    content_vs_metadata_docs = [
+        Document(content="This document mentions Python explicitly", meta={"topic": "cooking"}),
+        Document(content="Unrelated content about recipes", meta={"topic": "python-tutorial"}),
+    ]
+    document_store.write_documents(content_vs_metadata_docs)
+
+    unique_topics, total_topics = document_store.get_metadata_field_unique_values("meta.topic", "python", 0, 10)
+    # "cooking" doc's content contains "Python" but its topic value doesn't -> excluded
+    # "python-tutorial" doc's topic value contains "python" but its content doesn't -> included
+    assert set(unique_topics) == {"python-tutorial"}
+    assert total_topics == 1
+
     # Test with integer values
     int_docs = [
         Document(content="Doc 1", meta={"priority": 1}),
@@ -662,9 +736,10 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
     assert set(unique_priorities) == {"1", "2", "3"}
     assert total_priorities == 3
 
-    # Test with search term on integer field
+    # Test with search term on integer field - substring match against the field's own (stringified)
+    # value, e.g. "Doc 1" (content) no longer matches; "1" (the value itself) does.
     unique_priorities_filtered, total_priorities_filtered = document_store.get_metadata_field_unique_values(
-        "meta.priority", "Doc 1", 0, 10
+        "meta.priority", "1", 0, 10
     )
     assert set(unique_priorities_filtered) == {"1"}
     assert total_priorities_filtered == 1

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -675,9 +675,7 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
     assert total_filtered == 1
 
     # Case-insensitivity: lowercase search term should still match "Python"
-    unique_values_lower, total_lower = document_store.get_metadata_field_unique_values(
-        "meta.language", "python", 0, 10
-    )
+    unique_values_lower, total_lower = document_store.get_metadata_field_unique_values("meta.language", "python", 0, 10)
     assert set(unique_values_lower) == {"Python"}
     assert total_lower == 1
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/480

### Proposed Changes:

- search_term to case-insensitive substring matching on the metadata values
- defaults (search_term=None, from_=0, size=10)

### How did you test it?

- new integration tests ( against Docker image)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
