### PR TITLE
fix: PGVector adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -1926,7 +1926,12 @@ class PgvectorDocumentStore:
         return {"min": min_value, "max": max_value}
 
     def _build_unique_values_queries(
-        self, normalized_field: str, search_term: str | None, from_: int, size: int
+        self,
+        normalized_field: str,
+        search_term: str | None,
+        from_: int,
+        size: int,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[Composed, Composed, tuple]:
         """
         Builds SQL queries for getting unique metadata field values.
@@ -1936,6 +1941,7 @@ class PgvectorDocumentStore:
             against the metadata field's own value.
         :param from_: The offset for pagination (0-based).
         :param size: The number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing (count_query, select_query, params).
         """
         field_literal = SQLLiteral(normalized_field)
@@ -1951,10 +1957,18 @@ class PgvectorDocumentStore:
         sql_where = SQL(" WHERE meta->>{} IS NOT NULL").format(field_literal)
 
         params: tuple = ()
+        if filters:
+            _validate_filters(filters)
+            filters_where_clause, filters_params = _convert_filters_to_where_clause_and_params(
+                filters, operator="AND"
+            )
+            sql_where += filters_where_clause
+            params += filters_params
+
         if search_term:
             # Case-insensitive substring match against the metadata field's own (text) value.
             sql_where += SQL(" AND meta->>{} ILIKE %s").format(field_literal)
-            params = (f"%{search_term}%",)
+            params += (f"%{search_term}%",)
 
         # count query
         sql_count = SQL("SELECT COUNT(DISTINCT meta->{} ) AS total").format(field_literal)
@@ -1984,7 +1998,12 @@ class PgvectorDocumentStore:
         return unique_values, total_count
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Returns unique values for a given metadata field, optionally filtered by a search term.
@@ -1994,12 +2013,15 @@ class PgvectorDocumentStore:
             match against the metadata field's own value. If None, all values are considered.
         :param from_: The offset for pagination (0-based).
         :param size: The number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing:
             - A list of unique values in their original type
             - The total count of unique values
         """
         normalized_field = PgvectorDocumentStore._normalize_metadata_field_name(metadata_field)
-        sql_count, sql_query, params = self._build_unique_values_queries(normalized_field, search_term, from_, size)
+        sql_count, sql_query, params = self._build_unique_values_queries(
+            normalized_field, search_term, from_, size, filters
+        )
 
         self._ensure_db_setup()
         assert self._dict_cursor is not None
@@ -2022,7 +2044,12 @@ class PgvectorDocumentStore:
         return PgvectorDocumentStore._process_unique_values_result(count_result, records)
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Asynchronously returns unique values for a given metadata field, optionally filtered by a search term.
@@ -2032,12 +2059,15 @@ class PgvectorDocumentStore:
             match against the metadata field's own value. If None, all values are considered.
         :param from_: The offset for pagination (0-based).
         :param size: The number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing:
             - A list of unique values in their original type
             - The total count of unique values
         """
         normalized_field = PgvectorDocumentStore._normalize_metadata_field_name(metadata_field)
-        sql_count, sql_query, params = self._build_unique_values_queries(normalized_field, search_term, from_, size)
+        sql_count, sql_query, params = self._build_unique_values_queries(
+            normalized_field, search_term, from_, size, filters
+        )
 
         await self._ensure_db_setup_async()
         assert self._async_dict_cursor is not None

--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/document_store.py
@@ -1959,9 +1959,7 @@ class PgvectorDocumentStore:
         params: tuple = ()
         if filters:
             _validate_filters(filters)
-            filters_where_clause, filters_params = _convert_filters_to_where_clause_and_params(
-                filters, operator="AND"
-            )
+            filters_where_clause, filters_params = _convert_filters_to_where_clause_and_params(filters, operator="AND")
             sql_where += filters_where_clause
             params += filters_params
 

--- a/integrations/pgvector/tests/test_document_store.py
+++ b/integrations/pgvector/tests/test_document_store.py
@@ -736,6 +736,21 @@ def test_get_metadata_field_unique_values(document_store: PgvectorDocumentStore)
 
 
 @pytest.mark.integration
+def test_get_metadata_field_unique_values_with_filters(document_store: PgvectorDocumentStore):
+    docs = [
+        Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+        Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+        Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+    ]
+    document_store.write_documents(docs)
+
+    filters = {"field": "meta.status", "operator": "==", "value": "active"}
+    values, total = document_store.get_metadata_field_unique_values("meta.category", filters=filters)
+    assert set(values) == {"A", "B"}
+    assert total == 2
+
+
+@pytest.mark.integration
 def test_get_metadata_field_unique_values_no_search_term(document_store: PgvectorDocumentStore):
     docs = [
         Document(content="mentions tsvector and content in the body", meta={"category": "A"}),

--- a/integrations/pgvector/tests/test_document_store_async.py
+++ b/integrations/pgvector/tests/test_document_store_async.py
@@ -149,9 +149,7 @@ class TestDocumentStoreAsync(
         await document_store.write_documents_async(docs)
 
         filters = {"field": "meta.status", "operator": "==", "value": "active"}
-        values, total = await document_store.get_metadata_field_unique_values_async(
-            "meta.category", filters=filters
-        )
+        values, total = await document_store.get_metadata_field_unique_values_async("meta.category", filters=filters)
         assert set(values) == {"A", "B"}
         assert total == 2
 

--- a/integrations/pgvector/tests/test_document_store_async.py
+++ b/integrations/pgvector/tests/test_document_store_async.py
@@ -140,6 +140,21 @@ class TestDocumentStoreAsync(
         assert set(values) == {1, 2}
         assert total == 2
 
+    async def test_get_metadata_field_unique_values_with_filters_async(self, document_store: PgvectorDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await document_store.get_metadata_field_unique_values_async(
+            "meta.category", filters=filters
+        )
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     async def test_delete_table_async_first_call(self, document_store: PgvectorDocumentStore):
         """
         Test that delete_table_async can be executed as the initial operation on the Document Store


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
