### PR TITLE
test: Azure AI Search - fix test_count_unique_metadata_by_filter_with_multiple_filters for 3.0 changes

### DIFF
--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -677,7 +677,7 @@ class TestDocumentStore(
 
     @pytest.mark.parametrize(
         "document_store",
-        [{"metadata_fields": {"category": str, "year": int}}],
+        [{"metadata_fields": {"category": str, "year": int, "status": str}}],
         indirect=True,
     )
     def test_count_unique_metadata_by_filter_with_multiple_filters(self, document_store: AzureAISearchDocumentStore):


### PR DESCRIPTION
### Related Issues

- failing test: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/29969125312
- in https://github.com/deepset-ai/haystack/pull/12045, metadata fields have been changed but Azure AI Search needs them to be declared upfront

### Proposed Changes:
- fix the test

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
