### PR TITLE
test: make OpenRouter tests declare max_tokens + refactor

### DIFF
--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -9,11 +9,6 @@ import pytest
 import pytz
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-
-try:
-    from haystack.components.tools import ToolInvoker
-except ImportError:  # ToolInvoker was removed in Haystack 3.0
-    ToolInvoker = None
 from haystack.dataclasses import ChatMessage, ChatRole, ReasoningContent, StreamingChunk, ToolCall
 from haystack.tools import Tool, Toolset
 from haystack.utils.auth import Secret
@@ -107,7 +102,7 @@ def mock_chat_completion():
         yield mock_chat_completion_create
 
 
-class TestOpenRouterChatGenerator:
+class TestOpenRouterChatGeneratorUnit:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-api-key")
         component = OpenRouterChatGenerator()
@@ -293,278 +288,6 @@ class TestOpenRouterChatGenerator:
         assert api_args["openai_endpoint"] == "create"
         assert api_args["response_format"] == response_format
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run(self):
-        chat_messages = [ChatMessage.from_user("What's the capital of France")]
-        component = OpenRouterChatGenerator()
-        results = component.run(chat_messages)
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-        assert "openai/gpt-5-mini" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_wrong_model(self, chat_messages):
-        component = OpenRouterChatGenerator(model="something-obviously-wrong")
-        with pytest.raises(OpenAIError):
-            component.run(chat_messages)
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_streaming(self):
-        class Callback:
-            def __init__(self):
-                self.responses = ""
-                self.counter = 0
-
-            def __call__(self, chunk: StreamingChunk) -> None:
-                self.counter += 1
-                self.responses += chunk.content if chunk.content else ""
-
-        callback = Callback()
-        component = OpenRouterChatGenerator(streaming_callback=callback)
-        results = component.run([ChatMessage.from_user("What's the capital of France?")])
-
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-
-        assert "openai/gpt-5-mini" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-
-        assert callback.counter > 1
-        assert "Paris" in callback.responses
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_tools(self, tools):
-        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = OpenRouterChatGenerator(tools=tools)
-        results = component.run(chat_messages)
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-        assert not message.text
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.tool_name == "weather"
-        assert "paris" in tool_call.arguments["city"].lower(), f"Expected 'paris' in city: {tool_call.arguments}"
-        assert message.meta["finish_reason"] == "tool_calls"
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_tools_and_response(self, tools):
-        """
-        Integration test that the OpenRouterChatGenerator component can run with tools and get a response.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris and Berlin?")]
-        component = OpenRouterChatGenerator(tools=tools)
-        results = component.run(messages=initial_messages, generation_kwargs={"tool_choice": "auto"})
-
-        assert len(results["replies"]) == 1
-
-        # Find the message with tool calls
-        tool_message = results["replies"][0]
-
-        assert isinstance(tool_message, ChatMessage)
-        tool_calls = tool_message.tool_calls
-        assert len(tool_calls) == 2
-        assert ChatMessage.is_from(tool_message, ChatRole.ASSISTANT)
-
-        for tool_call in tool_calls:
-            assert tool_call.id is not None
-            assert isinstance(tool_call, ToolCall)
-            assert tool_call.tool_name == "weather"
-
-        arguments = [tool_call.arguments for tool_call in tool_calls]
-        # Extract city names and check they contain the expected cities
-        # (LLM may return "Paris, France" or "Berlin, Germany" instead of just city names)
-        cities = [arg["city"].lower() for arg in arguments]
-        assert len(cities) == 2
-        assert any("berlin" in city for city in cities), f"Expected 'berlin' in one of {cities}"
-        assert any("paris" in city for city in cities), f"Expected 'paris' in one of {cities}"
-        assert tool_message.meta["finish_reason"] == "tool_calls"
-
-        new_messages = [
-            initial_messages[0],
-            tool_message,
-            ChatMessage.from_tool(tool_result="22° C and sunny", origin=tool_calls[0]),
-            ChatMessage.from_tool(tool_result="16° C and windy", origin=tool_calls[1]),
-        ]
-        # Pass the tool result to the model to get the final response
-        results = component.run(new_messages)
-
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert final_message.is_from(ChatRole.ASSISTANT)
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
-        assert "berlin" in final_message.text.lower()
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_reasoning(self):
-        chat_messages = [ChatMessage.from_user("If x + 3 = 7, what is x?")]
-        component = OpenRouterChatGenerator(
-            model="deepseek/deepseek-r1",
-            generation_kwargs={"reasoning": {"effort": "high"}},
-        )
-        results = component.run(chat_messages)
-
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert message.reasoning is not None
-        assert message.reasoning.reasoning_text
-        assert message.reasoning.extra.get("reasoning_details")
-        assert message.text
-        assert "4" in message.text
-        assert message.meta["finish_reason"] == "stop"
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_tools_streaming(self, tools):
-        """
-        Integration test that the OpenRouterChatGenerator component can run with tools and streaming.
-        """
-        component = OpenRouterChatGenerator(tools=tools, streaming_callback=print_streaming_chunk)
-        results = component.run(
-            [ChatMessage.from_user("What's the weather like in Paris and Berlin?")],
-            generation_kwargs={"tool_choice": "auto"},
-        )
-
-        assert len(results["replies"]) == 1
-
-        # Find the message with tool calls
-        tool_message = results["replies"][0]
-
-        assert isinstance(tool_message, ChatMessage)
-        tool_calls = tool_message.tool_calls
-        assert len(tool_calls) == 2
-        assert ChatMessage.is_from(tool_message, ChatRole.ASSISTANT)
-
-        for tool_call in tool_calls:
-            assert tool_call.id is not None
-            assert isinstance(tool_call, ToolCall)
-            assert tool_call.tool_name == "weather"
-
-        arguments = [tool_call.arguments for tool_call in tool_calls]
-        # Extract city names and check they contain the expected cities
-        # (LLM may return "Paris, France" or "Berlin, Germany" instead of just city names)
-        cities = [arg["city"].lower() for arg in arguments]
-        assert len(cities) == 2
-        assert any("berlin" in city for city in cities), f"Expected 'berlin' in one of {cities}"
-        assert any("paris" in city for city in cities), f"Expected 'paris' in one of {cities}"
-        assert tool_message.meta["finish_reason"] == "tool_calls"
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
-    def test_pipeline_with_openrouter_chat_generator(self, tools):
-        """
-        Test that the OpenRouterChatGenerator component can be used in a pipeline
-        """
-        pipeline = Pipeline()
-        pipeline.add_component("generator", OpenRouterChatGenerator(tools=tools))
-        pipeline.add_component("tool_invoker", ToolInvoker(tools=tools))
-
-        pipeline.connect("generator", "tool_invoker")
-
-        results = pipeline.run(
-            data={
-                "generator": {
-                    "messages": [ChatMessage.from_user("What's the weather like in Paris?")],
-                    "generation_kwargs": {"tool_choice": "auto"},
-                }
-            }
-        )
-
-        result = results["tool_invoker"]["tool_messages"][0].tool_call_result.result
-        assert "paris" in result.lower(), f"Expected 'paris' in result: {result}"
-        assert "sunny and 32°c" in result.lower(), f"Expected 'sunny and 32°c' in result: {result}"
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
-    )
-    @pytest.mark.integration
-    def test_live_run_with_response_format_json_schema(self):
-        response_schema = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": "CapitalCity",
-                "strict": True,
-                "schema": {
-                    "title": "CapitalCity",
-                    "type": "object",
-                    "properties": {
-                        "city": {"title": "City", "type": "string"},
-                        "country": {"title": "Country", "type": "string"},
-                    },
-                    "required": ["city", "country"],
-                    "additionalProperties": False,
-                },
-            },
-        }
-
-        # Use a more explicit prompt that emphasizes JSON structure requirement
-        # gpt-5-mini is very rarely flaky but to harden CI we'll be more explicit
-        chat_messages = [
-            ChatMessage.from_user(
-                "What's the capital of France? "
-                "You must respond with a JSON object containing 'city' and 'country' fields."
-            )
-        ]
-        comp = OpenRouterChatGenerator(
-            model="openai/gpt-5-mini", generation_kwargs={"response_format": response_schema}
-        )
-        results = comp.run(chat_messages)
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        try:
-            msg = json.loads(message.text)
-        except json.JSONDecodeError as e:
-            pytest.fail(
-                f"Failed to parse response as JSON. "
-                f"Expected JSON with 'city' and 'country' fields, but got: {message.text!r}. "
-                f"Error: {e}"
-            )
-
-        # Validate JSON structure with descriptive error messages
-        assert "city" in msg, f"Response JSON missing 'city' field. Got: {msg}"
-        assert "country" in msg, f"Response JSON missing 'country' field. Got: {msg}"
-        assert "paris" in msg["city"].lower(), f"Expected 'Paris' in city field, got: {msg['city']}"
-        assert isinstance(msg["country"], str), f"Expected country to be string, got: {type(msg['country'])}"
-        assert "france" in msg["country"].lower(), f"Expected 'France' in country field, got: {msg['country']}"
-        assert message.meta["finish_reason"] == "stop"
-
     def test_serde_in_pipeline(self, monkeypatch):
         """
         Test serialization/deserialization of OpenRouterChatGenerator in a Pipeline,
@@ -642,11 +365,156 @@ class TestOpenRouterChatGenerator:
         assert loaded_generator.tools[0].description == generator.tools[0].description
         assert loaded_generator.tools[0].parameters == generator.tools[0].parameters
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
-    )
-    @pytest.mark.integration
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENROUTER_API_KEY", None),
+    reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
+)
+@pytest.mark.integration
+class TestOpenRouterChatGeneratorIntegration:
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_live_run(self, streaming):
+        callback = CollectorCallback() if streaming else None
+        component = OpenRouterChatGenerator(streaming_callback=callback, generation_kwargs={"max_tokens": 1000})
+        results = component.run([ChatMessage.from_user("What's the capital of France?")])
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "openai/gpt-5-mini" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+        if streaming:
+            assert len(callback.chunks) > 1
+            assert "Paris" in "".join(chunk.content for chunk in callback.chunks)
+
+    def test_live_run_wrong_model(self, chat_messages):
+        component = OpenRouterChatGenerator(model="something-obviously-wrong")
+        with pytest.raises(OpenAIError):
+            component.run(chat_messages)
+
+    @pytest.mark.parametrize("streaming_callback", [None, print_streaming_chunk])
+    def test_live_run_with_tools_and_response(self, tools, streaming_callback):
+        """
+        Integration test that the OpenRouterChatGenerator component can run with tools and get a response.
+        """
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris and Berlin?")]
+        component = OpenRouterChatGenerator(
+            tools=tools,
+            streaming_callback=streaming_callback,
+            generation_kwargs={"max_tokens": 1000, "tool_choice": "auto"},
+        )
+        results = component.run(messages=initial_messages)
+
+        assert len(results["replies"]) == 1
+
+        # Find the message with tool calls
+        tool_message = results["replies"][0]
+
+        assert isinstance(tool_message, ChatMessage)
+        assert tool_message.meta["finish_reason"] == "tool_calls"
+        assert not tool_message.text
+        tool_calls = tool_message.tool_calls
+        assert len(tool_calls) == 2
+        assert ChatMessage.is_from(tool_message, ChatRole.ASSISTANT)
+
+        for tool_call in tool_calls:
+            assert tool_call.id is not None
+            assert isinstance(tool_call, ToolCall)
+            assert tool_call.tool_name == "weather"
+
+        arguments = [tool_call.arguments for tool_call in tool_calls]
+        # Extract city names and check they contain the expected cities
+        # (LLM may return "Paris, France" or "Berlin, Germany" instead of just city names)
+        cities = [arg["city"].lower() for arg in arguments]
+        assert len(cities) == 2
+        assert any("berlin" in city for city in cities), f"Expected 'berlin' in one of {cities}"
+        assert any("paris" in city for city in cities), f"Expected 'paris' in one of {cities}"
+        assert tool_message.meta["finish_reason"] == "tool_calls"
+
+        new_messages = [
+            initial_messages[0],
+            tool_message,
+            ChatMessage.from_tool(tool_result="22° C and sunny", origin=tool_calls[0]),
+            ChatMessage.from_tool(tool_result="16° C and windy", origin=tool_calls[1]),
+        ]
+        # Pass the tool result to the model to get the final response
+        results = component.run(new_messages)
+
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert final_message.is_from(ChatRole.ASSISTANT)
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
+        assert "berlin" in final_message.text.lower()
+
+    def test_live_run_with_reasoning(self):
+        chat_messages = [ChatMessage.from_user("If x + 3 = 7, what is x?")]
+        component = OpenRouterChatGenerator(
+            model="deepseek/deepseek-r1",
+            generation_kwargs={"reasoning": {"effort": "high"}, "max_tokens": 1000},
+        )
+        results = component.run(chat_messages)
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert message.reasoning is not None
+        assert message.reasoning.reasoning_text
+        assert message.reasoning.extra.get("reasoning_details")
+        assert message.text
+        assert "4" in message.text
+        assert message.meta["finish_reason"] == "stop"
+
+    def test_live_run_with_response_format_json_schema(self):
+        response_schema = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "CapitalCity",
+                "strict": True,
+                "schema": {
+                    "title": "CapitalCity",
+                    "type": "object",
+                    "properties": {
+                        "city": {"title": "City", "type": "string"},
+                        "country": {"title": "Country", "type": "string"},
+                    },
+                    "required": ["city", "country"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+        # Use a more explicit prompt that emphasizes JSON structure requirement
+        # gpt-5-mini is very rarely flaky but to harden CI we'll be more explicit
+        chat_messages = [
+            ChatMessage.from_user(
+                "What's the capital of France? "
+                "You must respond with a JSON object containing 'city' and 'country' fields."
+            )
+        ]
+        comp = OpenRouterChatGenerator(
+            model="openai/gpt-5-mini", generation_kwargs={"response_format": response_schema, "max_tokens": 1000}
+        )
+        results = comp.run(chat_messages)
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        try:
+            msg = json.loads(message.text)
+        except json.JSONDecodeError as e:
+            pytest.fail(
+                f"Failed to parse response as JSON. "
+                f"Expected JSON with 'city' and 'country' fields, but got: {message.text!r}. "
+                f"Error: {e}"
+            )
+
+        # Validate JSON structure with descriptive error messages
+        assert "city" in msg, f"Response JSON missing 'city' field. Got: {msg}"
+        assert "country" in msg, f"Response JSON missing 'country' field. Got: {msg}"
+        assert "paris" in msg["city"].lower(), f"Expected 'Paris' in city field, got: {msg['city']}"
+        assert isinstance(msg["country"], str), f"Expected country to be string, got: {type(msg['country'])}"
+        assert "france" in msg["country"].lower(), f"Expected 'France' in country field, got: {msg['country']}"
+        assert message.meta["finish_reason"] == "stop"
+
     def test_live_run_with_response_format_pydantic_model(self, calendar_event_model):
         # Use a more explicit prompt that emphasizes JSON structure requirement
         chat_messages = [
@@ -657,7 +525,7 @@ class TestOpenRouterChatGenerator:
             )
         ]
         component = OpenRouterChatGenerator(
-            model="openai/gpt-5-mini", generation_kwargs={"response_format": calendar_event_model}
+            model="openai/gpt-5-mini", generation_kwargs={"response_format": calendar_event_model, "max_tokens": 1000}
         )
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
@@ -685,11 +553,6 @@ class TestOpenRouterChatGenerator:
             f"Expected event_location to be string, got: {type(msg['event_location'])}"
         )
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
-    )
-    @pytest.mark.integration
     def test_integration_mixing_tools_and_toolset(self):
         """Test mixing Tool list and Toolset at runtime."""
 
@@ -731,7 +594,7 @@ class TestOpenRouterChatGenerator:
         toolset = Toolset([weather_tool, time_tool])
 
         # Initialize with no tools, we'll pass them at runtime
-        component = OpenRouterChatGenerator()
+        component = OpenRouterChatGenerator(generation_kwargs={"max_tokens": 1000})
 
         # Pass mixed list: echo_tool (individual) and toolset (weather + time) at runtime
         # This tests that both individual tools and toolsets can be combined

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -289,14 +289,8 @@ class TestOpenRouterChatGeneratorUnit:
         assert api_args["response_format"] == response_format
 
     def test_serde_in_pipeline(self, monkeypatch):
-        """
-        Test serialization/deserialization of OpenRouterChatGenerator in a Pipeline,
-        including YAML conversion and detailed dictionary validation
-        """
-        # Set mock API key
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
-        # Create a test tool
         tool = Tool(
             name="weather",
             description="useful to determine the weather in a given location",
@@ -304,18 +298,15 @@ class TestOpenRouterChatGeneratorUnit:
             function=weather,
         )
 
-        # Create generator with specific configuration
         generator = OpenRouterChatGenerator(
             generation_kwargs={"temperature": 0.7},
             streaming_callback=print_streaming_chunk,
             tools=[tool],
         )
 
-        # Create and configure pipeline
         pipeline = Pipeline()
         pipeline.add_component("generator", generator)
 
-        # Get pipeline dictionary and verify its structure
         pipeline_dict = pipeline.to_dict()
 
         # the Tool serialization format is owned by haystack-ai and varies across its versions; the
@@ -328,7 +319,10 @@ class TestOpenRouterChatGeneratorUnit:
             "connection_type_validation": True,
             "components": {
                 "generator": {
-                    "type": "haystack_integrations.components.generators.openrouter.chat.chat_generator.OpenRouterChatGenerator",  # noqa: E501
+                    "type": (
+                        "haystack_integrations.components.generators.openrouter.chat.chat_generator"
+                        ".OpenRouterChatGenerator"
+                    ),
                     "init_parameters": {
                         "api_key": {"type": "env_var", "env_vars": ["OPENROUTER_API_KEY"], "strict": True},
                         "model": "openai/gpt-5-mini",
@@ -350,12 +344,10 @@ class TestOpenRouterChatGeneratorUnit:
 
         assert pipeline_dict == expected_dict
 
-        # Test YAML serialization/deserialization
         pipeline_yaml = pipeline.dumps()
         new_pipeline = Pipeline.loads(pipeline_yaml)
         assert new_pipeline == pipeline
 
-        # Verify the loaded pipeline's generator has the same configuration
         loaded_generator = new_pipeline.get_component("generator")
         assert loaded_generator.model == generator.model
         assert loaded_generator.generation_kwargs == generator.generation_kwargs

--- a/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
@@ -82,8 +82,8 @@ def mock_async_chat_completion():
         yield mock_chat_completion_create
 
 
-class TestOpenRouterChatGeneratorAsync:
-    @pytest.mark.asyncio
+@pytest.mark.asyncio
+class TestOpenRouterChatGeneratorAsyncUnit:
     async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-api-key")
         component = OpenRouterChatGenerator()
@@ -95,7 +95,6 @@ class TestOpenRouterChatGeneratorAsync:
         assert component.async_client.api_key == "test-api-key"
         assert component.async_client.base_url == "https://openrouter.ai/api/v1/"
 
-    @pytest.mark.asyncio
     async def test_run_async(self, chat_messages, mock_async_chat_completion, monkeypatch):  # noqa: ARG002
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
         component = OpenRouterChatGenerator()
@@ -108,7 +107,6 @@ class TestOpenRouterChatGeneratorAsync:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.asyncio
     async def test_run_async_with_params(self, chat_messages, mock_async_chat_completion, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
         component = OpenRouterChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
@@ -126,210 +124,6 @@ class TestOpenRouterChatGeneratorAsync:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_live_run_async(self):
-        chat_messages = [ChatMessage.from_user("What's the capital of France")]
-        component = OpenRouterChatGenerator()
-        results = await component.run_async(chat_messages)
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-        assert "openai/gpt-5-mini" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_live_run_streaming_async(self):
-        counter = 0
-        responses = ""
-
-        async def callback(chunk: StreamingChunk):
-            nonlocal counter
-            nonlocal responses
-            counter += 1
-            responses += chunk.content if chunk.content else ""
-
-        component = OpenRouterChatGenerator(streaming_callback=callback)
-        results = await component.run_async([ChatMessage.from_user("What's the capital of France?")])
-
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert "Paris" in message.text
-
-        assert "openai/gpt-5-mini" in message.meta["model"]
-        assert message.meta["finish_reason"] == "stop"
-
-        assert counter > 1
-        assert "Paris" in responses
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_live_run_with_tools_and_response_async(self, tools):
-        """
-        Integration test that the OpenRouterChatGenerator component can run with tools and get a response.
-        """
-        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        component = OpenRouterChatGenerator(tools=tools)
-        results = await component.run_async(messages=initial_messages, generation_kwargs={"tool_choice": "auto"})
-
-        assert len(results["replies"]) > 0, "No replies received"
-
-        # Find the message with tool calls
-        tool_message = None
-        for message in results["replies"]:
-            if message.tool_call:
-                tool_message = message
-                break
-
-        assert tool_message is not None, "No message with tool call found"
-        assert isinstance(tool_message, ChatMessage), "Tool message is not a ChatMessage instance"
-        assert ChatMessage.is_from(tool_message, ChatRole.ASSISTANT), "Tool message is not from the assistant"
-
-        tool_call = tool_message.tool_call
-        assert tool_call.id, "Tool call does not contain value for 'id' key"
-        assert tool_call.tool_name == "weather"
-        assert "paris" in tool_call.arguments["city"].lower(), f"Expected 'paris' in city: {tool_call.arguments}"
-        assert tool_message.meta["finish_reason"] == "tool_calls"
-
-        new_messages = [
-            initial_messages[0],
-            tool_message,
-            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
-        ]
-        # Pass the tool result to the model to get the final response
-        results = await component.run_async(new_messages)
-
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_call
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_live_run_with_tools_streaming_async(self, tools):
-        """
-        Integration test that the OpenRouterChatGenerator component can run with tools and streaming.
-        """
-
-        counter = 0
-        tool_calls = []
-
-        async def callback(chunk: StreamingChunk):
-            nonlocal counter
-            nonlocal tool_calls
-            counter += 1
-            if chunk.meta.get("tool_calls"):
-                tool_calls.extend(chunk.meta["tool_calls"])
-
-        component = OpenRouterChatGenerator(tools=tools, streaming_callback=callback)
-        results = await component.run_async(
-            [ChatMessage.from_user("What's the weather like in Paris?")],
-            generation_kwargs={"tool_choice": "auto"},
-        )
-
-        assert len(results["replies"]) > 0, "No replies received"
-        assert counter > 1, "Streaming callback was not called multiple times"
-        assert tool_calls, "No tool calls received in streaming"
-
-        # Find the message with tool calls
-        tool_message = None
-        for message in results["replies"]:
-            if message.tool_call:
-                tool_message = message
-                break
-
-        assert tool_message is not None, "No message with tool call found"
-        assert isinstance(tool_message, ChatMessage), "Tool message is not a ChatMessage instance"
-        assert ChatMessage.is_from(tool_message, ChatRole.ASSISTANT), "Tool message is not from the assistant"
-
-        tool_call = tool_message.tool_call
-        assert tool_call.id, "Tool call does not contain value for 'id' key"
-        assert tool_call.tool_name == "weather"
-        assert "paris" in tool_call.arguments["city"].lower(), f"Expected 'paris' in city: {tool_call.arguments}"
-        assert tool_message.meta["finish_reason"] == "tool_calls"
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENROUTER_API_KEY", None),
-        reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
-    )
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_integration_mixing_tools_and_toolset_async(self):
-        """Test mixing Tool list and Toolset at runtime in async mode."""
-
-        def weather_function(city: str) -> str:
-            """Get weather information for a city."""
-            return f"Weather in {city}: 22°C, sunny"
-
-        def time_function(city: str) -> str:
-            """Get current time in a city."""
-            return f"Current time in {city}: 14:30"
-
-        def echo_function(text: str) -> str:
-            """Echo a text."""
-            return text
-
-        # Create tools
-        weather_tool = Tool(
-            name="weather",
-            description="Get weather information for a city",
-            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
-            function=weather_function,
-        )
-
-        time_tool = Tool(
-            name="time",
-            description="Get current time in a city",
-            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
-            function=time_function,
-        )
-
-        echo_tool = Tool(
-            name="echo",
-            description="Echo a text",
-            parameters={"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
-            function=echo_function,
-        )
-
-        # Create Toolset with weather and time tools
-        toolset = Toolset([weather_tool, time_tool])
-
-        # Initialize with no tools, we'll pass them at runtime
-        component = OpenRouterChatGenerator()
-
-        # Pass mixed list: echo_tool (individual) and toolset (weather + time) at runtime
-        # This tests that both individual tools and toolsets can be combined
-        messages = [ChatMessage.from_user("Echo this via tool: Hello World")]
-        results = await component.run_async(messages, tools=[echo_tool, toolset])
-
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        # Should be able to use echo_tool from the runtime mixed list
-        assert message.tool_calls is not None
-        tool_call = message.tool_calls[0]
-        assert tool_call.tool_name == "echo"
-        assert tool_call.arguments == {"text": "Hello World"}
-
-    @pytest.mark.asyncio
     async def test_run_async_with_reasoning(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
 
@@ -377,14 +171,12 @@ class TestOpenRouterChatGeneratorAsync:
             assert "capitals" in reply.reasoning.reasoning_text
             assert reply.reasoning.extra["reasoning_details"][0]["type"] == "reasoning.text"
 
-    @pytest.mark.asyncio
     async def test_run_async_empty_messages(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
         component = OpenRouterChatGenerator()
         response = await component.run_async([])
         assert response == {"replies": []}
 
-    @pytest.mark.asyncio
     async def test_run_async_with_string_input(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
 
@@ -418,3 +210,154 @@ class TestOpenRouterChatGeneratorAsync:
 
             assert len(response["replies"]) == 1
             assert response["replies"][0].text == "Paris."
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENROUTER_API_KEY", None),
+    reason="Export an env var called OPENROUTER_API_KEY containing the OpenRouter API key to run this test.",
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestOpenRouterChatGeneratorAsyncIntegration:
+    @pytest.mark.parametrize("streaming", [False, True])
+    async def test_live_run_async(self, streaming):
+        counter = 0
+        responses = ""
+
+        async def callback(chunk: StreamingChunk):
+            nonlocal counter
+            nonlocal responses
+            counter += 1
+            responses += chunk.content if chunk.content else ""
+
+        component = OpenRouterChatGenerator(
+            streaming_callback=callback if streaming else None,
+            generation_kwargs={"max_tokens": 1000},
+        )
+        results = await component.run_async([ChatMessage.from_user("What's the capital of France?")])
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "openai/gpt-5-mini" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+        if streaming:
+            assert counter > 1
+            assert "Paris" in responses
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    async def test_live_run_with_tools_and_response_async(self, tools, streaming):
+        """
+        Integration test that the OpenRouterChatGenerator component can run with tools and get a response.
+        """
+        counter = 0
+        streamed_tool_calls = []
+
+        async def callback(chunk: StreamingChunk):
+            nonlocal counter
+            counter += 1
+            if chunk.meta.get("tool_calls"):
+                streamed_tool_calls.extend(chunk.meta["tool_calls"])
+
+        initial_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = OpenRouterChatGenerator(
+            tools=tools,
+            streaming_callback=callback if streaming else None,
+            generation_kwargs={"tool_choice": "auto", "max_tokens": 1000},
+        )
+        results = await component.run_async(messages=initial_messages)
+
+        assert len(results["replies"]) > 0, "No replies received"
+
+        if streaming:
+            assert counter > 1, "Streaming callback was not called multiple times"
+            assert streamed_tool_calls, "No tool calls received in streaming"
+
+        # Find the message with tool calls
+        tool_message = None
+        for message in results["replies"]:
+            if message.tool_call:
+                tool_message = message
+                break
+
+        assert tool_message is not None, "No message with tool call found"
+        assert isinstance(tool_message, ChatMessage), "Tool message is not a ChatMessage instance"
+        assert ChatMessage.is_from(tool_message, ChatRole.ASSISTANT), "Tool message is not from the assistant"
+
+        tool_call = tool_message.tool_call
+        assert tool_call.id, "Tool call does not contain value for 'id' key"
+        assert tool_call.tool_name == "weather"
+        assert "paris" in tool_call.arguments["city"].lower(), f"Expected 'paris' in city: {tool_call.arguments}"
+        assert tool_message.meta["finish_reason"] == "tool_calls"
+
+        new_messages = [
+            initial_messages[0],
+            tool_message,
+            ChatMessage.from_tool(tool_result="22° C", origin=tool_call),
+        ]
+        # Pass the tool result to the model to get the final response
+        results = await component.run_async(new_messages)
+
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_call
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower()
+
+    async def test_integration_mixing_tools_and_toolset_async(self):
+        """Test mixing Tool list and Toolset at runtime in async mode."""
+
+        def weather_function(city: str) -> str:
+            """Get weather information for a city."""
+            return f"Weather in {city}: 22°C, sunny"
+
+        def time_function(city: str) -> str:
+            """Get current time in a city."""
+            return f"Current time in {city}: 14:30"
+
+        def echo_function(text: str) -> str:
+            """Echo a text."""
+            return text
+
+        # Create tools
+        weather_tool = Tool(
+            name="weather",
+            description="Get weather information for a city",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=weather_function,
+        )
+
+        time_tool = Tool(
+            name="time",
+            description="Get current time in a city",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=time_function,
+        )
+
+        echo_tool = Tool(
+            name="echo",
+            description="Echo a text",
+            parameters={"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+            function=echo_function,
+        )
+
+        # Create Toolset with weather and time tools
+        toolset = Toolset([weather_tool, time_tool])
+
+        # Initialize with no tools, we'll pass them at runtime
+        component = OpenRouterChatGenerator(generation_kwargs={"max_tokens": 1000})
+
+        # Pass mixed list: echo_tool (individual) and toolset (weather + time) at runtime
+        # This tests that both individual tools and toolsets can be combined
+        messages = [ChatMessage.from_user("Echo this via tool: Hello World")]
+        results = await component.run_async(messages, tools=[echo_tool, toolset])
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        # Should be able to use echo_tool from the runtime mixed list
+        assert message.tool_calls is not None
+        tool_call = message.tool_calls[0]
+        assert tool_call.tool_name == "echo"
+        assert tool_call.arguments == {"text": "Hello World"}


### PR DESCRIPTION
### Related Issues

- failing tests with "This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens, but can only afford 58291". https://github.com/deepset-ai/haystack-core-integrations/actions/runs/31060136315/job/92486102372

### Proposed Changes:
- in integration tests, declare `max_tokens` upfront to avoid the error
- refactor integration tests: remove duplicates, parametrize, group them into a new class

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
