### PR TITLE
feat: Chroma - add sync closing methods

### DIFF
--- a/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
+++ b/integrations/chroma/src/haystack_integrations/components/retrievers/chroma/retriever.py
@@ -119,6 +119,12 @@ class ChromaQueryTextRetriever:
         top_k = top_k or self.top_k
         return {"documents": (await self.document_store.search_async([query], top_k, filters))[0]}
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ChromaQueryTextRetriever":
         """
@@ -237,6 +243,12 @@ class ChromaEmbeddingRetriever:
 
         query_embeddings = [query_embedding]
         return {"documents": (await self.document_store.search_embeddings_async(query_embeddings, top_k, filters))[0]}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ChromaEmbeddingRetriever":

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence
+from contextlib import suppress
 from typing import Any, Literal, cast
 
 import chromadb
+from chromadb.api import ClientAPI
 from chromadb.api.models.AsyncCollection import AsyncCollection
 from chromadb.api.types import GetResult, Metadata, OneOrMany, QueryResult
 from chromadb.config import Settings
@@ -101,6 +103,7 @@ class ChromaDocumentStore:
         self._host = host
         self._port = port
 
+        self._client: ClientAPI | None = None
         self._collection: chromadb.Collection | None = None
         self._async_collection: AsyncCollection | None = None
 
@@ -138,7 +141,7 @@ class ChromaDocumentStore:
                 # Local persistent storage
                 client = chromadb.PersistentClient(path=self._persist_path, **client_kwargs)
 
-            self._client = client  # store client for potential future use
+            self._client = client
 
             # Build the collection metadata locally so `self._metadata` stays exactly as the user passed it.
             # This keeps `to_dict()` deterministic and avoids mutating a user-supplied dict in place.
@@ -212,6 +215,15 @@ class ChromaDocumentStore:
                     metadata=collection_metadata,
                     embedding_function=self._embedding_func,
                 )
+
+    def close(self) -> None:
+        """Release the associated synchronous resources."""
+        if self._client is not None:
+            with suppress(Exception):
+                # `close` is not declared on the `ClientAPI` interface, but the concrete Chroma clients implement it
+                self._client.close()  # type: ignore[attr-defined]
+            self._client = None
+            self._collection = None
 
     @staticmethod
     def _prepare_get_kwargs(filters: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -904,6 +916,7 @@ class ChromaDocumentStore:
         """
         self._ensure_initialized()  # _ensure_initialized ensures _client is not None and a collection exists
         assert self._collection is not None
+        assert self._client is not None
 
         try:
             if recreate_index:

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -180,6 +180,29 @@ class TestDocumentStoreUnit:
             with pytest.raises(ValueError, match="Invalid client_settings"):
                 store._ensure_initialized()
 
+    def test_close(self):
+        store = ChromaDocumentStore()
+        client = mock.Mock()
+        store._client = client
+
+        store.close()
+
+        client.close.assert_called_once()
+        assert store._client is None
+
+        store.close()
+        client.close.assert_called_once()
+
+    def test_close_is_exception_safe(self):
+        store = ChromaDocumentStore()
+        client = mock.Mock()
+        client.close.side_effect = RuntimeError("boom")
+        store._client = client
+
+        store.close()
+
+        assert store._client is None
+
     def test_infer_type_from_value_fallback_for_unknown_type(self):
         assert ChromaDocumentStore._infer_type_from_value(None) == "keyword"
         assert ChromaDocumentStore._infer_type_from_value(["a", "b"]) == "keyword"
@@ -377,6 +400,16 @@ class TestDocumentStore(
         )
         assert store._collection.metadata["hnsw:space"] == "ip"
         assert new_store._collection.metadata["hnsw:space"] == "ip"
+
+    def test_close_and_reopen(self, tmp_path):
+        store = ChromaDocumentStore(collection_name="test_close_and_reopen", persist_path=str(tmp_path))
+        store.write_documents([Document(content="doc", embedding=TEST_EMBEDDING_1)])
+        assert store.count_documents() == 1
+
+        store.close()
+        assert store._client is None
+
+        assert store.count_documents() == 1
 
     def test_delete_empty(self, document_store: ChromaDocumentStore):
         """

--- a/integrations/chroma/tests/test_retriever.py
+++ b/integrations/chroma/tests/test_retriever.py
@@ -106,6 +106,15 @@ class TestChromaQueryTextRetriever:
         assert retriever.top_k == 42
         assert retriever.filter_policy == FilterPolicy.REPLACE  # default even if not specified
 
+    def test_close(self):
+        ds = mock.Mock(spec=ChromaDocumentStore)
+        retriever = ChromaQueryTextRetriever(ds)
+
+        retriever.close()
+
+        ds.close.assert_called_once()
+        assert retriever.document_store is ds
+
     def test_run_delegates_to_document_store_search(self):
         ds = mock.Mock(spec=ChromaDocumentStore)
         expected = [Document(content="hit")]
@@ -214,6 +223,15 @@ class TestChromaEmbeddingRetriever:
         }
         retriever = ChromaEmbeddingRetriever.from_dict(data)
         assert retriever.filter_policy == FilterPolicy.REPLACE
+
+    def test_close(self):
+        ds = mock.Mock(spec=ChromaDocumentStore)
+        retriever = ChromaEmbeddingRetriever(ds)
+
+        retriever.close()
+
+        ds.close.assert_called_once()
+        assert retriever.document_store is ds
 
     def test_run_delegates_to_document_store_search_embeddings(self):
         ds = mock.Mock(spec=ChromaDocumentStore)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- add methods to release resources
  - only sync because Chroma surprisingly does not provide a way to close the asynchronous client

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
