### PR TITLE
fix: `AlloyDBDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/document_store.py
+++ b/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/document_store.py
@@ -1282,7 +1282,10 @@ class AlloyDBDocumentStore(DocumentStore):
         """
         field_literal = SQLLiteral(normalized_field)
 
-        sql_select = SQL("SELECT DISTINCT meta->>{} AS value").format(field_literal)
+        # Use the `->` (jsonb) operator rather than `->>` (text) so DISTINCT/ORDER BY operate on the
+        # value's original JSON type (numbers sort numerically, not lexicographically) and psycopg
+        # decodes the result to its native Python type instead of a string.
+        sql_select = SQL("SELECT DISTINCT meta->{} AS value").format(field_literal)
         sql_from = SQL(" FROM {schema_name}.{table_name}").format(
             schema_name=Identifier(self.schema_name), table_name=Identifier(self.table_name)
         )
@@ -1296,11 +1299,11 @@ class AlloyDBDocumentStore(DocumentStore):
             params += filters_params
 
         if search_term:
-            # Case-insensitive substring match against the metadata field's own value.
+            # Case-insensitive substring match against the metadata field's own (text) value.
             sql_where += SQL(" AND meta->>{} ILIKE %s").format(field_literal)
             params += (f"%{search_term}%",)
 
-        sql_count = SQL("SELECT COUNT(DISTINCT meta->>{} ) AS total").format(field_literal)
+        sql_count = SQL("SELECT COUNT(DISTINCT meta->{} ) AS total").format(field_literal)
         sql_count += sql_from + sql_where
 
         sql_query = sql_select + sql_from + sql_where
@@ -1313,7 +1316,7 @@ class AlloyDBDocumentStore(DocumentStore):
     @staticmethod
     def _process_unique_values_result(
         count_result: dict[str, Any] | None, records: list[dict[str, Any]]
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Processes the results from unique values queries.
 
@@ -1322,7 +1325,7 @@ class AlloyDBDocumentStore(DocumentStore):
         :returns: A tuple containing (unique_values, total_count).
         """
         total_count = count_result.get("total", 0) if count_result else 0
-        unique_values = [str(record.get("value", "")) for record in records if record.get("value") is not None]
+        unique_values = [record.get("value") for record in records if record.get("value") is not None]
         return unique_values, total_count
 
     def get_metadata_field_unique_values(
@@ -1332,7 +1335,7 @@ class AlloyDBDocumentStore(DocumentStore):
         from_: int = 0,
         size: int = 10,
         filters: dict[str, Any] | None = None,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Returns unique values for a given metadata field, optionally restricted by filters and/or a search term.
 
@@ -1343,7 +1346,7 @@ class AlloyDBDocumentStore(DocumentStore):
         :param size: The number of unique values to return.
         :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing:
-            - A list of unique values (as strings)
+            - A list of unique values in their original type
             - The total count of unique values
         """
         normalized_field = self._normalize_metadata_field_name(metadata_field)

--- a/integrations/alloydb/tests/test_document_store.py
+++ b/integrations/alloydb/tests/test_document_store.py
@@ -28,6 +28,21 @@ from psycopg.sql import SQL
 from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
 
 
+def test_process_unique_values_result_preserves_non_string_types():
+    """Non-string metadata values (e.g. ints) are returned in their original type, not stringified.
+
+    Unit test (no live AlloyDB instance needed) since `_process_unique_values_result` is a pure
+    static method operating on already-fetched rows.
+    """
+    count_result = {"total": 2}
+    records = [{"value": 1}, {"value": 2}]
+
+    values, total = AlloyDBDocumentStore._process_unique_values_result(count_result, records)
+
+    assert set(values) == {1, 2}
+    assert total == 2
+
+
 @pytest.mark.integration
 class TestDocumentStore(
     CountDocumentsTest,
@@ -139,6 +154,19 @@ class TestDocumentStore(
         filters = {"field": "meta.language", "operator": "==", "value": "Python"}
         values, total = document_store.get_metadata_field_unique_values("meta.category", filters=filters)
         assert set(values) == {"A", "C"}
+        assert total == 2
+
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store: AlloyDBDocumentStore):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        docs = [
+            Document(content="Doc 1", meta={"priority": 1}),
+            Document(content="Doc 2", meta={"priority": 2}),
+            Document(content="Doc 3", meta={"priority": 1}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total = document_store.get_metadata_field_unique_values("meta.priority")
+        assert set(values) == {1, 2}
         assert total == 2
 
 


### PR DESCRIPTION
### Proposed Changes:

- fix: AlloyDBDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
