### PR TITLE
fix: `FastEmbedder` reordered the top_k fallback to happen after validation

### DIFF
--- a/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
+++ b/integrations/fastembed/src/haystack_integrations/components/rankers/fastembed/ranker.py
@@ -179,10 +179,10 @@ class FastembedRanker:
         if not documents:
             return {"documents": []}
 
-        top_k = top_k or self.top_k
-        if top_k <= 0:
+        if top_k is not None and top_k <= 0:
             msg = f"top_k must be > 0, but got {top_k}"
             raise ValueError(msg)
+        top_k = self.top_k if top_k is None else top_k
 
         if self._model is None:
             self.warm_up()

--- a/integrations/fastembed/tests/test_fastembed_ranker.py
+++ b/integrations/fastembed/tests/test_fastembed_ranker.py
@@ -226,6 +226,25 @@ class TestFastembedRanker:
         ):
             ranker.run(query=query, documents=list_document, top_k=-3)
 
+        with pytest.raises(
+            ValueError,
+            match="top_k must be > 0, but got 0",
+        ):
+            ranker.run(query=query, documents=list_document, top_k=0)
+
+    def test_run_runtime_top_k_zero_does_not_fall_back_to_instance_top_k(self):
+        """
+        A runtime top_k=0 must raise, not silently fall back to the instance top_k.
+        """
+        ranker = FastembedRanker(model_name="Xenova/ms-marco-MiniLM-L-12-v2", top_k=5)
+        ranker._model = "mock_model"
+
+        with pytest.raises(
+            ValueError,
+            match="top_k must be > 0, but got 0",
+        ):
+            ranker.run(query="query", documents=[Document("Document 1")], top_k=0)
+
     def test_run_empty_document_list(self):
         """
         Test for no error when sending no documents.

--- a/integrations/fastembed/tests/test_fastembed_ranker.py
+++ b/integrations/fastembed/tests/test_fastembed_ranker.py
@@ -232,19 +232,6 @@ class TestFastembedRanker:
         ):
             ranker.run(query=query, documents=list_document, top_k=0)
 
-    def test_run_runtime_top_k_zero_does_not_fall_back_to_instance_top_k(self):
-        """
-        A runtime top_k=0 must raise, not silently fall back to the instance top_k.
-        """
-        ranker = FastembedRanker(model_name="Xenova/ms-marco-MiniLM-L-12-v2", top_k=5)
-        ranker._model = "mock_model"
-
-        with pytest.raises(
-            ValueError,
-            match="top_k must be > 0, but got 0",
-        ):
-            ranker.run(query="query", documents=[Document("Document 1")], top_k=0)
-
     def test_run_empty_document_list(self):
         """
         Test for no error when sending no documents.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/506

### Proposed Changes:

- reordered the top_k fallback to happen after validation

### How did you test it?

- one new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
