### PR TITLE
fix: ArcadeDB adding optional parameter `filters` to `get_metadata_field_unique_values() `

### DIFF
--- a/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
+++ b/integrations/arcadedb/src/haystack_integrations/document_stores/arcadedb/document_store.py
@@ -575,7 +575,12 @@ class ArcadeDBDocumentStore:
         return {"min": rows[0].get("min_value"), "max": rows[0].get("max_value")}
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a field matching a search term or all possible values
@@ -584,17 +589,27 @@ class ArcadeDBDocumentStore:
         :param search_term: Optional case-insensitive substring search term.
         :param from_: The starting index for pagination.
         :param size: The number of values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing the paginated values (in their original type) and the total count.
         """
         self._ensure_initialized()
 
         metadata_field = metadata_field.removeprefix("meta.")
         field_ref = f"meta[{_sql_str(metadata_field)}]"
-        where = ""
+        conditions = []
+
+        try:
+            filters_where = _convert_filters(filters)
+        except ValueError as e:
+            raise FilterError(str(e)) from e
+        if filters_where:
+            conditions.append(filters_where)
 
         if search_term:
             search_val = _sql_str(f"%{search_term}%")
-            where = f" WHERE {field_ref} ILIKE {search_val}"
+            conditions.append(f"{field_ref} ILIKE {search_val}")
+
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
 
         sql = f"SELECT DISTINCT {field_ref} AS val FROM `{self._type_name}`{where}"
         rows = self._command(sql)

--- a/integrations/arcadedb/tests/test_document_store.py
+++ b/integrations/arcadedb/tests/test_document_store.py
@@ -536,6 +536,19 @@ class TestArcadeDBDocumentStore(
         assert set(values) == {1, 2}
         assert total == 2
 
+    def test_get_metadata_field_unique_values_with_filters(self, document_store: ArcadeDBDocumentStore):
+        docs = [
+            Document(id="1", content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(id="2", content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(id="3", content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     def test_write_documents_none_embedding_is_zero_padded(self, document_store: ArcadeDBDocumentStore):
         """Documents written without an embedding get a zero vector of the correct dimension."""
         dim = document_store._embedding_dimension


### PR DESCRIPTION
### Proposed Changes:

- adding optional paramater `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
