### PR TITLE
test: pin mcp<2 for llama-stack testing

### DIFF
--- a/.github/workflows/llama_stack.yml
+++ b/.github/workflows/llama_stack.yml
@@ -120,11 +120,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -q uv --uploaded-prior-to=P1D
 
-          # Install the starter distro's deps into the uv environment
-          uv run --with llama-stack bash -lc 'llama stack list-deps starter | xargs -L1 uv pip install'
+          # mcp 2.0.0 breaks llama-stack
+          echo 'mcp<2' > mcp-constraints.txt
+          export UV_CONSTRAINT="$PWD/mcp-constraints.txt"
 
-          # Start Llama Stack (no more --image-type flag)
-          uv run --with llama-stack llama stack run starter > server.log 2>&1 &
+          # Install llama-stack and the starter distro's deps into a dedicated venv
+          uv venv stack-env
+          uv pip install --python stack-env/bin/python llama-stack
+          stack-env/bin/llama stack list-deps starter | xargs -L1 uv pip install --python stack-env/bin/python
+
+          # Start Llama Stack
+          stack-env/bin/llama stack run starter > server.log 2>&1 &
           SERVER_PID=$!
 
           # Wait up to ~120s for health; fail fast if process dies


### PR DESCRIPTION
### Related Issues

- failing tests: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/30865926599/job/91857663181
- llama stack is incompatible with mcp>=2.0.0

### Proposed Changes:
- pin mcp<2 in the CI testing environment
- simplify llama stack installation

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
