### PR TITLE
feat: mongodb - add closing methods

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/embedding_retriever.py
@@ -106,6 +106,18 @@ class MongoDBAtlasEmbeddingRetriever:
             data["init_parameters"]["filter_policy"] = FilterPolicy.from_str(filter_policy)
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self.document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/components/retrievers/mongodb_atlas/full_text_retriever.py
@@ -101,6 +101,18 @@ class MongoDBAtlasFullTextRetriever:
 
         return default_from_dict(cls, data)
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        await self.document_store.close_async()
+
     @component.output_types(documents=list[Document])
     def run(
         self,

--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+from contextlib import suppress
 from typing import Any, Literal
 
 from haystack import default_from_dict, default_to_dict, logging
@@ -110,12 +111,25 @@ class MongoDBAtlasDocumentStore:
         self._collection: Collection | None = None
         self._collection_async: AsyncCollection | None = None
 
-    def __del__(self) -> None:
+    def close(self) -> None:
         """
-        Destructor method to close MongoDB connections when the instance is destroyed.
+        Release the associated synchronous resources.
         """
-        if self._connection:
-            self._connection.close()
+        if self._connection is not None:
+            with suppress(Exception):
+                self._connection.close()
+            self._connection = None
+            self._collection = None
+
+    async def close_async(self) -> None:
+        """
+        Release the associated asynchronous resources.
+        """
+        if self._connection_async is not None:
+            with suppress(Exception):
+                await self._connection_async.close()
+            self._connection_async = None
+            self._collection_async = None
 
     @property
     def connection(self) -> AsyncMongoClient | MongoClient:

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -134,6 +134,22 @@ class TestMongoDBDocumentStoreUnit:
         assert pipeline[1]["$match"] == {"_id": {"$regex": "val", "$options": "i"}}
         assert pipeline[2]["$facet"]["values"][2]["$limit"] == 2
 
+    def test_close(self, local_store):
+        connection = MagicMock()
+        local_store._connection = connection
+        local_store.close()
+        connection.close.assert_called_once()
+        assert local_store._connection is None
+        local_store.close()
+        connection.close.assert_called_once()
+
+    def test_close_is_exception_safe(self, local_store):
+        connection = MagicMock()
+        connection.close.side_effect = RuntimeError("boom")
+        local_store._connection = connection
+        local_store.close()
+        assert local_store._connection is None
+
 
 class TestMongoDBDocumentStoreConversion:
     def test_haystack_doc_to_mongo_doc_with_unsupported_fields(self, local_store):
@@ -371,3 +387,10 @@ class TestDocumentStore(
         new_docs = [Document(id="3", content="third doc")]
         document_store.write_documents(new_docs)
         assert document_store.count_documents() == 1
+
+    def test_close_and_reopen(self, document_store: MongoDBAtlasDocumentStore):
+        document_store.count_documents()
+        assert document_store._connection is not None
+        document_store.close()
+        assert document_store._connection is None
+        assert document_store.count_documents() == 0

--- a/integrations/mongodb_atlas/tests/test_document_store_async.py
+++ b/integrations/mongodb_atlas/tests/test_document_store_async.py
@@ -97,6 +97,22 @@ class TestMongoDBDocumentStoreAsyncUnit:
         assert pipeline[1]["$match"] == {"_id": {"$regex": "val", "$options": "i"}}
         assert pipeline[2]["$facet"]["values"][2]["$limit"] == 2
 
+    async def test_close_async(self, local_store):
+        connection = AsyncMock()
+        local_store._connection_async = connection
+        await local_store.close_async()
+        connection.close.assert_awaited_once()
+        assert local_store._connection_async is None
+        await local_store.close_async()
+        connection.close.assert_awaited_once()
+
+    async def test_close_async_is_exception_safe(self, local_store):
+        connection = AsyncMock()
+        connection.close.side_effect = RuntimeError("boom")
+        local_store._connection_async = connection
+        await local_store.close_async()
+        assert local_store._connection_async is None
+
 
 @pytest.mark.skipif(not os.environ.get("MONGO_CONNECTION_STRING"), reason="No MongoDBAtlas connection string provided")
 @pytest.mark.integration
@@ -161,3 +177,10 @@ class TestDocumentStoreAsync(
         new_docs = [Document(id="3", content="third doc")]
         await document_store.write_documents_async(new_docs)
         assert await document_store.count_documents_async() == 1
+
+    async def test_close_async_and_reopen(self, document_store: MongoDBAtlasDocumentStore):
+        await document_store.count_documents_async()
+        assert document_store._connection_async is not None
+        await document_store.close_async()
+        assert document_store._connection_async is None
+        assert await document_store.count_documents_async() == 0

--- a/integrations/mongodb_atlas/tests/test_retriever.py
+++ b/integrations/mongodb_atlas/tests/test_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from haystack.dataclasses import Document
@@ -145,6 +145,19 @@ class TestRetriever:
         assert retriever.filters == {"field": "value"}
         assert retriever.top_k == 5
         assert retriever.filter_policy == FilterPolicy.REPLACE
+
+    def test_close(self, case, mock_store):
+        retriever = case["retriever_cls"](document_store=mock_store)
+        retriever.close()
+        mock_store.close.assert_called_once()
+        assert retriever.document_store is mock_store
+
+    async def test_close_async(self, case, mock_store):
+        mock_store.close_async = AsyncMock()
+        retriever = case["retriever_cls"](document_store=mock_store)
+        await retriever.close_async()
+        mock_store.close_async.assert_awaited_once()
+        assert retriever.document_store is mock_store
 
     def test_run(self, case, mock_store):
         getattr(mock_store, case["sync_method"]).return_value = [case["doc"]]


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- implement methods to release resources

### How did you test it?
CI + new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
