### PR TITLE
chore: MCP - pin mcp<2.0.0

### DIFF
--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "mcp>=1.8.0",
+    "mcp>=1.8.0, <2.0.0",
     "haystack-ai>=2.23.0",
     "exceptiongroup",  # Backport of ExceptionGroup for Python < 3.11
     "httpx"  # HTTP client library used for SSE connections
@@ -68,7 +68,7 @@ dependencies = [
     "pytest-rerunfailures",
     "mypy",
     "pip",
-    "anyio", 
+    "anyio",
     "pytest-tornasync",
     "pytest-pythonpath",
     "mcp-server-time"
@@ -185,4 +185,3 @@ markers = [
 ]
 log_cli = true
 asyncio_default_fixture_loop_scope = "function"
- 

--- a/integrations/mcp/tests/test_mcp_integration.py
+++ b/integrations/mcp/tests/test_mcp_integration.py
@@ -93,7 +93,9 @@ class TestMCPToolInPipelineWithOpenAI:
         """Test using multiple MCPTools in a pipeline with OpenAI."""
 
         # Mix mcp tool with a simple echo tool
-        time_server_info = StdioServerInfo(command="uvx", args=["mcp-server-time", "--local-timezone=America/New_York"])
+        time_server_info = StdioServerInfo(
+            command="uvx", args=["--with", "mcp<2.0.0", "mcp-server-time", "--local-timezone=America/New_York"]
+        )
         time_tool = MCPTool(name="get_current_time", server_info=time_server_info)
         # Register for cleanup
         mcp_tool_cleanup(time_tool)

--- a/integrations/mcp/tests/test_mcp_tool.py
+++ b/integrations/mcp/tests/test_mcp_tool.py
@@ -512,7 +512,9 @@ class TestMCPTool:
         """Test lazy connection with Pipeline.warm_up() - replicates time_pipeline.py."""
 
         # Replicate time_pipeline.py using MCPTool instead of MCPToolset
-        server_info = StdioServerInfo(command="uvx", args=["mcp-server-time", "--local-timezone=Europe/Berlin"])
+        server_info = StdioServerInfo(
+            command="uvx", args=["--with", "mcp<2.0.0", "mcp-server-time", "--local-timezone=Europe/Berlin"]
+        )
 
         # Create tool with lazy connection (default behavior)
         tool = MCPTool(name="get_current_time", server_info=server_info)
@@ -535,7 +537,9 @@ class TestMCPTool:
         """Test Agent with MCPTool using state-mapping to inject location from state."""
 
         # Create MCPTool with state-mapping that injects home_city from state as timezone parameter
-        server_info = StdioServerInfo(command="uvx", args=["mcp-server-time", "--local-timezone=Europe/Berlin"])
+        server_info = StdioServerInfo(
+            command="uvx", args=["--with", "mcp<2.0.0", "mcp-server-time", "--local-timezone=Europe/Berlin"]
+        )
         tool = MCPTool(
             name="get_current_time",
             server_info=server_info,

--- a/integrations/mcp/tests/test_mcp_toolset.py
+++ b/integrations/mcp/tests/test_mcp_toolset.py
@@ -522,7 +522,9 @@ class TestMCPToolset:
         """Test lazy connection with Pipeline.warm_up() - replicates time_pipeline.py."""
 
         # Replicate time_pipeline.py using calculator instead of time server
-        server_info = StdioServerInfo(command="uvx", args=["mcp-server-time", "--local-timezone=Europe/Berlin"])
+        server_info = StdioServerInfo(
+            command="uvx", args=["--with", "mcp<2.0.0", "mcp-server-time", "--local-timezone=Europe/Berlin"]
+        )
 
         # Create toolset with lazy connection (default behavior)
         toolset = MCPToolset(server_info=server_info)


### PR DESCRIPTION
### Related Issues

- MCP tests failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/30410939052/job/90446681596
  - here the MCP new Python client is not yet installed (due to uv.toml config) but only the Time MCP Server 

### Proposed Changes:
- explicitly pin `mcp<2`
- also in tests where we use the Time MCP Server 

### How did you test it?
CI

### Notes for the reviewer
Opened this issue to track the future v2 MCP work: https://github.com/deepset-ai/haystack-core-integrations/issues/3687

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
