### PR TITLE
test: reduce the execution of tests that require API keys

### DIFF
--- a/.github/workflows/agent_pack.yml
+++ b/.github/workflows/agent_pack.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-agent_pack.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}

--- a/.github/workflows/aimlapi.yml
+++ b/.github/workflows/aimlapi.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-aimlapi.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           AIMLAPI_API_KEY: ${{ secrets.AIMLAPI_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/aimlapi.yml
+++ b/.github/workflows/aimlapi.yml
@@ -127,16 +127,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          AIMLAPI_API_KEY: ${{ secrets.AIMLAPI_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          AIMLAPI_API_KEY: ${{ secrets.AIMLAPI_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/anthropic.yml
+++ b/.github/workflows/anthropic.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-anthropic.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/astra.yml
+++ b/.github/workflows/astra.yml
@@ -106,6 +106,7 @@ jobs:
           path: python-coverage-comment-action-astra.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
           ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}

--- a/.github/workflows/azure_ai_search.yml
+++ b/.github/workflows/azure_ai_search.yml
@@ -101,6 +101,7 @@ jobs:
           path: python-coverage-comment-action-azure_ai_search.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           AZURE_AI_SEARCH_API_KEY: ${{ secrets.AZURE_AI_SEARCH_API_KEY }}
           AZURE_AI_SEARCH_ENDPOINT: ${{ secrets.AZURE_AI_SEARCH_ENDPOINT }}

--- a/.github/workflows/azure_doc_intelligence.yml
+++ b/.github/workflows/azure_doc_intelligence.yml
@@ -101,6 +101,7 @@ jobs:
           path: python-coverage-comment-action-azure_doc_intelligence.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           AZURE_DI_ENDPOINT: ${{ secrets.AZURE_DI_ENDPOINT }}
           AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}

--- a/.github/workflows/azure_form_recognizer.yml
+++ b/.github/workflows/azure_form_recognizer.yml
@@ -101,6 +101,7 @@ jobs:
           path: python-coverage-comment-action-azure_form_recognizer.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           CORE_AZURE_CS_ENDPOINT: ${{ secrets.CORE_AZURE_CS_ENDPOINT }}
           CORE_AZURE_CS_API_KEY: ${{ secrets.CORE_AZURE_CS_API_KEY }}

--- a/.github/workflows/brave.yml
+++ b/.github/workflows/brave.yml
@@ -103,6 +103,7 @@ jobs:
           path: python-coverage-comment-action-brave.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/cognee.yml
+++ b/.github/workflows/cognee.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-cognee.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           # cognee runs an LLM internally for remember/recall/improve; the integration suite needs a key.

--- a/.github/workflows/cohere.yml
+++ b/.github/workflows/cohere.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-cohere.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}

--- a/.github/workflows/cometapi.yml
+++ b/.github/workflows/cometapi.yml
@@ -127,16 +127,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          COMET_API_KEY: "${{ secrets.COMET_API_KEY }}"
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          COMET_API_KEY: "${{ secrets.COMET_API_KEY }}"
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/cometapi.yml
+++ b/.github/workflows/cometapi.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-cometapi.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           COMET_API_KEY: "${{ secrets.COMET_API_KEY }}"

--- a/.github/workflows/deepeval.yml
+++ b/.github/workflows/deepeval.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-deepeval.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/dspy.yml
+++ b/.github/workflows/dspy.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-dspy.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/e2b.yml
+++ b/.github/workflows/e2b.yml
@@ -102,6 +102,7 @@ jobs:
           path: python-coverage-comment-action-e2b.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/edenai.yml
+++ b/.github/workflows/edenai.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-edenai.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           EDENAI_API_KEY: ${{ secrets.EDENAI_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/edenai.yml
+++ b/.github/workflows/edenai.yml
@@ -127,16 +127,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          EDENAI_API_KEY: ${{ secrets.EDENAI_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          EDENAI_API_KEY: ${{ secrets.EDENAI_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/firecrawl.yml
+++ b/.github/workflows/firecrawl.yml
@@ -100,6 +100,7 @@ jobs:
           path: python-coverage-comment-action-firecrawl.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/google_drive.yml
+++ b/.github/workflows/google_drive.yml
@@ -111,7 +111,7 @@ jobs:
       # On any skipped run the token stays unset and `TestLive` skips itself.
       - name: Authenticate to Google Cloud
         id: gdrive_auth
-        if: env.HAS_GOOGLE_DRIVE_SECRET == 'true' && matrix.python-version == '3.14' && runner.os == 'Linux'
+        if: env.HAS_GOOGLE_DRIVE_SECRET == 'true' && matrix.python-version == '3.10' && runner.os == 'Linux'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: ${{ secrets.GOOGLE_DRIVE_SA_KEY }}
@@ -119,6 +119,7 @@ jobs:
           access_token_scopes: https://www.googleapis.com/auth/drive.readonly
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           GOOGLE_DRIVE_ACCESS_TOKEN: ${{ steps.gdrive_auth.outputs.access_token }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/google_genai.yml
+++ b/.github/workflows/google_genai.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-google_genai.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           GOOGLE_API_KEY: "${{ secrets.GOOGLE_API_KEY }}"
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/huggingface_api.yml
+++ b/.github/workflows/huggingface_api.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-huggingface_api.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/jina.yml
+++ b/.github/workflows/jina.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-jina.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/langfuse.yml
+++ b/.github/workflows/langfuse.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-langfuse.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}

--- a/.github/workflows/lara.yml
+++ b/.github/workflows/lara.yml
@@ -101,6 +101,7 @@ jobs:
           path: python-coverage-comment-action-lara.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           LARA_ACCESS_KEY_ID: ${{ secrets.LARA_ACCESS_KEY_ID }}
           LARA_ACCESS_KEY_SECRET: ${{ secrets.LARA_ACCESS_KEY_SECRET }}

--- a/.github/workflows/linkup.yml
+++ b/.github/workflows/linkup.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-linkup.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           LINKUP_API_KEY: ${{ secrets.LINKUP_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/litellm.yml
+++ b/.github/workflows/litellm.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-litellm.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -120,6 +120,7 @@ jobs:
           path: python-coverage-comment-action-mcp.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}

--- a/.github/workflows/mem0.yml
+++ b/.github/workflows/mem0.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-mem0.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           MEM0_API_KEY: ${{ secrets.MEM0_API_KEY }}

--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -113,7 +113,7 @@ jobs:
       # On any skipped run the token stays unset and `TestLiveGoogleDrive` skips itself.
       - name: Authenticate to Google Cloud
         id: gdrive_auth
-        if: env.HAS_GOOGLE_DRIVE_SECRET == 'true' && matrix.python-version == '3.14' && runner.os == 'Linux'
+        if: env.HAS_GOOGLE_DRIVE_SECRET == 'true' && matrix.python-version == '3.11' && runner.os == 'Linux'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: ${{ secrets.GOOGLE_DRIVE_SA_KEY }}
@@ -121,6 +121,7 @@ jobs:
           access_token_scopes: https://www.googleapis.com/auth/drive.readonly
 
       - name: Run integration tests
+        if: matrix.python-version == '3.11' && runner.os == 'Linux'
         env:
           GOOGLE_DRIVE_ACCESS_TOKEN: ${{ steps.gdrive_auth.outputs.access_token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-mistral.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}

--- a/.github/workflows/mistral.yml
+++ b/.github/workflows/mistral.yml
@@ -127,16 +127,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/mongodb_atlas.yml
+++ b/.github/workflows/mongodb_atlas.yml
@@ -100,6 +100,7 @@ jobs:
           path: python-coverage-comment-action-mongodb_atlas.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-nvidia.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -128,17 +128,20 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-          NVIDIA_CATALOG_API_KEY: ${{ secrets.NVIDIA_CATALOG_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NVIDIA_CATALOG_API_KEY: ${{ secrets.NVIDIA_CATALOG_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-openapi.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-openrouter.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -126,16 +126,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/orcarouter.yml
+++ b/.github/workflows/orcarouter.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-orcarouter.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           ORCAROUTER_API_KEY: ${{ secrets.ORCAROUTER_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/orcarouter.yml
+++ b/.github/workflows/orcarouter.yml
@@ -126,16 +126,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          ORCAROUTER_API_KEY: ${{ secrets.ORCAROUTER_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          ORCAROUTER_API_KEY: ${{ secrets.ORCAROUTER_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/paddleocr.yml
+++ b/.github/workflows/paddleocr.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-paddleocr.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           PADDLEOCR_ACCESS_TOKEN: ${{ secrets.PADDLEOCR_ACCESS_TOKEN }}
           PADDLEOCR_BASE_URL: ${{ secrets.PADDLEOCR_BASE_URL }}

--- a/.github/workflows/perplexity.yml
+++ b/.github/workflows/perplexity.yml
@@ -102,6 +102,7 @@ jobs:
           path: python-coverage-comment-action-perplexity.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/pinecone.yml
+++ b/.github/workflows/pinecone.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-pinecone.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           INDEX_NAME: ${{ matrix.INDEX_NAME }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}

--- a/.github/workflows/ragas.yml
+++ b/.github/workflows/ragas.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-ragas.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/searchapi.yml
+++ b/.github/workflows/searchapi.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-searchapi.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           SEARCHAPI_API_KEY: ${{ secrets.SEARCHAPI_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/sentence_transformers.yml
+++ b/.github/workflows/sentence_transformers.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-sentence_transformers.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/serperdev.yml
+++ b/.github/workflows/serperdev.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-serperdev.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           SERPERDEV_API_KEY: ${{ secrets.SERPERDEV_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/stackit.yml
+++ b/.github/workflows/stackit.yml
@@ -126,16 +126,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          STACKIT_API_KEY: ${{ secrets.STACKIT_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          STACKIT_API_KEY: ${{ secrets.STACKIT_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/stackit.yml
+++ b/.github/workflows/stackit.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-stackit.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           STACKIT_API_KEY: ${{ secrets.STACKIT_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/togetherai.yml
+++ b/.github/workflows/togetherai.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-togetherai.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_AI_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/togetherai.yml
+++ b/.github/workflows/togetherai.yml
@@ -126,16 +126,19 @@ jobs:
           hatch -e test env run -- uv pip install -r requirements_lowest_direct.txt
           hatch run test:unit
 
-      # Since this integration inherits from OpenAIChatGenerator, we run ALL tests with Haystack main branch to catch regressions
-      - name: Nightly - run tests with Haystack main branch
+      - name: Nightly - run unit tests with Haystack main branch
         if: github.event_name == 'schedule'
-        env:
-          TOGETHER_API_KEY: ${{ secrets.TOGETHER_AI_API_KEY }}
         run: |
           hatch env prune
           hatch -e test env run -- uv pip install git+https://github.com/deepset-ai/haystack.git@main
           hatch run test:unit-cov-retry
-          hatch run test:integration-cov-append-retry
+
+      # Since this integration inherits from OpenAIChatGenerator, we run also integration tests with Haystack main branch to catch regressions
+      - name: Nightly - run integration tests with Haystack main branch
+        if: github.event_name == 'schedule' && matrix.python-version == '3.10' && runner.os == 'Linux'
+        env:
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_AI_API_KEY }}
+        run: hatch run test:integration-cov-append-retry
 
   notify-slack-on-failure:
     needs: run

--- a/.github/workflows/twelvelabs.yml
+++ b/.github/workflows/twelvelabs.yml
@@ -104,6 +104,7 @@ jobs:
           path: python-coverage-comment-action-twelvelabs.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           TWELVELABS_API_KEY: "${{ secrets.TWELVELABS_API_KEY }}"
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/watsonx.yml
+++ b/.github/workflows/watsonx.yml
@@ -105,6 +105,7 @@ jobs:
           path: python-coverage-comment-action-watsonx.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           WATSONX_API_KEY: ${{ secrets.WATSONX_API_KEY }}
           WATSONX_PROJECT_ID: ${{ secrets.WATSONX_PROJECT_ID }}

--- a/.github/workflows/weave.yml
+++ b/.github/workflows/weave.yml
@@ -100,6 +100,7 @@ jobs:
           path: python-coverage-comment-action-weave.txt
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/.github/workflows/whisper.yml
+++ b/.github/workflows/whisper.yml
@@ -114,6 +114,7 @@ jobs:
         run: brew install ffmpeg
 
       - name: Run integration tests
+        if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: hatch run test:integration-cov-append-retry

--- a/scripts/create_new_integration.py
+++ b/scripts/create_new_integration.py
@@ -170,8 +170,9 @@ def main():
     print("  2. Export the component classes from the __init__.py in your module")
     print(f"  3. Add integration-specific dependencies to integrations/{name}/pyproject.toml")
     print(f"  4. Add tests in integrations/{name}/tests/")
-    print(f"  5. If your integration tests need API keys, update .github/workflows/{name}.yml accordingly")
-    print("     and ask a maintainer to add the secret to the GitHub repo.")
+    print(f"  5. If your integration tests consume API keys, update .github/workflows/{name}.yml accordingly ")
+    print("     (expose the secrets and uncomment the `if:` on the integration test step) and ask a maintainer to add "
+          "the secret to the GitHub repo.")
     print(f"  6. Add relevant keywords to integrations/{name}/pyproject.toml")
     print(f"  7. Check that the correct module paths are used in integrations/{name}/pydoc/config_docusaurus.yml")
 

--- a/scripts/utils/templates/workflow.yml
+++ b/scripts/utils/templates/workflow.yml
@@ -104,6 +104,8 @@ jobs:
           path: python-coverage-comment-action-$name.txt
 
       - name: Run integration tests
+        # If integration tests consume API credits, run them only on Linux and on the minimum Python version supported
+        # if: matrix.python-version == '3.10' && runner.os == 'Linux'
         run: hatch run test:integration-cov-append-retry
 
       - name: Store combined coverage


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/510

### Proposed Changes:
- run integration tests requiring an API key only on Linux and on the min supported Python version
- update the scaffolding script accordingly
- for OpenAI-inherited Chat Generators we also run nightly integration tests with Haystack main branch: also in this case, only test on Linux and on the min supported Python version

### How did you test it?
CI.
Some tests are still failing due to API credits exhaustion. I hope that this PR can reduce these failures in the long run.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
