### PR TITLE
fix(twelvelabs): avoid orphaned async embed tasks when a batch call fails

### DIFF
--- a/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/document_embedder.py
+++ b/integrations/twelvelabs/src/haystack_integrations/components/embedders/twelvelabs/document_embedder.py
@@ -176,6 +176,11 @@ class TwelveLabsDocumentEmbedder:
             desc="Calculating embeddings",
         ):
             batch = texts_to_embed[i : i + self.batch_size]
-            batch_embeddings = await asyncio.gather(*(embed_text_async(text, self.model, key) for text in batch))
-            embeddings.extend(batch_embeddings)
+            batch_embeddings = await asyncio.gather(
+                *(embed_text_async(text, self.model, key) for text in batch), return_exceptions=True
+            )
+            for embedding in batch_embeddings:
+                if isinstance(embedding, BaseException):
+                    raise embedding
+            embeddings.extend(batch_embeddings)  # type: ignore[arg-type]
         return self._build_result(documents, embeddings, self.model)

--- a/integrations/twelvelabs/tests/test_document_embedder.py
+++ b/integrations/twelvelabs/tests/test_document_embedder.py
@@ -98,6 +98,24 @@ async def test_run_async_rejects_non_documents():
         await embedder.run_async(documents="a string")
 
 
+@pytest.mark.asyncio
+async def test_run_async_propagates_exception_and_waits_for_all_tasks():
+    embedder = TwelveLabsDocumentEmbedder(api_key=Secret.from_token("tlk_test"))
+    docs = [Document(content="first"), Document(content="second")]
+
+    async def fake_embed(text: str, _model: str, _api_key: str) -> list[float]:
+        if text == "first":
+            msg = "boom"
+            raise ValueError(msg)
+        return [0.2] * 8
+
+    with patch(ASYNC_PATCH_TARGET, new_callable=AsyncMock, side_effect=fake_embed) as mock_embed:
+        with pytest.raises(ValueError, match="boom"):
+            await embedder.run_async(documents=docs)
+
+    assert mock_embed.await_count == 2
+
+
 @pytest.mark.skipif(not os.environ.get("TWELVELABS_API_KEY"), reason="TWELVELABS_API_KEY env var not set")
 @pytest.mark.integration
 def test_run_integration():


### PR DESCRIPTION
### Related Issues

- fixes #3578

### Proposed Changes

- Use `asyncio.gather(..., return_exceptions=True)` inside `TwelveLabsDocumentEmbedder.run_async`.
- Inspect the gathered results and raise the first exception that occurred.
- This prevents sibling `embed_text_async` coroutines from becoming orphaned / unretrieved when one call in a batch raises.

### How did you test it?

- Added `test_run_async_propagates_exception_and_waits_for_all_tasks`, which simulates one failing and one succeeding embed call and asserts both are awaited and the original exception is raised.
- Ran the unit tests for the integration:

```bash
cd integrations/twelvelabs
hatch run test:unit
```

Result: `27 passed, 5 deselected`.
- `hatch run fmt` and `hatch run test:types` are green.

### Notes for the reviewer

N/A