### PR TITLE
fix (pgvector): fix error messages to say pgvector instead of pinecone

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -227,14 +227,14 @@ def _less_than_equal(field: Composable, value: Any) -> tuple[Composed, Any]:
 
 def _not_in(field: Composable, value: Any) -> tuple[Composed, list]:
     if not isinstance(value, list):
-        msg = f"{field}'s value must be a list when using 'not in' comparator in Pinecone"
+        msg = f"{field}'s value must be a list when using 'not in' comparator in PgVector"
         raise FilterError(msg)
     return SQL("{} IS NULL OR {} != ALL(%s)").format(field, field), [value]
 
 
 def _in(field: Composable, value: Any) -> tuple[Composed, list]:
     if not isinstance(value, list):
-        msg = f"{field}'s value must be a list when using 'in' comparator in Pinecone"
+        msg = f"{field}'s value must be a list when using 'in' comparator in PgVector"
         raise FilterError(msg)
 
     # see https://www.psycopg.org/psycopg3/docs/basic/adapt.html#lists-adaptation

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -183,6 +183,42 @@ def test_comparison_condition_unknown_operator():
         _parse_comparison_condition(condition)
 
 
+def test_comparison_condition_in_requires_list_value():
+    condition = {"field": "meta.author", "operator": "in", "value": "not-a-list"}
+    with pytest.raises(FilterError, match="'in' comparator in PgVector"):
+        _parse_comparison_condition(condition)
+
+
+def test_comparison_condition_not_in_requires_list_value():
+    condition = {"field": "meta.author", "operator": "not in", "value": "not-a-list"}
+    with pytest.raises(FilterError, match="'not in' comparator in PgVector"):
+        _parse_comparison_condition(condition)
+
+
+@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
+def test_comparison_condition_range_operator_rejects_non_iso_string(operator):
+    # pgvector-specific: strings are only comparable with range operators if ISO-formatted dates.
+    condition = {"field": "meta.date", "operator": operator, "value": "not-a-date"}
+    with pytest.raises(FilterError, match="Strings are only comparable if they are ISO formatted dates"):
+        _parse_comparison_condition(condition)
+
+
+@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
+def test_comparison_condition_range_operator_rejects_list_value(operator):
+    # pgvector-specific: list/Jsonb values are not valid operands for range operators.
+    condition = {"field": "meta.number", "operator": operator, "value": [1, 2, 3]}
+    with pytest.raises(FilterError, match="Filter value can't be of type"):
+        _parse_comparison_condition(condition)
+
+
+@pytest.mark.parametrize("operator", ["like", "not like"])
+def test_comparison_condition_like_operator_requires_str_value(operator):
+    # pgvector-specific: LIKE / NOT LIKE require a string operand.
+    condition = {"field": "meta.name", "operator": operator, "value": 123}
+    with pytest.raises(FilterError, match="must be a str when using 'LIKE'"):
+        _parse_comparison_condition(condition)
+
+
 def test_logical_condition_missing_operator():
     condition = {"conditions": []}
     with pytest.raises(FilterError):

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -183,34 +183,6 @@ def test_comparison_condition_unknown_operator():
         _parse_comparison_condition(condition)
 
 
-def test_comparison_condition_in_requires_list_value():
-    condition = {"field": "meta.author", "operator": "in", "value": "not-a-list"}
-    with pytest.raises(FilterError, match="'in' comparator in PgVector"):
-        _parse_comparison_condition(condition)
-
-
-def test_comparison_condition_not_in_requires_list_value():
-    condition = {"field": "meta.author", "operator": "not in", "value": "not-a-list"}
-    with pytest.raises(FilterError, match="'not in' comparator in PgVector"):
-        _parse_comparison_condition(condition)
-
-
-@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
-def test_comparison_condition_range_operator_rejects_non_iso_string(operator):
-    # pgvector-specific: strings are only comparable with range operators if ISO-formatted dates.
-    condition = {"field": "meta.date", "operator": operator, "value": "not-a-date"}
-    with pytest.raises(FilterError, match="Strings are only comparable if they are ISO formatted dates"):
-        _parse_comparison_condition(condition)
-
-
-@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
-def test_comparison_condition_range_operator_rejects_list_value(operator):
-    # pgvector-specific: list/Jsonb values are not valid operands for range operators.
-    condition = {"field": "meta.number", "operator": operator, "value": [1, 2, 3]}
-    with pytest.raises(FilterError, match="Filter value can't be of type"):
-        _parse_comparison_condition(condition)
-
-
 @pytest.mark.parametrize("operator", ["like", "not like"])
 def test_comparison_condition_like_operator_requires_str_value(operator):
     # pgvector-specific: LIKE / NOT LIKE require a string operand.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Some left over error messages mentioned the wrong db

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
