### PR TITLE
fix: `FAISSDocumentStore` with `search_term`, pagination and returning `(values, total_count)`

### DIFF
--- a/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
+++ b/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
@@ -458,11 +458,7 @@ class FAISSDocumentStore:
         """
         values = []
         for doc in self.documents.values():
-            val = (
-                FAISSDocumentStore._get_doc_value(doc, field_name)
-                if not field_name.startswith("meta.")
-                else doc.meta.get(field_name[5:])
-            )
+            val = FAISSDocumentStore._get_doc_value(doc, field_name)
             if val is not None:
                 values.append(val)
 
@@ -471,23 +467,40 @@ class FAISSDocumentStore:
 
         return {"min": min(values), "max": max(values)}
 
-    def get_metadata_field_unique_values(self, field_name: str) -> list[Any]:
+    def get_metadata_field_unique_values(
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+    ) -> tuple[list[str], int]:
         """
-        Returns all unique values for a specific metadata field.
+        Returns unique values for a metadata field, optionally filtered by a search term, with pagination.
 
-        :param field_name: The name of the metadata field.
-        :returns: A list of unique values for the specified field.
+        :param metadata_field: The metadata field to get unique values for. Can include or omit the "meta." prefix.
+        :param search_term: Optional search term to filter values, matched as a case-insensitive substring
+            against the metadata field's value.
+        :param from_: The offset to start returning values from (for pagination).
+        :param size: The maximum number of unique values to return.
+        :returns: A tuple containing list of unique values and total count of unique values.
         """
-        values = set()
+        values = []
         for doc in self.documents.values():
-            val = (
-                FAISSDocumentStore._get_doc_value(doc, field_name)
-                if not field_name.startswith("meta.")
-                else doc.meta.get(field_name[5:])
-            )
+            val = FAISSDocumentStore._get_doc_value(doc, metadata_field)
             if val is not None:
-                values.add(val)
-        return list(values)
+                values.append(val)
+
+        if search_term:
+            search_term_lower = search_term.lower()
+            values = [val for val in values if search_term_lower in str(val).lower()]
+
+        unique_values = {str(val) for val in values}
+        sorted_values = sorted(unique_values)
+        total_count = len(sorted_values)
+        end = from_ + size
+        paginated_values = sorted_values[from_:end]
+
+        return paginated_values, total_count
 
     def count_unique_metadata_by_filter(self, filters: dict[str, Any], metadata_fields: list[str]) -> dict[str, int]:
         """

--- a/integrations/faiss/tests/test_document_store.py
+++ b/integrations/faiss/tests/test_document_store.py
@@ -212,7 +212,7 @@ class TestFAISSDocumentStore(
         assert set(values) == {"needle-in-haystack"}
 
     def test_get_metadata_field_unique_values_pagination(self, document_store):
-        docs = [Document(content=f"Doc {i}", meta={"category": chr(ord('A') + i)}) for i in range(5)]
+        docs = [Document(content=f"Doc {i}", meta={"category": chr(ord("A") + i)}) for i in range(5)]
         document_store.write_documents(docs)
 
         page1, total_count = document_store.get_metadata_field_unique_values("meta.category", from_=0, size=2)

--- a/integrations/faiss/tests/test_document_store.py
+++ b/integrations/faiss/tests/test_document_store.py
@@ -168,3 +168,72 @@ class TestFAISSDocumentStore(
         document_store.write_documents([Document(content="test", meta={"category": "A"})])
         with pytest.raises(FilterError, match="NOT operator expects at least one condition"):
             document_store.filter_documents(filters={"operator": "NOT", "conditions": []})
+
+    def test_get_metadata_field_unique_values_with_search_term(self, document_store):
+        docs = [
+            Document(content="Doc 1", meta={"category": "Apple"}),
+            Document(content="Doc 2", meta={"category": "Banana"}),
+            Document(content="Doc 3", meta={"category": "Apricot"}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total_count = document_store.get_metadata_field_unique_values("meta.category", search_term="ap")
+        assert set(values) == {"Apple", "Apricot"}
+        assert total_count == 2
+
+        values, total_count = document_store.get_metadata_field_unique_values(
+            "meta.category", search_term="nonexistent"
+        )
+        assert values == []
+        assert total_count == 0
+
+    def test_get_metadata_field_unique_values_search_term_is_case_insensitive(self, document_store):
+        docs = [
+            Document(content="Doc 1", meta={"language": "Python"}),
+            Document(content="Doc 2", meta={"language": "Java"}),
+            Document(content="Doc 3", meta={"language": "JavaScript"}),
+        ]
+        document_store.write_documents(docs)
+
+        values, _ = document_store.get_metadata_field_unique_values("meta.language", search_term="java")
+        assert set(values) == {"Java", "JavaScript"}
+
+        values, _ = document_store.get_metadata_field_unique_values("meta.language", search_term="JAVA")
+        assert set(values) == {"Java", "JavaScript"}
+
+    def test_get_metadata_field_unique_values_search_term_matches_value_not_content(self, document_store):
+        docs = [
+            Document(content="This mentions needle in the text", meta={"topic": "unrelated"}),
+            Document(content="Nothing special here", meta={"topic": "needle-in-haystack"}),
+        ]
+        document_store.write_documents(docs)
+
+        values, _ = document_store.get_metadata_field_unique_values("meta.topic", search_term="needle")
+        assert set(values) == {"needle-in-haystack"}
+
+    def test_get_metadata_field_unique_values_pagination(self, document_store):
+        docs = [Document(content=f"Doc {i}", meta={"category": chr(ord('A') + i)}) for i in range(5)]
+        document_store.write_documents(docs)
+
+        page1, total_count = document_store.get_metadata_field_unique_values("meta.category", from_=0, size=2)
+        assert page1 == ["A", "B"]
+        assert total_count == 5
+
+        page2, total_count = document_store.get_metadata_field_unique_values("meta.category", from_=2, size=2)
+        assert page2 == ["C", "D"]
+        assert total_count == 5
+
+        page3, total_count = document_store.get_metadata_field_unique_values("meta.category", from_=4, size=2)
+        assert page3 == ["E"]
+        assert total_count == 5
+
+    def test_get_metadata_field_unique_values_with_and_without_meta_prefix(self, document_store):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A"}),
+            Document(content="Doc 2", meta={"category": "B"}),
+        ]
+        document_store.write_documents(docs)
+
+        prefixed = document_store.get_metadata_field_unique_values("meta.category")
+        unprefixed = document_store.get_metadata_field_unique_values("category")
+        assert prefixed == unprefixed == (["A", "B"], 2)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/486

### Proposed Changes:

`search_term`, pagination and returning `(values, total_count)`

### How did you test it?

- new unit tests to cover the changes - run alls in local memory

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
