### PR TITLE
fix(alloydb): parenthesize `not in` clause so it does not escape an AND filter

### DIFF
--- a/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/filters.py
+++ b/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/filters.py
@@ -229,7 +229,7 @@ def _not_in(field: Composable, value: Any) -> tuple[Composed, list]:
     if not isinstance(value, list):
         msg = f"{field}'s value must be a list when using 'not in' comparator in AlloyDB"
         raise FilterError(msg)
-    return SQL("{} IS NULL OR {} != ALL(%s)").format(field, field), [value]
+    return SQL("({} IS NULL OR {} != ALL(%s))").format(field, field), [value]
 
 
 def _in(field: Composable, value: Any) -> tuple[Composed, list]:

--- a/integrations/alloydb/tests/test_filters.py
+++ b/integrations/alloydb/tests/test_filters.py
@@ -138,34 +138,6 @@ def test_comparison_condition_unknown_operator():
         _parse_comparison_condition(condition)
 
 
-def test_comparison_condition_in_requires_list_value():
-    condition = {"field": "meta.author", "operator": "in", "value": "not-a-list"}
-    with pytest.raises(FilterError, match="'in' comparator in AlloyDB"):
-        _parse_comparison_condition(condition)
-
-
-def test_comparison_condition_not_in_requires_list_value():
-    condition = {"field": "meta.author", "operator": "not in", "value": "not-a-list"}
-    with pytest.raises(FilterError, match="'not in' comparator in AlloyDB"):
-        _parse_comparison_condition(condition)
-
-
-@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
-def test_comparison_condition_range_operator_rejects_non_iso_string(operator):
-    # AlloyDB-specific: strings are only comparable with range operators if ISO-formatted dates.
-    condition = {"field": "meta.date", "operator": operator, "value": "not-a-date"}
-    with pytest.raises(FilterError, match="Strings are only comparable if they are ISO formatted dates"):
-        _parse_comparison_condition(condition)
-
-
-@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
-def test_comparison_condition_range_operator_rejects_list_value(operator):
-    # AlloyDB-specific: list/Jsonb values are not valid operands for range operators.
-    condition = {"field": "meta.number", "operator": operator, "value": [1, 2, 3]}
-    with pytest.raises(FilterError, match="Filter value can't be of type"):
-        _parse_comparison_condition(condition)
-
-
 @pytest.mark.parametrize("operator", ["like", "not like"])
 def test_comparison_condition_like_operator_requires_str_value(operator):
     # AlloyDB-specific: LIKE / NOT LIKE require a string operand.

--- a/integrations/alloydb/tests/test_filters.py
+++ b/integrations/alloydb/tests/test_filters.py
@@ -138,6 +138,61 @@ def test_comparison_condition_unknown_operator():
         _parse_comparison_condition(condition)
 
 
+def test_comparison_condition_in_requires_list_value():
+    condition = {"field": "meta.author", "operator": "in", "value": "not-a-list"}
+    with pytest.raises(FilterError, match="'in' comparator in AlloyDB"):
+        _parse_comparison_condition(condition)
+
+
+def test_comparison_condition_not_in_requires_list_value():
+    condition = {"field": "meta.author", "operator": "not in", "value": "not-a-list"}
+    with pytest.raises(FilterError, match="'not in' comparator in AlloyDB"):
+        _parse_comparison_condition(condition)
+
+
+@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
+def test_comparison_condition_range_operator_rejects_non_iso_string(operator):
+    # AlloyDB-specific: strings are only comparable with range operators if ISO-formatted dates.
+    condition = {"field": "meta.date", "operator": operator, "value": "not-a-date"}
+    with pytest.raises(FilterError, match="Strings are only comparable if they are ISO formatted dates"):
+        _parse_comparison_condition(condition)
+
+
+@pytest.mark.parametrize("operator", [">", ">=", "<", "<="])
+def test_comparison_condition_range_operator_rejects_list_value(operator):
+    # AlloyDB-specific: list/Jsonb values are not valid operands for range operators.
+    condition = {"field": "meta.number", "operator": operator, "value": [1, 2, 3]}
+    with pytest.raises(FilterError, match="Filter value can't be of type"):
+        _parse_comparison_condition(condition)
+
+
+@pytest.mark.parametrize("operator", ["like", "not like"])
+def test_comparison_condition_like_operator_requires_str_value(operator):
+    # AlloyDB-specific: LIKE / NOT LIKE require a string operand.
+    condition = {"field": "meta.name", "operator": operator, "value": 123}
+    with pytest.raises(FilterError, match="must be a str when using"):
+        _parse_comparison_condition(condition)
+
+
+def test_logical_condition_not_in_is_parenthesized_when_and_combined():
+    # `not in` renders an internal `OR` (`IS NULL OR != ALL`). Without surrounding
+    # parentheses that `OR` escapes an enclosing `AND` (AND binds tighter than OR in
+    # SQL), so an AND-combined `not in` would wrongly match documents.
+    condition = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.number", "operator": "==", "value": 5},
+            {"field": "meta.author", "operator": "not in", "value": ["John", "Jane"]},
+        ],
+    }
+    query, values = _parse_logical_condition(condition)
+    assert isinstance(query, Composed)
+
+    expected_sql = "((meta->>'number')::integer = %s AND (meta->>'author' IS NULL OR meta->>'author' != ALL(%s)))"
+    assert _render(query) == expected_sql
+    assert values == [5, [["John", "Jane"]]]
+
+
 def test_logical_condition_missing_operator():
     condition = {"conditions": []}
     with pytest.raises(FilterError):


### PR DESCRIPTION
### Related Issues

- found by reviewing similar issue in pgvector https://github.com/deepset-ai/haystack-core-integrations/pull/3586

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Same change as in https://github.com/deepset-ai/haystack-core-integrations/pull/3586

Wrap the expression in parentheses so the internal `OR` stays grouped:

```python
return SQL("({} IS NULL OR {} != ALL(%s))").format(field, field), [value]
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

- Added `test_logical_condition_not_in_is_parenthesized_when_and_combined`, which AND-combines `not in` with another condition and asserts the `not in` clause is parenthesized. It fails before the change (the `OR` escapes the `AND`) and passes after.
- Also added some additional unit tests that test filter errors that can occur

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
