### PR TITLE
fix: `AzureSearchDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -561,7 +561,7 @@ class AzureAISearchDocumentStore:
 
     def get_metadata_field_unique_values(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a metadata field with optional search and pagination.
 
@@ -569,17 +569,17 @@ class AzureAISearchDocumentStore:
         :param search_term: Optional search term to filter unique values.
         :param from_: Starting offset for pagination.
         :param size: Number of values to return.
-        :returns: Tuple of (list of unique values, total count of matching values).
+        :returns: Tuple of (list of unique values in their original type, total count of matching values).
         """
         field_name = _normalize_metadata_field_name(metadata_field)
         self._validate_index_fields([field_name])
 
         documents = self._fetch_raw_documents(select=[field_name])
-        unique_values = sorted(str(value) for value in self._collect_unique_values(documents, field_name))
+        unique_values = sorted(self._collect_unique_values(documents, field_name))
 
         if search_term:
             normalized_search_term = search_term.lower()
-            unique_values = [value for value in unique_values if normalized_search_term in value.lower()]
+            unique_values = [value for value in unique_values if normalized_search_term in str(value).lower()]
 
         total_count = len(unique_values)
         return unique_values[from_ : from_ + size], total_count

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -361,6 +361,25 @@ def test_get_metadata_field_unique_values():
     assert total_count == 1
 
 
+def test_get_metadata_field_unique_values_preserves_non_string_types():
+    index_fields = [
+        SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+        SimpleField(name="priority", type=SearchFieldDataType.Int32, filterable=True),
+    ]
+    document_store, search_client, _ = _build_mock_document_store_with_schema(index_fields)
+    search_client.search.return_value = [
+        {"priority": 1},
+        {"priority": 2},
+        {"priority": 1},
+    ]
+
+    values, total_count = document_store.get_metadata_field_unique_values(metadata_field="meta.priority")
+
+    assert values == [1, 2]
+    assert total_count == 2
+
+
 def test_query_sql_raises_not_implemented():
     document_store = AzureAISearchDocumentStore(
         api_key=Secret.from_token("fake-api-key"),


### PR DESCRIPTION
### Proposed Changes:

- fix: `AzureSearchDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
