### PR TITLE
fix: `MongoAtlasDocumentStore` get_metadata_field_unique_values setting list of values to return to Any

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -526,7 +526,7 @@ class MongoDBAtlasDocumentStore:
         )
         return pipeline
 
-    def _process_unique_values_result(self, result: list[Any]) -> tuple[list[str], int]:
+    def _process_unique_values_result(self, result: list[Any]) -> tuple[list[Any], int]:
         if not result or not result[0]["values"]:
             return [], 0
 
@@ -537,7 +537,7 @@ class MongoDBAtlasDocumentStore:
 
     def get_metadata_field_unique_values(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a field matching a search_term or all possible values if no search term is given.
 
@@ -545,8 +545,8 @@ class MongoDBAtlasDocumentStore:
         :param search_term: The search term to filter values. Matches as a case-insensitive substring.
         :param from_: The starting index for pagination.
         :param size: The number of values to return.
-        :returns: A tuple containing a list of unique values and the total count of unique values matching the
-        search term.
+        :returns: A tuple containing a list of unique values (in their original type) and the total count
+            of unique values matching the search term.
         """
         self._ensure_connection_setup()
         assert self._collection is not None
@@ -562,7 +562,7 @@ class MongoDBAtlasDocumentStore:
 
     async def get_metadata_field_unique_values_async(
         self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[Any], int]:
         """
         Asynchronously retrieves unique values for a metadata field, optionally filtered by a search term.
 
@@ -570,8 +570,8 @@ class MongoDBAtlasDocumentStore:
         :param search_term: The search term to filter values. Matches as a case-insensitive substring.
         :param from_: The starting index for pagination.
         :param size: The number of values to return.
-        :returns: A tuple containing a list of unique values and the total count of unique values matching the
-        search term.
+        :returns: A tuple containing a list of unique values (in their original type) and the total count
+            of unique values matching the search term.
         """
         await self._ensure_connection_setup_async()
         assert self._collection_async is not None

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -161,6 +161,15 @@ class TestMongoDBDocumentStoreUnit:
         pipeline = collection.aggregate.call_args[0][0]
         assert pipeline[0]["$group"] == {"_id": "$meta.category"}
 
+    def test_get_metadata_field_unique_values_preserves_non_string_types(self, mocked_store_collection):
+        store, collection = mocked_store_collection
+        collection.aggregate.return_value = [{"count": [{"count": 2}], "values": [{"_id": 1}, {"_id": 2}]}]
+
+        values, count = store.get_metadata_field_unique_values("priority")
+
+        assert values == [1, 2]
+        assert count == 2
+
 
 class TestMongoDBDocumentStoreConversion:
     def test_haystack_doc_to_mongo_doc_with_unsupported_fields(self, local_store):

--- a/integrations/mongodb_atlas/tests/test_document_store_async.py
+++ b/integrations/mongodb_atlas/tests/test_document_store_async.py
@@ -97,6 +97,17 @@ class TestMongoDBDocumentStoreAsyncUnit:
         assert pipeline[1]["$match"] == {"_id": {"$regex": "val", "$options": "i"}}
         assert pipeline[2]["$facet"]["values"][2]["$limit"] == 2
 
+    async def test_get_metadata_field_unique_values_preserves_non_string_types(self, mocked_store_collection_async):
+        store, collection = mocked_store_collection_async
+        cursor = MagicMock()
+        cursor.to_list = AsyncMock(return_value=[{"count": [{"count": 2}], "values": [{"_id": 1}, {"_id": 2}]}])
+        collection.aggregate = AsyncMock(return_value=cursor)
+
+        values, count = await store.get_metadata_field_unique_values_async("priority")
+
+        assert values == [1, 2]
+        assert count == 2
+
     async def test_close_async(self, local_store):
         connection = AsyncMock()
         local_store._connection_async = connection


### PR DESCRIPTION
### Proposed Changes:

- fix: `MongoAtlasDocumentStore` get_metadata_field_unique_values setting list of values to return to Any

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
