### PR TITLE
fix: `FalkorDB` `get_metadata_field_unique_values` match metadata value case insensitive

### DIFF
--- a/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
+++ b/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
@@ -607,14 +607,15 @@ SET d.{self.embedding_field} = vecf32(doc.emb)
         self,
         metadata_field: str,
         search_term: str | None = None,
-        size: int | None = 10000,
+        size: int | None = 10,
         after: dict[str, Any] | None = None,
     ) -> tuple[list[Any], dict[str, Any] | None]:
         """
         Return distinct values for the given metadata field with optional filtering and pagination.
 
         :param metadata_field: Metadata field name. May include or omit the `meta.` prefix.
-        :param search_term: Optional substring filter applied to string field values.
+        :param search_term: Optional case-insensitive substring filter applied to the metadata
+            field's own value.
         :param size: Maximum number of values to return per page. Defaults to 10 000.
         :param after: Pagination cursor returned by a previous call. Pass `None` for the first page.
         :returns: Tuple of `(values, next_cursor)`. `next_cursor` is `None` on the last page.
@@ -627,7 +628,7 @@ SET d.{self.embedding_field} = vecf32(doc.emb)
         query_params: dict[str, Any] = {}
         where_parts = [f"d.{field} IS NOT NULL"]
         if search_term:
-            where_parts.append(f"toString(d.{field}) CONTAINS $search_term")
+            where_parts.append(f"toLower(toString(d.{field})) CONTAINS toLower($search_term)")
             query_params["search_term"] = search_term
 
         where = " AND ".join(where_parts)

--- a/integrations/falkordb/tests/test_document_store.py
+++ b/integrations/falkordb/tests/test_document_store.py
@@ -383,6 +383,15 @@ class TestFalkorDBDocumentStoreUnit:
         assert values == ["A", "B"]
         assert cursor == {"offset": 2}
 
+    def test_get_metadata_field_unique_values_search_term_case_insensitive(self, mock_falkordb):
+        _, _, graph = mock_falkordb
+        graph.query.side_effect = [_result([]), _result([]), _result([["Apple"]])]
+        values, _ = FalkorDBDocumentStore().get_metadata_field_unique_values("category", search_term="APP")
+        assert values == ["Apple"]
+        cypher, params = graph.query.call_args[0]
+        assert "toLower(toString(d.category)) CONTAINS toLower($search_term)" in cypher
+        assert params == {"search_term": "APP"}
+
     def test_close(self):
         store = FalkorDBDocumentStore()
         client = MagicMock()


### PR DESCRIPTION
### Related Issues

- fixes partially https://github.com/deepset-ai/haystack-private/issues/483

### Proposed Changes:

- `get_metadata_field_unique_values` match metadata value case insensitive

### How did you test it?

- add one test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
