### PR TITLE
fix: `FalkorDBDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
+++ b/integrations/falkordb/src/haystack_integrations/document_stores/falkordb/document_store.py
@@ -609,7 +609,7 @@ SET d.{self.embedding_field} = vecf32(doc.emb)
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Return distinct values for the given metadata field with optional filtering and pagination.
 
@@ -618,8 +618,9 @@ SET d.{self.embedding_field} = vecf32(doc.emb)
             field's own value.
         :param from_: The offset for pagination (0-based).
         :param size: Maximum number of values to return per page. Defaults to 10.
-        :returns: Tuple of `(values, total_count)`. `total_count` is the number of distinct
-            values matching the filter, independent of pagination.
+        :returns: Tuple of `(values, total_count)`. Values are returned in their original type.
+            `total_count` is the number of distinct values matching the filter, independent of
+            pagination.
         """
         self._ensure_connected()
         field = metadata_field[5:] if metadata_field.startswith("meta.") else metadata_field

--- a/integrations/falkordb/tests/test_document_store.py
+++ b/integrations/falkordb/tests/test_document_store.py
@@ -405,6 +405,14 @@ class TestFalkorDBDocumentStoreUnit:
         assert "toLower(toString(d.category)) CONTAINS toLower($search_term)" in cypher
         assert params == {"from_": 0, "size": 10, "search_term": "APP"}
 
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, mock_falkordb):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        _, _, graph = mock_falkordb
+        graph.query.side_effect = [_result([]), _result([]), _result([[[1, 2, 3], 3]])]
+        values, total = FalkorDBDocumentStore().get_metadata_field_unique_values("priority", size=10)
+        assert values == [1, 2, 3]
+        assert total == 3
+
     def test_close(self):
         store = FalkorDBDocumentStore()
         client = MagicMock()


### PR DESCRIPTION
### Proposed Changes:

- FalkorDBDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
