### PR TITLE
fix: route ragas metric deserialization through the gated import helper

### DIFF
--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -97,9 +97,10 @@ class RagasEvaluator:
         deserialization; the API key is read from the `OPENAI_API_KEY` environment
         variable at load time.
 
-        With `haystack-ai` >= 3.0, the module a metric class lives in must be on the
-        deserialization allowlist, so metrics from `ragas` itself or from your own package have to be
-        trusted explicitly, e.g. via `Pipeline.load(..., allowed_modules=["ragas.*"])`.
+        With `haystack-ai` >= 3.0, the module a metric class lives in must be on the deserialization
+        allowlist. Metrics shipped by ragas are trusted automatically; a custom metric class from
+        your own package has to be trusted explicitly, e.g. via
+        `Pipeline.load(..., allowed_modules=["mypackage.*"])`.
 
         :param data:
             Dictionary to deserialize from.

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -97,10 +97,16 @@ class RagasEvaluator:
         deserialization; the API key is read from the `OPENAI_API_KEY` environment
         variable at load time.
 
+        With `haystack-ai` >= 3.0, the module a metric class lives in must be on the
+        deserialization allowlist, so metrics from `ragas` itself or from your own package have to be
+        trusted explicitly, e.g. via `Pipeline.load(..., allowed_modules=["ragas.*"])`.
+
         :param data:
             Dictionary to deserialize from.
         :returns:
             Deserialized component.
+        :raises DeserializationError:
+            If a metric class is not on the deserialization allowlist.
         """
         metrics_data = data.get("init_parameters", {}).get("ragas_metrics", [])
         data["init_parameters"]["ragas_metrics"] = [_deserialize_metric(m) for m in metrics_data]

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/utils.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/utils.py
@@ -3,12 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any
 
+from haystack.core import serialization as haystack_serialization
 from haystack.core.serialization import import_class_by_name
 from openai import AsyncOpenAI
 
 from ragas.embeddings.base import embedding_factory
 from ragas.llms import llm_factory
 from ragas.metrics.base import SimpleBaseMetric
+
+# Every metric shipped by ragas lives under `ragas.metrics.*` (including the private submodules that
+# back `ragas.metrics.collections`). That package is a hard dependency of this integration and is
+# imported at module load anyway, so it is trusted for deserialization instead of making every caller
+# allowlist it. Metric classes from anywhere else — your own package included — stay gated.
+_RAGAS_METRICS_MODULE_PATTERN = "ragas.metrics.*"
+
+
+def _trust_ragas_metrics_modules() -> None:
+    """
+    Add ragas' own metric modules to Haystack's process-wide deserialization allowlist.
+
+    No-op on `haystack-ai` < 3.0, which has no allowlist to extend and therefore does not expose
+    `allow_deserialization_module`.
+    """
+    allow_module = getattr(haystack_serialization, "allow_deserialization_module", None)
+    if allow_module is not None:
+        allow_module(_RAGAS_METRICS_MODULE_PATTERN)
 
 
 def _serialize_metric(metric: SimpleBaseMetric) -> dict[str, Any]:
@@ -46,9 +65,9 @@ def _deserialize_metric(data: dict[str, Any]) -> SimpleBaseMetric:
 
     The metric class is imported through Haystack's gated `import_class_by_name`, so with
     `haystack-ai` >= 3.0 the module it lives in must be on the deserialization allowlist. Metrics
-    from `ragas` itself or from your own package therefore need to be trusted explicitly, e.g. via
-    `Pipeline.load(..., allowed_modules=["ragas.*"])`, `allow_deserialization_module("ragas.*")` or
-    the `HAYSTACK_DESERIALIZATION_ALLOWLIST` environment variable.
+    shipped by ragas are trusted automatically; a custom metric class from your own package needs to
+    be trusted explicitly, e.g. via `Pipeline.load(..., allowed_modules=["mypackage.*"])`,
+    `allow_deserialization_module` or the `HAYSTACK_DESERIALIZATION_ALLOWLIST` environment variable.
 
     :param data: Dict produced by `_serialize_metric`.
     :returns: A fully constructed `SimpleBaseMetric` instance.
@@ -56,6 +75,8 @@ def _deserialize_metric(data: dict[str, Any]) -> SimpleBaseMetric:
     :raises DeserializationError: If the metric class is not on the deserialization allowlist.
     """
     type_path = data["type"]
+    if type_path.startswith("ragas.metrics."):
+        _trust_ragas_metrics_modules()
     # `import_class_by_name` returns `type[object]`; annotate as `Any` so that calling it with the
     # metric's own keyword arguments below type-checks.
     metric_cls: Any = import_class_by_name(type_path)

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/utils.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/utils.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2026-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import importlib
 from typing import Any
 
+from haystack.core.serialization import import_class_by_name
 from openai import AsyncOpenAI
 
 from ragas.embeddings.base import embedding_factory
@@ -44,13 +44,21 @@ def _deserialize_metric(data: dict[str, Any]) -> SimpleBaseMetric:
     provider is supported for automatic reconstruction; the API key is read from
     the `OPENAI_API_KEY` environment variable at deserialization time.
 
+    The metric class is imported through Haystack's gated `import_class_by_name`, so with
+    `haystack-ai` >= 3.0 the module it lives in must be on the deserialization allowlist. Metrics
+    from `ragas` itself or from your own package therefore need to be trusted explicitly, e.g. via
+    `Pipeline.load(..., allowed_modules=["ragas.*"])`, `allow_deserialization_module("ragas.*")` or
+    the `HAYSTACK_DESERIALIZATION_ALLOWLIST` environment variable.
+
     :param data: Dict produced by `_serialize_metric`.
     :returns: A fully constructed `SimpleBaseMetric` instance.
     :raises ValueError: If a non-`openai` provider is encountered.
+    :raises DeserializationError: If the metric class is not on the deserialization allowlist.
     """
     type_path = data["type"]
-    module_path, class_name = type_path.rsplit(".", 1)
-    metric_cls = getattr(importlib.import_module(module_path), class_name)
+    # `import_class_by_name` returns `type[object]`; annotate as `Any` so that calling it with the
+    # metric's own keyword arguments below type-checks.
+    metric_cls: Any = import_class_by_name(type_path)
 
     kwargs: dict[str, Any] = {}
 

--- a/integrations/ragas/tests/conftest.py
+++ b/integrations/ragas/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    haystack-ai >= 3.0 refuses to deserialize classes from modules outside its trusted-module
+    allowlist. The metrics used in these tests are defined in the test modules, which live outside
+    that allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/ragas/tests/test_utils.py
+++ b/integrations/ragas/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from haystack.core.errors import DeserializationError
 from openai import AsyncOpenAI
 from ragas.embeddings.base import embedding_factory
 from ragas.llms import llm_factory
@@ -72,6 +73,14 @@ class TestDeserializeMetric:
         }
 
         with pytest.raises(ValueError, match="only supports the 'openai' provider"):
+            _deserialize_metric(data)
+
+    def test_raises_for_untrusted_metric_module(self):
+        data = {"type": "some.untrusted.Metric", "name": "some_metric"}
+
+        # haystack-ai 2.x fails to import the unknown module; haystack-ai >= 3.0 refuses it upfront
+        # because it is not on the trusted-module allowlist
+        with pytest.raises((ImportError, DeserializationError)):
             _deserialize_metric(data)
 
     def test_round_trip(self):

--- a/integrations/ragas/tests/test_utils.py
+++ b/integrations/ragas/tests/test_utils.py
@@ -4,6 +4,7 @@ from openai import AsyncOpenAI
 from ragas.embeddings.base import embedding_factory
 from ragas.llms import llm_factory
 from ragas.metrics.base import SimpleBaseMetric
+from ragas.metrics.collections import Faithfulness
 from ragas.metrics.result import MetricResult
 
 from haystack_integrations.components.evaluators.ragas.utils import _deserialize_metric, _serialize_metric
@@ -82,6 +83,16 @@ class TestDeserializeMetric:
         # because it is not on the trusted-module allowlist
         with pytest.raises((ImportError, DeserializationError)):
             _deserialize_metric(data)
+
+    def test_ragas_own_metrics_need_no_allowlisting(self, monkeypatch):
+        """Metrics shipped by ragas deserialize without the caller extending the allowlist."""
+        monkeypatch.delenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        metric = Faithfulness(llm=llm_factory("gpt-4o-mini", client=AsyncOpenAI()))
+
+        result = _deserialize_metric(_serialize_metric(metric))
+
+        assert isinstance(result, Faithfulness)
 
     def test_round_trip(self):
         metric = ConcreteMetric(name="round_trip")


### PR DESCRIPTION
### Related Issues

- Part of https://github.com/deepset-ai/haystack-private/issues/402

### Proposed Changes:

- `_deserialize_metric` now resolves the metric class via `haystack.core.serialization.import_class_by_name` instead of raw `importlib.import_module` + `getattr`, so the class path from serialized data passes through Haystack 3.0's deserialization allowlist.
- Metrics shipped by ragas keep working with no configuration: when the serialized class path is under `ragas.metrics.`, the integration adds `ragas.metrics.*` to the allowlist before importing. Every metric ragas ships lives there. No-op on `haystack-ai` < 3.0 to ensure compatibility.
- Custom metric classes from users still need explicit trust

### How did you test it?

- Added `tests/conftest.py` with the autouse allowlist fixture used across this repo and other tests

### Notes for the reviewer

I believe auto-accepting `ragas.metrics.*` is best for the users of this ragas integration.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)