### PR TITLE
fix: `Qdrant` adding offset based pagination to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -1288,11 +1288,14 @@ class QdrantDocumentStore:
         from_: int = 0,
         size: int = 10,
         filters: dict[str, Any] | None = None,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Returns unique values for a metadata field, with optional filters, search term and pagination.
 
         Unique values are ordered by first occurrence during scroll.
+
+        **Note**: This operation can be expensive for metadata fields with many unique values, since all
+        matching documents must be scrolled through to compute the total count.
 
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
         :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
@@ -1339,11 +1342,14 @@ class QdrantDocumentStore:
         from_: int = 0,
         size: int = 10,
         filters: dict[str, Any] | None = None,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Asynchronously returns unique values for a metadata field, with optional filters, search term and pagination.
 
         Unique values are ordered by first occurrence during scroll.
+
+        **Note**: This operation can be expensive for metadata fields with many unique values, since all
+        matching documents must be scrolled through to compute the total count.
 
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
         :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -726,11 +726,9 @@ class QdrantDocumentStore:
         metadata_field: str,
         unique_values: list[Any],
         unique_values_set: set[Any],
-        offset: int,
-        limit: int,
         search_term: str | None = None,
-    ) -> bool:
-        """Collect unique values from a batch of records. Returns True when len(unique_values) >= offset + limit."""
+    ) -> None:
+        """Collect unique values from a batch of records into unique_values / unique_values_set."""
         for record in records:
             if record.payload and "meta" in record.payload:
                 meta = record.payload["meta"]
@@ -743,9 +741,6 @@ class QdrantDocumentStore:
                         if hashable_value not in unique_values_set:
                             unique_values_set.add(hashable_value)
                             unique_values.append(value)
-                            if len(unique_values) >= offset + limit:
-                                return True
-        return False
 
     @staticmethod
     def _create_updated_point_from_record(record: Any, meta: dict[str, Any]) -> rest.PointStruct:
@@ -1291,22 +1286,22 @@ class QdrantDocumentStore:
         metadata_field: str,
         filters: dict[str, Any] | None = None,
         search_term: str | None = None,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> list[Any]:
+        from_: int = 0,
+        size: int = 10,
+    ) -> tuple[list[str], int]:
         """
-        Returns unique values for a metadata field, with optional filters and offset/limit pagination.
+        Returns unique values for a metadata field, with optional filters, search term and pagination.
 
-        Unique values are ordered by first occurrence during scroll. Pagination is offset-based over that order.
+        Unique values are ordered by first occurrence during scroll.
 
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
         :param filters: Optional filters to restrict the documents considered.
             For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
         :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
-        :param limit: Maximum number of unique values to return per page. Defaults to 100.
-        :param offset: Number of unique values to skip (for pagination). Defaults to 0.
+        :param from_: The offset for pagination (0-based). Defaults to 0.
+        :param size: The maximum number of unique values to return. Defaults to 10.
 
-        :returns: A list of unique values for the field (at most ``limit`` items, starting at ``offset``).
+        :returns: A tuple containing (list of unique values, total count of unique matching values).
         """
         self._initialize_client()
         assert self._client is not None
@@ -1318,7 +1313,7 @@ class QdrantDocumentStore:
 
         try:
             next_offset = None
-            while len(unique_values) < offset + limit:
+            while True:
                 records, next_offset = self._client.scroll(
                     collection_name=self.index,
                     scroll_filter=qdrant_filter,
@@ -1327,39 +1322,37 @@ class QdrantDocumentStore:
                     with_payload=True,
                     with_vectors=False,
                 )
-                if self._process_records_unique_values(
-                    records, field_name, unique_values, unique_values_set, offset, limit, search_term
-                ):
-                    break
+                self._process_records_unique_values(records, field_name, unique_values, unique_values_set, search_term)
                 if self._check_stop_scrolling(next_offset):
                     break
 
-            return unique_values[offset : offset + limit]
+            total_count = len(unique_values)
+            return unique_values[from_ : from_ + size], total_count
         except Exception as e:
             logger.warning(f"Error {e} when calling QdrantDocumentStore.get_metadata_field_unique_values()")
-            return []
+            return [], 0
 
     async def get_metadata_field_unique_values_async(
         self,
         metadata_field: str,
         filters: dict[str, Any] | None = None,
         search_term: str | None = None,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> list[Any]:
+        from_: int = 0,
+        size: int = 10,
+    ) -> tuple[list[str], int]:
         """
-        Asynchronously returns unique values for a metadata field, with optional filters and offset/limit pagination.
+        Asynchronously returns unique values for a metadata field, with optional filters, search term and pagination.
 
-        Unique values are ordered by first occurrence during scroll. Pagination is offset-based over that order.
+        Unique values are ordered by first occurrence during scroll.
 
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
         :param filters: Optional filters to restrict the documents considered.
             For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
         :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
-        :param limit: Maximum number of unique values to return per page. Defaults to 100.
-        :param offset: Number of unique values to skip (for pagination). Defaults to 0.
+        :param from_: The offset for pagination (0-based). Defaults to 0.
+        :param size: The maximum number of unique values to return. Defaults to 10.
 
-        :returns: A list of unique values for the field (at most ``limit`` items, starting at ``offset``).
+        :returns: A tuple containing (list of unique values, total count of unique matching values).
         """
         await self._initialize_async_client()
         assert self._async_client is not None
@@ -1371,7 +1364,7 @@ class QdrantDocumentStore:
 
         try:
             next_offset = None
-            while len(unique_values) < offset + limit:
+            while True:
                 records, next_offset = await self._async_client.scroll(
                     collection_name=self.index,
                     scroll_filter=qdrant_filter,
@@ -1380,17 +1373,15 @@ class QdrantDocumentStore:
                     with_payload=True,
                     with_vectors=False,
                 )
-                if self._process_records_unique_values(
-                    records, field_name, unique_values, unique_values_set, offset, limit, search_term
-                ):
-                    break
+                self._process_records_unique_values(records, field_name, unique_values, unique_values_set, search_term)
                 if self._check_stop_scrolling(next_offset):
                     break
 
-            return unique_values[offset : offset + limit]
+            total_count = len(unique_values)
+            return unique_values[from_ : from_ + size], total_count
         except Exception as e:
             logger.warning(f"Error {e} when calling QdrantDocumentStore.get_metadata_field_unique_values_async()")
-            return []
+            return [], 0
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "QdrantDocumentStore":

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -1284,10 +1284,10 @@ class QdrantDocumentStore:
     def get_metadata_field_unique_values(
         self,
         metadata_field: str,
-        filters: dict[str, Any] | None = None,
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[str], int]:
         """
         Returns unique values for a metadata field, with optional filters, search term and pagination.
@@ -1295,11 +1295,11 @@ class QdrantDocumentStore:
         Unique values are ordered by first occurrence during scroll.
 
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
-        :param filters: Optional filters to restrict the documents considered.
-            For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
         :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
         :param from_: The offset for pagination (0-based). Defaults to 0.
         :param size: The maximum number of unique values to return. Defaults to 10.
+        :param filters: Optional filters to restrict the documents considered.
+            For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
 
         :returns: A tuple containing (list of unique values, total count of unique matching values).
         """
@@ -1335,10 +1335,10 @@ class QdrantDocumentStore:
     async def get_metadata_field_unique_values_async(
         self,
         metadata_field: str,
-        filters: dict[str, Any] | None = None,
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[str], int]:
         """
         Asynchronously returns unique values for a metadata field, with optional filters, search term and pagination.
@@ -1346,11 +1346,11 @@ class QdrantDocumentStore:
         Unique values are ordered by first occurrence during scroll.
 
         :param metadata_field: The metadata field key (inside ``meta``) to get unique values for.
-        :param filters: Optional filters to restrict the documents considered.
-            For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
         :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
         :param from_: The offset for pagination (0-based). Defaults to 0.
         :param size: The maximum number of unique values to return. Defaults to 10.
+        :param filters: Optional filters to restrict the documents considered.
+            For filter syntax, see [Haystack metadata filtering](https://docs.haystack.deepset.ai/docs/metadata-filtering)
 
         :returns: A tuple containing (list of unique values, total count of unique matching values).
         """

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -269,20 +269,18 @@ class TestQdrantDocumentStoreUnit:
         assert unique["category"] == {"A", "B"}
         assert unique["tags"] == {"['x']", "['y']"}
 
-    def test_process_records_unique_values_stops_when_filled(self):
+    def test_process_records_unique_values_collects_all(self):
         records = [SimpleNamespace(payload={"meta": {"v": i}}) for i in range(10)]
         values: list = []
         values_set: set = set()
-        done = QdrantDocumentStore._process_records_unique_values(records, "v", values, values_set, offset=0, limit=3)
-        assert done is True
-        assert values[:3] == [0, 1, 2]
+        QdrantDocumentStore._process_records_unique_values(records, "v", values, values_set)
+        assert values == list(range(10))
 
-    def test_process_records_unique_values_not_done(self):
+    def test_process_records_unique_values_skips_missing_payload(self):
         records = [SimpleNamespace(payload={"meta": {"v": 1}}), SimpleNamespace(payload=None)]
         values: list = []
         values_set: set = set()
-        done = QdrantDocumentStore._process_records_unique_values(records, "v", values, values_set, offset=0, limit=5)
-        assert done is False
+        QdrantDocumentStore._process_records_unique_values(records, "v", values, values_set)
         assert values == [1]
 
     def test_create_updated_point_from_record_adds_missing_meta(self):
@@ -356,7 +354,7 @@ class TestQdrantDocumentStoreUnit:
             ("get_metadata_fields_info", (), {}),
             ("get_metadata_field_min_max", ("score",), {}),
             ("count_unique_metadata_by_filter", ({}, ["category"]), {"category": 0}),
-            ("get_metadata_field_unique_values", ("category",), []),
+            ("get_metadata_field_unique_values", ("category",), ([], 0)),
         ],
     )
     def test_metadata_methods_swallow_client_errors(self, method_name, args, expected):
@@ -596,17 +594,19 @@ class TestQdrantDocumentStore(
         assert len(updated_docs[0].embedding) == 768
 
     def test_get_metadata_field_unique_values_pagination(self, document_store: QdrantDocumentStore):
-        """Test getting unique metadata field values with pagination."""
+        """Test getting unique metadata field values with pagination, total reflects the full unpaginated count."""
         docs = [Document(content=f"Doc {i}", meta={"value": i % 5}) for i in range(10)]
         document_store.write_documents(docs)
 
         # Get first 2 unique values
-        values_page_1 = document_store.get_metadata_field_unique_values("value", limit=2, offset=0)
+        values_page_1, total_1 = document_store.get_metadata_field_unique_values("value", from_=0, size=2)
         assert len(values_page_1) == 2
+        assert total_1 == 5
 
         # Get next 2 unique values
-        values_page_2 = document_store.get_metadata_field_unique_values("value", limit=2, offset=2)
+        values_page_2, total_2 = document_store.get_metadata_field_unique_values("value", from_=2, size=2)
         assert len(values_page_2) == 2
+        assert total_2 == 5
 
         # Values should not overlap
         assert set(values_page_1) != set(values_page_2)
@@ -620,10 +620,11 @@ class TestQdrantDocumentStore(
         ]
         document_store.write_documents(docs)
 
-        values = document_store.get_metadata_field_unique_values(
+        values, total = document_store.get_metadata_field_unique_values(
             "category", filters={"field": "meta.status", "operator": "==", "value": "active"}
         )
         assert set(values) == {"A", "B"}
+        assert total == 2
 
     def test_get_metadata_field_unique_values_with_meta_prefix(self, document_store: QdrantDocumentStore):
         """Test that a 'meta.'-prefixed field name is normalized before lookup."""
@@ -633,8 +634,9 @@ class TestQdrantDocumentStore(
         ]
         document_store.write_documents(docs)
 
-        values = document_store.get_metadata_field_unique_values("meta.category")
+        values, total = document_store.get_metadata_field_unique_values("meta.category")
         assert set(values) == {"A", "B"}
+        assert total == 2
 
     def test_get_metadata_field_unique_values_with_search_term(self, document_store: QdrantDocumentStore):
         """Test that search_term filters unique values by a case-insensitive substring match on the field value."""
@@ -645,8 +647,10 @@ class TestQdrantDocumentStore(
         ]
         document_store.write_documents(docs)
 
-        values = document_store.get_metadata_field_unique_values("category", search_term="ap")
+        values, total = document_store.get_metadata_field_unique_values("category", search_term="ap")
         assert set(values) == {"Apple", "Apricot"}
+        assert total == 2
 
-        values = document_store.get_metadata_field_unique_values("category", search_term="nonexistent")
+        values, total = document_store.get_metadata_field_unique_values("category", search_term="nonexistent")
         assert values == []
+        assert total == 0

--- a/integrations/qdrant/tests/test_document_store_async.py
+++ b/integrations/qdrant/tests/test_document_store_async.py
@@ -148,7 +148,7 @@ class TestQdrantDocumentStoreAsyncUnit:
             ("get_metadata_fields_info_async", (), {}),
             ("get_metadata_field_min_max_async", ("score",), {}),
             ("count_unique_metadata_by_filter_async", ({}, ["category"]), {"category": 0}),
-            ("get_metadata_field_unique_values_async", ("category",), []),
+            ("get_metadata_field_unique_values_async", ("category",), ([], 0)),
         ],
     )
     async def test_metadata_methods_async_absorb_client_errors(self, method_name, args, expected):
@@ -351,8 +351,9 @@ class TestQdrantDocumentStoreAsync(
         ]
         await document_store.write_documents_async(docs)
 
-        values = await document_store.get_metadata_field_unique_values_async("meta.category")
+        values, total = await document_store.get_metadata_field_unique_values_async("meta.category")
         assert set(values) == {"A", "B"}
+        assert total == 2
 
     async def test_get_metadata_field_unique_values_with_search_term_async(self, document_store: QdrantDocumentStore):
         """Test that search_term filters unique values by a case-insensitive substring match on the field value."""
@@ -363,8 +364,12 @@ class TestQdrantDocumentStoreAsync(
         ]
         await document_store.write_documents_async(docs)
 
-        values = await document_store.get_metadata_field_unique_values_async("category", search_term="ap")
+        values, total = await document_store.get_metadata_field_unique_values_async("category", search_term="ap")
         assert set(values) == {"Apple", "Apricot"}
+        assert total == 2
 
-        values = await document_store.get_metadata_field_unique_values_async("category", search_term="nonexistent")
+        values, total = await document_store.get_metadata_field_unique_values_async(
+            "category", search_term="nonexistent"
+        )
         assert values == []
+        assert total == 0


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/484

### Proposed Changes:

- adding offset based pagination 

### How did you test it?

- updated existing tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
