### PR TITLE
ci: run e2b integration tests unconditionally and skip them in the test files

### DIFF
--- a/.github/workflows/e2b.yml
+++ b/.github/workflows/e2b.yml
@@ -60,12 +60,6 @@ jobs:
         os: ${{ fromJSON(needs.compute-test-matrix.outputs.os) }}
         python-version: ${{ fromJSON(needs.compute-test-matrix.outputs.python-version) }}
 
-    # Scoped to this job (not the workflow-level env) so the secret is not exposed to other
-    # jobs, while remaining available to the "Run integration tests" step's `if:` condition
-    # (a step's own step-level env is not in scope for that same step's `if`).
-    env:
-      E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-
     steps:
       - name: Support longpaths
         if: matrix.os == 'windows-latest'
@@ -108,7 +102,8 @@ jobs:
           path: python-coverage-comment-action-e2b.txt
 
       - name: Run integration tests
-        if: env.E2B_API_KEY != ''
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: hatch run test:integration-cov-append-retry
 
       - name: Store combined coverage

--- a/integrations/e2b/tests/test_integration.py
+++ b/integrations/e2b/tests/test_integration.py
@@ -6,8 +6,12 @@
 Integration tests for the E2B sandbox tools.
 
 These tests require a valid E2B_API_KEY environment variable and will
-spin up a real cloud sandbox on each run.
+spin up a real cloud sandbox on each run. Every test in this module skips when
+the variable is unset, so the suite can always be invoked — including on fork
+PRs, which have no access to repository secrets.
 """
+
+import os
 
 import pytest
 
@@ -19,6 +23,8 @@ from haystack_integrations.tools.e2b import (
     RunBashCommandTool,
     WriteFileTool,
 )
+
+pytestmark = pytest.mark.skipif(not os.environ.get("E2B_API_KEY"), reason="E2B_API_KEY not set")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Related Issues

- Follow-up to https://github.com/deepset-ai/haystack-core-integrations/pull/3721#discussion_r3704514322

### Proposed Changes:

`e2b.yml` was the one workflow in #3721 that could not scope its secret to the step, because its integration-test step gated on that same secret:

```yaml
- name: Run integration tests
  if: env.E2B_API_KEY != ''
```

A step's own step-level `env:` is not in scope for that step's `if:`, so the secret had to sit at the job level with a comment explaining why. Rather than keep the exception, this moves the gate to where the rest of the repo puts it:

- **In the workflow:** always run the integration tests. The `if:` condition is gone, the job-level `env:` block is gone, and `E2B_API_KEY` is now scoped to the step exactly like every other workflow.
- **In the test files:** skip when the variable is unset. `tests/test_integration.py` contains nothing but integration tests, so a module-level `pytestmark` covers every case — including `TestE2BToolsetIntegration`, whose two tests build their own `E2BToolset` rather than taking the shared `sandbox` fixture and so would not be covered by a fixture-level skip.

```python
pytestmark = pytest.mark.skipif(not os.environ.get("E2B_API_KEY"), reason="E2B_API_KEY not set")
```

This also removes the awkward comment from #3721 that prompted the discussion.

### How did you test it?

With `E2B_API_KEY` unset, from `integrations/e2b`:

| Command | Result |
|---|---|
| `hatch run test:integration` | exit 0 — 9 skipped, 43 deselected |
| `hatch run test:integration-cov-append-retry` (what CI runs) | exit 0 |
| `hatch run test:unit` | 43 passed |

The tests are *collected* and then skipped, so this does not trip pytest's "no tests collected" exit code 5.

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the related issue with new insights and changes — n/a, no linked issue
- [ ] I added unit tests and updated the docstrings — n/a, no source change; the test-file change is the skip guard itself
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
