### PR TITLE
feat(qdrant): expose RRF k and weights parameters in QdrantHybridRetriever

### DIFF
--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.29.0",
-  "qdrant-client>=1.12.0"
+  "qdrant-client>=1.14.2"
 ]
 
 [project.urls]

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.29.0",
-  "qdrant-client>=1.14.2"
+  "qdrant-client>=1.16.0"
 ]
 
 [project.urls]

--- a/integrations/qdrant/pyproject.toml
+++ b/integrations/qdrant/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   "haystack-ai>=2.29.0",
-  "qdrant-client>=1.16.0"
+  "qdrant-client>=1.17.0"
 ]
 
 [project.urls]

--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -543,8 +543,10 @@ class QdrantHybridRetriever:
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
         :param rrf_k: The `k` constant for Reciprocal Rank Fusion. Controls ranking formula smoothing.
+            See https://qdrant.tech/documentation/search/hybrid-queries/#setting-rrf-constant-k.
             Requires Qdrant server >= 1.16.0.
         :param rrf_weights: Per-prefetch weights for RRF fusion — `[sparse_weight, dense_weight]`.
+            See https://qdrant.tech/documentation/search/hybrid-queries/#setting-rrf-weights.
             Requires Qdrant server >= 1.17.0.
 
         :raises ValueError: If 'document_store' is not an instance of QdrantDocumentStore.
@@ -638,8 +640,12 @@ class QdrantHybridRetriever:
         :param group_by: Payload field to group by, must be a string or number field. If the field contains more than 1
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
-        :param rrf_k: Override the init-time `rrf_k` for this run. Requires Qdrant server >= 1.16.0.
-        :param rrf_weights: Override the init-time `rrf_weights` for this run. Requires Qdrant server >= 1.17.0.
+        :param rrf_k: Override the init-time `rrf_k` for this run.
+            See https://qdrant.tech/documentation/search/hybrid-queries/#setting-rrf-constant-k.
+            Requires Qdrant server >= 1.16.0.
+        :param rrf_weights: Override the init-time `rrf_weights` for this run.
+            See https://qdrant.tech/documentation/search/hybrid-queries/#setting-rrf-weights.
+            Requires Qdrant server >= 1.17.0.
         :returns:
             The retrieved documents.
 
@@ -704,8 +710,12 @@ class QdrantHybridRetriever:
         :param group_by: Payload field to group by, must be a string or number field. If the field contains more than 1
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
-        :param rrf_k: Override the init-time `rrf_k` for this run. Requires Qdrant server >= 1.16.0.
-        :param rrf_weights: Override the init-time `rrf_weights` for this run. Requires Qdrant server >= 1.17.0.
+        :param rrf_k: Override the init-time `rrf_k` for this run.
+            See https://qdrant.tech/documentation/search/hybrid-queries/#setting-rrf-constant-k.
+            Requires Qdrant server >= 1.16.0.
+        :param rrf_weights: Override the init-time `rrf_weights` for this run.
+            See https://qdrant.tech/documentation/search/hybrid-queries/#setting-rrf-weights.
+            Requires Qdrant server >= 1.17.0.
         :returns:
             The retrieved documents.
 

--- a/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
+++ b/integrations/qdrant/src/haystack_integrations/components/retrievers/qdrant/retriever.py
@@ -523,6 +523,8 @@ class QdrantHybridRetriever:
         score_threshold: float | None = None,
         group_by: str | None = None,
         group_size: int | None = None,
+        rrf_k: int | None = None,
+        rrf_weights: list[float] | None = None,
     ) -> None:
         """
         Create a QdrantHybridRetriever component.
@@ -540,6 +542,10 @@ class QdrantHybridRetriever:
         :param group_by: Payload field to group by, must be a string or number field. If the field contains more than 1
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
+        :param rrf_k: The `k` constant for Reciprocal Rank Fusion. Controls ranking formula smoothing.
+            Requires Qdrant server >= 1.16.0.
+        :param rrf_weights: Per-prefetch weights for RRF fusion — `[sparse_weight, dense_weight]`.
+            Requires Qdrant server >= 1.17.0.
 
         :raises ValueError: If 'document_store' is not an instance of QdrantDocumentStore.
         """
@@ -558,6 +564,8 @@ class QdrantHybridRetriever:
         self._score_threshold = score_threshold
         self._group_by = group_by
         self._group_size = group_size
+        self._rrf_k = rrf_k
+        self._rrf_weights = rrf_weights
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -576,6 +584,8 @@ class QdrantHybridRetriever:
             score_threshold=self._score_threshold,
             group_by=self._group_by,
             group_size=self._group_size,
+            rrf_k=self._rrf_k,
+            rrf_weights=self._rrf_weights,
         )
 
     @classmethod
@@ -607,6 +617,8 @@ class QdrantHybridRetriever:
         score_threshold: float | None = None,
         group_by: str | None = None,
         group_size: int | None = None,
+        rrf_k: int | None = None,
+        rrf_weights: list[float] | None = None,
     ) -> dict[str, list[Document]]:
         """
         Run the Sparse Embedding Retriever on the given input data.
@@ -626,6 +638,8 @@ class QdrantHybridRetriever:
         :param group_by: Payload field to group by, must be a string or number field. If the field contains more than 1
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
+        :param rrf_k: Override the init-time `rrf_k` for this run. Requires Qdrant server >= 1.16.0.
+        :param rrf_weights: Override the init-time `rrf_weights` for this run. Requires Qdrant server >= 1.17.0.
         :returns:
             The retrieved documents.
 
@@ -652,6 +666,8 @@ class QdrantHybridRetriever:
             score_threshold=score_threshold or self._score_threshold,
             group_by=group_by or self._group_by,
             group_size=group_size or self._group_size,
+            rrf_k=rrf_k if rrf_k is not None else self._rrf_k,
+            rrf_weights=rrf_weights if rrf_weights is not None else self._rrf_weights,
         )
 
         return {"documents": docs}
@@ -667,6 +683,8 @@ class QdrantHybridRetriever:
         score_threshold: float | None = None,
         group_by: str | None = None,
         group_size: int | None = None,
+        rrf_k: int | None = None,
+        rrf_weights: list[float] | None = None,
     ) -> dict[str, list[Document]]:
         """
         Asynchronously run the Sparse Embedding Retriever on the given input data.
@@ -686,6 +704,8 @@ class QdrantHybridRetriever:
         :param group_by: Payload field to group by, must be a string or number field. If the field contains more than 1
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
+        :param rrf_k: Override the init-time `rrf_k` for this run. Requires Qdrant server >= 1.16.0.
+        :param rrf_weights: Override the init-time `rrf_weights` for this run. Requires Qdrant server >= 1.17.0.
         :returns:
             The retrieved documents.
 
@@ -712,6 +732,8 @@ class QdrantHybridRetriever:
             score_threshold=score_threshold or self._score_threshold,
             group_by=group_by or self._group_by,
             group_size=group_size or self._group_size,
+            rrf_k=rrf_k if rrf_k is not None else self._rrf_k,
+            rrf_weights=rrf_weights if rrf_weights is not None else self._rrf_weights,
         )
 
         return {"documents": docs}

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -59,7 +59,12 @@ def _build_rrf_query(
 ) -> Any:
     """Build a Qdrant RRF query object, using custom params when provided."""
     if rrf_k is not None or rrf_weights is not None:
-        return rest.RrfQuery(rrf=rest.Rrf(k=rrf_k, weights=rrf_weights))
+        rrf_kwargs: dict[str, Any] = {}
+        if rrf_k is not None:
+            rrf_kwargs["k"] = rrf_k
+        if rrf_weights is not None:
+            rrf_kwargs["weights"] = rrf_weights
+        return rest.RrfQuery(rrf=rest.Rrf(**rrf_kwargs))
     return rest.FusionQuery(fusion=rest.Fusion.RRF)
 
 

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -53,6 +53,16 @@ def get_batches_from_generator(iterable: list, n: int) -> Generator:
         x = tuple(islice(it, n))
 
 
+def _build_rrf_query(
+    rrf_k: int | None = None,
+    rrf_weights: list[float] | None = None,
+) -> rest.RrfQuery | rest.FusionQuery:
+    """Build a Qdrant RRF query object, using custom params when provided."""
+    if rrf_k is not None or rrf_weights is not None:
+        return rest.RrfQuery(rrf=rest.Rrf(k=rrf_k, weights=rrf_weights))
+    return rest.FusionQuery(fusion=rest.Fusion.RRF)
+
+
 class QdrantDocumentStore:
     """
     A QdrantDocumentStore implementation that you can use with any Qdrant instance.
@@ -1675,6 +1685,8 @@ class QdrantDocumentStore:
         score_threshold: float | None = None,
         group_by: str | None = None,
         group_size: int | None = None,
+        rrf_k: int | None = None,
+        rrf_weights: list[float] | None = None,
     ) -> list[Document]:
         """
         Retrieves documents based on dense and sparse embeddings and fuses the results using Reciprocal Rank Fusion.
@@ -1695,6 +1707,10 @@ class QdrantDocumentStore:
         :param group_by: Payload field to group by, must be a string or number field. If the field contains more than 1
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
+        :param rrf_k: The `k` constant for Reciprocal Rank Fusion. Controls the ranking formula smoothing.
+            Requires Qdrant server >= 1.16.0.
+        :param rrf_weights: Per-prefetch weights for RRF fusion. Must have 2 elements: [sparse_weight, dense_weight].
+            Requires Qdrant server >= 1.17.0.
 
         :returns: List of Document that are most similar to `query_embedding` and `query_sparse_embedding`.
 
@@ -1716,6 +1732,7 @@ class QdrantDocumentStore:
             raise QdrantStoreError(message)
 
         qdrant_filters = convert_filters_to_qdrant(filters)
+        rrf_query = _build_rrf_query(rrf_k=rrf_k, rrf_weights=rrf_weights)
 
         try:
             if group_by:
@@ -1736,7 +1753,7 @@ class QdrantDocumentStore:
                             filter=qdrant_filters,
                         ),
                     ],
-                    query=rest.FusionQuery(fusion=rest.Fusion.RRF),
+                    query=rrf_query,
                     limit=top_k,
                     group_by=group_by,
                     group_size=group_size or DEFAULT_GROUP_SIZE,
@@ -1762,7 +1779,7 @@ class QdrantDocumentStore:
                             filter=qdrant_filters,
                         ),
                     ],
-                    query=rest.FusionQuery(fusion=rest.Fusion.RRF),
+                    query=rrf_query,
                     limit=top_k,
                     score_threshold=score_threshold,
                     with_payload=True,
@@ -1929,6 +1946,8 @@ class QdrantDocumentStore:
         score_threshold: float | None = None,
         group_by: str | None = None,
         group_size: int | None = None,
+        rrf_k: int | None = None,
+        rrf_weights: list[float] | None = None,
     ) -> list[Document]:
         """
         Asynchronously retrieves documents based on dense and sparse embeddings.
@@ -1951,6 +1970,8 @@ class QdrantDocumentStore:
         :param group_by: Payload field to group by, must be a string or number field. If the field contains more than 1
              value, all values will be used for grouping. One point can be in multiple groups.
         :param group_size: Maximum amount of points to return per group. Default is 3.
+        :param rrf_k: The `k` constant for Reciprocal Rank Fusion. Requires Qdrant server >= 1.16.0.
+        :param rrf_weights: Per-prefetch weights for RRF fusion. Requires Qdrant server >= 1.17.0.
 
         :returns: List of Document that are most similar to `query_embedding` and `query_sparse_embedding`.
 
@@ -1969,6 +1990,7 @@ class QdrantDocumentStore:
             raise QdrantStoreError(message)
 
         qdrant_filters = convert_filters_to_qdrant(filters)
+        rrf_query = _build_rrf_query(rrf_k=rrf_k, rrf_weights=rrf_weights)
 
         try:
             if group_by:
@@ -1989,7 +2011,7 @@ class QdrantDocumentStore:
                             filter=qdrant_filters,
                         ),
                     ],
-                    query=rest.FusionQuery(fusion=rest.Fusion.RRF),
+                    query=rrf_query,
                     limit=top_k,
                     group_by=group_by,
                     group_size=group_size or DEFAULT_GROUP_SIZE,
@@ -2016,7 +2038,7 @@ class QdrantDocumentStore:
                             filter=qdrant_filters,
                         ),
                     ],
-                    query=rest.FusionQuery(fusion=rest.Fusion.RRF),
+                    query=rrf_query,
                     limit=top_k,
                     score_threshold=score_threshold,
                     with_payload=True,

--- a/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
+++ b/integrations/qdrant/src/haystack_integrations/document_stores/qdrant/document_store.py
@@ -56,7 +56,7 @@ def get_batches_from_generator(iterable: list, n: int) -> Generator:
 def _build_rrf_query(
     rrf_k: int | None = None,
     rrf_weights: list[float] | None = None,
-) -> rest.RrfQuery | rest.FusionQuery:
+) -> Any:
     """Build a Qdrant RRF query object, using custom params when provided."""
     if rrf_k is not None or rrf_weights is not None:
         return rest.RrfQuery(rrf=rest.Rrf(k=rrf_k, weights=rrf_weights))

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -24,8 +24,6 @@ from haystack.testing.document_store import (
 from haystack.utils import Secret
 from qdrant_client.http import models as rest
 
-from qdrant_client.http import models as rest
-
 from haystack_integrations.document_stores.qdrant.document_store import (
     DENSE_VECTORS_NAME,
     SPARSE_VECTORS_NAME,

--- a/integrations/qdrant/tests/test_document_store.py
+++ b/integrations/qdrant/tests/test_document_store.py
@@ -24,11 +24,14 @@ from haystack.testing.document_store import (
 from haystack.utils import Secret
 from qdrant_client.http import models as rest
 
+from qdrant_client.http import models as rest
+
 from haystack_integrations.document_stores.qdrant.document_store import (
     DENSE_VECTORS_NAME,
     SPARSE_VECTORS_NAME,
     QdrantDocumentStore,
     QdrantStoreError,
+    _build_rrf_query,
     get_batches_from_generator,
 )
 
@@ -341,6 +344,24 @@ class TestQdrantDocumentStoreUnit:
         batches = list(get_batches_from_generator([1, 2, 3, 4, 5], 2))
         assert batches == [(1, 2), (3, 4), (5,)]
         assert list(get_batches_from_generator([], 2)) == []
+
+    @pytest.mark.parametrize(
+        ("rrf_k", "rrf_weights", "expected_type"),
+        [
+            (None, None, rest.FusionQuery),
+            (20, None, rest.RrfQuery),
+            (None, [2.0, 1.0], rest.RrfQuery),
+            (20, [2.0, 1.0], rest.RrfQuery),
+        ],
+    )
+    def test_build_rrf_query(self, rrf_k, rrf_weights, expected_type):
+        query = _build_rrf_query(rrf_k=rrf_k, rrf_weights=rrf_weights)
+        assert isinstance(query, expected_type)
+        if expected_type is rest.RrfQuery:
+            if rrf_k is not None:
+                assert query.rrf.k == rrf_k
+            if rrf_weights is not None:
+                assert query.rrf.weights == rrf_weights
 
     def test_query_by_sparse_raises_when_sparse_disabled(self):
         document_store = QdrantDocumentStore(location=":memory:", use_sparse_embeddings=False)

--- a/integrations/qdrant/tests/test_hybrid_retriever.py
+++ b/integrations/qdrant/tests/test_hybrid_retriever.py
@@ -175,21 +175,20 @@ class TestQdrantHybridRetriever:
         assert call_args[1]["query_sparse_embedding"].values == [0.1, 0.7]
         assert call_args[1]["top_k"] == 10
         assert call_args[1]["return_embedding"] is False
+        assert call_args[1]["rrf_k"] is None
+        assert call_args[1]["rrf_weights"] is None
 
         assert res["documents"][0].content == "Test doc"
         assert res["documents"][0].embedding == [0.1, 0.2]
         assert res["documents"][0].sparse_embedding == sparse_embedding
 
-    def test_run_passes_rrf_params(self):
-        mock_store = Mock(spec=QdrantDocumentStore)
+        # rrf params are forwarded when set at init
         mock_store._query_hybrid.return_value = []
-
-        retriever = QdrantHybridRetriever(document_store=mock_store, rrf_k=20, rrf_weights=[2.0, 1.0])
-        retriever.run(
+        retriever_rrf = QdrantHybridRetriever(document_store=mock_store, rrf_k=20, rrf_weights=[2.0, 1.0])
+        retriever_rrf.run(
             query_embedding=[0.5, 0.7],
             query_sparse_embedding=SparseEmbedding(indices=[0, 5], values=[0.1, 0.7]),
         )
-
         call_args = mock_store._query_hybrid.call_args
         assert call_args[1]["rrf_k"] == 20
         assert call_args[1]["rrf_weights"] == [2.0, 1.0]

--- a/integrations/qdrant/tests/test_hybrid_retriever.py
+++ b/integrations/qdrant/tests/test_hybrid_retriever.py
@@ -28,6 +28,8 @@ class TestQdrantHybridRetriever:
         assert retriever._score_threshold is None
         assert retriever._group_by is None
         assert retriever._group_size is None
+        assert retriever._rrf_k is None
+        assert retriever._rrf_weights is None
 
         retriever = QdrantHybridRetriever(document_store=document_store, filter_policy="replace")
         assert retriever._filter_policy == FilterPolicy.REPLACE
@@ -88,8 +90,17 @@ class TestQdrantHybridRetriever:
                 "score_threshold": None,
                 "group_by": None,
                 "group_size": None,
+                "rrf_k": None,
+                "rrf_weights": None,
             },
         }
+
+    def test_to_dict_with_rrf_params(self):
+        document_store = QdrantDocumentStore(location=":memory:", index="test")
+        retriever = QdrantHybridRetriever(document_store=document_store, rrf_k=20, rrf_weights=[2.0, 1.0])
+        res = retriever.to_dict()
+        assert res["init_parameters"]["rrf_k"] == 20
+        assert res["init_parameters"]["rrf_weights"] == [2.0, 1.0]
 
     def test_from_dict(self):
         data = {
@@ -168,6 +179,36 @@ class TestQdrantHybridRetriever:
         assert res["documents"][0].content == "Test doc"
         assert res["documents"][0].embedding == [0.1, 0.2]
         assert res["documents"][0].sparse_embedding == sparse_embedding
+
+    def test_run_passes_rrf_params(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        mock_store._query_hybrid.return_value = []
+
+        retriever = QdrantHybridRetriever(document_store=mock_store, rrf_k=20, rrf_weights=[2.0, 1.0])
+        retriever.run(
+            query_embedding=[0.5, 0.7],
+            query_sparse_embedding=SparseEmbedding(indices=[0, 5], values=[0.1, 0.7]),
+        )
+
+        call_args = mock_store._query_hybrid.call_args
+        assert call_args[1]["rrf_k"] == 20
+        assert call_args[1]["rrf_weights"] == [2.0, 1.0]
+
+    def test_run_runtime_rrf_params_override_init(self):
+        mock_store = Mock(spec=QdrantDocumentStore)
+        mock_store._query_hybrid.return_value = []
+
+        retriever = QdrantHybridRetriever(document_store=mock_store, rrf_k=20, rrf_weights=[2.0, 1.0])
+        retriever.run(
+            query_embedding=[0.5, 0.7],
+            query_sparse_embedding=SparseEmbedding(indices=[0, 5], values=[0.1, 0.7]),
+            rrf_k=100,
+            rrf_weights=[3.0, 1.0],
+        )
+
+        call_args = mock_store._query_hybrid.call_args
+        assert call_args[1]["rrf_k"] == 100
+        assert call_args[1]["rrf_weights"] == [3.0, 1.0]
 
     def test_run_with_group_by(self):
         mock_store = Mock(spec=QdrantDocumentStore)


### PR DESCRIPTION
## Related Issues

- closes #3701

## Proposed Changes

Exposes the `k` and `weights` RRF parameters introduced in Qdrant v1.16/v1.17 in `QdrantHybridRetriever` and the underlying `_query_hybrid` / `_query_hybrid_async` methods of `QdrantDocumentStore`.

- Added `rrf_k: int | None` and `rrf_weights: list[float] | None` to `QdrantHybridRetriever.__init__`, `run`, and `run_async`
- Added same params to `QdrantDocumentStore._query_hybrid` and `_query_hybrid_async`
- Added `_build_rrf_query()` helper that returns `rest.RrfQuery` when either param is set, falling back to `rest.FusionQuery(fusion=rest.Fusion.RRF)` for backward compatibility
- Runtime params in `run` / `run_async` override init-time defaults
- Bumped `qdrant-client` minimum from `>=1.12.0` to `>=1.14.2` (when `RrfQuery` was introduced)

## Testing

- All 259 tests pass (118 unit + 141 integration), all run locally against `:memory:` mode  no Docker required
- Added `test_to_dict_with_rrf_params`, `test_run_passes_rrf_params`, `test_run_runtime_rrf_params_override_init`