### PR TITLE
chore: drop haystack-experimental references

### DIFF
--- a/integrations/cognee/src/haystack_integrations/memory_stores/cognee/memory_store.py
+++ b/integrations/cognee/src/haystack_integrations/memory_stores/cognee/memory_store.py
@@ -82,7 +82,7 @@ def _render(item: Any) -> str | None:
 
 class CogneeMemoryStore:
     """
-    Memory backend backed by Cognee, implementing the haystack-experimental `MemoryStore` protocol.
+    Memory backend backed by Cognee.
 
     Wraps cognee's V2 memory API: `add_memories` -> `cognee.remember`,
     `search_memories` -> `cognee.recall`, `improve` -> `cognee.improve`,

--- a/integrations/github/src/haystack_integrations/prompts/github/context_prompt.py
+++ b/integrations/github/src/haystack_integrations/prompts/github/context_prompt.py
@@ -168,9 +168,4 @@ This is a mono-repo maintained by the deepset-Team that contains integrations fo
 Typically, an integration consists of one or more components. Some integrations only contain document stores.
 Each integration is a standalone pypi-package but you can find all of them in the core integrations repo.
 
-
-3. "deepset-ai/haystack-experimental"
-
-Contains experimental features for the Haystack framework.
-
 """


### PR DESCRIPTION
### Related Issues

- None. Part of archiving [deepset-ai/haystack-experimental](https://github.com/deepset-ai/haystack-experimental).

### Proposed Changes:

- **cognee**: drop the `CogneeMemoryStore` docstring that claimed it implements "the haystack-experimental `MemoryStore` protocol", which was was deleted from haystack-experimental's `main`.
- **github**: drop `deepset-ai/haystack-experimental` from the repo-context few-shot prompt so the agent is not pointed at an archived repo.

### How did you test it?

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
