### PR TITLE
feat: add Python 3.14 support for WatsonX integration

### DIFF
--- a/.github/workflows/watsonx.yml
+++ b/.github/workflows/watsonx.yml
@@ -30,7 +30,7 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-  TEST_MATRIX_PYTHON: '["3.10", "3.13"]'
+  TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 
 jobs:
   compute-test-matrix:

--- a/.github/workflows/watsonx.yml
+++ b/.github/workflows/watsonx.yml
@@ -30,7 +30,7 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-  TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
+  TEST_MATRIX_PYTHON: '["3.11", "3.14"]'
 
 jobs:
   compute-test-matrix:
@@ -45,7 +45,7 @@ jobs:
       - id: set
         run: |
           echo 'os=${{ github.event_name == 'push' && '["ubuntu-latest"]' || env.TEST_MATRIX_OS }}' >> "$GITHUB_OUTPUT"
-          echo 'python-version=${{ github.event_name == 'push' && '["3.10"]' || env.TEST_MATRIX_PYTHON }}' >> "$GITHUB_OUTPUT"
+          echo 'python-version=${{ github.event_name == 'push' && '["3.11"]' || env.TEST_MATRIX_PYTHON }}' >> "$GITHUB_OUTPUT"
 
   run:
     name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
@@ -79,7 +79,7 @@ jobs:
           pip install hatch --uploaded-prior-to=P1D
 
       - name: Lint
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
+        if: matrix.python-version == '3.11' && runner.os == 'Linux'
         run: hatch run fmt-check && hatch run test:types
 
       - name: Run unit tests
@@ -88,7 +88,7 @@ jobs:
       # On PR: posts coverage comment (directly on same-repo PRs; via artifact for fork PRs). On push to main: stores coverage baseline on data branch.
       - name: Store unit tests coverage
         id: coverage_comment
-        if: matrix.python-version == '3.10' && runner.os == 'Linux' && github.event_name != 'schedule'
+        if: matrix.python-version == '3.11' && runner.os == 'Linux' && github.event_name != 'schedule'
         uses: py-cov-action/python-coverage-comment-action@5d8df5979747514c914e1c5a12335a7cf9a2745f # v4.1
         with:
           GITHUB_TOKEN: ${{ github.token }}
@@ -98,7 +98,7 @@ jobs:
           MINIMUM_ORANGE: 60
 
       - name: Upload coverage comment to be posted
-        if: matrix.python-version == '3.10' && runner.os == 'Linux' && github.event_name == 'pull_request' && steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        if: matrix.python-version == '3.11' && runner.os == 'Linux' && github.event_name == 'pull_request' && steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-comment-watsonx

--- a/integrations/watsonx/pyproject.toml
+++ b/integrations/watsonx/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["haystack-ai>=2.30.0", "ibm-watsonx-ai>=1.6.0", "pandas>=2.2.3"]
+dependencies = ["haystack-ai>=2.30.0", "ibm-watsonx-ai>=1.5.13", "pandas>=2.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/watsonx#readme"

--- a/integrations/watsonx/pyproject.toml
+++ b/integrations/watsonx/pyproject.toml
@@ -21,8 +21,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["haystack-ai>=2.30.0", "ibm-watsonx-ai>=1.3.26", "pandas>=2.2.3"]
+dependencies = ["haystack-ai>=2.30.0", "ibm-watsonx-ai>=1.6.0", "pandas>=2.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/watsonx#readme"

--- a/integrations/watsonx/pyproject.toml
+++ b/integrations/watsonx/pyproject.toml
@@ -7,7 +7,7 @@ name = "watsonx-haystack"
 dynamic = ["version"]
 description = "Watsonx integration for Haystack"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [
     { name = "Divya", email = "divyaruhil999@gmail.com" },
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
@@ -116,7 +116,7 @@ class WatsonxDocumentEmbedder:
             model_id=model,
             credentials=credentials,
             project_id=project_id.resolve_value(),
-            params=params if params else None,
+            params=params if params else None,  # type: ignore[arg-type]
             batch_size=batch_size,
             concurrency_limit=concurrency_limit,
             max_retries=max_retries,

--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/text_embedder.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/text_embedder.py
@@ -100,7 +100,7 @@ class WatsonxTextEmbedder:
             model_id=model,
             credentials=credentials,
             project_id=project_id.resolve_value(),
-            params=params if params else None,
+            params=params if params else None,  # type: ignore[arg-type]
             max_retries=max_retries,
         )
 


### PR DESCRIPTION
`ibm-watsonx-ai>=1.6.0` now supports Python 3.14. This updates the dependency pin, adds the 3.14 classifier, and switches CI to test against 3.14.

Closes #3036