### PR TITLE
fix: `OracleDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
@@ -783,7 +783,7 @@ class OracleDocumentStore:
 
     def get_metadata_field_unique_values(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Return a paginated list of distinct values for a metadata field, plus the total distinct count.
 
@@ -794,7 +794,7 @@ class OracleDocumentStore:
         :param size: Maximum number of values to return. Defaults to ``10``. When ``None`` all values
             from ``from_`` onward are returned.
         :returns: A tuple ``(values, total)`` where ``values`` is the paginated list of distinct field
-            values as strings and ``total`` is the overall distinct count (before pagination).
+            values in their original type and ``total`` is the overall distinct count (before pagination).
         :raises ValueError: If ``metadata_field`` contains characters outside ``[A-Za-z0-9_.]``.
         """
         field_path = metadata_field[5:] if metadata_field.startswith("meta.") else metadata_field
@@ -820,7 +820,13 @@ class OracleDocumentStore:
                 params["row_offset"] = from_
             cur.execute(sql_vals, params)
             rows = cur.fetchall()
-            return [str(r[0]) for r in rows], total
+            values: list[Any] = []
+            for r in rows:
+                try:
+                    values.append(json.loads(r[0]))
+                except (json.JSONDecodeError, TypeError):
+                    values.append(r[0])
+            return values, total
 
     async def get_metadata_fields_info_async(self) -> dict[str, dict[str, str]]:
         """
@@ -851,7 +857,7 @@ class OracleDocumentStore:
 
     async def get_metadata_field_unique_values_async(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Asynchronously returns a paginated list of distinct values for a metadata field, plus the total count.
 
@@ -862,7 +868,7 @@ class OracleDocumentStore:
         :param size: Maximum number of values to return. Defaults to ``10``. When ``None`` all values
             from ``from_`` onward are returned.
         :returns: A tuple ``(values, total)`` where ``values`` is the paginated list of distinct field
-            values as strings and ``total`` is the overall distinct count (before pagination).
+            values in their original type and ``total`` is the overall distinct count (before pagination).
         :raises ValueError: If ``metadata_field`` contains characters outside ``[A-Za-z0-9_.]``.
         """
         return await asyncio.to_thread(self.get_metadata_field_unique_values, metadata_field, search_term, from_, size)

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -202,6 +202,18 @@ class TestOracleDocumentStoreUnit:
         assert count_params["search"] == "%bar%"
         assert vals_params["search"] == "%bar%"
 
+    def test_get_metadata_field_unique_values_parses_json_scalar_types(self, patched_store, mock_pool):
+        """Numeric/boolean JSON_VALUE results (returned by Oracle as text) are parsed back to their
+        original type; plain strings (not valid JSON when unquoted) are left as-is."""
+        _, _, cursor = mock_pool
+        cursor.fetchone.return_value = (3,)
+        cursor.fetchall.return_value = [("1",), ("true",), ("bar",)]
+
+        values, total = patched_store.get_metadata_field_unique_values("priority")
+
+        assert values == [1, True, "bar"]
+        assert total == 3
+
     def test_delete_table_executes_drop_and_index_sql(self, patched_store, mock_pool):
         _, _, cursor = mock_pool
         patched_store.delete_table()
@@ -449,6 +461,19 @@ class TestOracleDocumentStore(
         values, total = document_store.get_metadata_field_unique_values("category", search_term="APPLE")
         assert values == ["Apple-Tart"]
         assert total == 1
+
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        document_store.write_documents(
+            [
+                _doc(_uid("P001"), content="one", meta={"priority": 1}),
+                _doc(_uid("P002"), content="two", meta={"priority": 2}),
+                _doc(_uid("P003"), content="three", meta={"priority": 1}),
+            ]
+        )
+        values, total = document_store.get_metadata_field_unique_values("priority")
+        assert set(values) == {1, 2}
+        assert total == 2
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Proposed Changes:

- fix: OracleDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
