### PR TITLE
feat: arangodb - add closing methods

### DIFF
--- a/integrations/arangodb/src/haystack_integrations/components/retrievers/arangodb/embedding_retriever.py
+++ b/integrations/arangodb/src/haystack_integrations/components/retrievers/arangodb/embedding_retriever.py
@@ -100,3 +100,9 @@ class ArangoEmbeddingRetriever:
             data["init_parameters"]["document_store"]
         )
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()

--- a/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/document_store.py
+++ b/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+from contextlib import suppress
 from typing import Any, Literal, cast
 
 from arango import ArangoClient
@@ -102,6 +103,7 @@ class ArangoDocumentStore:
         self.embedding_dimension = embedding_dimension
         self.recreate_collection = recreate_collection
         self.similarity_function = similarity_function
+        self._client: ArangoClient | None = None
         self._db: StandardDatabase | None = None
         self._col: StandardCollection | None = None
 
@@ -119,6 +121,7 @@ class ArangoDocumentStore:
             db.delete_collection(self.collection_name)
         if not db.has_collection(self.collection_name):
             db.create_collection(self.collection_name)
+        self._client = client
         self._db = db
         self._col = db.collection(self.collection_name)
 
@@ -348,3 +351,14 @@ class ArangoDocumentStore:
         """
         deserialize_secrets_inplace(data["init_parameters"], ["password", "username"])
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the associated synchronous resources.
+        """
+        if self._client is not None:
+            with suppress(Exception):
+                self._client.close()
+            self._client = None
+            self._db = None
+            self._col = None

--- a/integrations/arangodb/tests/test_document_store.py
+++ b/integrations/arangodb/tests/test_document_store.py
@@ -296,6 +296,30 @@ class TestArangoDocumentStoreVectorIndex:
         store._col.add_index.assert_not_called()
 
 
+class TestArangoDocumentStoreClose:
+    def test_close(self):
+        store = _make_store()
+        client = MagicMock()
+        store._client = client
+        store._db = MagicMock()
+        store._col = MagicMock()
+        store.close()
+        client.close.assert_called_once()
+        assert store._client is None
+        assert store._db is None
+        assert store._col is None
+        store.close()
+        client.close.assert_called_once()
+
+    def test_close_is_exception_safe(self):
+        store = _make_store()
+        client = MagicMock()
+        client.close.side_effect = RuntimeError("boom")
+        store._client = client
+        store.close()
+        assert store._client is None
+
+
 class TestArangoDocumentStoreEmbeddingRetrieval:
     def test_embedding_retrieval(self):
         store = _make_store()
@@ -376,6 +400,12 @@ class TestArangoDocumentStoreIntegration(DocumentStoreBaseTests):
     def test_write_documents(self, document_store):
         docs = [Document(content="doc1"), Document(content="doc2")]
         assert document_store.write_documents(docs) == 2
+
+    def test_close_and_reopen(self, document_store):
+        assert document_store.count_documents() == 0
+        document_store.close()
+        assert document_store._client is None
+        assert document_store.count_documents() == 0
 
     @pytest.fixture
     def document_store(self, request):

--- a/integrations/arangodb/tests/test_embedding_retriever.py
+++ b/integrations/arangodb/tests/test_embedding_retriever.py
@@ -108,6 +108,13 @@ class TestArangoEmbeddingRetriever:
         with pytest.raises(ValueError, match="ArangoDocumentStore"):
             ArangoEmbeddingRetriever(document_store=MagicMock())
 
+    def test_close(self):
+        mock_store = MagicMock(spec=ArangoDocumentStore)
+        retriever = ArangoEmbeddingRetriever(document_store=mock_store)
+        retriever.close()
+        mock_store.close.assert_called_once()
+        assert retriever.document_store is mock_store
+
 
 @pytest.mark.integration
 class TestArangoEmbeddingRetrieverIntegration:


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- implement methods to close resources
  - this DB is sync-only so just `close`
  - we need to store the client in the object to actually release resources

### How did you test it?
CI + new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
