### PR TITLE
feat(deepeval): add run_async method to DeepEvalEvaluator

### DIFF
--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
@@ -110,8 +110,8 @@ class DeepEvalEvaluator:
         Run the DeepEval evaluator asynchronously on the provided inputs.
 
         Each test case is evaluated concurrently using the metric's async
-        ``a_measure`` method. A separate metric copy is used per test case
-        because DeepEval metrics keep state (``score``, ``reason``) on the
+        `a_measure` method. A separate metric copy is used per test case
+        because DeepEval metrics keep state (`score`, `reason`) on the
         metric instance.
 
         :param inputs:
@@ -121,7 +121,7 @@ class DeepEvalEvaluator:
         :returns:
             A dictionary with a single `results` entry that contains
             a nested list of metric results. The shape matches the
-            output of :meth:`run`.
+            output of the `run` method.
         """
         InputConverters.validate_input_parameters(self.metric, self.descriptor.input_parameters, inputs)
         converted_inputs: list[LLMTestCase] = list(self.descriptor.input_converter(**inputs))  # type: ignore
@@ -179,30 +179,37 @@ class DeepEvalEvaluator:
         return evaluate(test_cases=test_cases, metrics=[metric])
 
     @staticmethod
-    async def _invoke_deepeval_async(test_cases: list[LLMTestCase], metric: BaseMetric) -> EvaluationResult:
-        """Evaluate ``test_cases`` concurrently using the metric's ``a_measure``."""
+    async def _invoke_deepeval_async(
+        test_cases: list[LLMTestCase],
+        metric: BaseMetric,
+        max_concurrent: int = 4,
+    ) -> EvaluationResult:
+        """Evaluate `test_cases` concurrently using the metric's `a_measure`."""
+
+        semaphore = asyncio.Semaphore(max_concurrent)
 
         async def _evaluate_one(test_case: LLMTestCase) -> TestResult:
-            # DeepEval metrics keep their result state on the instance, so each
-            # concurrent evaluation needs its own copy.
-            metric_copy = cast(BaseMetric, copy_metrics([metric])[0])
-            await metric_copy.a_measure(test_case)
-            metric_data = MetricData.model_construct(
-                name=metric_copy.__class__.__name__,
-                score=metric_copy.score,
-                reason=metric_copy.reason,
-            )
-            return TestResult(
-                name=test_case.name or "",
-                success=False,
-                conversational=False,
-                metrics_data=[metric_data],
-                input=test_case.input,
-                actual_output=test_case.actual_output,
-                expected_output=test_case.expected_output,
-                context=test_case.context,
-                retrieval_context=cast(list[str] | None, test_case.retrieval_context),
-            )
+            async with semaphore:
+                # DeepEval metrics keep their result state on the instance, so each
+                # concurrent evaluation needs its own copy.
+                metric_copy = cast(BaseMetric, copy_metrics([metric])[0])
+                await metric_copy.a_measure(test_case)
+                metric_data = MetricData.model_construct(
+                    name=metric_copy.__class__.__name__,
+                    score=metric_copy.score,
+                    reason=metric_copy.reason,
+                )
+                return TestResult(
+                    name=test_case.name or "",
+                    success=False,
+                    conversational=False,
+                    metrics_data=[metric_data],
+                    input=test_case.input,
+                    actual_output=test_case.actual_output,
+                    expected_output=test_case.expected_output,
+                    context=test_case.context,
+                    retrieval_context=cast(list[str] | None, test_case.retrieval_context),
+                )
 
         results = await asyncio.gather(*[_evaluate_one(tc) for tc in test_cases])
         return EvaluationResult(test_results=list(results), confident_link=None, test_run_id=None)

--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
@@ -1,12 +1,14 @@
+import asyncio
 import json
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 from haystack import DeserializationError, component, default_from_dict, default_to_dict
 
 from deepeval.evaluate import evaluate
-from deepeval.evaluate.types import EvaluationResult
+from deepeval.evaluate.types import EvaluationResult, MetricData, TestResult
 from deepeval.metrics import BaseMetric
+from deepeval.metrics.utils import copy_metrics
 from deepeval.test_case import LLMTestCase
 
 from .metrics import (
@@ -51,6 +53,7 @@ class DeepEvalEvaluator:
     _backend_metric: BaseMetric
     # Wrapped for easy mocking.
     _backend_callable: Callable[[list[LLMTestCase], BaseMetric], EvaluationResult]
+    _backend_callable_async: Callable[[list[LLMTestCase], BaseMetric], Awaitable[EvaluationResult]]
 
     def __init__(
         self,
@@ -97,11 +100,40 @@ class DeepEvalEvaluator:
         converted_inputs: list[LLMTestCase] = list(self.descriptor.input_converter(**inputs))  # type: ignore
 
         results = self._backend_callable(converted_inputs, self._backend_metric)
-        converted_results = [
-            [result.to_dict() for result in self.descriptor.output_converter(x)] for x in results.test_results
-        ]
+        converted_results = self._convert_results(results)
 
         return {"results": converted_results}
+
+    @component.output_types(results=list[list[dict[str, Any]]])
+    async def run_async(self, **inputs: Any) -> dict[str, Any]:
+        """
+        Run the DeepEval evaluator asynchronously on the provided inputs.
+
+        Each test case is evaluated concurrently using the metric's async
+        ``a_measure`` method. A separate metric copy is used per test case
+        because DeepEval metrics keep state (``score``, ``reason``) on the
+        metric instance.
+
+        :param inputs:
+            The inputs to evaluate. These are determined by the
+            metric being calculated. See `DeepEvalMetric` for more
+            information.
+        :returns:
+            A dictionary with a single `results` entry that contains
+            a nested list of metric results. The shape matches the
+            output of :meth:`run`.
+        """
+        InputConverters.validate_input_parameters(self.metric, self.descriptor.input_parameters, inputs)
+        converted_inputs: list[LLMTestCase] = list(self.descriptor.input_converter(**inputs))  # type: ignore
+
+        results = await self._backend_callable_async(converted_inputs, self._backend_metric)
+        converted_results = self._convert_results(results)
+
+        return {"results": converted_results}
+
+    def _convert_results(self, results: EvaluationResult) -> list[list[dict[str, Any]]]:
+        """Convert an ``EvaluationResult`` to the evaluator's output format."""
+        return [[result.to_dict() for result in self.descriptor.output_converter(x)] for x in results.test_results]
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -146,6 +178,35 @@ class DeepEvalEvaluator:
     def _invoke_deepeval(test_cases: list[LLMTestCase], metric: BaseMetric) -> EvaluationResult:
         return evaluate(test_cases=test_cases, metrics=[metric])
 
+    @staticmethod
+    async def _invoke_deepeval_async(test_cases: list[LLMTestCase], metric: BaseMetric) -> EvaluationResult:
+        """Evaluate ``test_cases`` concurrently using the metric's ``a_measure``."""
+
+        async def _evaluate_one(test_case: LLMTestCase) -> TestResult:
+            # DeepEval metrics keep their result state on the instance, so each
+            # concurrent evaluation needs its own copy.
+            metric_copy = cast(BaseMetric, copy_metrics([metric])[0])
+            await metric_copy.a_measure(test_case)
+            metric_data = MetricData.model_construct(
+                name=metric_copy.__class__.__name__,
+                score=metric_copy.score,
+                reason=metric_copy.reason,
+            )
+            return TestResult(
+                name=test_case.name or "",
+                success=False,
+                conversational=False,
+                metrics_data=[metric_data],
+                input=test_case.input,
+                actual_output=test_case.actual_output,
+                expected_output=test_case.expected_output,
+                context=test_case.context,
+                retrieval_context=cast(list[str] | None, test_case.retrieval_context),
+            )
+
+        results = await asyncio.gather(*[_evaluate_one(tc) for tc in test_cases])
+        return EvaluationResult(test_results=list(results), confident_link=None, test_run_id=None)
+
     def _init_backend(self) -> None:
         """
         Initialize the DeepEval backend.
@@ -167,3 +228,4 @@ class DeepEvalEvaluator:
         backend_metric_params["threshold"] = 0.0
         self._backend_metric = self.descriptor.backend(**backend_metric_params)
         self._backend_callable = DeepEvalEvaluator._invoke_deepeval
+        self._backend_callable_async = DeepEvalEvaluator._invoke_deepeval_async

--- a/integrations/deepeval/tests/test_evaluator.py
+++ b/integrations/deepeval/tests/test_evaluator.py
@@ -495,3 +495,63 @@ def test_integration_run(metric, inputs, metric_params):
     assert len(output) == 1
     assert "results" in output
     assert len(output["results"]) == len(next(iter(inputs.values())))
+
+
+# This integration test validates the async evaluator by running it against the
+# OpenAI API. It is parameterized by the metric, the inputs to the evaluator
+# and the metric parameters.
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "metric, inputs, metric_params",
+    [
+        (
+            DeepEvalMetric.ANSWER_RELEVANCY,
+            {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS, "responses": DEFAULT_RESPONSES},
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.FAITHFULNESS,
+            {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS, "responses": DEFAULT_RESPONSES},
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.CONTEXTUAL_PRECISION,
+            {
+                "questions": DEFAULT_QUESTIONS,
+                "contexts": DEFAULT_CONTEXTS,
+                "responses": DEFAULT_RESPONSES,
+                "ground_truths": DEFAULT_GROUND_TRUTHS,
+            },
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.CONTEXTUAL_RECALL,
+            {
+                "questions": DEFAULT_QUESTIONS,
+                "contexts": DEFAULT_CONTEXTS,
+                "responses": DEFAULT_RESPONSES,
+                "ground_truths": DEFAULT_GROUND_TRUTHS,
+            },
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.CONTEXTUAL_RELEVANCE,
+            {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS, "responses": DEFAULT_RESPONSES},
+            {"model": "gpt-4o"},
+        ),
+    ],
+)
+async def test_integration_run_async(metric, inputs, metric_params):
+    init_params = {
+        "metric": metric,
+        "metric_params": metric_params,
+    }
+    evaluator = DeepEvalEvaluator(**init_params)
+    output = await evaluator.run_async(**inputs)
+
+    assert isinstance(output, dict)
+    assert len(output) == 1
+    assert "results" in output
+    assert len(output["results"]) == len(next(iter(inputs.values())))

--- a/integrations/deepeval/tests/test_evaluator.py
+++ b/integrations/deepeval/tests/test_evaluator.py
@@ -86,6 +86,16 @@ class MockBackend:
         return EvaluationResult(test_results=out, confident_link=None, test_run_id=None)
 
 
+class MockAsyncBackend:
+    """Async wrapper around ``MockBackend`` for ``run_async`` tests."""
+
+    def __init__(self, metric: DeepEvalMetric) -> None:
+        self._backend = MockBackend(metric)
+
+    async def eval(self, test_cases, metric) -> EvaluationResult:
+        return self._backend.eval(test_cases, metric)
+
+
 def test_evaluator_metric_init_params(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
 
@@ -272,6 +282,75 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params, monk
     evaluator = DeepEvalEvaluator(**init_params)
     evaluator._backend_callable = lambda testcases, metrics: MockBackend(metric).eval(testcases, metrics)
     results = evaluator.run(**inputs)["results"]
+
+    assert isinstance(results, type(expected_outputs))
+    assert len(results) == len(expected_outputs)
+
+    for r, o in zip(results, expected_outputs, strict=True):
+        assert len(r) == len(o)
+
+        expected = {(name if name is not None else str(metric), score, exp) for name, score, exp in o}
+        got = {(x["name"], x["score"], x["explanation"]) for x in r}
+        assert got == expected
+
+
+@pytest.mark.parametrize(
+    "metric, inputs, expected_outputs, metric_params",
+    [
+        (
+            DeepEvalMetric.ANSWER_RELEVANCY,
+            {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS, "responses": DEFAULT_RESPONSES},
+            [[(None, 0.5, "1")]] * 2,
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.FAITHFULNESS,
+            {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS, "responses": DEFAULT_RESPONSES},
+            [[(None, 0.1, "2")]] * 2,
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.CONTEXTUAL_PRECISION,
+            {
+                "questions": DEFAULT_QUESTIONS,
+                "contexts": DEFAULT_CONTEXTS,
+                "responses": DEFAULT_RESPONSES,
+                "ground_truths": DEFAULT_GROUND_TRUTHS,
+            },
+            [[(None, 0.2, "3")]] * 2,
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.CONTEXTUAL_RECALL,
+            {
+                "questions": DEFAULT_QUESTIONS,
+                "contexts": DEFAULT_CONTEXTS,
+                "responses": DEFAULT_RESPONSES,
+                "ground_truths": DEFAULT_GROUND_TRUTHS,
+            },
+            [[(None, 35, "4")]] * 2,
+            {"model": "gpt-4o"},
+        ),
+        (
+            DeepEvalMetric.CONTEXTUAL_RELEVANCE,
+            {"questions": DEFAULT_QUESTIONS, "contexts": DEFAULT_CONTEXTS, "responses": DEFAULT_RESPONSES},
+            [[(None, 1.5, "5")]] * 2,
+            {"model": "gpt-4o"},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_evaluator_outputs_async(metric, inputs, expected_outputs, metric_params, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
+    init_params = {
+        "metric": metric,
+        "metric_params": metric_params,
+    }
+    evaluator = DeepEvalEvaluator(**init_params)
+    backend = MockAsyncBackend(metric)
+    evaluator._backend_callable_async = backend.eval
+    results = (await evaluator.run_async(**inputs))["results"]
 
     assert isinstance(results, type(expected_outputs))
     assert len(results) == len(expected_outputs)

--- a/integrations/deepeval/tests/test_evaluator.py
+++ b/integrations/deepeval/tests/test_evaluator.py
@@ -3,11 +3,13 @@ import os
 from dataclasses import dataclass
 
 import pytest
-from deepeval.evaluate.types import EvaluationResult, TestResult
+from deepeval.evaluate.types import EvaluationResult, MetricData, TestResult
 from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
 from haystack import DeserializationError
 
 from haystack_integrations.components.evaluators.deepeval import DeepEvalEvaluator
+from haystack_integrations.components.evaluators.deepeval import evaluator as deepeval_evaluator_module
 from haystack_integrations.components.evaluators.deepeval.metrics import DeepEvalMetric, InputConverters
 
 DEFAULT_QUESTIONS = [
@@ -361,6 +363,79 @@ async def test_evaluator_outputs_async(metric, inputs, expected_outputs, metric_
         expected = {(name if name is not None else str(metric), score, exp) for name, score, exp in o}
         got = {(x["name"], x["score"], x["explanation"]) for x in r}
         assert got == expected
+
+
+def test_invoke_deepeval(monkeypatch):
+    """The sync helper should delegate to ``deepeval.evaluate.evaluate``."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
+    metric = DeepEvalMetric.ANSWER_RELEVANCY
+    evaluator = DeepEvalEvaluator(metric, metric_params={"model": "gpt-4o"})
+    test_cases = [
+        LLMTestCase(input="Which sport?", actual_output="Football."),
+    ]
+
+    expected = EvaluationResult(
+        test_results=[
+            TestResult(
+                name="tc-1",
+                success=True,
+                conversational=False,
+                metrics_data=[MetricData.model_construct(name="AnswerRelevancyMetric", score=0.5, reason="ok")],
+                input="Which sport?",
+                actual_output="Football.",
+                expected_output=None,
+                context=None,
+                retrieval_context=None,
+            ),
+        ],
+        confident_link=None,
+        test_run_id=None,
+    )
+
+    def fake_evaluate(test_cases: list, metrics: list):
+        assert len(test_cases) == 1
+        assert metrics == [evaluator._backend_metric]
+        return expected
+
+    monkeypatch.setattr(deepeval_evaluator_module, "evaluate", fake_evaluate)
+    result = DeepEvalEvaluator._invoke_deepeval(test_cases, evaluator._backend_metric)
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_invoke_deepeval_async(monkeypatch):
+    """The async helper should evaluate each test case concurrently with a copied metric."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
+    metric = DeepEvalMetric.ANSWER_RELEVANCY
+    evaluator = DeepEvalEvaluator(metric, metric_params={"model": "gpt-4o"})
+    test_cases = [
+        LLMTestCase(input="Which sport?", actual_output="Football."),
+        LLMTestCase(input="Who created Python?", actual_output="Guido van Rossum."),
+    ]
+
+    class FakeMetric:
+        def __init__(self):
+            self.score = 0.8
+            self.reason = "looks good"
+
+        async def a_measure(self, test_case: LLMTestCase) -> None:
+            pass
+
+    def fake_copy_metrics(_metrics: list):
+        return [FakeMetric()]
+
+    monkeypatch.setattr(deepeval_evaluator_module, "copy_metrics", fake_copy_metrics)
+    result = await DeepEvalEvaluator._invoke_deepeval_async(test_cases, evaluator._backend_metric)
+
+    assert len(result.test_results) == 2
+    for test_case, test_result in zip(test_cases, result.test_results, strict=True):
+        assert test_result.input == test_case.input
+        assert test_result.actual_output == test_case.actual_output
+        assert test_result.metrics_data[0].name == "FakeMetric"
+        assert test_result.metrics_data[0].score == 0.8
+        assert test_result.metrics_data[0].reason == "looks good"
 
 
 # This integration test validates the evaluator by running it against the


### PR DESCRIPTION
### Related Issues

- fixes #3667

### Proposed Changes:

- Add `run_async` to `DeepEvalEvaluator` so it can be used in `Pipeline.run_async()` without blocking the caller's loop.
- The async implementation uses each metric's native `a_measure` method and evaluates test cases concurrently with `asyncio.gather`.
- A separate metric copy is created per test case using `deepeval.metrics.utils.copy_metrics`, because DeepEval metrics keep result state (`score`, `reason`) on the metric instance.
- Extracted `_convert_results` so both `run` and `run_async` share the same output-formatting logic.
- Added parameterized async tests covering all five supported metrics.

### How did you test it?

```bash
cd integrations/deepeval
hatch run test:unit -v
hatch run test:types
hatch run fmt-check
```

- 24 unit tests pass (including 5 new async output tests).
- Mypy reports no issues.
- Ruff format/lint passes.

### Notes for the reviewer

This follows the same pattern used by `RagasEvaluator.run_async` in this repo and by the public `a_measure` API suggested in the issue discussion. It intentionally does not bump the `deepeval` pin (`>=2.9.0` remains supported).
