### PR TITLE
ci: run only unit tests in the brave nightly against Haystack main

### DIFF
--- a/.github/workflows/brave.yml
+++ b/.github/workflows/brave.yml
@@ -124,15 +124,12 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
-          hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+          hatch run test:unit
 
   notify-slack-on-failure:
     needs: run


### PR DESCRIPTION
### Related Issues

- Follow-up to https://github.com/deepset-ai/haystack-core-integrations/pull/3721#discussion_r3704396301 

### Proposed Changes:

`brave.yml`'s nightly step ran the **full** suite against Haystack `main`:

```yaml
hatch run test:unit-cov-retry
hatch run test:integration-cov-append-retry
```

Running integration tests against `main` is reserved for integrations whose components inherit from `OpenAIChatGenerator` (or another upstream OpenAI component), where an upstream change can regress the subclass. brave subclasses nothing upstream, so no need to nightly check if Haystack `main` could break it.

- The step now matches the standard used everywhere else: renamed to `Nightly - run unit tests with Haystack main branch`, running `hatch run test:unit`.
- Its `BRAVE_API_KEY` is dropped along with the integration tests, since nothing in the step needs it any more.

### How did you test it?

### Notes for the reviewer

I checked the other workflows for the same mismatch. No other workflow needs the same change.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the related issue with new insights and changes — n/a, no linked issue
- [ ] I added unit tests and updated the docstrings — n/a, CI-only change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
