### PR TITLE
fix: `ValkeyDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -1025,12 +1025,12 @@ class ValkeyDocumentStore(DocumentStore):
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Return unique values for a metadata field with optional search and pagination.
 
-        Values are stringified. For tag fields the distinct values are returned; for numeric fields
-        the string representation of each distinct value is returned.
+        Values are returned in their original type (e.g. int, bool). The `search_term` filter, when
+        provided, matches against the string representation of each value.
 
         :param metadata_field: Metadata field name (e.g. "category" or "meta.category").
         :param search_term: Optional case-insensitive substring filter on the value.
@@ -1056,9 +1056,12 @@ class ValkeyDocumentStore(DocumentStore):
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Asynchronously return unique values for a metadata field with optional search and pagination.
+
+        Values are returned in their original type (e.g. int, bool). The `search_term` filter, when
+        provided, matches against the string representation of each value.
 
         :param metadata_field: Metadata field name (e.g. "category" or "meta.category").
         :param search_term: Optional case-insensitive substring filter on the value.
@@ -1481,9 +1484,9 @@ class ValkeyDocumentStore(DocumentStore):
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """Extract unique values for a metadata field with optional search and pagination."""
-        unique_vals: list[str] = []
+        unique_vals: list[Any] = []
         seen: set[str] = set()
         for doc in documents:
             val = (doc.meta or {}).get(ValkeyDocumentStore._metadata_field_to_doc_meta_key(metadata_field))
@@ -1495,8 +1498,8 @@ class ValkeyDocumentStore(DocumentStore):
             if search_term is not None and search_term.lower() not in str_val.lower():
                 continue
             seen.add(str_val)
-            unique_vals.append(str_val)
-        unique_vals.sort()
+            unique_vals.append(val)
+        unique_vals.sort(key=str)
         total = len(unique_vals)
         page = unique_vals[from_ : from_ + size]
         return page, total

--- a/integrations/valkey/tests/test_document_store.py
+++ b/integrations/valkey/tests/test_document_store.py
@@ -777,6 +777,18 @@ class TestValkeyDocumentStore(
         assert total == 2
         assert set(values) == {"apple_pie", "apple_jam"}
 
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        docs = [
+            Document(id="gmvt1", content="doc 1", embedding=[0.1, 0.2, 0.3], meta={"priority": 1}),
+            Document(id="gmvt2", content="doc 2", embedding=[0.2, 0.3, 0.4], meta={"priority": 2}),
+            Document(id="gmvt3", content="doc 3", embedding=[0.3, 0.4, 0.5], meta={"priority": 1}),
+        ]
+        document_store.write_documents(docs)
+        values, total = document_store.get_metadata_field_unique_values("priority")
+        assert total == 2
+        assert set(values) == {1, 2}
+
     def test_get_metadata_field_unique_values_unknown_field_raises(self, document_store):
         """Test get_metadata_field_unique_values raises for unconfigured field."""
         with pytest.raises(ValueError, match="not configured for filtering"):

--- a/integrations/valkey/tests/test_document_store_async.py
+++ b/integrations/valkey/tests/test_document_store_async.py
@@ -624,3 +624,16 @@ class TestValkeyDocumentStoreAsync(
         )
         assert total == 2
         assert set(values) == {"apple_pie", "apple_jam"}
+
+    async def test_get_metadata_field_unique_values_async_preserves_non_string_types(self, document_store):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        test_id = str(uuid.uuid4())[:8]
+        docs = [
+            Document(id=f"gmvt1_{test_id}", content="doc 1", embedding=[0.1, 0.2, 0.3], meta={"priority": 1}),
+            Document(id=f"gmvt2_{test_id}", content="doc 2", embedding=[0.2, 0.3, 0.4], meta={"priority": 2}),
+            Document(id=f"gmvt3_{test_id}", content="doc 3", embedding=[0.3, 0.4, 0.5], meta={"priority": 1}),
+        ]
+        await document_store.write_documents_async(docs)
+        values, total = await document_store.get_metadata_field_unique_values_async("priority")
+        assert total == 2
+        assert set(values) == {1, 2}


### PR DESCRIPTION
### Proposed Changes:

- fix: ValkeyDocumentStore get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
