### PR TITLE
fix: CohereRanker reordered the top_k fallback to happen after validation

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -54,7 +54,13 @@ class CohereRanker:
         :param meta_data_separator: Separator used to concatenate the meta fields
             to the Document content.
         :param max_tokens_per_doc: The maximum number of tokens to embed for each document defaults to 4096.
+
+        :raises ValueError: If `top_k` is not > 0.
         """
+        if top_k <= 0:
+            msg = f"top_k must be > 0, but got {top_k}"
+            raise ValueError(msg)
+
         self.model_name = model
         self.api_key = api_key
         self.api_base_url = api_base_url
@@ -116,10 +122,10 @@ class CohereRanker:
         :return: A tuple of (list of strings to be given as input to Cohere model, resolved top_k).
         :raises ValueError: If `top_k` is not > 0.
         """
-        top_k = top_k or self.top_k
-        if top_k <= 0:
+        if top_k is not None and top_k <= 0:
             msg = f"top_k must be > 0, but got {top_k}"
             raise ValueError(msg)
+        top_k = self.top_k if top_k is None else top_k
 
         concatenated_input_list = []
         for doc in documents:

--- a/integrations/cohere/tests/test_ranker.py
+++ b/integrations/cohere/tests/test_ranker.py
@@ -248,36 +248,39 @@ class TestCohereRanker:
         assert texts == []
         assert top_k == 10
 
-    def test_run_negative_topk_in_init(self, monkeypatch):
+    def test_init_negative_topk(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
-        ranker = CohereRanker(top_k=-2)
-        query = "test"
-        documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
-        with pytest.raises(ValueError, match=r"top_k must be > 0, but got *"):
-            ranker.run(query, documents)
+        with pytest.raises(ValueError, match=r"top_k must be > 0, but got -2"):
+            CohereRanker(top_k=-2)
 
-    def test_run_zero_topk_in_init(self, monkeypatch):
+    def test_init_zero_topk(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
-        ranker = CohereRanker(top_k=0)
-        query = "test"
-        documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
-        with pytest.raises(ValueError, match=r"top_k must be > 0, but got *"):
-            ranker.run(query, documents)
+        with pytest.raises(ValueError, match=r"top_k must be > 0, but got 0"):
+            CohereRanker(top_k=0)
 
     def test_run_negative_topk_in_run(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
         ranker = CohereRanker()
         query = "test"
         documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
-        with pytest.raises(ValueError, match=r"top_k must be > 0, but got *"):
+        with pytest.raises(ValueError, match=r"top_k must be > 0, but got -3"):
             ranker.run(query, documents, -3)
 
-    def test_run_zero_topk_in_run_and_init(self, monkeypatch):
+    def test_run_zero_topk_in_run(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
-        ranker = CohereRanker(top_k=0)
+        ranker = CohereRanker()
         query = "test"
         documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
-        with pytest.raises(ValueError, match=r"top_k must be > 0, but got *"):
+        with pytest.raises(ValueError, match=r"top_k must be > 0, but got 0"):
+            ranker.run(query, documents, 0)
+
+    def test_run_zero_topk_does_not_fall_back_to_instance_topk(self, monkeypatch):
+        # a runtime top_k=0 must raise, not silently fall back to the instance top_k
+        monkeypatch.setenv("CO_API_KEY", "test-api-key")
+        ranker = CohereRanker(top_k=5)
+        query = "test"
+        documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+        with pytest.raises(ValueError, match=r"top_k must be > 0, but got 0"):
             ranker.run(query, documents, 0)
 
     def test_run_documents_provided(self, monkeypatch, mock_ranker_response):  # noqa: ARG002
@@ -360,11 +363,21 @@ class TestCohereRanker:
     @pytest.mark.asyncio
     async def test_run_async_negative_topk(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
-        ranker = CohereRanker(top_k=-2)
+        ranker = CohereRanker()
         query = "test"
         documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
-        with pytest.raises(ValueError, match=r"top_k must be > 0, but got *"):
-            await ranker.run_async(query, documents)
+        with pytest.raises(ValueError, match=r"top_k must be > 0, but got -3"):
+            await ranker.run_async(query, documents, -3)
+
+    @pytest.mark.asyncio
+    async def test_run_async_zero_topk_does_not_fall_back_to_instance_topk(self, monkeypatch):
+        # a runtime top_k=0 must raise, not silently fall back to the instance top_k
+        monkeypatch.setenv("CO_API_KEY", "test-api-key")
+        ranker = CohereRanker(top_k=5)
+        query = "test"
+        documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+        with pytest.raises(ValueError, match=r"top_k must be > 0, but got 0"):
+            await ranker.run_async(query, documents, 0)
 
     @pytest.mark.skipif(
         not os.environ.get("COHERE_API_KEY", None) and not os.environ.get("CO_API_KEY", None),


### PR DESCRIPTION
### Related Issues

- fixes  https://github.com/deepset-ai/haystack-private/issues/506

### Proposed Changes:
  
- Added init-time top_k <= 0 validation
- Reordered _prepare_cohere_input_docs (shared by run/run_async) to validate before falling back.
   
### How did you test it?

- Fixed 3 pre-existing tests that constructed CohereRanker(top_k=-2/0) outside a pytest.raises block, those would now fail at construction time since init validates. 
- Added test_run_zero_topk_does_not_fall_back_to_instance_topk and its async counterpart, the exact swallowed-fallback scenario, with a non-default instance top_k=5.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
