### PR TITLE
feat: Oracle - make connection lazy, add closing methods and refactor tests

### DIFF
--- a/integrations/oracle/src/haystack_integrations/components/retrievers/oracle/embedding_retriever.py
+++ b/integrations/oracle/src/haystack_integrations/components/retrievers/oracle/embedding_retriever.py
@@ -84,6 +84,12 @@ class OracleEmbeddingRetriever:
         )
         return {"documents": docs}
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.

--- a/integrations/oracle/src/haystack_integrations/components/retrievers/oracle/keyword_retriever.py
+++ b/integrations/oracle/src/haystack_integrations/components/retrievers/oracle/keyword_retriever.py
@@ -82,6 +82,12 @@ class OracleKeywordRetriever:
         )
         return {"documents": docs}
 
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        self.document_store.close()
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serializes the component to a dictionary.

--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import threading
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -177,11 +178,7 @@ class OracleDocumentStore:
 
         self._pool: oracledb.ConnectionPool | None = None
         self._pool_lock = threading.Lock()
-
-        if create_table_if_not_exists:
-            self._ensure_table()
-        if create_index:
-            self.create_hnsw_index()
+        self._setup_done = False
 
     def _get_pool(self) -> oracledb.ConnectionPool:
         if self._pool is not None:
@@ -212,14 +209,33 @@ class OracleDocumentStore:
         return self._pool
 
     def _get_connection(self) -> oracledb.Connection:
+        self._ensure_setup()
         return self._get_pool().acquire()
 
-    def __del__(self) -> None:
+    def _ensure_setup(self) -> None:
+        """
+        Create the backing table and optional HNSW index once, on first use if needed.
+        """
+        if self._setup_done:
+            return
+        self._setup_done = True
+        try:
+            if self.create_table_if_not_exists:
+                self._ensure_table()
+            if self.create_index:
+                self.create_hnsw_index()
+        except Exception:
+            self._setup_done = False
+            raise
+
+    def close(self) -> None:
+        """
+        Release the associated synchronous resources.
+        """
         if self._pool is not None:
-            try:
+            with suppress(Exception):
                 self._pool.close()
-            except Exception:
-                logger.warning("Failed to close Oracle connection pool during cleanup.", exc_info=True)
+            self._pool = None
 
     def _ensure_table(self) -> None:
         sql = f"""

--- a/integrations/oracle/tests/conftest.py
+++ b/integrations/oracle/tests/conftest.py
@@ -16,25 +16,30 @@ _PASSWORD = "haystack"
 _DSN = "localhost:1521/freepdb1"
 
 
-def _make_store(table: str, embedding_dim: int) -> OracleDocumentStore:
-    return OracleDocumentStore(
-        connection_config=OracleConnectionConfig(
-            user=Secret.from_token(_USER),
-            password=Secret.from_token(_PASSWORD),
-            dsn=Secret.from_token(_DSN),
-        ),
-        table_name=table,
-        embedding_dim=embedding_dim,
-        distance_metric="COSINE",
-        create_table_if_not_exists=True,
-    )
+@pytest.fixture
+def make_store():
+    """Factory for a real OracleDocumentStore. Uses token secrets, so instances are not serialization-safe."""
+
+    def _make(table: str, embedding_dim: int = 4, *, create_table_if_not_exists: bool = True) -> OracleDocumentStore:
+        return OracleDocumentStore(
+            connection_config=OracleConnectionConfig(
+                user=Secret.from_token(_USER),
+                password=Secret.from_token(_PASSWORD),
+                dsn=Secret.from_token(_DSN),
+            ),
+            table_name=table,
+            embedding_dim=embedding_dim,
+            create_table_if_not_exists=create_table_if_not_exists,
+        )
+
+    return _make
 
 
 @pytest.fixture
-def document_store():
+def document_store(make_store):
     """768-dim store required by the mixin's filterable_docs fixture."""
     table = f"hs_sync_{uuid.uuid4().hex[:8]}"
-    s = _make_store(table, embedding_dim=768)
+    s = make_store(table, 768)
     yield s
     with s._get_connection() as conn, conn.cursor() as cur:
         cur.execute(f"DROP TABLE {table} PURGE")
@@ -42,10 +47,10 @@ def document_store():
 
 
 @pytest.fixture
-def embedding_store():
+def embedding_store(make_store):
     """4-dim store for embedding-retrieval, HNSW, and async tests."""
     table = f"hs_emb_{uuid.uuid4().hex[:8]}"
-    s = _make_store(table, embedding_dim=4)
+    s = make_store(table)
     yield s
     with s._get_connection() as conn, conn.cursor() as cur:
         cur.execute(f"DROP TABLE {table} PURGE")

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -44,7 +44,7 @@ def _uid(suffix: str = "") -> str:
 
 
 def _lob(value: str) -> MagicMock:
-    """Stand-in for an oracledb LOB — an object whose read() returns the stored value."""
+    """Mock for an oracledb Large Object (LOB)"""
     lob = MagicMock()
     lob.read.return_value = value
     return lob

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import uuid
+from unittest.mock import MagicMock
 
 import oracledb as _oracledb
 import pytest
@@ -27,13 +28,8 @@ from haystack.testing.document_store_async import (
     FilterableDocsFixtureMixin,
     UpdateByFilterAsyncTest,
 )
-from haystack.utils import Secret
 
-from haystack_integrations.document_stores.oracle import OracleConnectionConfig, OracleDocumentStore
-
-_USER = "haystack"
-_PASSWORD = "haystack"
-_DSN = "localhost:1521/freepdb1"
+from haystack_integrations.document_stores.oracle import OracleDocumentStore
 
 
 def _doc(doc_id: str, content: str = "hello", meta: dict | None = None, embedding: list[float] | None = None):
@@ -65,6 +61,50 @@ def test_get_metadata_field_unique_values_search_term_filters_value_only(patched
     assert vals_params["search"] == "%bar%"
 
 
+def test_close(patched_store):
+    pool = MagicMock()
+    patched_store._pool = pool
+    patched_store.close()
+    pool.close.assert_called_once()
+    assert patched_store._pool is None
+    patched_store.close()
+    pool.close.assert_called_once()
+
+
+def test_close_is_exception_safe(patched_store):
+    pool = MagicMock()
+    pool.close.side_effect = RuntimeError("boom")
+    patched_store._pool = pool
+    patched_store.close()
+    assert patched_store._pool is None
+
+
+def test_init_opens_no_connection(make_store, mock_pool):  # noqa: ARG001
+    store = make_store("lazy_docs")
+    assert store._pool is None
+    assert store._setup_done is False
+
+
+def test_setup_is_deferred_and_runs_once(make_store, mock_pool):
+    store = make_store("lazy_docs")
+    store.count_documents()
+    store.count_documents()
+    assert store._pool is not None
+    assert store._setup_done is True
+    _, _, cursor = mock_pool
+    create_calls = [c for c in cursor.execute.call_args_list if "CREATE TABLE IF NOT EXISTS" in c[0][0]]
+    assert len(create_calls) == 1
+
+
+def test_setup_failure_resets_flag(make_store, mock_pool):
+    _, _, cursor = mock_pool
+    cursor.execute.side_effect = RuntimeError("boom")
+    store = make_store("lazy_docs")
+    with pytest.raises(RuntimeError):
+        store.count_documents()
+    assert store._setup_done is False
+
+
 @pytest.mark.integration
 class TestOracleDocumentStore(
     DocumentStoreBaseTests,
@@ -84,20 +124,10 @@ class TestOracleDocumentStore(
         return Document(id=doc_id, content=content, meta={"k": "v"}, embedding=embedding)
 
     @pytest.fixture
-    def document_store(self):
+    def document_store(self, make_store):
         """768-dim store — overrides the mixin's NotImplementedError stub."""
         table = f"hs_sync_{uuid.uuid4().hex[:8]}"
-        s = OracleDocumentStore(
-            connection_config=OracleConnectionConfig(
-                user=Secret.from_token(_USER),
-                password=Secret.from_token(_PASSWORD),
-                dsn=Secret.from_token(_DSN),
-            ),
-            table_name=table,
-            embedding_dim=768,
-            distance_metric="COSINE",
-            create_table_if_not_exists=True,
-        )
+        s = make_store(table, 768)
         yield s
         with s._get_connection() as conn, conn.cursor() as cur:
             cur.execute(f"DROP TABLE {table} PURGE")
@@ -328,6 +358,14 @@ class TestOracleDocumentStore(
     def test_create_table_idempotent(self, document_store):
         """Calling _ensure_table() a second time must not raise."""
         document_store._ensure_table()
+
+    def test_close_and_reopen(self, document_store):
+        document_store.count_documents()
+        assert document_store._pool is not None
+        document_store.close()
+        assert document_store._pool is None
+        assert document_store.count_documents() == 0
+        assert document_store._pool is not None
 
     def test_get_metadata_field_unique_values_search_term_matches_value_not_content(self, document_store):
         """search_term filters on the metadata field's own value; document content is not considered."""

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import oracledb as _oracledb
 import pytest
 from haystack.dataclasses import Document
-from haystack.document_stores.errors import DuplicateDocumentError
+from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.testing.document_store import (
     CountDocumentsByFilterTest,
@@ -43,124 +43,54 @@ def _uid(suffix: str = "") -> str:
     return f"{base}{suffix.upper():>4}"[:32]
 
 
-def test_get_metadata_field_unique_values_search_term_filters_value_only(patched_store, mock_pool):
-    """search_term must filter on the metadata field's own JSON value, not on document text."""
-    _, _, cursor = mock_pool
-    cursor.fetchone.return_value = (1,)
-    cursor.fetchall.return_value = [("bar",)]
-
-    patched_store.get_metadata_field_unique_values("category", search_term="bar")
-
-    count_sql, count_params = cursor.execute.call_args_list[0][0]
-    vals_sql, vals_params = cursor.execute.call_args_list[1][0]
-
-    for sql in (count_sql, vals_sql):
-        assert "UPPER(JSON_VALUE(metadata, '$.category')) LIKE UPPER(:search)" in sql
-
-    assert count_params["search"] == "%bar%"
-    assert vals_params["search"] == "%bar%"
+def _lob(value: str) -> MagicMock:
+    """Stand-in for an oracledb LOB — an object whose read() returns the stored value."""
+    lob = MagicMock()
+    lob.read.return_value = value
+    return lob
 
 
-def test_close(patched_store):
-    pool = MagicMock()
-    patched_store._pool = pool
-    patched_store.close()
-    pool.close.assert_called_once()
-    assert patched_store._pool is None
-    patched_store.close()
-    pool.close.assert_called_once()
-
-
-def test_close_is_exception_safe(patched_store):
-    pool = MagicMock()
-    pool.close.side_effect = RuntimeError("boom")
-    patched_store._pool = pool
-    patched_store.close()
-    assert patched_store._pool is None
-
-
-def test_init_opens_no_connection(make_store, mock_pool):  # noqa: ARG001
-    store = make_store("lazy_docs")
-    assert store._pool is None
-    assert store._setup_done is False
-
-
-def test_setup_is_deferred_and_runs_once(make_store, mock_pool):
-    store = make_store("lazy_docs")
-    store.count_documents()
-    store.count_documents()
-    assert store._pool is not None
-    assert store._setup_done is True
-    _, _, cursor = mock_pool
-    create_calls = [c for c in cursor.execute.call_args_list if "CREATE TABLE IF NOT EXISTS" in c[0][0]]
-    assert len(create_calls) == 1
-
-
-def test_setup_failure_resets_flag(make_store, mock_pool):
-    _, _, cursor = mock_pool
-    cursor.execute.side_effect = RuntimeError("boom")
-    store = make_store("lazy_docs")
-    with pytest.raises(RuntimeError):
-        store.count_documents()
-    assert store._setup_done is False
-
-
-@pytest.mark.integration
-class TestOracleDocumentStore(
-    DocumentStoreBaseTests,
-    CountDocumentsByFilterTest,
-    CountUniqueMetadataByFilterTest,
-    DeleteAllTest,
-    DeleteByFilterTest,
-    DeleteDocumentsTest,
-    GetMetadataFieldMinMaxTest,
-    GetMetadataFieldsInfoTest,
-    GetMetadataFieldUniqueValuesTest,
-    UpdateByFilterTest,
-):
+class TestOracleDocumentStoreUnit:
     @staticmethod
     def _mock_doc(content="hello", embedding=None, doc_id="AABB" * 8):
         """Lightweight document builder for mock-based tests."""
         return Document(id=doc_id, content=content, meta={"k": "v"}, embedding=embedding)
 
-    @pytest.fixture
-    def document_store(self, make_store):
-        """768-dim store — overrides the mixin's NotImplementedError stub."""
-        table = f"hs_sync_{uuid.uuid4().hex[:8]}"
-        s = make_store(table, 768)
-        yield s
-        with s._get_connection() as conn, conn.cursor() as cur:
-            cur.execute(f"DROP TABLE {table} PURGE")
-            conn.commit()
-
-    # Mixin override
-    def assert_documents_are_equal(self, received: list[Document], expected: list[Document]) -> None:
-        # filter_documents does not SELECT the embedding column — ignore it when comparing
-        assert len(received) == len(expected)
-        received_sorted = sorted(received, key=lambda d: d.id)
-        expected_sorted = sorted(expected, key=lambda d: d.id)
-        for r, e in zip(received_sorted, expected_sorted, strict=True):
-            assert r.id == e.id
-            assert r.content == e.content
-            assert r.meta == e.meta
-
-    # Mixin override
-    def test_write_documents(self, document_store: OracleDocumentStore) -> None:
-        # Default policy is NONE — a second write of the same doc raises DuplicateDocumentError
-        doc = Document(content="test doc")
-        assert document_store.write_documents([doc]) == 1
-        with pytest.raises(DuplicateDocumentError):
-            document_store.write_documents([doc])
-        self.assert_documents_are_equal(document_store.filter_documents(), [doc])
-
-    # test_comparison_equal_with_none     → IS NULL
-    # test_comparison_not_equal_with_none → IS NOT NULL
-    # test_comparison_not_equal           → col != x OR IS NULL
-    # test_comparison_not_in              → IS NULL OR NOT IN
-    @pytest.mark.skip(
-        reason="Oracle NULL propagation in NOT(...) cannot match Python 'not (None == x) is True' semantics"
+    @pytest.mark.parametrize(
+        ("table_name", "embedding_dim", "match"),
+        [
+            pytest.param("1invalid", 4, "Invalid table_name", id="table_name_starts_with_digit"),
+            pytest.param("bad-name", 4, "Invalid table_name", id="table_name_illegal_char"),
+            pytest.param("valid", 0, "embedding_dim must be a positive integer", id="embedding_dim_zero"),
+            pytest.param("valid", -1, "embedding_dim must be a positive integer", id="embedding_dim_negative"),
+        ],
     )
-    def test_not_operator(self, document_store, filterable_docs): ...
+    def test_init_rejects_invalid_arguments(self, make_store, table_name, embedding_dim, match):
+        with pytest.raises(ValueError, match=match):
+            make_store(table_name, embedding_dim)
+
+    def test_init_opens_no_connection(self, make_store, mock_pool):  # noqa: ARG002
+        store = make_store("lazy_docs")
+        assert store._pool is None
+        assert store._setup_done is False
+
+    def test_setup_is_deferred_and_runs_once(self, make_store, mock_pool):
+        store = make_store("lazy_docs")
+        store.count_documents()
+        store.count_documents()
+        assert store._pool is not None
+        assert store._setup_done is True
+        _, _, cursor = mock_pool
+        create_calls = [c for c in cursor.execute.call_args_list if "CREATE TABLE IF NOT EXISTS" in c[0][0]]
+        assert len(create_calls) == 1
+
+    def test_setup_failure_resets_flag(self, make_store, mock_pool):
+        _, _, cursor = mock_pool
+        cursor.execute.side_effect = RuntimeError("boom")
+        store = make_store("lazy_docs")
+        with pytest.raises(RuntimeError):
+            store.count_documents()
+        assert store._setup_done is False
 
     def test_write_documents_none_policy_calls_insert(self, patched_store, mock_pool):
         _, _, cursor = mock_pool
@@ -255,6 +185,78 @@ class TestOracleDocumentStore(
         cursor.fetchone.return_value = (42,)
         assert patched_store.count_documents() == 42
 
+    def test_get_metadata_field_unique_values_search_term_filters_value_only(self, patched_store, mock_pool):
+        """search_term must filter on the metadata field's own JSON value, not on document text."""
+        _, _, cursor = mock_pool
+        cursor.fetchone.return_value = (1,)
+        cursor.fetchall.return_value = [("bar",)]
+
+        patched_store.get_metadata_field_unique_values("category", search_term="bar")
+
+        count_sql, count_params = cursor.execute.call_args_list[0][0]
+        vals_sql, vals_params = cursor.execute.call_args_list[1][0]
+
+        for sql in (count_sql, vals_sql):
+            assert "UPPER(JSON_VALUE(metadata, '$.category')) LIKE UPPER(:search)" in sql
+
+        assert count_params["search"] == "%bar%"
+        assert vals_params["search"] == "%bar%"
+
+    def test_delete_table_executes_drop_and_index_sql(self, patched_store, mock_pool):
+        _, _, cursor = mock_pool
+        patched_store.delete_table()
+        executed = [c[0][0] for c in cursor.execute.call_args_list]
+        assert any("DROP TABLE" in sql and "PURGE" in sql for sql in executed)
+        assert any("DBMS_SEARCH.DROP_INDEX" in sql for sql in executed)
+
+    def test_keyword_retrieval_builds_contains_query(self, patched_store, mock_pool):
+        _, _, cursor = mock_pool
+        cursor.fetchall.return_value = [("AABB" * 8, "hello", '{"k": "v"}', 1.5)]
+        docs = patched_store._keyword_retrieval("hello world", top_k=5)
+        sql, params = cursor.execute.call_args[0]
+        assert "CONTAINS(DATA, :query, 1)" in sql
+        assert "SCORE(1)" in sql
+        assert params["query"] == "hello world"
+        assert params["top_k"] == 5
+        assert docs[0].score == 1.5
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            pytest.param(lambda s: s._embedding_retrieval([0.1, 0.2, 0.3, 0.4]), id="embedding_retrieval"),
+            pytest.param(lambda s: s._keyword_retrieval("query"), id="keyword_retrieval"),
+            pytest.param(lambda s: s.delete_table(), id="delete_table"),
+        ],
+    )
+    def test_query_methods_wrap_database_errors(self, patched_store, mock_pool, operation):
+        _, _, cursor = mock_pool
+        cursor.execute.side_effect = _oracledb.DatabaseError("ORA-00942")
+        with pytest.raises(DocumentStoreError):
+            operation(patched_store)
+
+    @pytest.mark.parametrize(
+        ("text_raw", "metadata_raw", "expected_content", "expected_meta"),
+        [
+            pytest.param("plain", '{"k": "v"}', "plain", {"k": "v"}, id="str_text_and_json_metadata"),
+            pytest.param(_lob("from_lob"), _lob('{"k": "v"}'), "from_lob", {"k": "v"}, id="lob_text_and_metadata"),
+            pytest.param("plain", {"k": "v"}, "plain", {"k": "v"}, id="dict_metadata"),
+            pytest.param("plain", None, "plain", {}, id="unsupported_metadata_type"),
+        ],
+    )
+    def test_row_to_document_reads_lob_and_maps_metadata(self, text_raw, metadata_raw, expected_content, expected_meta):
+        doc = OracleDocumentStore._row_to_document(("id1", text_raw, metadata_raw))
+        assert doc.content == expected_content
+        assert doc.meta == expected_meta
+
+    def test_create_hnsw_index_sql(self, patched_store, mock_pool):
+        _, _, cursor = mock_pool
+        patched_store.create_hnsw_index()
+        sql = cursor.execute.call_args[0][0]
+        assert "CREATE VECTOR INDEX" in sql
+        assert "HNSW" in sql
+        assert str(patched_store.hnsw_neighbors) in sql
+        assert str(patched_store.hnsw_ef_construction) in sql
+
     def test_to_dict_does_not_expose_plain_password(self, patched_store):
         d = patched_store.to_dict()
         pw = d["init_parameters"]["connection_config"]["password"]
@@ -268,17 +270,74 @@ class TestOracleDocumentStore(
         assert restored.embedding_dim == patched_store.embedding_dim
         assert restored.distance_metric == patched_store.distance_metric
 
-    def test_create_hnsw_index_sql(self, patched_store, mock_pool):
-        _, _, cursor = mock_pool
-        patched_store.create_hnsw_index()
-        sql = cursor.execute.call_args[0][0]
-        assert "CREATE VECTOR INDEX" in sql
-        assert "HNSW" in sql
-        assert str(patched_store.hnsw_neighbors) in sql
-        assert str(patched_store.hnsw_ef_construction) in sql
+    def test_close(self, patched_store):
+        pool = MagicMock()
+        patched_store._pool = pool
+        patched_store.close()
+        pool.close.assert_called_once()
+        assert patched_store._pool is None
+        patched_store.close()
+        pool.close.assert_called_once()
 
-    def test_write_documents_empty_list_returns_zero(self, document_store):
-        assert document_store.write_documents([]) == 0
+    def test_close_is_exception_safe(self, patched_store):
+        pool = MagicMock()
+        pool.close.side_effect = RuntimeError("boom")
+        patched_store._pool = pool
+        patched_store.close()
+        assert patched_store._pool is None
+
+
+@pytest.mark.integration
+class TestOracleDocumentStore(
+    DocumentStoreBaseTests,
+    CountDocumentsByFilterTest,
+    CountUniqueMetadataByFilterTest,
+    DeleteAllTest,
+    DeleteByFilterTest,
+    DeleteDocumentsTest,
+    GetMetadataFieldMinMaxTest,
+    GetMetadataFieldsInfoTest,
+    GetMetadataFieldUniqueValuesTest,
+    UpdateByFilterTest,
+):
+    @pytest.fixture
+    def document_store(self, make_store):
+        """768-dim store — overrides the mixin's NotImplementedError stub."""
+        table = f"hs_sync_{uuid.uuid4().hex[:8]}"
+        s = make_store(table, 768)
+        yield s
+        with s._get_connection() as conn, conn.cursor() as cur:
+            cur.execute(f"DROP TABLE {table} PURGE")
+            conn.commit()
+
+    # Mixin override
+    def assert_documents_are_equal(self, received: list[Document], expected: list[Document]) -> None:
+        # filter_documents does not SELECT the embedding column — ignore it when comparing
+        assert len(received) == len(expected)
+        received_sorted = sorted(received, key=lambda d: d.id)
+        expected_sorted = sorted(expected, key=lambda d: d.id)
+        for r, e in zip(received_sorted, expected_sorted, strict=True):
+            assert r.id == e.id
+            assert r.content == e.content
+            assert r.meta == e.meta
+
+    # Mixin override
+    def test_write_documents(self, document_store: OracleDocumentStore) -> None:
+        # Default policy is NONE — a second write of the same doc raises DuplicateDocumentError
+        doc = Document(content="test doc")
+        assert document_store.write_documents([doc]) == 1
+        with pytest.raises(DuplicateDocumentError):
+            document_store.write_documents([doc])
+        self.assert_documents_are_equal(document_store.filter_documents(), [doc])
+
+    # test_comparison_equal_with_none     → IS NULL
+    # test_comparison_not_equal_with_none → IS NOT NULL
+    # test_comparison_not_equal           → col != x OR IS NULL
+    # test_comparison_not_in              → IS NULL OR NOT IN
+    @pytest.mark.skip(
+        reason="Oracle NULL propagation in NOT(...) cannot match Python 'not (None == x) is True' semantics"
+    )
+    def test_not_operator(self, document_store, filterable_docs): ...
 
     def test_filter_documents_not_operator(self, document_store):
         # Scoped to two fresh docs — no NULL-valued rows, so NOT works correctly.

--- a/integrations/oracle/tests/test_embedding_retriever.py
+++ b/integrations/oracle/tests/test_embedding_retriever.py
@@ -67,6 +67,13 @@ def test_to_dict_from_dict_roundtrip(mock_store):
     assert restored.document_store.embedding_dim == 4
 
 
+def test_close(mock_store):
+    retriever = OracleEmbeddingRetriever(document_store=mock_store)
+    retriever.close()
+    mock_store.close.assert_called_once()
+    assert retriever.document_store is mock_store
+
+
 def test_invalid_document_store_raises_type_error():
     with pytest.raises(TypeError, match="must be an instance of OracleDocumentStore"):
         OracleEmbeddingRetriever(document_store="not_a_store")

--- a/integrations/oracle/tests/test_keyword_retriever.py
+++ b/integrations/oracle/tests/test_keyword_retriever.py
@@ -67,6 +67,13 @@ def test_to_dict_from_dict_roundtrip(mock_store):
     assert restored.document_store.embedding_dim == 4
 
 
+def test_close(mock_store):
+    retriever = OracleKeywordRetriever(document_store=mock_store)
+    retriever.close()
+    mock_store.close.assert_called_once()
+    assert retriever.document_store is mock_store
+
+
 def test_invalid_document_store_raises_type_error():
     with pytest.raises(TypeError, match="must be an instance of OracleDocumentStore"):
         OracleKeywordRetriever(document_store="not_a_store")


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-core-integrations/issues/1628

### Proposed Changes:
- I realized this was diverging from other document stores since it connects at initialization: I implemented lazy connection
- add sync closing methods: the resource to close here is a sync connection pool (which is also used in async methods via `asyncio.to_thread`). Once we implement proper async using an async connection pool (supported by Oracle), we can also add `close_async`
- new tests for new behaviors, convert some integration tests to unit tests with minimal changes

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
