### PR TITLE
fix: MongoDB adding optional para `filters` to `get_metadata_field_unique_values() `

### DIFF
--- a/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
+++ b/integrations/mongodb_atlas/src/haystack_integrations/document_stores/mongodb_atlas/document_store.py
@@ -503,15 +503,23 @@ class MongoDBAtlasDocumentStore:
             raise DocumentStoreError(msg) from e
 
     def _create_unique_values_pipeline(
-        self, metadata_field: str, search_term: str | None, from_: int, size: int
+        self,
+        metadata_field: str,
+        search_term: str | None,
+        from_: int,
+        size: int,
+        filters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         if metadata_field.startswith("meta."):
             mongo_field = f"${metadata_field}"
         else:
             mongo_field = f"$meta.{metadata_field}"
-        pipeline: list[dict[str, Any]] = [
-            {"$group": {"_id": mongo_field}},
-        ]
+        pipeline: list[dict[str, Any]] = []
+
+        if filters:
+            pipeline.append({"$match": _normalize_filters(filters)})
+
+        pipeline.append({"$group": {"_id": mongo_field}})
 
         if search_term:
             pipeline.append({"$match": {"_id": {"$regex": re.escape(search_term), "$options": "i"}}})
@@ -536,7 +544,12 @@ class MongoDBAtlasDocumentStore:
         return values, total_count
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a field matching a search_term or all possible values if no search term is given.
@@ -545,13 +558,14 @@ class MongoDBAtlasDocumentStore:
         :param search_term: The search term to filter values. Matches as a case-insensitive substring.
         :param from_: The starting index for pagination.
         :param size: The number of values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing a list of unique values (in their original type) and the total count
             of unique values matching the search term.
         """
         self._ensure_connection_setup()
         assert self._collection is not None
 
-        pipeline = self._create_unique_values_pipeline(metadata_field, search_term, from_, size)
+        pipeline = self._create_unique_values_pipeline(metadata_field, search_term, from_, size, filters)
 
         try:
             result = list(self._collection.aggregate(pipeline))
@@ -561,7 +575,12 @@ class MongoDBAtlasDocumentStore:
             raise DocumentStoreError(msg) from e
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Asynchronously retrieves unique values for a metadata field, optionally filtered by a search term.
@@ -570,13 +589,14 @@ class MongoDBAtlasDocumentStore:
         :param search_term: The search term to filter values. Matches as a case-insensitive substring.
         :param from_: The starting index for pagination.
         :param size: The number of values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing a list of unique values (in their original type) and the total count
             of unique values matching the search term.
         """
         await self._ensure_connection_setup_async()
         assert self._collection_async is not None
 
-        pipeline = self._create_unique_values_pipeline(metadata_field, search_term, from_, size)
+        pipeline = self._create_unique_values_pipeline(metadata_field, search_term, from_, size, filters)
 
         try:
             cursor = await self._collection_async.aggregate(pipeline)

--- a/integrations/mongodb_atlas/tests/test_document_store.py
+++ b/integrations/mongodb_atlas/tests/test_document_store.py
@@ -372,6 +372,19 @@ class TestDocumentStore(
         assert len(values_page) == 1
         assert values_page[0] in ["alpha", "beta", "gamma"]
 
+    def test_get_metadata_field_unique_values_with_filters(self, document_store: MongoDBAtlasDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     def test_custom_content_field(self, real_collection):
         database_name, collection_name, client = real_collection
         custom_store = MongoDBAtlasDocumentStore(

--- a/integrations/mongodb_atlas/tests/test_document_store_async.py
+++ b/integrations/mongodb_atlas/tests/test_document_store_async.py
@@ -195,3 +195,16 @@ class TestDocumentStoreAsync(
         await document_store.close_async()
         assert document_store._connection_async is None
         assert await document_store.count_documents_async() == 0
+
+    async def test_get_metadata_field_unique_values_with_filters(self, document_store: MongoDBAtlasDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await document_store.get_metadata_field_unique_values_async("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2


### PR DESCRIPTION
### Proposed Changes:

- adding optional para `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
