### PR TITLE
fix: `ChromDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -362,7 +362,7 @@ class ChromaDocumentStore:
         search_term: str | None,
         from_: int,
         size: int,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Computes paginated unique values for a metadata field from a Chroma get result.
 
@@ -372,7 +372,7 @@ class ChromaDocumentStore:
             substring against the value of `field_name`.
         :param from_: The offset to start returning values from.
         :param size: The maximum number of unique values to return.
-        :returns: A tuple of the paginated unique values list and the total count.
+        :returns: A tuple of the paginated unique values (in their original type) list and the total count.
         """
         metadatas = result.get("metadatas", [])
 
@@ -394,12 +394,12 @@ class ChromaDocumentStore:
             return [], 0
 
         unique_values = {
-            str(meta.get(field_name))
+            meta.get(field_name)
             for meta in metadatas
             if meta and field_name in meta and meta.get(field_name) is not None
         }
 
-        sorted_values = sorted(unique_values)
+        sorted_values = sorted(unique_values, key=str)
         total_count = len(sorted_values)
         end = from_ + size
         paginated_values = sorted_values[from_:end]
@@ -1308,7 +1308,7 @@ class ChromaDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Return unique metadata field values, optionally filtered by a search term, with pagination.
 
@@ -1318,7 +1318,7 @@ class ChromaDocumentStore:
             case-insensitive substring against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
-        :returns: A tuple containing list of unique values and total count of unique values.
+        :returns: A tuple containing list of unique values (in their original type) and total count of unique values.
         """
         self._ensure_initialized()
         assert self._collection is not None
@@ -1334,7 +1334,7 @@ class ChromaDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Asynchronously return unique metadata field values, optionally filtered by a search term, with pagination.
 
@@ -1346,7 +1346,7 @@ class ChromaDocumentStore:
             case-insensitive substring against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
-        :returns: A tuple containing list of unique values and total count of unique values.
+        :returns: A tuple containing list of unique values (in their original type) and total count of unique values.
         """
         await self._ensure_initialized_async()
         assert self._async_collection is not None

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -866,3 +866,9 @@ class TestMetadataOperations:
         values, total = populated_store.get_metadata_field_unique_values("category", from_=10, size=10)
         assert values == []  # No values beyond offset
         assert total == 3  # Total count is still 3
+
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, populated_store):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        values, total = populated_store.get_metadata_field_unique_values("priority", from_=0, size=10)
+        assert set(values) == {1, 2, 3}
+        assert total == 3

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -249,3 +249,18 @@ class TestDocumentStoreAsync(
         )
         assert values == ["special-value"]
         assert total == 1
+
+    async def test_get_metadata_field_unique_values_async_preserves_non_string_types(
+        self, document_store: ChromaDocumentStore
+    ):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        docs = [
+            Document(content="Doc 1", meta={"priority": 1}),
+            Document(content="Doc 2", meta={"priority": 2}),
+            Document(content="Doc 3", meta={"priority": 1}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        values, total = await document_store.get_metadata_field_unique_values_async("priority", from_=0, size=10)
+        assert set(values) == {1, 2}
+        assert total == 2


### PR DESCRIPTION
### Proposed Changes:

- fix: ChromaDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
