### PR TITLE
ci: annotate GitHubPRCreator pr_data to satisfy the requests stubs

### DIFF
--- a/integrations/github/src/haystack_integrations/components/connectors/github/pr_creator.py
+++ b/integrations/github/src/haystack_integrations/components/connectors/github/pr_creator.py
@@ -248,7 +248,7 @@ class GitHubPRCreator:
             # For cross-repository PRs, head must be in the format username:branch
             head = f"{fork_owner}:{branch}"
 
-            pr_data = {
+            pr_data: dict[str, Any] = {
                 "title": title,
                 "body": body,
                 "head": head,


### PR DESCRIPTION
### Related Issues

- None. Unblocks CI on `main` for the github integration; noticed while working on #3674.

mypy currently fails on `main`:

```
pr_creator.py:260: error: Argument "json" to "post" has incompatible type "dict[str, object]"; expected "JsonType"  [arg-type]
```

### Proposed Changes:

`pr_data` mixes `str` and `bool` values, so mypy infers `dict[str, object]`, and `object` is not assignable to the `JsonType` that recent `types-requests` releases declare for `requests.post(json=)`. Nothing changed in this file — the stubs got stricter and are resolved unpinned at CI time.

Annotate the dict as `dict[str, Any]`, matching the existing idiom two methods up in the same file (line 164) and the `_undo_changes` payload in `file_editor.py`. Runtime behaviour is unchanged.

### How did you test it?

CI tests

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
