### PR TITLE
feat: IBM Db2 - lazy connection + closing methods

### DIFF
--- a/integrations/ibm_db/src/haystack_integrations/components/retrievers/ibm_db/embedding_retriever.py
+++ b/integrations/ibm_db/src/haystack_integrations/components/retrievers/ibm_db/embedding_retriever.py
@@ -76,6 +76,12 @@ class IBMDb2EmbeddingRetriever:
         )
         return {"documents": docs}
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.

--- a/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
+++ b/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import threading
+from contextlib import suppress
 from typing import Any, Literal
 
 import ibm_db_dbi  # type: ignore[import-untyped]
@@ -135,19 +136,19 @@ class IBMDb2DocumentStore:
         self.table_name = table_name
         self.embedding_dim = embedding_dim
         self.distance_metric = distance_metric
+        self.recreate_table = recreate_table
 
-        # Connection pool (lazy initialization)
+        # Connection and table are set up lazily on first use (see _get_connection)
         self._connection: ibm_db_dbi.Connection | None = None
         self._connection_lock = threading.Lock()
-
-        # Initialize table
-        self._ensure_table_exists(recreate=recreate_table)
+        self._table_initialized = False
 
     def _get_connection(self) -> ibm_db_dbi.Connection:
         """
-        Get or create a persistent database connection.
+        Get or create a persistent database connection and ensure the table exists.
 
-        Thread-safe lazy initialization with SSL support.
+        Thread-safe lazy initialization with SSL support. The table is created (or
+        recreated, if ``recreate_table`` was set) once, on the first call.
 
         :return: IBM Db2 connection object
         """
@@ -189,15 +190,33 @@ class IBMDb2DocumentStore:
 
                     self._connection = conn
 
+        if not self._table_initialized:
+            self._ensure_table_exists(recreate=self.recreate_table)
+            self._table_initialized = True
+
         return self._connection
+
+    def close(self) -> None:
+        """
+        Release the associated synchronous resources.
+        """
+        with self._connection_lock:
+            if self._connection is not None:
+                with suppress(Exception):
+                    self._connection.close()
+                self._connection = None
 
     def _ensure_table_exists(self, recreate: bool = False) -> None:
         """
         Ensure the document table exists in the database.
 
+        Assumes a live connection is already available (``self._connection``); it is
+        invoked from ``_get_connection`` right after the connection is established.
+
         :param recreate: If True, drop and recreate the table
         """
-        conn = self._get_connection()
+        assert self._connection is not None  # noqa: S101  # established by _get_connection before this call
+        conn = self._connection
 
         with conn.cursor() as cur:
             if recreate:
@@ -845,6 +864,7 @@ class IBMDb2DocumentStore:
             table_name=self.table_name,
             embedding_dim=self.embedding_dim,
             distance_metric=self.distance_metric,
+            recreate_table=self.recreate_table,
         )
 
     @classmethod

--- a/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
+++ b/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
@@ -152,7 +152,7 @@ class IBMDb2DocumentStore:
 
         :return: IBM Db2 connection object
         """
-        if self._connection is None:
+        if self._connection is None or not self._table_initialized:
             with self._connection_lock:
                 if self._connection is None:
                     # Build connection string
@@ -190,9 +190,9 @@ class IBMDb2DocumentStore:
 
                     self._connection = conn
 
-        if not self._table_initialized:
-            self._ensure_table_exists(recreate=self.recreate_table)
-            self._table_initialized = True
+                if not self._table_initialized:
+                    self._ensure_table_exists(recreate=self.recreate_table)
+                    self._table_initialized = True
 
         return self._connection
 

--- a/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
+++ b/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
@@ -138,7 +138,6 @@ class IBMDb2DocumentStore:
         self.distance_metric = distance_metric
         self.recreate_table = recreate_table
 
-        # Connection and table are set up lazily on first use (see _get_connection)
         self._connection: ibm_db_dbi.Connection | None = None
         self._connection_lock = threading.Lock()
         self._table_initialized = False

--- a/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
+++ b/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
@@ -146,52 +146,53 @@ class IBMDb2DocumentStore:
         """
         Get or create a persistent database connection and ensure the table exists.
 
-        Thread-safe lazy initialization with SSL support. The table is created (or
-        recreated, if ``recreate_table`` was set) once, on the first call.
+        Thread-safe lazy initialization with SSL support.
 
         :return: IBM Db2 connection object
         """
-        if self._connection is None or not self._table_initialized:
-            with self._connection_lock:
-                if self._connection is None:
-                    # Build connection string
-                    dsn = f"DATABASE={self.database};HOSTNAME={self.hostname};PORT={self.port};PROTOCOL={self.protocol}"
+        if self._connection is not None and self._table_initialized:
+            return self._connection
 
-                    # Add SSL configuration if enabled
-                    if self.use_ssl:
-                        dsn += ";SECURITY=SSL"
-                        if self.ssl_certificate:
-                            dsn += f";SSLServerCertificate={self.ssl_certificate}"
+        with self._connection_lock:
+            if self._connection is None:
+                # Build connection string
+                dsn = f"DATABASE={self.database};HOSTNAME={self.hostname};PORT={self.port};PROTOCOL={self.protocol}"
 
-                    # Set connection options (autocommit OFF by default)
-                    conn_options = {ibm_db_dbi.SQL_ATTR_AUTOCOMMIT: ibm_db_dbi.SQL_AUTOCOMMIT_OFF}
-                    if self.connection_options:
-                        conn_options.update(self.connection_options)
+                # Add SSL configuration if enabled
+                if self.use_ssl:
+                    dsn += ";SECURITY=SSL"
+                    if self.ssl_certificate:
+                        dsn += f";SSLServerCertificate={self.ssl_certificate}"
 
-                    # Create persistent connection
-                    conn = ibm_db_dbi.pconnect(
-                        dsn=dsn,
-                        user=self.username.resolve_value() or "",
-                        password=self.password.resolve_value() or "",
-                        conn_options=conn_options,
-                    )
+                # Set connection options (autocommit OFF by default)
+                conn_options = {ibm_db_dbi.SQL_ATTR_AUTOCOMMIT: ibm_db_dbi.SQL_AUTOCOMMIT_OFF}
+                if self.connection_options:
+                    conn_options.update(self.connection_options)
 
-                    # Set schema if specified
-                    if self.schema:
-                        with conn.cursor() as cur:
-                            try:
-                                cur.execute(f"SET SCHEMA {self.schema}")
-                                conn.commit()
-                            except Exception as e:
-                                conn.rollback()
-                                msg = f"Failed to set schema {self.schema}: {e}"
-                                raise RuntimeError(msg) from e
+                # Create persistent connection
+                conn = ibm_db_dbi.pconnect(
+                    dsn=dsn,
+                    user=self.username.resolve_value() or "",
+                    password=self.password.resolve_value() or "",
+                    conn_options=conn_options,
+                )
 
-                    self._connection = conn
+                # Set schema if specified
+                if self.schema:
+                    with conn.cursor() as cur:
+                        try:
+                            cur.execute(f"SET SCHEMA {self.schema}")
+                            conn.commit()
+                        except Exception as e:
+                            conn.rollback()
+                            msg = f"Failed to set schema {self.schema}: {e}"
+                            raise RuntimeError(msg) from e
 
-                if not self._table_initialized:
-                    self._ensure_table_exists(recreate=self.recreate_table)
-                    self._table_initialized = True
+                self._connection = conn
+
+            if not self._table_initialized:
+                self._ensure_table_exists(recreate=self.recreate_table)
+                self._table_initialized = True
 
         return self._connection
 
@@ -209,12 +210,9 @@ class IBMDb2DocumentStore:
         """
         Ensure the document table exists in the database.
 
-        Assumes a live connection is already available (``self._connection``); it is
-        invoked from ``_get_connection`` right after the connection is established.
-
         :param recreate: If True, drop and recreate the table
         """
-        assert self._connection is not None  # noqa: S101  # established by _get_connection before this call
+        assert self._connection is not None  # noqa: S101
         conn = self._connection
 
         with conn.cursor() as cur:

--- a/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
+++ b/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
@@ -7,13 +7,14 @@
 import json
 import logging
 import threading
-from contextlib import suppress
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from typing import Any, Literal
 
 import ibm_db_dbi  # type: ignore[import-untyped]
 from haystack import default_from_dict, default_to_dict
 from haystack.dataclasses import Document
-from haystack.document_stores.errors import DuplicateDocumentError
+from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.utils import Secret, deserialize_secrets_inplace
 
@@ -206,6 +207,26 @@ class IBMDb2DocumentStore:
                     self._connection.close()
                 self._connection = None
 
+    @contextmanager
+    def _transaction(self, error_msg: str) -> Iterator[Any]:
+        """
+        Yield a cursor for a unit of work, committing on success.
+
+        On any error the transaction is rolled back and the exception is re-raised
+        as a ``DocumentStoreError`` prefixed with ``error_msg``.
+
+        :param error_msg: Human-readable prefix for the wrapped error.
+        """
+        conn = self._get_connection()
+        with conn.cursor() as cur:
+            try:
+                yield cur
+                conn.commit()
+            except Exception as e:
+                conn.rollback()
+                msg = f"{error_msg}: {e}"
+                raise DocumentStoreError(msg) from e
+
     def _ensure_table_exists(self, recreate: bool = False) -> None:
         """
         Ensure the document table exists in the database.
@@ -295,16 +316,10 @@ class IBMDb2DocumentStore:
 
         :return: Number of documents
         """
-        conn = self._get_connection()
-
-        with conn.cursor() as cur:
-            try:
-                cur.execute(f"SELECT COUNT(*) FROM {self.table_name}")
-                result = cur.fetchone()
-                return result[0] if result else 0
-            except Exception as e:
-                msg = f"Failed to count documents: {e}"
-                raise RuntimeError(msg) from e
+        with self._transaction("Failed to count documents") as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {self.table_name}")
+            result = cur.fetchone()
+            return result[0] if result else 0
 
     def count_documents_by_filter(self, filters: dict[str, Any] | None = None) -> int:
         """
@@ -316,18 +331,13 @@ class IBMDb2DocumentStore:
         if not filters:
             return self.count_documents()
 
-        conn = self._get_connection()
         where_clause, params = self._build_where_clause(filters)
 
-        with conn.cursor() as cur:
-            try:
-                query = f"SELECT COUNT(*) FROM {self.table_name} {where_clause}"
-                cur.execute(query, params)
-                result = cur.fetchone()
-                return result[0] if result else 0
-            except Exception as e:
-                msg = f"Failed to count documents by filter: {e}"
-                raise RuntimeError(msg) from e
+        with self._transaction("Failed to count documents by filter") as cur:
+            query = f"SELECT COUNT(*) FROM {self.table_name} {where_clause}"
+            cur.execute(query, params)
+            result = cur.fetchone()
+            return result[0] if result else 0
 
     def write_documents(
         self,
@@ -364,21 +374,20 @@ class IBMDb2DocumentStore:
                     msg = f"Invalid embedding for document '{doc.id}': {e}"
                     raise type(e)(msg) from e
 
-        conn = self._get_connection()
-
         if policy in (DuplicatePolicy.NONE, DuplicatePolicy.FAIL):
-            return self._insert_documents(conn, documents)
+            return self._insert_documents(documents)
         elif policy == DuplicatePolicy.SKIP:
-            return self._skip_duplicate_documents(conn, documents)
+            return self._skip_duplicate_documents(documents)
         elif policy == DuplicatePolicy.OVERWRITE:
-            return self._upsert_documents(conn, documents)
+            return self._upsert_documents(documents)
         else:
             msg = f"Unsupported duplicate policy: {policy}"
             raise ValueError(msg)
 
-    def _insert_documents(self, conn: ibm_db_dbi.Connection, documents: list[Document]) -> int:
+    def _insert_documents(self, documents: list[Document]) -> int:
         """Insert documents and fail on duplicates via database integrity errors."""
         rows = [self._to_row(doc) for doc in documents]
+        conn = self._get_connection()
         with conn.cursor() as cur:
             sql = (
                 f"INSERT INTO {self.table_name} (id, content, meta, embedding) "
@@ -405,7 +414,7 @@ class IBMDb2DocumentStore:
                 raise
         return len(documents)
 
-    def _skip_duplicate_documents(self, conn: ibm_db_dbi.Connection, documents: list[Document]) -> int:
+    def _skip_duplicate_documents(self, documents: list[Document]) -> int:
         rows = [self._to_row(doc) for doc in documents]
         inserted_count = 0
         merge_sql = (
@@ -418,20 +427,14 @@ class IBMDb2DocumentStore:
             "INSERT (id, content, meta, embedding) "
             "VALUES (s.id, s.content, s.meta, s.embedding)"
         )
-        with conn.cursor() as cur:
-            try:
-                for row in rows:
-                    cur.execute(merge_sql, row)
-                    if cur.rowcount > 0:
-                        inserted_count += 1
-                conn.commit()
-            except Exception as e:
-                conn.rollback()
-                msg = f"Failed to skip duplicate documents: {e}"
-                raise RuntimeError(msg) from e
+        with self._transaction("Failed to skip duplicate documents") as cur:
+            for row in rows:
+                cur.execute(merge_sql, row)
+                if cur.rowcount > 0:
+                    inserted_count += 1
         return inserted_count
 
-    def _upsert_documents(self, conn: ibm_db_dbi.Connection, documents: list[Document]) -> int:
+    def _upsert_documents(self, documents: list[Document]) -> int:
         rows = [self._to_row(doc) for doc in documents]
         merge_sql = (
             f"MERGE INTO {self.table_name} AS t "
@@ -445,15 +448,9 @@ class IBMDb2DocumentStore:
             "INSERT (id, content, meta, embedding) "
             "VALUES (s.id, s.content, s.meta, s.embedding)"
         )
-        with conn.cursor() as cur:
-            try:
-                for row in rows:
-                    cur.execute(merge_sql, row)
-                conn.commit()
-            except Exception as e:
-                conn.rollback()
-                msg = f"Failed to upsert documents: {e}"
-                raise RuntimeError(msg) from e
+        with self._transaction("Failed to upsert documents") as cur:
+            for row in rows:
+                cur.execute(merge_sql, row)
         return len(documents)
 
     def filter_documents(self, filters: dict[str, Any] | None = None) -> list[Document]:
@@ -463,7 +460,6 @@ class IBMDb2DocumentStore:
         :param filters: Optional filter dictionary to constrain the returned documents.
         :return: List of matching documents.
         """
-        conn = self._get_connection()
         sql = f"SELECT id, content, SYSTOOLS.BSON2JSON(meta) AS meta, embedding FROM {self.table_name}"
         params: list[Any] = []
         if filters:
@@ -471,13 +467,9 @@ class IBMDb2DocumentStore:
             sql = f"{sql} {where_clause}"
         # Add ORDER BY to ensure consistent ordering for test reproducibility
         sql = f"{sql} ORDER BY id"
-        with conn.cursor() as cur:
-            try:
-                cur.execute(sql, params)
-                rows = cur.fetchall()
-            except Exception as e:
-                msg = f"Failed to filter documents: {e}"
-                raise RuntimeError(msg) from e
+        with self._transaction("Failed to filter documents") as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
         return [_row_to_document(row) for row in rows]
 
     def _build_where_clause(self, filters: dict[str, Any]) -> tuple[str, list[Any]]:
@@ -504,18 +496,10 @@ class IBMDb2DocumentStore:
         if not document_ids:
             return
 
-        conn = self._get_connection()
-
-        with conn.cursor() as cur:
-            try:
-                placeholders = ", ".join("?" for _ in document_ids)
-                sql = f"DELETE FROM {self.table_name} WHERE id IN ({placeholders})"
-                cur.execute(sql, document_ids)
-                conn.commit()
-            except Exception as e:
-                conn.rollback()
-                msg = f"Failed to delete documents: {e}"
-                raise RuntimeError(msg) from e
+        placeholders = ", ".join("?" for _ in document_ids)
+        sql = f"DELETE FROM {self.table_name} WHERE id IN ({placeholders})"
+        with self._transaction("Failed to delete documents") as cur:
+            cur.execute(sql, document_ids)
 
     def delete_by_filter(self, filters: dict[str, Any] | None = None) -> int:
         """
@@ -527,20 +511,11 @@ class IBMDb2DocumentStore:
         if not filters:
             return 0
 
-        conn = self._get_connection()
         where_clause, params = self._build_where_clause(filters)
 
-        with conn.cursor() as cur:
-            try:
-                sql = f"DELETE FROM {self.table_name} {where_clause}"
-                cur.execute(sql, params)
-                deleted_count = cur.rowcount
-                conn.commit()
-                return deleted_count
-            except Exception as e:
-                conn.rollback()
-                msg = f"Failed to delete documents by filter: {e}"
-                raise RuntimeError(msg) from e
+        with self._transaction("Failed to delete documents by filter") as cur:
+            cur.execute(f"DELETE FROM {self.table_name} {where_clause}", params)
+            return cur.rowcount
 
     def delete_all_documents(self, recreate_index: bool = False) -> int:
         """
@@ -549,29 +524,19 @@ class IBMDb2DocumentStore:
         :param recreate_index: If True, recreate the table after deletion
         :return: Number of documents deleted
         """
-        conn = self._get_connection()
+        with self._transaction("Failed to delete all documents") as cur:
+            # Count documents before deletion
+            cur.execute(f"SELECT COUNT(*) FROM {self.table_name}")
+            deleted_count = cur.fetchone()[0]
 
-        with conn.cursor() as cur:
-            try:
-                # Count documents before deletion
-                count_sql = f"SELECT COUNT(*) FROM {self.table_name}"
-                cur.execute(count_sql)
-                deleted_count = cur.fetchone()[0]
+            if recreate_index:
+                # Drop and recreate the table
+                self._ensure_table_exists(recreate=True)
+            else:
+                # Just delete all rows
+                cur.execute(f"DELETE FROM {self.table_name}")
 
-                if recreate_index:
-                    # Drop and recreate the table
-                    self._ensure_table_exists(recreate=True)
-                else:
-                    # Just delete all rows
-                    delete_sql = f"DELETE FROM {self.table_name}"
-                    cur.execute(delete_sql)
-                    conn.commit()
-
-                return deleted_count
-            except Exception as e:
-                conn.rollback()
-                msg = f"Failed to delete all documents: {e}"
-                raise RuntimeError(msg) from e
+            return deleted_count
 
     def update_by_filter(self, filters: dict[str, Any] | None = None, meta: dict[str, Any] | None = None) -> int:
         """
@@ -588,38 +553,31 @@ class IBMDb2DocumentStore:
         if not filters:
             return 0
 
-        conn = self._get_connection()
         where_clause, params = self._build_where_clause(filters)
 
-        with conn.cursor() as cur:
-            try:
-                # Db2 doesn't have a simple JSON merge operator like PostgreSQL's ||
-                # We need to read, merge, and update
-                # First, get the documents that match the filter
-                select_sql = f"SELECT id, SYSTOOLS.BSON2JSON(meta) AS meta FROM {self.table_name} {where_clause}"
-                cur.execute(select_sql, params)
-                rows = cur.fetchall()
+        with self._transaction("Failed to update documents by filter") as cur:
+            # Db2 doesn't have a simple JSON merge operator like PostgreSQL's ||
+            # We need to read, merge, and update
+            # First, get the documents that match the filter
+            select_sql = f"SELECT id, SYSTOOLS.BSON2JSON(meta) AS meta FROM {self.table_name} {where_clause}"
+            cur.execute(select_sql, params)
+            rows = cur.fetchall()
 
-                updated_count = 0
-                # Update each document
-                for row in rows:
-                    doc_id, meta_json = row
-                    existing_meta = json.loads(meta_json) if meta_json else {}
-                    # Merge the metadata
-                    existing_meta.update(meta)
-                    merged_meta_json = json.dumps(existing_meta)
+            updated_count = 0
+            # Update each document
+            for row in rows:
+                doc_id, meta_json = row
+                existing_meta = json.loads(meta_json) if meta_json else {}
+                # Merge the metadata
+                existing_meta.update(meta)
+                merged_meta_json = json.dumps(existing_meta)
 
-                    # Update the document
-                    update_sql = f"UPDATE {self.table_name} SET meta = SYSTOOLS.JSON2BSON(?) WHERE id = ?"
-                    cur.execute(update_sql, (merged_meta_json, doc_id))
-                    updated_count += 1
+                # Update the document
+                update_sql = f"UPDATE {self.table_name} SET meta = SYSTOOLS.JSON2BSON(?) WHERE id = ?"
+                cur.execute(update_sql, (merged_meta_json, doc_id))
+                updated_count += 1
 
-                conn.commit()
-                return updated_count
-            except Exception as e:
-                conn.rollback()
-                msg = f"Failed to update documents by filter: {e}"
-                raise RuntimeError(msg) from e
+            return updated_count
 
     def get_metadata_field_unique_values(self, field: str) -> list[Any]:
         """
@@ -631,24 +589,18 @@ class IBMDb2DocumentStore:
         # Strip 'meta.' prefix if present
         field_name = field.removeprefix("meta.")
 
-        conn = self._get_connection()
-
         # Extract values from the JSON metadata field
         # Db2 has issues with DISTINCT/GROUP BY on JSON_VALUE results (SQL0134N error)
         # So we fetch all values and deduplicate in Python
         # Use RETURNING VARCHAR to explicitly specify the return type
-        with conn.cursor() as cur:
-            try:
-                sql = (
-                    f"SELECT JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) "
-                    f"FROM {self.table_name} "
-                    f"WHERE JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) IS NOT NULL"
-                )
-                cur.execute(sql)
-                rows = cur.fetchall()
-            except Exception as e:
-                msg = f"Failed to get unique values for field '{field}': {e}"
-                raise RuntimeError(msg) from e
+        sql = (
+            f"SELECT JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) "
+            f"FROM {self.table_name} "
+            f"WHERE JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) IS NOT NULL"
+        )
+        with self._transaction(f"Failed to get unique values for field '{field}'") as cur:
+            cur.execute(sql)
+            rows = cur.fetchall()
 
         # Parse and deduplicate the values
         seen = set()
@@ -715,7 +667,7 @@ class IBMDb2DocumentStore:
                         return {"min": row[0], "max": row[1]}
                 except Exception as e:
                     msg = f"Failed to get min/max for field '{field}': {e}"
-                    raise RuntimeError(msg) from e
+                    raise DocumentStoreError(msg) from e
 
         return {"min": None, "max": None}
 
@@ -725,17 +677,11 @@ class IBMDb2DocumentStore:
 
         :return: Dictionary mapping field names to their type information
         """
-        conn = self._get_connection()
-
-        with conn.cursor() as cur:
-            try:
-                # Get all metadata from documents
-                sql = f"SELECT SYSTOOLS.BSON2JSON(meta) AS meta FROM {self.table_name} WHERE meta IS NOT NULL"
-                cur.execute(sql)
-                rows = cur.fetchall()
-            except Exception as e:
-                msg = f"Failed to get metadata fields info: {e}"
-                raise RuntimeError(msg) from e
+        # Get all metadata from documents
+        sql = f"SELECT SYSTOOLS.BSON2JSON(meta) AS meta FROM {self.table_name} WHERE meta IS NOT NULL"
+        with self._transaction("Failed to get metadata fields info") as cur:
+            cur.execute(sql)
+            rows = cur.fetchall()
 
         # Analyze the metadata to infer field types
         fields_info: dict[str, dict[str, Any]] = {}
@@ -775,7 +721,6 @@ class IBMDb2DocumentStore:
         if not metadata_fields:
             return {}
 
-        conn = self._get_connection()
         where_clause, params = self._build_where_clause(filters) if filters else ("", [])
 
         result = {}
@@ -785,23 +730,19 @@ class IBMDb2DocumentStore:
 
             # Count distinct values for this field
             # We need to fetch all values and deduplicate in Python due to Db2's JSON handling
-            with conn.cursor() as cur:
-                try:
-                    sql = (
-                        f"SELECT JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) "
-                        f"FROM {self.table_name} "
-                    )
-                    if where_clause:
-                        sql += where_clause + " AND "
-                    else:
-                        sql += "WHERE "
-                    sql += f"JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) IS NOT NULL"
+            sql = (
+                f"SELECT JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) "
+                f"FROM {self.table_name} "
+            )
+            if where_clause:
+                sql += where_clause + " AND "
+            else:
+                sql += "WHERE "
+            sql += f"JSON_VALUE(SYSTOOLS.BSON2JSON(meta), '$.{field_name}' RETURNING VARCHAR(1000)) IS NOT NULL"
 
-                    cur.execute(sql, params)
-                    rows = cur.fetchall()
-                except Exception as e:
-                    msg = f"Failed to count unique metadata for field '{field}': {e}"
-                    raise RuntimeError(msg) from e
+            with self._transaction(f"Failed to count unique metadata for field '{field}'") as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
 
             # Deduplicate values
             unique_values = set()

--- a/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
+++ b/integrations/ibm_db/src/haystack_integrations/document_stores/ibm_db/document_store.py
@@ -213,7 +213,7 @@ class IBMDb2DocumentStore:
         Yield a cursor for a unit of work, committing on success.
 
         On any error the transaction is rolled back and the exception is re-raised
-        as a ``DocumentStoreError`` prefixed with ``error_msg``.
+        as a `DocumentStoreError` prefixed with `error_msg`.
 
         :param error_msg: Human-readable prefix for the wrapped error.
         """

--- a/integrations/ibm_db/tests/test_document_store.py
+++ b/integrations/ibm_db/tests/test_document_store.py
@@ -161,57 +161,6 @@ class TestDocumentStore(
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents([doc])
 
-    @staticmethod
-    def _serializable_store(monkeypatch) -> IBMDb2DocumentStore:
-        """
-        Build a store whose credentials are env-var Secrets so it can be serialized.
-
-        The live ``document_store`` fixture uses ``Secret.from_token(...)``, which cannot
-        be serialized, so serialization tests build their own env-var-backed store.
-        """
-        monkeypatch.setenv("DB2_USERNAME", "db2inst1")
-        monkeypatch.setenv("DB2_PASSWORD", "Passw0rd123!")
-        return IBMDb2DocumentStore(
-            database="testdb",
-            hostname="localhost",
-            username=Secret.from_env_var("DB2_USERNAME"),
-            password=Secret.from_env_var("DB2_PASSWORD"),
-            embedding_dim=768,
-            distance_metric="COSINE",
-        )
-
-    def test_to_dict(self, monkeypatch):
-        """Test serializing document store to dictionary without exposing credentials."""
-        store = self._serializable_store(monkeypatch)
-        data = store.to_dict()
-
-        assert "type" in data
-        assert data["type"] == "haystack_integrations.document_stores.ibm_db.document_store.IBMDb2DocumentStore"
-        assert "init_parameters" in data
-
-        init_params = data["init_parameters"]
-        assert init_params["database"] == store.database
-        assert init_params["hostname"] == store.hostname
-        assert init_params["embedding_dim"] == 768
-        assert init_params["distance_metric"] == "COSINE"
-        assert init_params["recreate_table"] == store.recreate_table
-        # Credentials are serialized as env-var references, never as plaintext.
-        assert init_params["password"] == {"type": "env_var", "env_vars": ["DB2_PASSWORD"], "strict": True}
-
-    def test_from_dict(self, monkeypatch):
-        """Test deserializing document store from dictionary."""
-        store = self._serializable_store(monkeypatch)
-        data = store.to_dict()
-
-        new_store = IBMDb2DocumentStore.from_dict(data)
-
-        assert new_store.embedding_dim == store.embedding_dim
-        assert new_store.distance_metric == store.distance_metric
-        assert new_store.database == store.database
-        assert new_store.hostname == store.hostname
-        assert isinstance(new_store.username, Secret)
-        assert isinstance(new_store.password, Secret)
-
     def test_connection_reuse(self, document_store: IBMDb2DocumentStore):
         """Test that connection is reused across operations."""
         docs = [Document(id="1", content="test", embedding=[0.1] * 768)]
@@ -338,84 +287,118 @@ class TestIBMDb2DocumentStoreUtilMethods:
         assert IBMDb2DocumentStore._infer_field_type(value) == expected
 
 
+@pytest.fixture
+def unit_store(monkeypatch) -> IBMDb2DocumentStore:
+    monkeypatch.setenv("DB2_USERNAME", "db2inst1")
+    monkeypatch.setenv("DB2_PASSWORD", "Passw0rd123!")
+    return IBMDb2DocumentStore(
+        database="testdb",
+        hostname="localhost",
+        username=Secret.from_env_var("DB2_USERNAME"),
+        password=Secret.from_env_var("DB2_PASSWORD"),
+        embedding_dim=768,
+        distance_metric="COSINE",
+    )
+
+
 class TestIBMDb2DocumentStoreUnit:
     """Unit tests for IBMDb2DocumentStore that don't require a database."""
 
-    @staticmethod
-    def _unit_store() -> IBMDb2DocumentStore:
-        return IBMDb2DocumentStore(
-            database="testdb",
-            hostname="localhost",
-            username=Secret.from_token("db2inst1"),
-            password=Secret.from_token("Passw0rd123!"),
-        )
+    def test_init_is_lazy_and_does_not_connect(self, unit_store):
+        assert unit_store._connection is None
+        assert unit_store._table_initialized is False
 
-    def test_init_is_lazy_and_does_not_connect(self):
-        store = self._unit_store()
-        assert store._connection is None
-        assert store._table_initialized is False
+    def test_to_dict(self, unit_store):
+        """Test serializing document store to dictionary without exposing credentials."""
+        data = unit_store.to_dict()
 
-    def test_close(self):
-        store = self._unit_store()
+        assert "type" in data
+        assert data["type"] == "haystack_integrations.document_stores.ibm_db.document_store.IBMDb2DocumentStore"
+        assert "init_parameters" in data
+
+        init_params = data["init_parameters"]
+        assert init_params["database"] == unit_store.database
+        assert init_params["hostname"] == unit_store.hostname
+        assert init_params["embedding_dim"] == 768
+        assert init_params["distance_metric"] == "COSINE"
+        assert init_params["recreate_table"] == unit_store.recreate_table
+        # Credentials are serialized as env-var references, never as plaintext.
+        assert init_params["password"] == {"type": "env_var", "env_vars": ["DB2_PASSWORD"], "strict": True}
+
+    def test_from_dict(self, unit_store):
+        """Test deserializing document store from dictionary."""
+        data = unit_store.to_dict()
+
+        new_store = IBMDb2DocumentStore.from_dict(data)
+
+        assert new_store.embedding_dim == unit_store.embedding_dim
+        assert new_store.distance_metric == unit_store.distance_metric
+        assert new_store.database == unit_store.database
+        assert new_store.hostname == unit_store.hostname
+        assert isinstance(new_store.username, Secret)
+        assert isinstance(new_store.password, Secret)
+
+    def test_close(self, unit_store):
         mock_conn = Mock()
-        store._connection = mock_conn
+        unit_store._connection = mock_conn
 
-        store.close()
+        unit_store.close()
 
         mock_conn.close.assert_called_once()
-        assert store._connection is None
+        assert unit_store._connection is None
 
-        store.close()
+        unit_store.close()
         mock_conn.close.assert_called_once()
 
-    def test_close_is_exception_safe(self):
-        store = self._unit_store()
+    def test_close_is_exception_safe(self, unit_store):
         mock_conn = Mock()
         mock_conn.close.side_effect = RuntimeError("boom")
-        store._connection = mock_conn
+        unit_store._connection = mock_conn
 
-        store.close()
+        unit_store.close()
 
-        assert store._connection is None
+        assert unit_store._connection is None
 
-    def test_to_row_with_none_metadata(self, document_store):
+    def test_to_row_with_none_metadata(self, unit_store):
         """Test _to_row with None metadata."""
         doc = Document(id="1", content="test", meta=None, embedding=[0.1] * 768)
-        row = document_store._to_row(doc)
+        row = unit_store._to_row(doc)
 
         assert row[0] == "1"  # id
         assert row[1] == "test"  # content
         assert row[2] == "{}"  # meta should be empty JSON object
         assert row[3] is not None  # embedding
 
-    def test_to_row_with_none_embedding(self, document_store):
+    def test_to_row_with_none_embedding(self, unit_store):
         """Test _to_row with None embedding."""
         doc = Document(id="1", content="test", meta={"key": "value"}, embedding=None)
-        row = document_store._to_row(doc)
+        row = unit_store._to_row(doc)
 
         assert row[0] == "1"  # id
         assert row[1] == "test"  # content
         assert '"key"' in row[2]  # meta JSON
         assert row[3] is None  # embedding should be None
 
-    def test_build_where_clause_empty_filters(self, document_store):
+    def test_build_where_clause_empty_filters(self, unit_store):
         """Test _build_where_clause with empty filters."""
-        where_clause, params = document_store._build_where_clause({})
+        where_clause, params = unit_store._build_where_clause({})
         assert where_clause == ""
         assert params == []
 
-    def test_write_documents_invalid_type(self, document_store):
+    def test_write_documents_invalid_type(self, unit_store):
         """Test write_documents with invalid type."""
         with pytest.raises(ValueError, match="Expected a list of Document objects"):
-            document_store.write_documents("not a list")
+            unit_store.write_documents("not a list")
 
-    def test_write_documents_invalid_document_type(self, document_store):
+    def test_write_documents_invalid_document_type(self, unit_store):
         """Test write_documents with invalid document type in list."""
         with pytest.raises(ValueError, match="Expected Document objects"):
-            document_store.write_documents([{"id": "1", "content": "test"}])
+            unit_store.write_documents([{"id": "1", "content": "test"}])
 
-    def test_write_documents_unsupported_policy(self, document_store):
+    def test_write_documents_unsupported_policy(self, unit_store):
         """Test write_documents with unsupported duplicate policy."""
+        unit_store._connection = Mock()
+        unit_store._table_initialized = True
         doc = Document(id="1", content="test", embedding=[0.1] * 768)
 
         # Create a mock unsupported policy
@@ -423,7 +406,7 @@ class TestIBMDb2DocumentStoreUnit:
             pass
 
         with pytest.raises(ValueError, match="Unsupported duplicate policy"):
-            document_store.write_documents([doc], policy=UnsupportedPolicy())
+            unit_store.write_documents([doc], policy=UnsupportedPolicy())
 
     def test_row_to_document_with_none_values(self):
         """Test _row_to_document with None values."""

--- a/integrations/ibm_db/tests/test_document_store.py
+++ b/integrations/ibm_db/tests/test_document_store.py
@@ -168,7 +168,6 @@ class TestDocumentStore(
 
         The live ``document_store`` fixture uses ``Secret.from_token(...)``, which cannot
         be serialized, so serialization tests build their own env-var-backed store.
-        Construction is connection-free (setup is lazy), so no DB is needed.
         """
         monkeypatch.setenv("DB2_USERNAME", "db2inst1")
         monkeypatch.setenv("DB2_PASSWORD", "Passw0rd123!")
@@ -343,7 +342,7 @@ class TestIBMDb2DocumentStoreUnit:
     """Unit tests for IBMDb2DocumentStore that don't require a database."""
 
     @staticmethod
-    def _disconnected_store() -> IBMDb2DocumentStore:
+    def _unit_store() -> IBMDb2DocumentStore:
         return IBMDb2DocumentStore(
             database="testdb",
             hostname="localhost",
@@ -352,12 +351,12 @@ class TestIBMDb2DocumentStoreUnit:
         )
 
     def test_init_is_lazy_and_does_not_connect(self):
-        store = self._disconnected_store()
+        store = self._unit_store()
         assert store._connection is None
         assert store._table_initialized is False
 
     def test_close(self):
-        store = self._disconnected_store()
+        store = self._unit_store()
         mock_conn = Mock()
         store._connection = mock_conn
 
@@ -370,7 +369,7 @@ class TestIBMDb2DocumentStoreUnit:
         mock_conn.close.assert_called_once()
 
     def test_close_is_exception_safe(self):
-        store = self._disconnected_store()
+        store = self._unit_store()
         mock_conn = Mock()
         mock_conn.close.side_effect = RuntimeError("boom")
         store._connection = mock_conn

--- a/integrations/ibm_db/tests/test_document_store.py
+++ b/integrations/ibm_db/tests/test_document_store.py
@@ -6,11 +6,11 @@
 
 import math
 from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from haystack.dataclasses import Document
-from haystack.document_stores.errors import DuplicateDocumentError
+from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.testing.document_store import (
     CountDocumentsByFilterTest,
     CountDocumentsTest,
@@ -225,6 +225,20 @@ class TestDocumentStore(
         assert retrieved[0].meta["nested"]["level1"]["level2"]["level3"] == "deep"
         assert retrieved[0].meta["list"] == [1, 2, 3, "four"]
 
+    def test_embedding_retrieval(self, document_store: IBMDb2DocumentStore):
+        document_store.write_documents(
+            [
+                Document(id="a", content="alpha", embedding=[1.0, 0.0] + [0.0] * 766),
+                Document(id="b", content="beta", embedding=[0.0, 1.0] + [0.0] * 766),
+                Document(id="c", content="gamma", embedding=[0.9, 0.1] + [0.0] * 766),
+            ]
+        )
+
+        results = document_store._embedding_retrieval([1.0, 0.0] + [0.0] * 766, top_k=2)
+
+        assert [doc.id for doc in results] == ["a", "c"]
+        assert all(doc.score is not None for doc in results)
+
 
 class TestIBMDb2DocumentStoreUtilMethods:
     """Unit tests for pure utility methods: _parse_embedding, _validate_embedding, _infer_field_type."""
@@ -301,12 +315,119 @@ def unit_store(monkeypatch) -> IBMDb2DocumentStore:
     )
 
 
+@pytest.fixture
+def mocked_store(unit_store) -> tuple:
+    conn = MagicMock()
+    cursor_cm = conn.cursor.return_value
+    cursor_cm.__exit__.return_value = False
+    cur = cursor_cm.__enter__.return_value
+    unit_store._connection = conn
+    unit_store._table_initialized = True
+    return unit_store, conn, cur
+
+
+_FILTER = {"operator": "==", "field": "meta.k", "value": "v"}
+
+
 class TestIBMDb2DocumentStoreUnit:
     """Unit tests for IBMDb2DocumentStore that don't require a database."""
 
     def test_init_is_lazy_and_does_not_connect(self, unit_store):
         assert unit_store._connection is None
         assert unit_store._table_initialized is False
+
+    def test_get_connection_applies_ssl_options_and_schema(self, monkeypatch):
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value.__exit__.return_value = False
+        pconnect = Mock(return_value=fake_conn)
+        monkeypatch.setattr(
+            "haystack_integrations.document_stores.ibm_db.document_store.ibm_db_dbi.pconnect",
+            pconnect,
+        )
+        store = IBMDb2DocumentStore(
+            database="db",
+            hostname="h",
+            username=Secret.from_token("u"),
+            password=Secret.from_token("p"),
+            use_ssl=True,
+            ssl_certificate="certs/db2.arm",
+            connection_options={"foo": "bar"},
+            schema="myschema",
+        )
+        store._table_initialized = True
+
+        conn = store._get_connection()
+
+        assert conn is fake_conn
+        dsn = pconnect.call_args.kwargs["dsn"]
+        assert "SECURITY=SSL" in dsn
+        assert "SSLServerCertificate=certs/db2.arm" in dsn
+        assert pconnect.call_args.kwargs["conn_options"]["foo"] == "bar"
+        schema_cur = fake_conn.cursor.return_value.__enter__.return_value
+        executed = [c.args[0] for c in schema_cur.execute.call_args_list]
+        assert any("SET SCHEMA myschema" in s for s in executed)
+
+    def test_ensure_table_exists_drops_and_creates_when_recreate(self, mocked_store):
+        store, _, cur = mocked_store
+        cur.execute.side_effect = [None, Exception("table not found"), None]
+
+        store._ensure_table_exists(recreate=True)
+
+        executed = [call.args[0] for call in cur.execute.call_args_list]
+        assert any("DROP TABLE" in sql for sql in executed)
+        assert any("CREATE TABLE" in sql for sql in executed)
+
+    def test_ensure_table_exists_reraises_on_create_error(self, mocked_store):
+        store, conn, cur = mocked_store
+        cur.execute.side_effect = [Exception("table not found"), Exception("create failed")]
+
+        with pytest.raises(Exception, match="create failed"):
+            store._ensure_table_exists(recreate=False)
+
+        conn.rollback.assert_called()
+
+    def test_close(self, unit_store):
+        mock_conn = Mock()
+        unit_store._connection = mock_conn
+
+        unit_store.close()
+
+        mock_conn.close.assert_called_once()
+        assert unit_store._connection is None
+
+        unit_store.close()
+        mock_conn.close.assert_called_once()
+
+    def test_close_is_exception_safe(self, unit_store):
+        mock_conn = Mock()
+        mock_conn.close.side_effect = RuntimeError("boom")
+        unit_store._connection = mock_conn
+
+        unit_store.close()
+
+        assert unit_store._connection is None
+
+    def test_transaction_commits_on_success(self, mocked_store):
+        store, conn, cur = mocked_store
+
+        with store._transaction("unused on success") as transaction_cursor:
+            assert transaction_cursor is cur
+
+        conn.commit.assert_called_once()
+        conn.rollback.assert_not_called()
+
+    def test_transaction_rolls_back_and_wraps_error(self, mocked_store):
+        store, conn, _ = mocked_store
+        db_error = "unique constraint violated"
+
+        with (
+            pytest.raises(DocumentStoreError, match=f"delete failed: {db_error}"),
+            store._transaction("delete failed"),
+        ):
+            raise ValueError(db_error)
+
+        conn.rollback.assert_called_once()
+        conn.commit.assert_not_called()
 
     def test_to_dict(self, unit_store):
         """Test serializing document store to dictionary without exposing credentials."""
@@ -338,27 +459,6 @@ class TestIBMDb2DocumentStoreUnit:
         assert isinstance(new_store.username, Secret)
         assert isinstance(new_store.password, Secret)
 
-    def test_close(self, unit_store):
-        mock_conn = Mock()
-        unit_store._connection = mock_conn
-
-        unit_store.close()
-
-        mock_conn.close.assert_called_once()
-        assert unit_store._connection is None
-
-        unit_store.close()
-        mock_conn.close.assert_called_once()
-
-    def test_close_is_exception_safe(self, unit_store):
-        mock_conn = Mock()
-        mock_conn.close.side_effect = RuntimeError("boom")
-        unit_store._connection = mock_conn
-
-        unit_store.close()
-
-        assert unit_store._connection is None
-
     def test_to_row_with_none_metadata(self, unit_store):
         """Test _to_row with None metadata."""
         doc = Document(id="1", content="test", meta=None, embedding=[0.1] * 768)
@@ -378,6 +478,29 @@ class TestIBMDb2DocumentStoreUnit:
         assert row[1] == "test"  # content
         assert '"key"' in row[2]  # meta JSON
         assert row[3] is None  # embedding should be None
+
+    def test_row_to_document_with_none_values(self):
+        """Test _row_to_document with None values."""
+        # Test with None content and meta
+        row = ("doc_id", None, None, None)
+        doc = _row_to_document(row)
+
+        assert doc.id == "doc_id"
+        assert doc.content is None
+        assert doc.meta == {}
+        assert doc.embedding is None
+
+    def test_row_to_document_with_valid_embedding(self):
+        """Test _row_to_document with valid embedding."""
+        # Test with valid embedding (as tuple/list)
+        embedding_data = [0.1, 0.2, 0.3]
+        row = ("doc_id", "content", '{"key": "value"}', embedding_data)
+        doc = _row_to_document(row)
+
+        assert doc.id == "doc_id"
+        assert doc.content == "content"
+        assert doc.meta == {"key": "value"}
+        assert doc.embedding == [0.1, 0.2, 0.3]
 
     def test_build_where_clause_empty_filters(self, unit_store):
         """Test _build_where_clause with empty filters."""
@@ -408,25 +531,47 @@ class TestIBMDb2DocumentStoreUnit:
         with pytest.raises(ValueError, match="Unsupported duplicate policy"):
             unit_store.write_documents([doc], policy=UnsupportedPolicy())
 
-    def test_row_to_document_with_none_values(self):
-        """Test _row_to_document with None values."""
-        # Test with None content and meta
-        row = ("doc_id", None, None, None)
-        doc = _row_to_document(row)
+    def test_embedding_retrieval_returns_documents_with_scores(self, mocked_store):
+        store, _, cur = mocked_store
+        cur.fetchall.return_value = [
+            ("d1", "content one", '{"k": "v"}', [0.1, 0.2, 0.3, 0.4], 0.05),
+            ("d2", "content two", None, None, 0.2),
+        ]
 
-        assert doc.id == "doc_id"
-        assert doc.content is None
-        assert doc.meta == {}
-        assert doc.embedding is None
+        docs = store._embedding_retrieval([0.1, 0.2, 0.3, 0.4], top_k=2)
 
-    def test_row_to_document_with_valid_embedding(self):
-        """Test _row_to_document with valid embedding."""
-        # Test with valid embedding (as tuple/list)
-        embedding_data = [0.1, 0.2, 0.3]
-        row = ("doc_id", "content", '{"key": "value"}', embedding_data)
-        doc = _row_to_document(row)
+        assert [d.id for d in docs] == ["d1", "d2"]
+        assert docs[0].meta == {"k": "v"}
+        assert docs[0].embedding == [0.1, 0.2, 0.3, 0.4]
+        assert docs[0].score == 0.05
+        assert docs[1].meta == {}
+        assert docs[1].embedding is None
 
-        assert doc.id == "doc_id"
-        assert doc.content == "content"
-        assert doc.meta == {"key": "value"}
-        assert doc.embedding == [0.1, 0.2, 0.3]
+    def test_embedding_retrieval_appends_filter_and_null_check(self, mocked_store):
+        store, _, cur = mocked_store
+        cur.fetchall.return_value = []
+
+        store._embedding_retrieval([0.1, 0.2], filters=_FILTER, top_k=5)
+
+        executed_sql = cur.execute.call_args.args[0]
+        assert "AND embedding IS NOT NULL" in executed_sql
+
+    @pytest.mark.parametrize(
+        "fetch_error",
+        [
+            Exception("SQL0801N division by zero"),
+            Exception("Division by zero"),
+        ],
+    )
+    def test_embedding_retrieval_returns_empty_on_zero_vector_error(self, mocked_store, fetch_error):
+        store, _, cur = mocked_store
+        cur.fetchall.side_effect = fetch_error
+
+        assert store._embedding_retrieval([0.1, 0.2], top_k=1) == []
+
+    def test_embedding_retrieval_reraises_unexpected_fetch_error(self, mocked_store):
+        store, _, cur = mocked_store
+        cur.fetchall.side_effect = RuntimeError("connection reset")
+
+        with pytest.raises(RuntimeError, match="connection reset"):
+            store._embedding_retrieval([0.1, 0.2], top_k=1)

--- a/integrations/ibm_db/tests/test_document_store.py
+++ b/integrations/ibm_db/tests/test_document_store.py
@@ -6,7 +6,7 @@
 
 import math
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import Mock
 
 import pytest
 from haystack.dataclasses import Document
@@ -167,20 +167,19 @@ class TestDocumentStore(
         Build a store whose credentials are env-var Secrets so it can be serialized.
 
         The live ``document_store`` fixture uses ``Secret.from_token(...)``, which cannot
-        be serialized, so serialization tests build their own env-var-backed store (no DB
-        connection needed).
+        be serialized, so serialization tests build their own env-var-backed store.
+        Construction is connection-free (setup is lazy), so no DB is needed.
         """
         monkeypatch.setenv("DB2_USERNAME", "db2inst1")
         monkeypatch.setenv("DB2_PASSWORD", "Passw0rd123!")
-        with patch.object(IBMDb2DocumentStore, "_ensure_table_exists", return_value=None):
-            return IBMDb2DocumentStore(
-                database="testdb",
-                hostname="localhost",
-                username=Secret.from_env_var("DB2_USERNAME"),
-                password=Secret.from_env_var("DB2_PASSWORD"),
-                embedding_dim=768,
-                distance_metric="COSINE",
-            )
+        return IBMDb2DocumentStore(
+            database="testdb",
+            hostname="localhost",
+            username=Secret.from_env_var("DB2_USERNAME"),
+            password=Secret.from_env_var("DB2_PASSWORD"),
+            embedding_dim=768,
+            distance_metric="COSINE",
+        )
 
     def test_to_dict(self, monkeypatch):
         """Test serializing document store to dictionary without exposing credentials."""
@@ -196,6 +195,7 @@ class TestDocumentStore(
         assert init_params["hostname"] == store.hostname
         assert init_params["embedding_dim"] == 768
         assert init_params["distance_metric"] == "COSINE"
+        assert init_params["recreate_table"] == store.recreate_table
         # Credentials are serialized as env-var references, never as plaintext.
         assert init_params["password"] == {"type": "env_var", "env_vars": ["DB2_PASSWORD"], "strict": True}
 
@@ -204,9 +204,7 @@ class TestDocumentStore(
         store = self._serializable_store(monkeypatch)
         data = store.to_dict()
 
-        # Create new instance from dict
-        with patch.object(IBMDb2DocumentStore, "_ensure_table_exists", return_value=None):
-            new_store = IBMDb2DocumentStore.from_dict(data)
+        new_store = IBMDb2DocumentStore.from_dict(data)
 
         assert new_store.embedding_dim == store.embedding_dim
         assert new_store.distance_metric == store.distance_metric
@@ -250,6 +248,15 @@ class TestDocumentStore(
         retrieved = document_store.filter_documents({"operator": "==", "field": "id", "value": "no_content"})
         assert len(retrieved) == 1
         assert retrieved[0].content is None
+
+    def test_close_and_reopen(self, document_store: IBMDb2DocumentStore):
+        document_store.write_documents([Document(id="1", content="test", embedding=[0.1] * 768)])
+        assert document_store.count_documents() == 1
+
+        document_store.close()
+        assert document_store._connection is None
+
+        assert document_store.count_documents() == 1
 
     def test_complex_metadata(self, document_store: IBMDb2DocumentStore):
         """Test storing document with complex nested metadata."""
@@ -334,6 +341,43 @@ class TestIBMDb2DocumentStoreUtilMethods:
 
 class TestIBMDb2DocumentStoreUnit:
     """Unit tests for IBMDb2DocumentStore that don't require a database."""
+
+    @staticmethod
+    def _disconnected_store() -> IBMDb2DocumentStore:
+        return IBMDb2DocumentStore(
+            database="testdb",
+            hostname="localhost",
+            username=Secret.from_token("db2inst1"),
+            password=Secret.from_token("Passw0rd123!"),
+        )
+
+    def test_init_is_lazy_and_does_not_connect(self):
+        store = self._disconnected_store()
+        assert store._connection is None
+        assert store._table_initialized is False
+
+    def test_close(self):
+        store = self._disconnected_store()
+        mock_conn = Mock()
+        store._connection = mock_conn
+
+        store.close()
+
+        mock_conn.close.assert_called_once()
+        assert store._connection is None
+
+        store.close()
+        mock_conn.close.assert_called_once()
+
+    def test_close_is_exception_safe(self):
+        store = self._disconnected_store()
+        mock_conn = Mock()
+        mock_conn.close.side_effect = RuntimeError("boom")
+        store._connection = mock_conn
+
+        store.close()
+
+        assert store._connection is None
 
     def test_to_row_with_none_metadata(self, document_store):
         """Test _to_row with None metadata."""

--- a/integrations/ibm_db/tests/test_embedding_retriever.py
+++ b/integrations/ibm_db/tests/test_embedding_retriever.py
@@ -133,6 +133,15 @@ class TestIBMDb2EmbeddingRetrieverUnit:
         assert restored.filter_policy == FilterPolicy.REPLACE
         assert restored.document_store is mock_store
 
+    def test_close(self):
+        mock_store = Mock(spec=IBMDb2DocumentStore)
+        retriever = IBMDb2EmbeddingRetriever(document_store=mock_store)
+
+        retriever.close()
+
+        mock_store.close.assert_called_once()
+        assert retriever.document_store is mock_store
+
 
 class TestIBMDb2EmbeddingRetrieverRun:
     """Unit tests for run using a mocked document store (no database)."""


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- I realized this was diverging from other document stores since it connects at initialization: I implemented lazy connection
- add a transaction context manager to wrap DB operations in a standardized way
- add closing methods
- add tests to increase low coverage and better organize them

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
