### PR TITLE
fix: AzureAISearch adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -560,7 +560,12 @@ class AzureAISearchDocumentStore:
         return self._get_min_max_from_documents(documents, field_name)
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Retrieves unique values for a metadata field with optional search and pagination.
@@ -569,12 +574,13 @@ class AzureAISearchDocumentStore:
         :param search_term: Optional search term to filter unique values.
         :param from_: Starting offset for pagination.
         :param size: Number of values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: Tuple of (list of unique values in their original type, total count of matching values).
         """
         field_name = _normalize_metadata_field_name(metadata_field)
         self._validate_index_fields([field_name])
 
-        documents = self._fetch_raw_documents(select=[field_name])
+        documents = self._fetch_raw_documents(filters=filters, select=[field_name])
         unique_values = sorted(self._collect_unique_values(documents, field_name))
 
         if search_term:

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -908,6 +908,24 @@ class TestDocumentStore(
         assert values == ["docs", "guides"]
         assert total_count == 2
 
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str, "status": str}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_with_filters(self, document_store: AzureAISearchDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("meta.category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     def test_query_sql_integration(self, document_store: AzureAISearchDocumentStore):
         with pytest.raises(NotImplementedError, match="does not support SQL queries"):
             document_store.query_sql("SELECT * FROM documents")


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
