### PR TITLE
fix: route DSPy signature deserialization through the gated import helper

### DIFF
--- a/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
+++ b/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
@@ -190,10 +190,7 @@ class DSPySignatureChatGenerator:
         `{"type": "class", "value": "mymodule.QASignature"}`.
 
         Signature classes are imported through Haystack's gated `import_class_by_name`, so with
-        `haystack-ai` >= 3.0 the module they live in must be on the deserialization allowlist. A
-        signature class defined in your own package therefore needs to be trusted explicitly, e.g.
-        via `Pipeline.load(..., allowed_modules=["mymodule.*"])`, `allow_deserialization_module`
-        or the `HAYSTACK_DESERIALIZATION_ALLOWLIST` environment variable.
+        `haystack-ai` >= 3.0 the module they live in must be on the deserialization allowlist.
         """
         signature_type = data["type"]
         value = data["value"]
@@ -229,10 +226,20 @@ class DSPySignatureChatGenerator:
         """
         Deserialize a component from a dictionary.
 
-        With `haystack-ai` >= 3.0, a serialized signature class is only imported if its module is on
-        the deserialization allowlist; see `_deserialize_signature`.
+        A signature serialized as a `dspy.Signature` subclass is imported by its fully qualified class
+        path. With `haystack-ai` >= 3.0 that import is gated: the module holding the class must be on
+        the deserialization allowlist, which by default covers only Haystack's own packages. To load a
+        component whose signature class lives in your own package, trust that package explicitly with
+        one of:
 
-        :raises DeserializationError: If the signature class is not on the deserialization allowlist.
+        - `Pipeline.loads(..., allowed_modules=["mymodule"])` for a single call,
+        - `haystack.core.serialization.allow_deserialization_module("mymodule")` for the whole process,
+        - the `HAYSTACK_DESERIALIZATION_ALLOWLIST=mymodule` environment variable.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        :raises DeserializationError:
+            If the module holding the serialized signature class is not on the deserialization allowlist.
         """
         init_params = data.get("init_parameters", {})
 

--- a/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
+++ b/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
@@ -1,8 +1,8 @@
-import importlib
 from typing import Any
 
 import dspy
 from haystack import component, default_from_dict, default_to_dict
+from haystack.core.serialization import import_class_by_name
 from haystack.dataclasses import ChatMessage, ChatRole
 
 VALID_MODULE_TYPES = {"Predict", "ChainOfThought", "ReAct"}
@@ -188,6 +188,12 @@ class DSPySignatureChatGenerator:
 
         Accepts `{"type": "str", "value": "question -> answer"}` or
         `{"type": "class", "value": "mymodule.QASignature"}`.
+
+        Signature classes are imported through Haystack's gated `import_class_by_name`, so with
+        `haystack-ai` >= 3.0 the module they live in must be on the deserialization allowlist. A
+        signature class defined in your own package therefore needs to be trusted explicitly, e.g.
+        via `Pipeline.load(..., allowed_modules=["mymodule.*"])`, `allow_deserialization_module`
+        or the `HAYSTACK_DESERIALIZATION_ALLOWLIST` environment variable.
         """
         signature_type = data["type"]
         value = data["value"]
@@ -196,9 +202,10 @@ class DSPySignatureChatGenerator:
             return value
 
         if signature_type == "class":
-            module_path, class_name = value.rsplit(".", 1)
-            module = importlib.import_module(module_path)
-            return getattr(module, class_name)
+            # `import_class_by_name` returns `type[object]`; annotate as `Any` so that returning it
+            # as a `dspy.Signature` subclass type-checks.
+            signature_cls: Any = import_class_by_name(value)
+            return signature_cls
 
         msg = f"Unknown signature type '{signature_type}'. Must be 'str' or 'class'."
         raise ValueError(msg)
@@ -219,7 +226,14 @@ class DSPySignatureChatGenerator:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "DSPySignatureChatGenerator":
-        """Deserialize a component from a dictionary."""
+        """
+        Deserialize a component from a dictionary.
+
+        With `haystack-ai` >= 3.0, a serialized signature class is only imported if its module is on
+        the deserialization allowlist; see `_deserialize_signature`.
+
+        :raises DeserializationError: If the signature class is not on the deserialization allowlist.
+        """
         init_params = data.get("init_parameters", {})
 
         signature = init_params.get("signature")

--- a/integrations/dspy/tests/conftest.py
+++ b/integrations/dspy/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_deserialization_of_test_modules(monkeypatch):
+    """
+    Trust the modules that hold the signature classes used in these tests.
+
+    haystack-ai >= 3.0 refuses to deserialize classes from modules outside its trusted-module
+    allowlist. Signature classes live in the test modules or in `dspy` itself, both outside that
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    """
+    monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*,dspy")

--- a/integrations/dspy/tests/test_chat_generator.py
+++ b/integrations/dspy/tests/test_chat_generator.py
@@ -1,4 +1,5 @@
 import os
+from importlib import metadata
 from unittest.mock import MagicMock, patch
 
 import dspy
@@ -12,6 +13,17 @@ from haystack_integrations.components.generators.dspy.chat.chat_generator import
     _create_dspy_lm,
     _get_dspy_module_class,
 )
+
+# haystack-ai >= 3.0 gates class imports during deserialization behind a trusted-module allowlist.
+# 2.x has no allowlist and imports any resolvable class path, so allowlist tests do not apply there.
+HAYSTACK_GATES_DESERIALIZATION = int(metadata.version("haystack-ai").split(".")[0]) >= 3
+
+
+class UntrustedQASignature(dspy.Signature):
+    """A signature class living in this test module, which is not on the default allowlist."""
+
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField()
 
 
 @pytest.fixture
@@ -297,12 +309,19 @@ class TestDSPySignatureChatGenerator:
         component = DSPySignatureChatGenerator.from_dict(data)
         assert component.signature is dspy.Signature
 
-    def test_from_dict_raises_for_untrusted_signature_module(self, mock_dspy_module):
-        """Test that a signature class from an untrusted module is not imported."""
+    @pytest.mark.skipif(
+        not HAYSTACK_GATES_DESERIALIZATION,
+        reason="The deserialization allowlist was introduced in haystack-ai 3.0",
+    )
+    def test_from_dict_refuses_signature_class_from_untrusted_module(self, mock_dspy_module, monkeypatch):
+        """Test that from_dict refuses a signature class whose module is not on the allowlist."""
+        # Drop the allowlist that tests/conftest.py installs, so this test module becomes untrusted.
+        # The signature class itself is importable, so an allowlist refusal is the only way this fails.
+        monkeypatch.delenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", raising=False)
         data = {
             "type": "haystack_integrations.components.generators.dspy.chat.chat_generator.DSPySignatureChatGenerator",
             "init_parameters": {
-                "signature": {"type": "class", "value": "some.untrusted.Signature"},
+                "signature": {"type": "class", "value": f"{__name__}.UntrustedQASignature"},
                 "model": "openai/gpt-5-mini",
                 "module_type": "Predict",
                 "output_field": "answer",
@@ -311,9 +330,7 @@ class TestDSPySignatureChatGenerator:
                 "input_mapping": None,
             },
         }
-        # haystack-ai 2.x fails to import the unknown module; haystack-ai >= 3.0 refuses it upfront
-        # because it is not on the trusted-module allowlist
-        with pytest.raises((ImportError, DeserializationError)):
+        with pytest.raises(DeserializationError, match="not on the trusted-module allowlist"):
             DSPySignatureChatGenerator.from_dict(data)
 
     def test_from_dict_with_unknown_signature_type(self, mock_dspy_module):

--- a/integrations/dspy/tests/test_chat_generator.py
+++ b/integrations/dspy/tests/test_chat_generator.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import dspy
 import pytest
+from haystack.core.errors import DeserializationError
 from haystack.dataclasses import ChatMessage
 
 from haystack_integrations.components.generators.dspy.chat.chat_generator import (
@@ -295,6 +296,25 @@ class TestDSPySignatureChatGenerator:
         }
         component = DSPySignatureChatGenerator.from_dict(data)
         assert component.signature is dspy.Signature
+
+    def test_from_dict_raises_for_untrusted_signature_module(self, mock_dspy_module):
+        """Test that a signature class from an untrusted module is not imported."""
+        data = {
+            "type": "haystack_integrations.components.generators.dspy.chat.chat_generator.DSPySignatureChatGenerator",
+            "init_parameters": {
+                "signature": {"type": "class", "value": "some.untrusted.Signature"},
+                "model": "openai/gpt-5-mini",
+                "module_type": "Predict",
+                "output_field": "answer",
+                "generation_kwargs": {},
+                "module_kwargs": {},
+                "input_mapping": None,
+            },
+        }
+        # haystack-ai 2.x fails to import the unknown module; haystack-ai >= 3.0 refuses it upfront
+        # because it is not on the trusted-module allowlist
+        with pytest.raises((ImportError, DeserializationError)):
+            DSPySignatureChatGenerator.from_dict(data)
 
     def test_from_dict_with_unknown_signature_type(self, mock_dspy_module):
         """Test that from_dict raises an error for unknown signature types."""


### PR DESCRIPTION
### Related Issues

- Fixes https://github.com/deepset-ai/haystack-private/issues/402

### Proposed Changes:

- `DSPySignatureChatGenerator._deserialize_signature` now resolves a serialized signature class via `haystack.core.serialization.import_class_by_name` instead of raw `importlib.import_module` + `getattr`, so the class path from serialized data passes through Haystack 3.0's deserialization allowlist.
- Documented the allowlist requirement in `_deserialize_signature` and `from_dict`

### How did you test it?

- Added `tests/conftest.py` with the autouse allowlist fixture used across this repo and other tests

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)