### PR TITLE
fix: `WeaviateDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
+++ b/integrations/weaviate/src/haystack_integrations/document_stores/weaviate/document_store.py
@@ -635,7 +635,7 @@ class WeaviateDocumentStore:
     @staticmethod
     def _compute_field_unique_values(
         agg_result: Any, search_term: str | None, from_: int, size: int
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Computes paginated unique values from a Weaviate group-by aggregation result.
 
@@ -648,13 +648,14 @@ class WeaviateDocumentStore:
             substring against each value.
         :param from_: The starting offset for pagination (0-indexed).
         :param size: The maximum number of unique values to return.
-        :returns: A tuple of (paginated list of unique values, total count of unique values).
+        :returns: A tuple of (paginated list of unique values in their original type, total count of
+            unique values).
         """
-        all_values = [str(g.grouped_by.value) for g in agg_result.groups] if agg_result.groups else []
+        all_values = [g.grouped_by.value for g in agg_result.groups] if agg_result.groups else []
         if search_term:
             search_term_lower = search_term.lower()
-            all_values = [value for value in all_values if search_term_lower in value.lower()]
-        all_values.sort()  # Sort for consistent pagination
+            all_values = [value for value in all_values if search_term_lower in str(value).lower()]
+        all_values.sort(key=str)  # Sort for consistent pagination
         total_count = len(all_values)
 
         paginated_values = all_values[from_ : from_ + size]
@@ -667,7 +668,7 @@ class WeaviateDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Returns unique values for a metadata field with pagination support.
 
@@ -679,7 +680,7 @@ class WeaviateDocumentStore:
             Note: Uses case-insensitive substring matching (no stemming).
         :param from_: The starting offset for pagination (0-indexed). Defaults to 0.
         :param size: The maximum number of unique values to return. Defaults to 10.
-        :returns: A tuple of (list of unique values, total count of unique values).
+        :returns: A tuple of (list of unique values in their original type, total count of unique values).
         :raises ValueError: If the field is not found in the collection schema.
         """
         field_name = _normalize_metadata_field_name(metadata_field)
@@ -705,7 +706,7 @@ class WeaviateDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Asynchronously returns unique values for a metadata field with pagination support.
 
@@ -717,7 +718,7 @@ class WeaviateDocumentStore:
             Note: Uses case-insensitive substring matching (no stemming).
         :param from_: The starting offset for pagination (0-indexed). Defaults to 0.
         :param size: The maximum number of unique values to return. Defaults to 10.
-        :returns: A tuple of (list of unique values, total count of unique values).
+        :returns: A tuple of (list of unique values in their original type, total count of unique values).
         :raises ValueError: If the field is not found in the collection schema.
         """
         field_name = _normalize_metadata_field_name(metadata_field)

--- a/integrations/weaviate/tests/test_document_store.py
+++ b/integrations/weaviate/tests/test_document_store.py
@@ -1234,6 +1234,19 @@ class TestWeaviateDocumentStore(
         assert total_count == 0
         assert values == []
 
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        docs = [
+            Document(content="Doc 1", meta={"number": 1}),
+            Document(content="Doc 2", meta={"number": 2}),
+            Document(content="Doc 3", meta={"number": 1}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total_count = document_store.get_metadata_field_unique_values("number")
+        assert total_count == 2
+        assert set(values) == {1, 2}
+
     # --- Overrides of mixin tests to account for Weaviate-specific behaviour ---
 
     def test_count_documents_by_filter_simple(self, document_store):

--- a/integrations/weaviate/tests/test_document_store_async.py
+++ b/integrations/weaviate/tests/test_document_store_async.py
@@ -533,6 +533,20 @@ class TestWeaviateDocumentStoreAsync(
         assert values == []
 
     @pytest.mark.asyncio
+    async def test_get_metadata_field_unique_values_async_preserves_non_string_types(self, document_store):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        docs = [
+            Document(content="Doc 1", meta={"priority": 1}),
+            Document(content="Doc 2", meta={"priority": 2}),
+            Document(content="Doc 3", meta={"priority": 1}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        values, total_count = await document_store.get_metadata_field_unique_values_async("priority")
+        assert total_count == 2
+        assert set(values) == {1, 2}
+
+    @pytest.mark.asyncio
     async def test_delete_all_documents_excessive_batch_size_async(
         self, document_store: WeaviateDocumentStore, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
### Proposed Changes:

- fix: WeaviateDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
