### PR TITLE
fix: Oracle adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
@@ -782,7 +782,12 @@ class OracleDocumentStore:
             return {"min": _try_parse_number(row[0]), "max": _try_parse_number(row[1])}
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int | None = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Return a paginated list of distinct values for a metadata field, plus the total distinct count.
@@ -793,6 +798,7 @@ class OracleDocumentStore:
         :param from_: Zero-based offset for pagination. Defaults to ``0``.
         :param size: Maximum number of values to return. Defaults to ``10``. When ``None`` all values
             from ``from_`` onward are returned.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple ``(values, total)`` where ``values`` is the paginated list of distinct field
             values in their original type and ``total`` is the overall distinct count (before pagination).
         :raises ValueError: If ``metadata_field`` contains characters outside ``[A-Za-z0-9_.]``.
@@ -801,6 +807,10 @@ class OracleDocumentStore:
         _validate_field_path(field_path)
         base_sql = f"FROM {self.table_name} WHERE JSON_VALUE(metadata, '$.{field_path}') IS NOT NULL"
         params: dict[str, Any] = {}
+        if filters:
+            counter = [0]
+            filters_fragment = FilterTranslator().translate(filters, params, counter)
+            base_sql += f" AND {filters_fragment}"
         if search_term:
             base_sql += f" AND UPPER(JSON_VALUE(metadata, '$.{field_path}')) LIKE UPPER(:search)"
             params["search"] = f"%{search_term}%"
@@ -856,7 +866,12 @@ class OracleDocumentStore:
         return await asyncio.to_thread(self.get_metadata_field_min_max, metadata_field)
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int | None = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int | None = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Asynchronously returns a paginated list of distinct values for a metadata field, plus the total count.
@@ -867,11 +882,14 @@ class OracleDocumentStore:
         :param from_: Zero-based offset for pagination. Defaults to ``0``.
         :param size: Maximum number of values to return. Defaults to ``10``. When ``None`` all values
             from ``from_`` onward are returned.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple ``(values, total)`` where ``values`` is the paginated list of distinct field
             values in their original type and ``total`` is the overall distinct count (before pagination).
         :raises ValueError: If ``metadata_field`` contains characters outside ``[A-Za-z0-9_.]``.
         """
-        return await asyncio.to_thread(self.get_metadata_field_unique_values, metadata_field, search_term, from_, size)
+        return await asyncio.to_thread(
+            self.get_metadata_field_unique_values, metadata_field, search_term, from_, size, filters
+        )
 
     def _embedding_retrieval(
         self,

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -475,6 +475,20 @@ class TestOracleDocumentStore(
         assert set(values) == {1, 2}
         assert total == 2
 
+    def test_get_metadata_field_unique_values_with_filters(self, document_store):
+        document_store.write_documents(
+            [
+                _doc(_uid("R001"), meta={"category": "A", "status": "active"}),
+                _doc(_uid("R002"), meta={"category": "B", "status": "active"}),
+                _doc(_uid("R003"), meta={"category": "C", "status": "inactive"}),
+            ]
+        )
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
 
 @pytest.mark.integration
 class TestOracleDocumentStoreAsync(
@@ -518,3 +532,18 @@ class TestOracleDocumentStoreAsync(
         await embedding_store.write_documents_async([_doc(doc_id, embedding=[0.5, 0.5, 0.0, 0.0])])
         results = await embedding_store._embedding_retrieval_async([0.5, 0.5, 0.0, 0.0], top_k=1)
         assert len(results) >= 1
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_field_unique_values_with_filters_async(self, embedding_store):
+        await embedding_store.write_documents_async(
+            [
+                _doc(_uid("S001"), meta={"category": "A", "status": "active"}),
+                _doc(_uid("S002"), meta={"category": "B", "status": "active"}),
+                _doc(_uid("S003"), meta={"category": "C", "status": "inactive"}),
+            ]
+        )
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await embedding_store.get_metadata_field_unique_values_async("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
