### PR TITLE
fix: `PineConeDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -891,26 +891,26 @@ class PineconeDocumentStore:
     @staticmethod
     def _get_metadata_field_unique_values_impl(
         documents: list[Document], metadata_field: str, search_term: str | None, from_: int, size: int
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """Helper method to get unique values for a metadata field with search and pagination."""
         field_name = metadata_field.removeprefix("meta.")
-        unique_values: set[str] = set()
+        unique_values: set[Any] = set()
         for doc in documents:
             if doc.meta and field_name in doc.meta:
                 value = doc.meta[field_name]
                 # Handle list values
                 if isinstance(value, list):
-                    unique_values.update(str(v) for v in value)
+                    unique_values.update(value)
                 else:
-                    unique_values.add(str(value))
+                    unique_values.add(value)
 
         # Convert to sorted list
-        unique_values_list = sorted(unique_values)
+        unique_values_list = sorted(unique_values, key=str)
 
         # Apply search term filter if provided
         if search_term:
             search_term_lower = search_term.lower()
-            unique_values_list = [v for v in unique_values_list if search_term_lower in v.lower()]
+            unique_values_list = [v for v in unique_values_list if search_term_lower in str(v).lower()]
 
         total_count = len(unique_values_list)
 
@@ -1071,7 +1071,7 @@ class PineconeDocumentStore:
 
     def get_metadata_field_unique_values(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a metadata field with optional search and pagination.
 
@@ -1082,14 +1082,14 @@ class PineconeDocumentStore:
         :param search_term: Optional search term to filter values (case-insensitive substring match).
         :param from_: Starting offset for pagination (default: 0).
         :param size: Number of values to return (default: 10).
-        :returns: Tuple of (list of unique values, total count of matching values).
+        :returns: Tuple of (list of unique values in their original type, total count of matching values).
         """
         documents = self.filter_documents(filters=None)
         return self._get_metadata_field_unique_values_impl(documents, metadata_field, search_term, from_, size)
 
     async def get_metadata_field_unique_values_async(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Asynchronously retrieves unique values for a metadata field with optional search and pagination.
 
@@ -1100,7 +1100,7 @@ class PineconeDocumentStore:
         :param search_term: Optional search term to filter values (case-insensitive substring match).
         :param from_: Starting offset for pagination (default: 0).
         :param size: Number of values to return (default: 10).
-        :returns: Tuple of (list of unique values, total count of matching values).
+        :returns: Tuple of (list of unique values in their original type, total count of matching values).
         """
         documents = await self.filter_documents_async(filters=None)
         return self._get_metadata_field_unique_values_impl(documents, metadata_field, search_term, from_, size)

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -339,6 +339,20 @@ def test_get_metadata_field_unique_values_impl_pagination_search_and_lists():
     assert values == ["python"]
 
 
+def test_get_metadata_field_unique_values_impl_preserves_non_string_types():
+    docs = [
+        Document(content="a", meta={"priority": 1}),
+        Document(content="b", meta={"priority": 2}),
+        Document(content="c", meta={"priority": 1}),
+    ]
+
+    values, total = PineconeDocumentStore._get_metadata_field_unique_values_impl(
+        docs, "priority", search_term=None, from_=0, size=10
+    )
+    assert total == 2
+    assert set(values) == {1, 2}
+
+
 def test_get_metadata_field_unique_values_impl_strips_meta_prefix():
     docs = [
         Document(content="a", meta={"category": "news"}),


### PR DESCRIPTION
### Proposed Changes:

- fix: PineConeDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
