### PR TITLE
feat: FalkorDB - add closing methods

### DIFF
--- a/integrations/falkordb/src/haystack_integrations/components/retrievers/falkordb/cypher_retriever.py
+++ b/integrations/falkordb/src/haystack_integrations/components/retrievers/falkordb/cypher_retriever.py
@@ -111,3 +111,9 @@ class FalkorDBCypherRetriever:
         )
 
         return {"documents": docs}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()

--- a/integrations/falkordb/src/haystack_integrations/components/retrievers/falkordb/embedding_retriever.py
+++ b/integrations/falkordb/src/haystack_integrations/components/retrievers/falkordb/embedding_retriever.py
@@ -118,3 +118,9 @@ class FalkorDBEmbeddingRetriever:
         )
 
         return {"documents": docs}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()

--- a/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
+++ b/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import re
+from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime
 from typing import Any, Literal
@@ -166,6 +167,17 @@ class FalkorDBDocumentStore(DocumentStore):
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["password"])
         return default_from_dict(cls, data)
+
+    def close(self) -> None:
+        """
+        Release the associated synchronous resources.
+        """
+        if self.client is not None:
+            with suppress(Exception):
+                self.client.close()
+            self.client = None
+            self.graph = None
+            self.initialized = False
 
     # ------------------------------------------------------------------
     # Internal connection helpers

--- a/integrations/falkordb/tests/test_document_store.py
+++ b/integrations/falkordb/tests/test_document_store.py
@@ -383,6 +383,31 @@ class TestFalkorDBDocumentStoreUnit:
         assert values == ["A", "B"]
         assert cursor == {"offset": 2}
 
+    def test_close(self):
+        store = FalkorDBDocumentStore()
+        client = MagicMock()
+        store.client = client
+        store.initialized = True
+
+        store.close()
+
+        client.close.assert_called_once()
+        assert store.client is None
+
+        store.close()
+        client.close.assert_called_once()
+
+    def test_close_is_exception_safe(self):
+        store = FalkorDBDocumentStore()
+        client = MagicMock()
+        client.close.side_effect = RuntimeError("boom")
+        store.client = client
+        store.initialized = True
+
+        store.close()
+
+        assert store.client is None
+
 
 @pytest.mark.integration
 class TestDocumentStore(
@@ -445,6 +470,12 @@ class TestDocumentStore(
         doc = Document(content="test doc")
         assert document_store.write_documents([doc]) == 1
         self.assert_documents_are_equal(document_store.filter_documents(), [doc])
+
+    def test_close_and_reopen(self, document_store):
+        assert document_store.count_documents() == 0
+        document_store.close()
+        assert document_store.client is None
+        assert document_store.count_documents() == 0
 
     @pytest.fixture
     def embedding_store(self):

--- a/integrations/falkordb/tests/test_retrievers.py
+++ b/integrations/falkordb/tests/test_retrievers.py
@@ -102,6 +102,15 @@ class TestFalkorDBEmbeddingRetriever:
         with pytest.raises(KeyError):
             FalkorDBEmbeddingRetriever.from_dict(data)
 
+    def test_close(self):
+        store = MagicMock(spec=FalkorDBDocumentStore)
+        retriever = FalkorDBEmbeddingRetriever(document_store=store)
+
+        retriever.close()
+
+        store.close.assert_called_once()
+        assert retriever.document_store is store
+
 
 class TestFalkorDBCypherRetriever:
     def test_init_invalid_store(self):
@@ -164,6 +173,15 @@ class TestFalkorDBCypherRetriever:
         }
         with pytest.raises(KeyError):
             FalkorDBCypherRetriever.from_dict(data)
+
+    def test_close(self):
+        store = MagicMock(spec=FalkorDBDocumentStore)
+        retriever = FalkorDBCypherRetriever(document_store=store)
+
+        retriever.close()
+
+        store.close.assert_called_once()
+        assert retriever.document_store is store
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- add methods to release resources
  - only sync because FalkorDB does not have async methods

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
