### PR TITLE
feat: pgvector - add closing methods

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/embedding_retriever.py
@@ -136,6 +136,18 @@ class PgvectorEmbeddingRetriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self.document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
+++ b/integrations/pgvector/src/haystack_integrations/components/retrievers/pgvector/keyword_retriever.py
@@ -109,6 +109,18 @@ class PgvectorKeywordRetriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self.document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import suppress
 from typing import Any, Literal, overload
 
 from haystack import default_from_dict, default_to_dict, logging
@@ -222,6 +223,28 @@ class PgvectorDocumentStore:
         """
         deserialize_secrets_inplace(data["init_parameters"], ["connection_string"])
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the associated synchronous resources.
+        """
+        if self._connection is not None:
+            with suppress(Exception):
+                self._connection.close()
+            self._connection = None
+            self._cursor = None
+            self._dict_cursor = None
+
+    async def close_async(self) -> None:
+        """
+        Release the associated asynchronous resources.
+        """
+        if self._async_connection is not None:
+            with suppress(Exception):
+                await self._async_connection.close()
+            self._async_connection = None
+            self._async_cursor = None
+            self._async_dict_cursor = None
 
     @staticmethod
     def _connection_is_valid(connection: Connection) -> bool:

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -103,6 +103,18 @@ class TestDocumentStore(
             document_store._ensure_db_setup()
         assert "Failed to connect to PostgreSQL database" in str(e)
 
+    def test_close_and_reopen(self, document_store: PgvectorDocumentStore):
+        assert document_store.count_documents() == 0
+        assert document_store._connection is not None
+
+        document_store.close()
+        assert document_store._connection is None
+        assert document_store._cursor is None
+        assert document_store._dict_cursor is None
+
+        assert document_store.count_documents() == 0
+        assert document_store._connection is not None
+
 
 @pytest.mark.usefixtures("patches_for_unit_tests")
 def test_init(monkeypatch):
@@ -351,6 +363,33 @@ def test_process_count_unique_metadata_result_returns_zero_dict_when_result_none
 def test_process_count_unique_metadata_result_uses_zero_for_missing_keys():
     counts = PgvectorDocumentStore._process_count_unique_metadata_result({"category": 5}, ["category", "language"])
     assert counts == {"category": 5, "language": 0}
+
+
+def test_close(mock_store):
+    mock_connection = Mock(spec=Connection)
+    mock_store._connection = mock_connection
+    mock_store._cursor = Mock(spec=Cursor)
+    mock_store._dict_cursor = Mock(spec=Cursor)
+
+    mock_store.close()
+
+    mock_connection.close.assert_called_once()
+    assert mock_store._connection is None
+    assert mock_store._cursor is None
+    assert mock_store._dict_cursor is None
+
+    mock_store.close()
+    mock_connection.close.assert_called_once()
+
+
+def test_close_is_exception_safe(mock_store):
+    mock_connection = Mock(spec=Connection)
+    mock_connection.close.side_effect = RuntimeError("boom")
+    mock_store._connection = mock_connection
+
+    mock_store.close()
+
+    assert mock_store._connection is None
 
 
 @pytest.mark.integration

--- a/integrations/pgvector/tests/test_document_store_async.py
+++ b/integrations/pgvector/tests/test_document_store_async.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import psycopg
 import pytest
@@ -130,6 +130,18 @@ class TestDocumentStoreAsync(
         without triggering errors due to an uninitialized state.
         """
         await document_store.delete_table_async()  # if throw error, test fails
+
+    async def test_close_async_and_reopen(self, document_store: PgvectorDocumentStore):
+        assert await document_store.count_documents_async() == 0
+        assert document_store._async_connection is not None
+
+        await document_store.close_async()
+        assert document_store._async_connection is None
+        assert document_store._async_cursor is None
+        assert document_store._async_dict_cursor is None
+
+        assert await document_store.count_documents_async() == 0
+        assert document_store._async_connection is not None
 
 
 @pytest.mark.integration
@@ -302,3 +314,33 @@ async def test_write_documents_async_rejects_non_document_items(mock_store):
 async def test_count_unique_metadata_by_filter_async_rejects_empty_fields(mock_store):
     with pytest.raises(ValueError, match="metadata_fields must be a non-empty list"):
         await mock_store.count_unique_metadata_by_filter_async(filters={}, metadata_fields=[])
+
+
+@pytest.mark.asyncio
+async def test_close_async(mock_store):
+    mock_connection = Mock(spec=AsyncConnection)
+    mock_connection.close = AsyncMock()
+    mock_store._async_connection = mock_connection
+    mock_store._async_cursor = Mock(spec=AsyncCursor)
+    mock_store._async_dict_cursor = Mock(spec=AsyncCursor)
+
+    await mock_store.close_async()
+
+    mock_connection.close.assert_awaited_once()
+    assert mock_store._async_connection is None
+    assert mock_store._async_cursor is None
+    assert mock_store._async_dict_cursor is None
+
+    await mock_store.close_async()
+    mock_connection.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_async_is_exception_safe(mock_store):
+    mock_connection = Mock(spec=AsyncConnection)
+    mock_connection.close = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_store._async_connection = mock_connection
+
+    await mock_store.close_async()
+
+    assert mock_store._async_connection is None

--- a/integrations/pgvector/tests/test_retrievers.py
+++ b/integrations/pgvector/tests/test_retrievers.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from haystack.dataclasses import Document
@@ -125,6 +125,26 @@ class TestEmbeddingRetriever:
         assert retriever.top_k == 5
         assert retriever.filter_policy == FilterPolicy.REPLACE
         assert retriever.vector_function == "l2_distance"
+
+    def test_close(self):
+        mock_store = Mock(spec=PgvectorDocumentStore)
+        retriever = PgvectorEmbeddingRetriever(document_store=mock_store, vector_function="l2_distance")
+
+        retriever.close()
+
+        mock_store.close.assert_called_once()
+        assert retriever.document_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        mock_store = Mock(spec=PgvectorDocumentStore)
+        mock_store.close_async = AsyncMock()
+        retriever = PgvectorEmbeddingRetriever(document_store=mock_store, vector_function="l2_distance")
+
+        await retriever.close_async()
+
+        mock_store.close_async.assert_awaited_once()
+        assert retriever.document_store is mock_store
 
     def test_run(self):
         mock_store = Mock(spec=PgvectorDocumentStore)
@@ -314,6 +334,26 @@ class TestKeywordRetriever:
         assert retriever.filters == {"field": "value"}
         assert retriever.filter_policy == FilterPolicy.REPLACE  # defaults to REPLACE
         assert retriever.top_k == 5
+
+    def test_close(self):
+        mock_store = Mock(spec=PgvectorDocumentStore)
+        retriever = PgvectorKeywordRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once()
+        assert retriever.document_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        mock_store = Mock(spec=PgvectorDocumentStore)
+        mock_store.close_async = AsyncMock()
+        retriever = PgvectorKeywordRetriever(document_store=mock_store)
+
+        await retriever.close_async()
+
+        mock_store.close_async.assert_awaited_once()
+        assert retriever.document_store is mock_store
 
     def test_run(self):
         mock_store = Mock(spec=PgvectorDocumentStore)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- implement methods to release resources

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
