### PR TITLE
fix: AmazonBedRockRanker reordered the top_k fallback to happen after validation

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/rankers/amazon_bedrock/ranker.py
@@ -91,9 +91,14 @@ class AmazonBedrockRanker:
             with the document content for reranking.
         :param meta_data_separator: Separator used to concatenate the meta fields
             to the Document content.
+
+        :raises ValueError: If `model` is empty or if `top_k` is not > 0.
         """
         if not model:
             msg = "'model' cannot be None or empty string"
+            raise ValueError(msg)
+        if top_k <= 0:
+            msg = f"top_k must be > 0, but got {top_k}"
             raise ValueError(msg)
         self.model_name = model
         self.aws_access_key_id = aws_access_key_id
@@ -193,10 +198,10 @@ class AmazonBedrockRanker:
 
         :raises ValueError: If `top_k` is not > 0.
         """
-        top_k = top_k or self.top_k
-        if top_k <= 0:
+        if top_k is not None and top_k <= 0:
             msg = f"top_k must be > 0, but got {top_k}"
             raise ValueError(msg)
+        top_k = self.top_k if top_k is None else top_k
 
         if not documents:
             return {"documents": []}

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -158,6 +158,25 @@ def test_amazon_bedrock_ranker_invalid_top_k(mock_aws_session):
         ranker.run(query="q", documents=[Document(content="x")], top_k=-1)
 
 
+@pytest.mark.parametrize("top_k", [0, -1])
+def test_amazon_bedrock_ranker_init_invalid_top_k(mock_aws_session, top_k):
+    with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {top_k}"):
+        AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"), top_k=top_k)
+
+
+def test_amazon_bedrock_ranker_run_zero_top_k(mock_aws_session):
+    ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
+    with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
+        ranker.run(query="q", documents=[Document(content="x")], top_k=0)
+
+
+def test_amazon_bedrock_ranker_run_zero_top_k_does_not_fall_back_to_instance_top_k(mock_aws_session):
+    # a runtime top_k=0 must raise, not silently fall back to the instance top_k
+    ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"), top_k=5)
+    with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
+        ranker.run(query="q", documents=[Document(content="x")], top_k=0)
+
+
 def test_amazon_bedrock_ranker_truncates_large_input(mock_aws_session, caplog):
     ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
     mock_aws_session.rerank.return_value = {"results": []}

--- a/integrations/amazon_bedrock/tests/test_ranker.py
+++ b/integrations/amazon_bedrock/tests/test_ranker.py
@@ -170,13 +170,6 @@ def test_amazon_bedrock_ranker_run_zero_top_k(mock_aws_session):
         ranker.run(query="q", documents=[Document(content="x")], top_k=0)
 
 
-def test_amazon_bedrock_ranker_run_zero_top_k_does_not_fall_back_to_instance_top_k(mock_aws_session):
-    # a runtime top_k=0 must raise, not silently fall back to the instance top_k
-    ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"), top_k=5)
-    with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
-        ranker.run(query="q", documents=[Document(content="x")], top_k=0)
-
-
 def test_amazon_bedrock_ranker_truncates_large_input(mock_aws_session, caplog):
     ranker = AmazonBedrockRanker(aws_region_name=Secret.from_token("us-west-2"))
     mock_aws_session.rerank.return_value = {"results": []}


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/506

### Proposed Changes:
  
- Added missing init-time top_k <= 0 validation.
- Reordered run()'s runtime validation before the fallback.

### How did you test it?

- Added init boundary tests (0, -1), a runtime top_k=0 test, and the fallback-swallow regression test (top_k=5 at init, top_k=0 at runtime must raise, not silently return 5 results).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
