### PR TITLE
fix: `FAISSDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
+++ b/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
@@ -473,7 +473,7 @@ class FAISSDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Returns unique values for a metadata field, optionally filtered by a search term, with pagination.
 
@@ -482,7 +482,8 @@ class FAISSDocumentStore:
             against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
-        :returns: A tuple containing list of unique values and total count of unique values.
+        :returns: A tuple containing list of unique values (in their original type) and total count of
+            unique values.
         """
         values = []
         for doc in self.documents.values():
@@ -494,8 +495,8 @@ class FAISSDocumentStore:
             search_term_lower = search_term.lower()
             values = [val for val in values if search_term_lower in str(val).lower()]
 
-        unique_values = {str(val) for val in values}
-        sorted_values = sorted(unique_values)
+        unique_values = set(values)
+        sorted_values = sorted(unique_values, key=str)
         total_count = len(sorted_values)
         end = from_ + size
         paginated_values = sorted_values[from_:end]

--- a/integrations/faiss/tests/test_document_store.py
+++ b/integrations/faiss/tests/test_document_store.py
@@ -237,3 +237,16 @@ class TestFAISSDocumentStore(
         prefixed = document_store.get_metadata_field_unique_values("meta.category")
         unprefixed = document_store.get_metadata_field_unique_values("category")
         assert prefixed == unprefixed == (["A", "B"], 2)
+
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        docs = [
+            Document(content="Doc 1", meta={"priority": 1}),
+            Document(content="Doc 2", meta={"priority": 2}),
+            Document(content="Doc 3", meta={"priority": 1}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total_count = document_store.get_metadata_field_unique_values("priority")
+        assert set(values) == {1, 2}
+        assert total_count == 2


### PR DESCRIPTION
### Proposed Changes:

- fix: FAISSDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
