### PR TITLE
fix: Chroma adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -1302,12 +1302,31 @@ class ChromaDocumentStore:
         result = await self._async_collection.get(include=["metadatas"])
         return self._compute_field_min_max(result.get("metadatas", []), field_name)
 
+    @staticmethod
+    def _prepare_get_metadatas_kwargs(filters: dict[str, Any] | None = None) -> dict[str, Any]:
+        """
+        Prepare kwargs for a metadata-only Chroma get operation, optionally restricted by filters.
+        """
+        kwargs: dict[str, Any] = {"include": ["metadatas"]}
+
+        if filters:
+            chroma_filter = _convert_filters(filters)
+            kwargs["where"] = chroma_filter.where
+
+            if chroma_filter.ids:
+                kwargs["ids"] = chroma_filter.ids
+            if chroma_filter.where_document:
+                kwargs["where_document"] = chroma_filter.where_document
+
+        return kwargs
+
     def get_metadata_field_unique_values(
         self,
         metadata_field: str,
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Return unique metadata field values, optionally filtered by a search term, with pagination.
@@ -1318,6 +1337,7 @@ class ChromaDocumentStore:
             case-insensitive substring against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing list of unique values (in their original type) and total count of unique values.
         """
         self._ensure_initialized()
@@ -1325,7 +1345,8 @@ class ChromaDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        result = self._collection.get(include=["metadatas"])
+        kwargs = ChromaDocumentStore._prepare_get_metadatas_kwargs(filters)
+        result = self._collection.get(**kwargs)
         return self._compute_field_unique_values(result, field_name, search_term, from_, size)
 
     async def get_metadata_field_unique_values_async(
@@ -1334,6 +1355,7 @@ class ChromaDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Asynchronously return unique metadata field values, optionally filtered by a search term, with pagination.
@@ -1346,6 +1368,7 @@ class ChromaDocumentStore:
             case-insensitive substring against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing list of unique values (in their original type) and total count of unique values.
         """
         await self._ensure_initialized_async()
@@ -1353,7 +1376,8 @@ class ChromaDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        result = await self._async_collection.get(include=["metadatas"])
+        kwargs = ChromaDocumentStore._prepare_get_metadatas_kwargs(filters)
+        result = await self._async_collection.get(**kwargs)
         return self._compute_field_unique_values(result, field_name, search_term, from_, size)
 
     @classmethod

--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/document_store.py
@@ -1302,24 +1302,6 @@ class ChromaDocumentStore:
         result = await self._async_collection.get(include=["metadatas"])
         return self._compute_field_min_max(result.get("metadatas", []), field_name)
 
-    @staticmethod
-    def _prepare_get_metadatas_kwargs(filters: dict[str, Any] | None = None) -> dict[str, Any]:
-        """
-        Prepare kwargs for a metadata-only Chroma get operation, optionally restricted by filters.
-        """
-        kwargs: dict[str, Any] = {"include": ["metadatas"]}
-
-        if filters:
-            chroma_filter = _convert_filters(filters)
-            kwargs["where"] = chroma_filter.where
-
-            if chroma_filter.ids:
-                kwargs["ids"] = chroma_filter.ids
-            if chroma_filter.where_document:
-                kwargs["where_document"] = chroma_filter.where_document
-
-        return kwargs
-
     def get_metadata_field_unique_values(
         self,
         metadata_field: str,
@@ -1345,7 +1327,8 @@ class ChromaDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        kwargs = ChromaDocumentStore._prepare_get_metadatas_kwargs(filters)
+        kwargs = ChromaDocumentStore._prepare_get_kwargs(filters)
+        kwargs["include"] = ["metadatas"]
         result = self._collection.get(**kwargs)
         return self._compute_field_unique_values(result, field_name, search_term, from_, size)
 
@@ -1376,7 +1359,8 @@ class ChromaDocumentStore:
 
         field_name = _normalize_metadata_field_name(metadata_field)
 
-        kwargs = ChromaDocumentStore._prepare_get_metadatas_kwargs(filters)
+        kwargs = ChromaDocumentStore._prepare_get_kwargs(filters)
+        kwargs["include"] = ["metadatas"]
         result = await self._async_collection.get(**kwargs)
         return self._compute_field_unique_values(result, field_name, search_term, from_, size)
 

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -872,3 +872,15 @@ class TestMetadataOperations:
         values, total = populated_store.get_metadata_field_unique_values("priority", from_=0, size=10)
         assert set(values) == {1, 2, 3}
         assert total == 3
+
+    def test_get_metadata_field_unique_values_with_filters(self, populated_store):
+        """Test that filters restrict which documents' values are considered"""
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = populated_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B", "C"}
+        assert total == 3
+
+        filters = {"field": "meta.status", "operator": "==", "value": "inactive"}
+        values, total = populated_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2

--- a/integrations/chroma/tests/test_document_store_async.py
+++ b/integrations/chroma/tests/test_document_store_async.py
@@ -264,3 +264,16 @@ class TestDocumentStoreAsync(
         values, total = await document_store.get_metadata_field_unique_values_async("priority", from_=0, size=10)
         assert set(values) == {1, 2}
         assert total == 2
+
+    async def test_get_metadata_field_unique_values_with_filters_async(self, document_store: ChromaDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await document_store.get_metadata_field_unique_values_async("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
