### PR TITLE
chore: update new-integration scaffold to match current integration layouts

### DIFF
--- a/scripts/create_new_integration.py
+++ b/scripts/create_new_integration.py
@@ -20,37 +20,51 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INTEGRATIONS_DIR = REPO_ROOT / "integrations"
 
 COMPONENT_TYPES = [
+    "audio",
+    "classifiers",
     "connectors",
     "converters",
     "document_stores",
     "downloaders",
     "embedders",
     "evaluators",
+    "extractors",
     "fetchers",
     "generators",
     "preprocessors",
     "rankers",
+    "readers",
     "retrievers",
+    "routers",
     "tools",
     "tracing",
     "translators",
+    "websearch",
+    "writers",
 ]
 
 TYPE_LABELS = {
+    "audio": "Audio",
+    "classifiers": "Classifier",
     "connectors": "Connector",
     "converters": "Converter",
     "document_stores": "Document Store",
     "downloaders": "Downloader",
     "embedders": "Embedder",
     "evaluators": "Evaluator",
+    "extractors": "Extractor",
     "fetchers": "Fetcher",
     "generators": "Generator",
     "preprocessors": "Preprocessor",
     "rankers": "Ranker",
+    "readers": "Reader",
     "retrievers": "Retriever",
+    "routers": "Router",
     "tools": "Tool",
     "tracing": "Tracer",
     "translators": "Translator",
+    "websearch": "Websearch",
+    "writers": "Writer",
 }
 
 LICENSE_HEADER = """\

--- a/scripts/utils/naming.py
+++ b/scripts/utils/naming.py
@@ -36,22 +36,35 @@ def folder_to_label(folder_name: str) -> str:
     return "integration:" + folder_name.replace("_", "-")
 
 
+# Component types that live directly under the `haystack_integrations` namespace
+# instead of under `haystack_integrations.components`.
+TOP_LEVEL_TYPES = frozenset(
+    {
+        "document_stores",
+        "memory_stores",
+        "tools",
+        "tracing",
+    }
+)
+
+# Types whose module name is not derived by simply stripping a trailing "s".
 _SINGULAR_OVERRIDES: dict[str, str] = {
-    "tracing": "tracing",
+    "tracing": "tracer",
 }
 
 
 def singularize_type(component_type: str) -> str:
     """Return the singular form of a component type for use in module names.
 
-    Falls back to stripping the trailing character, which works for regular
-    plural forms (e.g. ``connectors`` -> ``connector``).
+    Strips a trailing "s", which works for the regular plural forms
+    (e.g. `connectors` -> `connector`) and leaves the already-singular
+    types untouched (e.g. `websearch`, `audio`).
     """
-    return _SINGULAR_OVERRIDES.get(component_type, component_type[:-1])
+    return _SINGULAR_OVERRIDES.get(component_type, component_type.removesuffix("s"))
 
 
 def get_module_path(folder_name: str, component_type: str) -> str:
     """Return the dotted import path for a given folder name and component type."""
-    if component_type == "document_stores":
+    if component_type in TOP_LEVEL_TYPES:
         return f"haystack_integrations.{component_type}.{folder_name}"
     return f"haystack_integrations.components.{component_type}.{folder_name}"

--- a/scripts/utils/scaffold.py
+++ b/scripts/utils/scaffold.py
@@ -38,18 +38,16 @@ def create_integration_files(
         path.write_text(content)
         created_files.append(path)
 
-    if component_type == "document_stores":
-        src_dir = f"src/haystack_integrations/{component_type}"
-    else:
-        src_dir = f"src/haystack_integrations/components/{component_type}"
+    pkg = folder_to_package(name)
+    mod = get_module_path(name, component_type)
+
+    # e.g. haystack_integrations.components.embedders.foo -> src/haystack_integrations/components/embedders
+    src_dir = "src/" + "/".join(mod.split(".")[:-1])
 
     write_file(f"{src_dir}/{name}/__init__.py", license_header)
     write_file(f"{src_dir}/py.typed", "")
 
     write_file("tests/__init__.py", license_header)
-
-    pkg = folder_to_package(name)
-    mod = get_module_path(name, component_type)
 
     write_file("pyproject.toml", render("pyproject.toml", name=name, pkg=pkg, mod=mod))
     write_file("README.md", render("readme.md", name=name, pkg=pkg))


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

- Route `tools` and `tracing` to the top-level `haystack_integrations` namespace instead of `haystack_integrations.components`, matching all 10 existing integrations of those types (e2b, github, mcp, mem0, mirage, tavily, datadog, langfuse, opentelemetry, weave).
- Derive the source directory from `get_module_path` so the layout and the dotted module path can no longer drift apart.
- Add the component types already used in the repo but missing from the menu: audio, classifiers, extractors, readers, routers, websearch (8 integrations), writers.
- Fix `singularize_type` for already-singular types (`websearch` no longer becomes `websearc`) and map `tracing` to `tracer`, the module name all four tracing integrations use.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
