### PR TITLE
fix: Valkey adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
+++ b/integrations/valkey/src/haystack_integrations/document_stores/valkey/document_store.py
@@ -1025,6 +1025,7 @@ class ValkeyDocumentStore(DocumentStore):
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Return unique values for a metadata field with optional search and pagination.
@@ -1036,13 +1037,14 @@ class ValkeyDocumentStore(DocumentStore):
         :param search_term: Optional case-insensitive substring filter on the value.
         :param from_: Start index for pagination (default 0).
         :param size: Number of values to return (default 10).
+        :param filters: Optional filters to restrict the documents considered.
         :return: Tuple of (list of unique values for the requested page, total count of unique values).
         :raises ValueError: If the field is not configured for filtering.
         :raises ValkeyDocumentStoreError: If the operation fails.
         """
         self._validate_metadata_field_names([metadata_field])
         try:
-            docs = self.filter_documents(filters=None)
+            docs = self.filter_documents(filters=filters)
             return ValkeyDocumentStore._get_metadata_field_unique_values_impl(
                 docs, metadata_field, search_term=search_term, from_=from_, size=size
             )
@@ -1056,6 +1058,7 @@ class ValkeyDocumentStore(DocumentStore):
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Asynchronously return unique values for a metadata field with optional search and pagination.
@@ -1067,13 +1070,14 @@ class ValkeyDocumentStore(DocumentStore):
         :param search_term: Optional case-insensitive substring filter on the value.
         :param from_: Start index for pagination (default 0).
         :param size: Number of values to return (default 10).
+        :param filters: Optional filters to restrict the documents considered.
         :return: Tuple of (list of unique values for the requested page, total count of unique values).
         :raises ValueError: If the field is not configured for filtering.
         :raises ValkeyDocumentStoreError: If the operation fails.
         """
         self._validate_metadata_field_names([metadata_field])
         try:
-            docs = await self.filter_documents_async(filters=None)
+            docs = await self.filter_documents_async(filters=filters)
             return ValkeyDocumentStore._get_metadata_field_unique_values_impl(
                 docs, metadata_field, search_term=search_term, from_=from_, size=size
             )

--- a/integrations/valkey/tests/test_document_store.py
+++ b/integrations/valkey/tests/test_document_store.py
@@ -780,9 +780,15 @@ class TestValkeyDocumentStore(
     def test_get_metadata_field_unique_values_with_filters(self, document_store):
         """Test get_metadata_field_unique_values restricts documents using the filters param."""
         docs = [
-            Document(id="gmvf1", content="doc 1", embedding=[0.1, 0.2, 0.3], meta={"category": "A", "status": "active"}),
-            Document(id="gmvf2", content="doc 2", embedding=[0.2, 0.3, 0.4], meta={"category": "B", "status": "active"}),
-            Document(id="gmvf3", content="doc 3", embedding=[0.3, 0.4, 0.5], meta={"category": "C", "status": "inactive"}),
+            Document(
+                id="gmvf1", content="doc 1", embedding=[0.1, 0.2, 0.3], meta={"category": "A", "status": "active"}
+            ),
+            Document(
+                id="gmvf2", content="doc 2", embedding=[0.2, 0.3, 0.4], meta={"category": "B", "status": "active"}
+            ),
+            Document(
+                id="gmvf3", content="doc 3", embedding=[0.3, 0.4, 0.5], meta={"category": "C", "status": "inactive"}
+            ),
         ]
         document_store.write_documents(docs)
 

--- a/integrations/valkey/tests/test_document_store.py
+++ b/integrations/valkey/tests/test_document_store.py
@@ -777,6 +777,20 @@ class TestValkeyDocumentStore(
         assert total == 2
         assert set(values) == {"apple_pie", "apple_jam"}
 
+    def test_get_metadata_field_unique_values_with_filters(self, document_store):
+        """Test get_metadata_field_unique_values restricts documents using the filters param."""
+        docs = [
+            Document(id="gmvf1", content="doc 1", embedding=[0.1, 0.2, 0.3], meta={"category": "A", "status": "active"}),
+            Document(id="gmvf2", content="doc 2", embedding=[0.2, 0.3, 0.4], meta={"category": "B", "status": "active"}),
+            Document(id="gmvf3", content="doc 3", embedding=[0.3, 0.4, 0.5], meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store):
         """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
         docs = [

--- a/integrations/valkey/tests/test_document_store_async.py
+++ b/integrations/valkey/tests/test_document_store_async.py
@@ -625,6 +625,36 @@ class TestValkeyDocumentStoreAsync(
         assert total == 2
         assert set(values) == {"apple_pie", "apple_jam"}
 
+    async def test_get_metadata_field_unique_values_with_filters_async(self, document_store):
+        """Test async get_metadata_field_unique_values restricts documents using the filters param."""
+        test_id = str(uuid.uuid4())[:8]
+        docs = [
+            Document(
+                id=f"gmvf1_{test_id}",
+                content="doc 1",
+                embedding=[0.1, 0.2, 0.3],
+                meta={"category": "A", "status": "active"},
+            ),
+            Document(
+                id=f"gmvf2_{test_id}",
+                content="doc 2",
+                embedding=[0.2, 0.3, 0.4],
+                meta={"category": "B", "status": "active"},
+            ),
+            Document(
+                id=f"gmvf3_{test_id}",
+                content="doc 3",
+                embedding=[0.3, 0.4, 0.5],
+                meta={"category": "C", "status": "inactive"},
+            ),
+        ]
+        await document_store.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await document_store.get_metadata_field_unique_values_async("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     async def test_get_metadata_field_unique_values_async_preserves_non_string_types(self, document_store):
         """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
         test_id = str(uuid.uuid4())[:8]


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
