### PR TITLE
fix: prevent AQL injection via collection and filter field names in the arangodb document store

### DIFF
--- a/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/document_store.py
+++ b/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import re
 from contextlib import suppress
 from typing import Any, Literal, cast
 
@@ -29,6 +30,23 @@ _SIMILARITY_AQL: dict[str, tuple[str, str, str]] = {
 }
 
 _VECTOR_INDEX_NAME = "haystack_vector_index"
+
+# ArangoDB "traditional" collection naming rules: start with a letter, followed by letters,
+# digits, underscores, or dashes; at most 256 characters. The collection name is interpolated
+# directly into AQL queries (it cannot be a bind parameter), so it is validated against this
+# allowlist to prevent AQL injection.
+# Matched with `fullmatch`, not `match`: `$` would also match before a trailing newline, which
+# would let `"docs\n"` through and defeat the length bound.
+_SAFE_COLLECTION_NAME = re.compile(r"[A-Za-z][A-Za-z0-9_-]{0,255}")
+
+
+def _validate_collection_name(collection_name: str) -> None:
+    if not _SAFE_COLLECTION_NAME.fullmatch(collection_name):
+        msg = (
+            f"Invalid collection_name {collection_name!r}. Must start with a letter and contain only "
+            "letters, digits, underscores, or dashes (max 256 characters)."
+        )
+        raise ValueError(msg)
 
 
 def _doc_to_arango(doc: Document) -> dict[str, Any]:
@@ -89,12 +107,15 @@ class ArangoDocumentStore:
         :param username: ArangoDB username as a `Secret`. Defaults to `ARANGO_USERNAME` env var,
             falling back to `root` if the variable is not set.
         :param password: ArangoDB password as a `Secret`. Defaults to `ARANGO_PASSWORD` env var.
-        :param collection_name: Name of the collection to store documents in.
+        :param collection_name: Name of the collection to store documents in. Must start with a letter
+            and contain only letters, digits, underscores, or dashes (max 256 characters).
         :param embedding_dimension: Dimensionality of document embeddings.
         :param recreate_collection: If `True`, drop and recreate the collection on startup.
         :param similarity_function: Vector similarity function to use for embedding retrieval.
             One of `"cosine"` (default), `"dot_product"`, or `"l2"`.
+        :raises ValueError: If `collection_name` is not a valid ArangoDB collection identifier.
         """
+        _validate_collection_name(collection_name)
         self.host = host
         self.database = database
         self.username = username

--- a/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/document_store.py
+++ b/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/document_store.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-import re
 from contextlib import suppress
 from typing import Any, Literal, cast
 
@@ -31,22 +30,14 @@ _SIMILARITY_AQL: dict[str, tuple[str, str, str]] = {
 
 _VECTOR_INDEX_NAME = "haystack_vector_index"
 
-# ArangoDB "traditional" collection naming rules: start with a letter, followed by letters,
-# digits, underscores, or dashes; at most 256 characters. The collection name is interpolated
-# directly into AQL queries (it cannot be a bind parameter), so it is validated against this
-# allowlist to prevent AQL injection.
-# Matched with `fullmatch`, not `match`: `$` would also match before a trailing newline, which
-# would let `"docs\n"` through and defeat the length bound.
-_SAFE_COLLECTION_NAME = re.compile(r"[A-Za-z][A-Za-z0-9_-]{0,255}")
-
-
-def _validate_collection_name(collection_name: str) -> None:
-    if not _SAFE_COLLECTION_NAME.fullmatch(collection_name):
-        msg = (
-            f"Invalid collection_name {collection_name!r}. Must start with a letter and contain only "
-            "letters, digits, underscores, or dashes (max 256 characters)."
-        )
-        raise ValueError(msg)
+# The collection name is never interpolated into AQL. It is passed as a collection bind parameter
+# (`@@collection`), so an attacker-controlled name can only ever name a collection — a payload such
+# as "docs` FOR s IN secrets RETURN s //" fails with ERR 1203 (collection not found) instead of
+# being parsed as query text. Backtick-quoting the name would not be enough: AQL has no escape
+# sequence for a backtick inside a backtick-quoted identifier, and ArangoDB 3.12 accepts collection
+# names that contain one. Binding also keeps every name the server accepts working, including
+# extended names with dots or Unicode. Index selection is unaffected: bind parameters are
+# substituted before query optimization, so `APPROX_NEAR_*` still resolves to the vector index.
 
 
 def _doc_to_arango(doc: Document) -> dict[str, Any]:
@@ -107,15 +98,12 @@ class ArangoDocumentStore:
         :param username: ArangoDB username as a `Secret`. Defaults to `ARANGO_USERNAME` env var,
             falling back to `root` if the variable is not set.
         :param password: ArangoDB password as a `Secret`. Defaults to `ARANGO_PASSWORD` env var.
-        :param collection_name: Name of the collection to store documents in. Must start with a letter
-            and contain only letters, digits, underscores, or dashes (max 256 characters).
+        :param collection_name: Name of the collection to store documents in.
         :param embedding_dimension: Dimensionality of document embeddings.
         :param recreate_collection: If `True`, drop and recreate the collection on startup.
         :param similarity_function: Vector similarity function to use for embedding retrieval.
             One of `"cosine"` (default), `"dot_product"`, or `"l2"`.
-        :raises ValueError: If `collection_name` is not a valid ArangoDB collection identifier.
         """
-        _validate_collection_name(collection_name)
         self.host = host
         self.database = database
         self.username = username
@@ -210,11 +198,12 @@ class ArangoDocumentStore:
         self._ensure_connected()
         db = cast(StandardDatabase, self._db)
 
-        aql = f"FOR doc IN {self.collection_name}"
-        bind_vars: dict[str, Any] = {}
+        aql = "FOR doc IN @@collection"
+        bind_vars: dict[str, Any] = {"@collection": self.collection_name}
 
         if filters:
-            expr, bind_vars = _convert_filters(filters)
+            expr, fvars = _convert_filters(filters)
+            bind_vars.update(fvars)
             aql += f" FILTER {expr}"
 
         aql += " RETURN doc"
@@ -304,7 +293,11 @@ class ArangoDocumentStore:
         self._ensure_vector_index()
 
         aql_func, sort_order, _ = _SIMILARITY_AQL[self.similarity_function]
-        bind_vars: dict[str, Any] = {"query_vec": query_embedding, "top_k": top_k}
+        bind_vars: dict[str, Any] = {
+            "@collection": self.collection_name,
+            "query_vec": query_embedding,
+            "top_k": top_k,
+        }
 
         # ArangoDB only uses the vector index when the `APPROX_NEAR_*` call is followed
         # directly by `SORT` + `LIMIT` with no preceding `FILTER`. Metadata filters are
@@ -315,7 +308,7 @@ class ArangoDocumentStore:
             bind_vars["candidates"] = doc_count
             aql = f"""
             FOR doc IN (
-                FOR d IN {self.collection_name}
+                FOR d IN @@collection
                     LET score = {aql_func}(d.embedding, @query_vec)
                     SORT score {sort_order}
                     LIMIT @candidates
@@ -327,7 +320,7 @@ class ArangoDocumentStore:
             """
         else:
             aql = f"""
-            FOR doc IN {self.collection_name}
+            FOR doc IN @@collection
                 LET score = {aql_func}(doc.embedding, @query_vec)
                 SORT score {sort_order}
                 LIMIT @top_k

--- a/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/filters.py
+++ b/integrations/arangodb/src/haystack_integrations/document_stores/arangodb/filters.py
@@ -16,18 +16,31 @@ def _is_iso_date(value: str) -> bool:
         return False
 
 
-def _field_to_aql(field: str) -> str:
-    """Maps a Haystack field name to an AQL document field reference."""
+def _field_to_aql(field: str, bind_vars: dict[str, Any], counter: list[int]) -> str:
+    """
+    Maps a Haystack field name to an AQL document field reference.
+
+    Field names come from the caller's filters, so they are never interpolated into the query.
+    AQL has no escape sequence for a backtick inside a backtick-quoted identifier, so quoting is
+    not enough: a name such as ``meta.a` == 1 OR true //`` would escape it. Names are bound and
+    applied with dynamic attribute access instead, which treats them as data. Filters run as a
+    full scan either way (see `retrieve_by_embedding`), so this costs no index usage.
+    """
     if field == "id":
         return "doc._key"
     if field == "content":
         return "doc.content"
     if field == "embedding":
         return "doc.embedding"
+
+    idx = counter[0]
+    counter[0] += 1
+    var = f"fk{idx}"
     if field.startswith("meta."):
-        key = field[5:]
-        return f"doc.meta.`{key}`"
-    return f"doc.`{field}`"
+        bind_vars[var] = field[5:]
+        return f"doc.meta[@{var}]"
+    bind_vars[var] = field
+    return f"doc[@{var}]"
 
 
 def _convert_filters(filters: dict[str, Any]) -> tuple[str, dict[str, Any]]:
@@ -68,13 +81,18 @@ _COMPARISON_OPS = {">", ">=", "<", "<="}
 
 
 def _parse_comparison(node: dict[str, Any], bind_vars: dict[str, Any], counter: list[int]) -> str:
-    field = _field_to_aql(node["field"])
     op = node["operator"]
     value = node["value"]
 
+    # A range comparison against null matches nothing, and the resulting expression references no
+    # field. Return before binding the field name: ArangoDB rejects a query that declares a bind
+    # parameter it never uses.
+    if op in _COMPARISON_OPS and value is None:
+        return "false"
+
+    field = _field_to_aql(node["field"], bind_vars, counter)
+
     if op in _COMPARISON_OPS:
-        if value is None:
-            return "false"
         if isinstance(value, list):
             msg = f"Filter operator '{op}' does not support list values."
             raise FilterError(msg)

--- a/integrations/arangodb/tests/test_document_store.py
+++ b/integrations/arangodb/tests/test_document_store.py
@@ -14,6 +14,7 @@ from haystack.testing.document_store import DocumentStoreBaseTests
 from haystack.utils import Secret
 
 from haystack_integrations.document_stores.arangodb import ArangoDocumentStore
+from haystack_integrations.document_stores.arangodb.filters import _convert_filters
 
 _MODULE = "haystack_integrations.document_stores.arangodb.document_store"
 
@@ -286,6 +287,65 @@ class TestArangoDocumentStoreFilterDocuments:
         mock_db.aql.execute.assert_called_once()
         call_args = mock_db.aql.execute.call_args
         assert "FILTER" in call_args[0][0]
+
+
+class TestFilterFieldNameBinding:
+    """Field names come from caller-supplied filters, so they must never reach the AQL as text."""
+
+    def test_meta_field_name_is_bound(self):
+        expr, bind_vars = _convert_filters({"field": "meta.topic", "operator": "==", "value": "ai"})
+        assert expr == "doc.meta[@fk0] == @fv1"
+        assert bind_vars == {"fk0": "topic", "fv1": "ai"}
+
+    def test_top_level_field_name_is_bound(self):
+        expr, bind_vars = _convert_filters({"field": "topic", "operator": "==", "value": "ai"})
+        assert expr == "doc[@fk0] == @fv1"
+        assert bind_vars == {"fk0": "topic", "fv1": "ai"}
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            pytest.param("meta.a` == 1 OR true //", id="backtick_breakout"),
+            pytest.param("meta.a`], doc.secret, doc[`b", id="bracket_breakout"),
+            pytest.param('meta.a" OR true //', id="double_quote"),
+            pytest.param("meta.a\nOR true", id="newline"),
+        ],
+    )
+    def test_injected_field_name_stays_a_bind_value(self, field):
+        expr, bind_vars = _convert_filters({"field": field, "operator": "==", "value": "x"})
+
+        # The name appears only as a bind value, never in the query text.
+        assert expr == "doc.meta[@fk0] == @fv1"
+        assert bind_vars["fk0"] == field.removeprefix("meta.")
+        assert "true" not in expr
+        assert "`" not in expr
+
+    def test_reserved_fields_are_not_bound(self):
+        for field, ref in (("id", "doc._key"), ("content", "doc.content"), ("embedding", "doc.embedding")):
+            expr, bind_vars = _convert_filters({"field": field, "operator": "==", "value": "x"})
+            assert expr == f"{ref} == @fv0"
+            assert "fk0" not in bind_vars
+
+    @pytest.mark.parametrize("op", [">", ">=", "<", "<="])
+    def test_range_comparison_against_none_binds_nothing(self, op):
+        # The expression references no field, so binding its name would leave an unused bind
+        # parameter and ArangoDB would reject the query with ERR 1552.
+        expr, bind_vars = _convert_filters({"field": "meta.a", "operator": op, "value": None})
+        assert expr == "false"
+        assert bind_vars == {}
+
+    def test_bind_var_names_stay_unique_across_conditions(self):
+        expr, bind_vars = _convert_filters(
+            {
+                "operator": "AND",
+                "conditions": [
+                    {"field": "meta.a", "operator": "==", "value": 1},
+                    {"field": "meta.b", "operator": "==", "value": 2},
+                ],
+            }
+        )
+        assert expr == "(doc.meta[@fk0] == @fv1 AND doc.meta[@fk2] == @fv3)"
+        assert bind_vars == {"fk0": "a", "fv1": 1, "fk2": "b", "fv3": 2}
 
 
 class TestArangoDocumentStoreVectorIndex:

--- a/integrations/arangodb/tests/test_document_store.py
+++ b/integrations/arangodb/tests/test_document_store.py
@@ -30,6 +30,17 @@ def _make_store(**kwargs) -> ArangoDocumentStore:
     )
 
 
+def _make_store_named(collection_name: str) -> ArangoDocumentStore:
+    return ArangoDocumentStore(
+        host="http://localhost:8529",
+        database="haystack",
+        username=Secret.from_token("root"),
+        password=Secret.from_token("test-password"),
+        collection_name=collection_name,
+        embedding_dimension=3,
+    )
+
+
 def _mock_db(store: ArangoDocumentStore, collection_docs: list[dict] | None = None) -> MagicMock:
     mock_col = MagicMock()
     mock_col.count.return_value = len(collection_docs or [])
@@ -66,6 +77,47 @@ class TestArangoDocumentStoreInit:
         assert store.recreate_collection is True
         assert store.embedding_dimension == 3
         assert store.similarity_function == "dot_product"
+
+
+class TestArangoDocumentStoreCollectionNameValidation:
+    """`collection_name` is interpolated into AQL, so it must be validated up front."""
+
+    @pytest.mark.parametrize(
+        "collection_name",
+        [
+            pytest.param("docs` FOR d IN secrets RETURN d //", id="aql_injection"),
+            pytest.param("docs secrets", id="whitespace"),
+            pytest.param("docs;drop", id="semicolon"),
+            pytest.param("docs`backtick", id="backtick"),
+            pytest.param('docs"quote', id="double_quote"),
+            pytest.param("docs\nsecrets", id="newline"),
+            pytest.param("docs\n", id="trailing_newline"),
+            pytest.param("d" * 256 + "\n", id="too_long_trailing_newline"),
+            pytest.param("1docs", id="leading_digit"),
+            pytest.param("_docs", id="leading_underscore"),
+            pytest.param("-docs", id="leading_dash"),
+            pytest.param("", id="empty"),
+            pytest.param("d" * 257, id="too_long"),
+        ],
+    )
+    def test_init_rejects_invalid_collection_name(self, collection_name):
+        with pytest.raises(ValueError, match="Invalid collection_name"):
+            _make_store_named(collection_name)
+
+    @pytest.mark.parametrize(
+        "collection_name",
+        [
+            pytest.param("docs", id="lowercase"),
+            pytest.param("Docs", id="uppercase"),
+            pytest.param("test_docs", id="underscore"),
+            pytest.param("test-docs", id="dash"),
+            pytest.param("docs123", id="digits"),
+            pytest.param("d", id="single_char"),
+            pytest.param("d" * 256, id="max_length"),
+        ],
+    )
+    def test_init_accepts_valid_collection_name(self, collection_name):
+        assert _make_store_named(collection_name).collection_name == collection_name
 
 
 class TestArangoDocumentStoreSerialization:

--- a/integrations/arangodb/tests/test_document_store.py
+++ b/integrations/arangodb/tests/test_document_store.py
@@ -42,6 +42,14 @@ def _make_store_named(collection_name: str) -> ArangoDocumentStore:
     )
 
 
+def _require_live_arango() -> tuple[str, str]:
+    host = os.environ.get("ARANGO_HOST")
+    password = os.environ.get("ARANGO_PASSWORD")
+    if not host or not password:
+        pytest.skip("Set ARANGO_HOST and ARANGO_PASSWORD to run integration tests.")
+    return host, password
+
+
 def _mock_db(store: ArangoDocumentStore, collection_docs: list[dict] | None = None) -> MagicMock:
     mock_col = MagicMock()
     mock_col.count.return_value = len(collection_docs or [])
@@ -80,45 +88,64 @@ class TestArangoDocumentStoreInit:
         assert store.similarity_function == "dot_product"
 
 
-class TestArangoDocumentStoreCollectionNameValidation:
-    """`collection_name` is interpolated into AQL, so it must be validated up front."""
+# Names outside ArangoDB's "traditional" rules — extended names the server accepts, plus payloads
+# that would be dangerous if the name were interpolated into AQL instead of bound.
+_COLLECTION_NAMES = [
+    pytest.param("docs", id="traditional"),
+    pytest.param("docs.v2", id="extended_dot"),
+    pytest.param("möbius", id="extended_unicode"),
+    pytest.param("docs` FOR s IN secrets RETURN s //", id="aql_injection"),
+    pytest.param("docs\nsecrets", id="newline"),
+    pytest.param("d" * 257, id="over_traditional_length"),
+]
 
-    @pytest.mark.parametrize(
-        "collection_name",
-        [
-            pytest.param("docs` FOR d IN secrets RETURN d //", id="aql_injection"),
-            pytest.param("docs secrets", id="whitespace"),
-            pytest.param("docs;drop", id="semicolon"),
-            pytest.param("docs`backtick", id="backtick"),
-            pytest.param('docs"quote', id="double_quote"),
-            pytest.param("docs\nsecrets", id="newline"),
-            pytest.param("docs\n", id="trailing_newline"),
-            pytest.param("d" * 256 + "\n", id="too_long_trailing_newline"),
-            pytest.param("1docs", id="leading_digit"),
-            pytest.param("_docs", id="leading_underscore"),
-            pytest.param("-docs", id="leading_dash"),
-            pytest.param("", id="empty"),
-            pytest.param("d" * 257, id="too_long"),
-        ],
-    )
-    def test_init_rejects_invalid_collection_name(self, collection_name):
-        with pytest.raises(ValueError, match="Invalid collection_name"):
-            _make_store_named(collection_name)
 
-    @pytest.mark.parametrize(
-        "collection_name",
-        [
-            pytest.param("docs", id="lowercase"),
-            pytest.param("Docs", id="uppercase"),
-            pytest.param("test_docs", id="underscore"),
-            pytest.param("test-docs", id="dash"),
-            pytest.param("docs123", id="digits"),
-            pytest.param("d", id="single_char"),
-            pytest.param("d" * 256, id="max_length"),
-        ],
-    )
-    def test_init_accepts_valid_collection_name(self, collection_name):
+class TestCollectionNameBinding:
+    """`collection_name` is a collection bind parameter, so it never reaches the AQL as text."""
+
+    @pytest.mark.parametrize("collection_name", _COLLECTION_NAMES)
+    def test_init_accepts_any_name(self, collection_name):
+        # ArangoDB itself is the authority on which names are valid; binding means we need no
+        # allowlist of our own, so no name that the server accepts is rejected here.
         assert _make_store_named(collection_name).collection_name == collection_name
+
+    @pytest.mark.parametrize("collection_name", _COLLECTION_NAMES)
+    def test_filter_documents_binds_collection_name(self, collection_name):
+        store = _make_store_named(collection_name)
+        mock_db = _mock_db(store)
+        store.filter_documents()
+
+        aql, bind_vars = mock_db.aql.execute.call_args[0][0], mock_db.aql.execute.call_args[1]["bind_vars"]
+        assert aql == "FOR doc IN @@collection RETURN doc"
+        assert bind_vars == {"@collection": collection_name}
+        assert collection_name not in aql
+
+    @pytest.mark.parametrize("collection_name", _COLLECTION_NAMES)
+    def test_embedding_retrieval_binds_collection_name(self, collection_name):
+        store = _make_store_named(collection_name)
+        mock_db = _mock_db(store, [{"_key": "1", "content": "x", "meta": {}}])
+        store._embedding_retrieval(query_embedding=[0.1, 0.2, 0.3], top_k=2)
+
+        aql, bind_vars = mock_db.aql.execute.call_args[0][0], mock_db.aql.execute.call_args[1]["bind_vars"]
+        assert "FOR doc IN @@collection" in aql
+        assert bind_vars["@collection"] == collection_name
+        assert collection_name not in aql
+
+    def test_filtered_embedding_retrieval_keeps_collection_and_filter_bind_vars(self):
+        store = _make_store_named("docs.v2")
+        mock_db = _mock_db(store, [{"_key": "1", "content": "x", "meta": {"topic": "ai"}}])
+        store._embedding_retrieval(
+            query_embedding=[0.1, 0.2, 0.3],
+            top_k=2,
+            filters={"field": "meta.topic", "operator": "==", "value": "ai"},
+        )
+
+        aql, bind_vars = mock_db.aql.execute.call_args[0][0], mock_db.aql.execute.call_args[1]["bind_vars"]
+        assert "FOR d IN @@collection" in aql
+        assert bind_vars["@collection"] == "docs.v2"
+        # The filter's own bind vars survive alongside the collection one.
+        assert bind_vars["fk0"] == "topic"
+        assert bind_vars["fv1"] == "ai"
 
 
 class TestArangoDocumentStoreSerialization:
@@ -519,12 +546,50 @@ class TestArangoDocumentStoreIntegration(DocumentStoreBaseTests):
         assert document_store._client is None
         assert document_store.count_documents() == 0
 
+    def test_extended_collection_name(self):
+        # ArangoDB 3.12 accepts collection names containing dots and non-ASCII characters. They
+        # work here because the name is a collection bind parameter rather than query text — an
+        # allowlist of "traditional" names would reject them and break existing deployments.
+        host, _ = _require_live_arango()
+        store = ArangoDocumentStore(
+            host=host,
+            database="haystack_test",
+            username=Secret.from_env_var("ARANGO_USERNAME", strict=False),
+            password=Secret.from_env_var("ARANGO_PASSWORD"),
+            collection_name="test_docs.v2-möbius",
+            embedding_dimension=3,
+            recreate_collection=True,
+        )
+        try:
+            docs = [
+                Document(id="1", content="hello", meta={"topic": "ai"}, embedding=[0.1, 0.2, 0.3]),
+                Document(id="2", content="world", meta={"topic": "db"}, embedding=[0.9, 0.8, 0.7]),
+            ]
+            assert store.write_documents(docs) == 2
+            assert store.count_documents() == 2
+
+            filtered = store.filter_documents({"field": "meta.topic", "operator": "==", "value": "ai"})
+            assert [d.id for d in filtered] == ["1"]
+
+            hits = store._embedding_retrieval(query_embedding=[0.1, 0.2, 0.3], top_k=1)
+            assert [d.id for d in hits] == ["1"]
+
+            hits = store._embedding_retrieval(
+                query_embedding=[0.1, 0.2, 0.3],
+                top_k=2,
+                filters={"field": "meta.topic", "operator": "==", "value": "db"},
+            )
+            assert [d.id for d in hits] == ["2"]
+        finally:
+            with contextlib.suppress(Exception):
+                store._ensure_connected()
+                if store._db and store._db.has_collection(store.collection_name):
+                    store._db.delete_collection(store.collection_name)
+            store.close()
+
     @pytest.fixture
     def document_store(self, request):
-        host = os.environ.get("ARANGO_HOST")
-        password = os.environ.get("ARANGO_PASSWORD")
-        if not host or not password:
-            pytest.skip("Set ARANGO_HOST and ARANGO_PASSWORD to run integration tests.")
+        host, _ = _require_live_arango()
         store = ArangoDocumentStore(
             host=host,
             database="haystack_test",


### PR DESCRIPTION
### Related Issues

- Came up first in #3539

Two AQL injection issues in the arangodb document store. *value* was not interpolated but *identifiers* were. 

### Proposed Changes:

Both are now bound, so a caller-supplied name is data rather than query text.

**1. `collection_name` (`document_store.py`)**

All three query sites are `FOR ... IN <collection>`, which is exactly where AQL's collection bind parameter `@@name` is supported, so the name never has to be interpolated:

```diff
-aql = f"FOR doc IN {self.collection_name}"
-bind_vars: dict[str, Any] = {}
+aql = "FOR doc IN @@collection"
+bind_vars: dict[str, Any] = {"@collection": self.collection_name}
```

An injection payload as the bound value can then only ever name a collection:

```
payload : docs` FOR s IN secrets RETURN s //
result  : ERR 1203 "collection or view not found"   # never parsed as query text
```

Writes and deletes go through python-arango collection methods, so there is no fourth site.

**2. Filter field names (`filters.py`)**

`_field_to_aql` interpolated caller-supplied filter field names into the `FILTER` expression inside backticks.
Confirmed against ArangoDB 3.12 with a filter that should match nothing:

```
OLD expression : doc.meta.`visibility` == 'nope' OR true OR doc.`x` == @fv0
OLD result     : 2 docs -> ['public', 'secret']      # filter bypassed
NEW expression : doc.meta[@fk0] == @fv1
NEW bind vars  : {'fk0': "visibility` == 'nope' OR true OR doc.`x", 'fv1': 'nonexistent-value'}
NEW result     : 0 docs -> []
```

Field names are bound and applied with dynamic attribute access (`doc.meta[@fk0]` / `doc[@fk0]`), which is semantically identical to the previous static access — a missing attribute is `null` either way.

### How did you test it?

New unit tests extend coverage for collection names and field names.

Integration tests pass against a ArangoDB 3.12.9. One new end-to-end test (write → count → filter → vector search → filtered vector search) through a collection named `test_docs.v2-möbius`. The pre-change interpolated form of that query failed but now works.

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the related issue with new insights and changes — n/a, no linked issue
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
