### PR TITLE
fix: `ArcadeDBDocumentStore` get_metadata_field_unique_values setting list of values to return to `Any`

### DIFF
--- a/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
+++ b/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
@@ -254,19 +254,19 @@ class ArcadeDBDocumentStore:
         return 0
 
     @staticmethod
-    def _extract_distinct_values(rows: list[dict[str, Any]]) -> set[str]:
+    def _extract_distinct_values(rows: list[dict[str, Any]]) -> set[Any]:
         """
-        Extracts and flattens unique non-None strings from 'val' column result rows.
+        Extracts and flattens unique non-None values from 'val' column result rows.
         :param rows: Raw result rows from ``_command``.
-        :returns: A set of unique string values.
+        :returns: A set of unique values, preserving their original type.
         """
-        result: set[str] = set()
+        result: set[Any] = set()
         for row in rows:
             val = row.get("val")
             if isinstance(val, list):
-                result.update(str(item) for item in val if item is not None)
+                result.update(item for item in val if item is not None)
             elif val is not None:
-                result.add(str(val))
+                result.add(val)
         return result
 
     def _get_metadata_projection_documents(self) -> list[dict[str, Any]]:
@@ -576,7 +576,7 @@ class ArcadeDBDocumentStore:
 
     def get_metadata_field_unique_values(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a field matching a search term or all possible values
         if no search term is given.
@@ -584,7 +584,7 @@ class ArcadeDBDocumentStore:
         :param search_term: Optional case-insensitive substring search term.
         :param from_: The starting index for pagination.
         :param size: The number of values to return.
-        :returns: A tuple containing the paginated values and the total count.
+        :returns: A tuple containing the paginated values (in their original type) and the total count.
         """
         self._ensure_initialized()
 

--- a/integrations/arcadedb/tests/test_document_store.py
+++ b/integrations/arcadedb/tests/test_document_store.py
@@ -92,7 +92,7 @@ class TestStaticHelpers:
             ([], set()),
             ([{"val": "a"}, {"val": "b"}], {"a", "b"}),
             ([{"val": None}], set()),
-            ([{"val": [1, 2, None, 3]}], {"1", "2", "3"}),
+            ([{"val": [1, 2, None, 3]}], {1, 2, 3}),
             ([{"val": "x"}, {"val": None}, {"val": ["a", "b"]}], {"x", "a", "b"}),
         ],
     )
@@ -521,6 +521,20 @@ class TestArcadeDBDocumentStore(
 
         assert values == []
         assert total == 0
+
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store: ArcadeDBDocumentStore):
+        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
+        docs = [
+            Document(id="1", content="Doc 1", meta={"priority": 1}),
+            Document(id="2", content="Doc 2", meta={"priority": 2}),
+            Document(id="3", content="Doc 3", meta={"priority": 1}),
+        ]
+        document_store.write_documents(docs)
+
+        values, total = document_store.get_metadata_field_unique_values("priority")
+
+        assert set(values) == {1, 2}
+        assert total == 2
 
     def test_write_documents_none_embedding_is_zero_padded(self, document_store: ArcadeDBDocumentStore):
         """Documents written without an embedding get a zero vector of the correct dimension."""


### PR DESCRIPTION
### Proposed Changes:

- fix: ArcadeDBDocumentStore get_metadata_field_unique_values setting list of values to return to Any- #3715

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
