### PR TITLE
fix: `AmazonSageMaker` fixing Python 3.10 typing issue

### DIFF
--- a/integrations/amazon_sagemaker/src/haystack_integrations/components/generators/amazon_sagemaker/sagemaker.py
+++ b/integrations/amazon_sagemaker/src/haystack_integrations/components/generators/amazon_sagemaker/sagemaker.py
@@ -247,6 +247,10 @@ class SagemakerGenerator:
 
         except requests.HTTPError as err:
             res = err.response
+            if res is None:
+                msg = "SageMaker Inference returned an error, but no response was attached to the exception."
+                raise SagemakerInferenceError(msg) from err
+
             if res.status_code == MODEL_NOT_READY_STATUS_CODE:
                 msg = f"Sagemaker model not ready: {res.text}"
                 raise SagemakerNotReadyError(msg) from err


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/actions/runs/30502836943/job/90746112046

### Proposed Changes:

- `requests.HTTPError.response` is typed as `Response | None` in the requests stubs, 

### How did you test it?

- CI tests workflow

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
