### PR TITLE
fix: `FAISSDocumentStore` adding filter to unique metadata values

### DIFF
--- a/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
+++ b/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
@@ -488,7 +488,7 @@ class FAISSDocumentStore:
             unique values.
         """
         values = []
-        for doc in self.filter_documents(filters):
+        for doc in self.filter_documents(filters=filters):
             val = FAISSDocumentStore._get_doc_value(doc, metadata_field)
             if val is not None:
                 values.append(val)

--- a/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
+++ b/integrations/faiss/src/haystack_integrations/document_stores/faiss/document_store.py
@@ -473,6 +473,7 @@ class FAISSDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Returns unique values for a metadata field, optionally filtered by a search term, with pagination.
@@ -482,11 +483,12 @@ class FAISSDocumentStore:
             against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple containing list of unique values (in their original type) and total count of
             unique values.
         """
         values = []
-        for doc in self.documents.values():
+        for doc in self.filter_documents(filters):
             val = FAISSDocumentStore._get_doc_value(doc, metadata_field)
             if val is not None:
                 values.append(val)

--- a/integrations/faiss/tests/test_document_store.py
+++ b/integrations/faiss/tests/test_document_store.py
@@ -250,3 +250,16 @@ class TestFAISSDocumentStore(
         values, total_count = document_store.get_metadata_field_unique_values("priority")
         assert set(values) == {1, 2}
         assert total_count == 2
+
+    def test_get_metadata_field_unique_values_with_filters(self, document_store):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/486

### Proposed Changes:

- adding filters param to get_metadata_unique_values()

### How did you test it?

- added one specific test with filters

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
