### PR TITLE
fix: PineCone adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -1070,7 +1070,12 @@ class PineconeDocumentStore:
         return self._get_metadata_field_min_max_impl(documents, metadata_field)
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a metadata field with optional search and pagination.
@@ -1082,13 +1087,19 @@ class PineconeDocumentStore:
         :param search_term: Optional search term to filter values (case-insensitive substring match).
         :param from_: Starting offset for pagination (default: 0).
         :param size: Number of values to return (default: 10).
+        :param filters: Optional filters to restrict the documents considered.
         :returns: Tuple of (list of unique values in their original type, total count of matching values).
         """
-        documents = self.filter_documents(filters=None)
+        documents = self.filter_documents(filters=filters)
         return self._get_metadata_field_unique_values_impl(documents, metadata_field, search_term, from_, size)
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Asynchronously retrieves unique values for a metadata field with optional search and pagination.
@@ -1100,7 +1111,8 @@ class PineconeDocumentStore:
         :param search_term: Optional search term to filter values (case-insensitive substring match).
         :param from_: Starting offset for pagination (default: 0).
         :param size: Number of values to return (default: 10).
+        :param filters: Optional filters to restrict the documents considered.
         :returns: Tuple of (list of unique values in their original type, total count of matching values).
         """
-        documents = await self.filter_documents_async(filters=None)
+        documents = await self.filter_documents_async(filters=filters)
         return self._get_metadata_field_unique_values_impl(documents, metadata_field, search_term, from_, size)

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -616,3 +616,16 @@ class TestDocumentStore(
         values, total = document_store.get_metadata_field_unique_values("tags", size=10)
         assert total == 4  # python, java, rust, go
         assert set(values) == {"go", "java", "python", "rust"}
+
+    def test_get_metadata_field_unique_values_with_filters(self, document_store: PineconeDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -170,6 +170,21 @@ class TestDocumentStoreAsync(
         assert document_store_async._async_index is not None
         assert await document_store_async.count_documents_async() == 0
 
+    async def test_get_metadata_field_unique_values_with_filters(self, document_store_async: PineconeDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        await document_store_async.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await document_store_async.get_metadata_field_unique_values_async(
+            "category", filters=filters
+        )
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     async def test_sentence_window_retriever(self, document_store_async: PineconeDocumentStore):
         # indexing
         splitter = DocumentSplitter(split_length=10, split_overlap=5, split_by="word")

--- a/integrations/pinecone/tests/test_document_store_async.py
+++ b/integrations/pinecone/tests/test_document_store_async.py
@@ -179,9 +179,7 @@ class TestDocumentStoreAsync(
         await document_store_async.write_documents_async(docs)
 
         filters = {"field": "meta.status", "operator": "==", "value": "active"}
-        values, total = await document_store_async.get_metadata_field_unique_values_async(
-            "category", filters=filters
-        )
+        values, total = await document_store_async.get_metadata_field_unique_values_async("category", filters=filters)
         assert set(values) == {"A", "B"}
         assert total == 2
 


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
