### PR TITLE
fix: Astra adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
+++ b/integrations/astra/src/haystack_integrations/document_stores/astra/document_store.py
@@ -612,7 +612,12 @@ class AstraDocumentStore:
         return {"min": min(comparable_values), "max": max(comparable_values)}
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a field matching a search term or all possible values if no search term is given.
@@ -621,10 +626,17 @@ class AstraDocumentStore:
         :param search_term: Optional case-insensitive substring search term.
         :param from_: The starting index for pagination.
         :param size: The number of values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing the paginated values (in their original type) and the total count.
         """
         field = metadata_field.removeprefix("meta.")
-        values = AstraDocumentStore._normalize_distinct_values(self.index.distinct(f"meta.{field}"))
+        converted_filters = None
+        if filters:
+            normalized_filters = AstraDocumentStore._normalize_new_filter_input(filters)
+            converted_filters = _convert_filters(normalized_filters)
+        values = AstraDocumentStore._normalize_distinct_values(
+            self.index.distinct(f"meta.{field}", filters=converted_filters)
+        )
         if search_term:
             search_term_lower = search_term.lower()
             values = [value for value in values if search_term_lower in str(value).lower()]

--- a/integrations/astra/tests/test_document_store.py
+++ b/integrations/astra/tests/test_document_store.py
@@ -123,7 +123,7 @@ def test_get_metadata_field_unique_values(mocked_store):
 
     assert values == ["alpha", "alphabet"]
     assert total_count == 2
-    mock_index.distinct.assert_called_once_with("meta.category")
+    mock_index.distinct.assert_called_once_with("meta.category", filters=None)
 
 
 def test_get_metadata_field_unique_values_preserves_non_string_types(mocked_store):
@@ -134,7 +134,7 @@ def test_get_metadata_field_unique_values_preserves_non_string_types(mocked_stor
 
     assert values == [1, 2, 3]
     assert total_count == 3
-    mock_index.distinct.assert_called_once_with("meta.priority")
+    mock_index.distinct.assert_called_once_with("meta.priority", filters=None)
 
 
 @pytest.mark.parametrize(
@@ -410,3 +410,16 @@ class TestDocumentStore(
         TestDocumentStore.assert_documents_are_equal(
             result, [d for d in filterable_docs if d.meta.get("number") is None]
         )
+
+    def test_get_metadata_field_unique_values_with_filters(self, document_store):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
