### PR TITLE
fix: `OpenSearchDocumentStore` adding filter to unique metadata values

### DIFF
--- a/integrations/opensearch/docker-compose.yml
+++ b/integrations/opensearch/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
       - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=SecureHaystack!2026"
     healthcheck:
-        test: curl --fail https://localhost:9200/_cat/health -ku admin:admin || exit 1
+        test: curl --fail https://localhost:9200/_cat/health -ku admin:SecureHaystack!2026 || exit 1
         interval: 10s
         timeout: 1s
         retries: 10

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -2049,32 +2049,43 @@ class OpenSearchDocumentStore:
 
         return self._extract_min_max_from_stats(stats)
 
-    @staticmethod
-    def _build_unique_values_field_query(field_name: str, search_term: str | None) -> dict[str, Any]:
+    def _build_unique_values_field_query(
+        self, field_name: str, search_term: str | None, filters: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """
-        Builds a query matching documents whose metadata field's own value contains `search_term`.
+        Builds a query matching docs whose metadata field's contains `search_term`, optionally restricted by `filters`.
 
         Matching is a case-insensitive substring match (not against the document content).
         """
-        if not search_term:
-            return {"match_all": {}}
-        # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
-        # standalone `terms` aggregations), and a `regexp` query only works on keyword/text fields, not
-        # numeric ones. A doc-value script query works uniformly across field types by stringifying the
-        # field's value, matching the case-insensitive substring semantics documented above. The term is
-        # lower-cased once here rather than per-document in the script.
-        return {
-            "script": {
-                "script": {
-                    "source": (
-                        "def v = doc[params.field]; "
-                        "if (v.size() == 0) { return false; } "
-                        "return v.value.toString().toLowerCase().contains(params.term)"
-                    ),
-                    "params": {"field": field_name, "term": search_term.lower()},
+        clauses: list[dict[str, Any]] = []
+        if filters:
+            clauses.append({"bool": {"filter": normalize_filters(filters, nested_fields=self._resolved_nested_fields)}})
+        if search_term:
+            # Composite aggregation terms sources don't support `include`/`exclude` (that's only valid on
+            # standalone `terms` aggregations), and a `regexp` query only works on keyword/text fields, not
+            # numeric ones. A doc-value script query works uniformly across field types by stringifying the
+            # field's value, matching the case-insensitive substring semantics documented above. The term is
+            # lower-cased once here rather than per-document in the script.
+            clauses.append(
+                {
+                    "script": {
+                        "script": {
+                            "source": (
+                                "def v = doc[params.field]; "
+                                "if (v.size() == 0) { return false; } "
+                                "return v.value.toString().toLowerCase().contains(params.term)"
+                            ),
+                            "params": {"field": field_name, "term": search_term.lower()},
+                        }
+                    }
                 }
-            }
-        }
+            )
+
+        if not clauses:
+            return {"match_all": {}}
+        if len(clauses) == 1:
+            return clauses[0]
+        return {"bool": {"filter": clauses}}
 
     @staticmethod
     def _build_composite_agg_body(
@@ -2161,6 +2172,7 @@ class OpenSearchDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Returns unique values for a metadata field, optionally filtered by a search term.
@@ -2184,6 +2196,7 @@ class OpenSearchDocumentStore:
             with a server-side script and is quite expensive for a large corpus.
         :param from_: Offset to start returning values from. Defaults to 0.
         :param size: The number of unique values to return per page. Defaults to 10.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple of (list of unique values in their original type, total count of distinct values
             for the field matching `search_term`).
         """
@@ -2191,7 +2204,7 @@ class OpenSearchDocumentStore:
         assert self._client is not None
 
         field_name = _normalize_metadata_field_name(metadata_field)
-        query = self._build_unique_values_field_query(field_name, search_term)
+        query = self._build_unique_values_field_query(field_name, search_term, filters)
 
         after_key = self._skip_unique_values(field_name, query, from_) if from_ > 0 else None
 
@@ -2205,6 +2218,7 @@ class OpenSearchDocumentStore:
         search_term: str | None = None,
         from_: int = 0,
         size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Asynchronous counterpart of `get_metadata_field_unique_values`.
@@ -2216,6 +2230,7 @@ class OpenSearchDocumentStore:
             with a server-side script and is quite expensive for a large corpus.
         :param from_: Offset to start returning values from. Defaults to 0.
         :param size: The number of unique values to return per page. Defaults to 10.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple of (list of unique values in their original type, total count of distinct values
             for the field matching `search_term`).
         """
@@ -2223,7 +2238,7 @@ class OpenSearchDocumentStore:
         assert self._async_client is not None
 
         field_name = _normalize_metadata_field_name(metadata_field)
-        query = self._build_unique_values_field_query(field_name, search_term)
+        query = self._build_unique_values_field_query(field_name, search_term, filters)
 
         after_key = await self._skip_unique_values_async(field_name, query, from_) if from_ > 0 else None
 

--- a/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
+++ b/integrations/opensearch/src/haystack_integrations/document_stores/opensearch/document_store.py
@@ -2198,7 +2198,8 @@ class OpenSearchDocumentStore:
         :param size: The number of unique values to return per page. Defaults to 10.
         :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple of (list of unique values in their original type, total count of distinct values
-            for the field matching `search_term`).
+            for the field matching `search_term`). Note that filters also narrows down the number of documents
+            against which the search term is matched.
         """
         self._ensure_initialized()
         assert self._client is not None
@@ -2232,7 +2233,8 @@ class OpenSearchDocumentStore:
         :param size: The number of unique values to return per page. Defaults to 10.
         :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple of (list of unique values in their original type, total count of distinct values
-            for the field matching `search_term`).
+            for the field matching `search_term`). Note that filters also narrows down the number of documents
+            against which the search term is matched.
         """
         await self._ensure_initialized_async()
         assert self._async_client is not None

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -1311,6 +1311,19 @@ class TestDocumentStore(
         assert set(unique_topics_value_only) == {"needle-in-haystack"}
         assert total_topics_value_only == 1
 
+    def test_get_metadata_field_unique_values_with_filters(self, document_store: OpenSearchDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("meta.category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     def test_write_with_routing(self, document_store: OpenSearchDocumentStore):
         """Test writing documents with routing metadata"""
         docs = [

--- a/integrations/opensearch/tests/test_document_store.py
+++ b/integrations/opensearch/tests/test_document_store.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import random
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from haystack.dataclasses.document import Document
@@ -602,77 +602,6 @@ def test_ensure_index_exists_no_create_when_disabled(_mock_opensearch_client):
     mock_client.indices.get_mapping.assert_not_called()
 
 
-@pytest.mark.asyncio
-@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
-@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
-async def test_ensure_index_exists_async_direct_index(_mock_sync_client, _mock_async_client):
-    """Async: When an index exists and is referenced directly, mappings are loaded without error."""
-    store = OpenSearchDocumentStore(hosts="testhost", index="my-index", http_auth=("a", "b"))
-    mock_client = AsyncMock()
-    store._async_client = mock_client
-    mock_client.indices.exists = AsyncMock(return_value=True)
-    mock_client.indices.get_mapping = AsyncMock(
-        return_value={"my-index": {"mappings": {"properties": {"content": {"type": "text"}}}}}
-    )
-
-    await store._ensure_index_exists_async()
-
-    mock_client.indices.exists.assert_called_once_with(index="my-index")
-    mock_client.indices.get_mapping.assert_called_once_with(index="my-index")
-    mock_client.indices.create.assert_not_called()
-
-
-@pytest.mark.asyncio
-@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
-@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
-async def test_ensure_index_exists_async_with_alias(_mock_sync_client, _mock_async_client):
-    """Async: When self._index is an alias, get_mapping keys by real index name; no KeyError."""
-    store = OpenSearchDocumentStore(hosts="testhost", index="my-alias", http_auth=("a", "b"))
-    mock_client = AsyncMock()
-    store._async_client = mock_client
-    mock_client.indices.exists = AsyncMock(return_value=True)
-    mock_client.indices.get_mapping = AsyncMock(
-        return_value={"my-real-index-v1": {"mappings": {"properties": {"content": {"type": "text"}}}}}
-    )
-
-    await store._ensure_index_exists_async()  # must not raise KeyError
-
-    mock_client.indices.get_mapping.assert_called_once_with(index="my-alias")
-    mock_client.indices.create.assert_not_called()
-
-
-@pytest.mark.asyncio
-@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
-@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
-async def test_ensure_index_exists_async_creates_index_when_not_exists(_mock_sync_client, _mock_async_client):
-    """Async: When the index does not exist and create_index=True, the index is created."""
-    store = OpenSearchDocumentStore(hosts="testhost", index="new-index", http_auth=("a", "b"))
-    mock_client = AsyncMock()
-    store._async_client = mock_client
-    mock_client.indices.exists = AsyncMock(return_value=False)
-
-    await store._ensure_index_exists_async()
-
-    mock_client.indices.create.assert_called_once()
-    mock_client.indices.get_mapping.assert_not_called()
-
-
-@pytest.mark.asyncio
-@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
-@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
-async def test_ensure_index_exists_async_no_create_when_disabled(_mock_sync_client, _mock_async_client):
-    """Async: When the index does not exist and create_index=False, no index is created."""
-    store = OpenSearchDocumentStore(hosts="testhost", index="new-index", create_index=False, http_auth=("a", "b"))
-    mock_client = AsyncMock()
-    store._async_client = mock_client
-    mock_client.indices.exists = AsyncMock(return_value=False)
-
-    await store._ensure_index_exists_async()
-
-    mock_client.indices.create.assert_not_called()
-    mock_client.indices.get_mapping.assert_not_called()
-
-
 @patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
 def test_delete_all_documents_recreate_raises_for_alias(_mock_opensearch_client):
     """delete_all_documents(recreate_index=True) raises DocumentStoreError when self._index is an alias."""
@@ -698,39 +627,6 @@ def test_delete_all_documents_recreate_works_for_concrete_index(_mock_opensearch
     mock_client.indices.get.return_value = {"my-index": {"mappings": {}, "settings": {"index": {}}}}
 
     store.delete_all_documents(recreate_index=True)
-
-    mock_client.indices.delete.assert_called_once_with(index="my-index")
-    mock_client.indices.create.assert_called_once()
-
-
-@pytest.mark.asyncio
-@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
-@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
-async def test_delete_all_documents_async_recreate_raises_for_alias(_mock_sync_client, _mock_async_client):
-    """delete_all_documents_async(recreate_index=True) raises DocumentStoreError when self._index is an alias."""
-    store = OpenSearchDocumentStore(hosts="testhost", index="my-alias", http_auth=("a", "b"))
-    mock_client = AsyncMock()
-    store._async_client = mock_client
-    mock_client.indices.get = AsyncMock(return_value={"my-real-index-v1": {"mappings": {}, "settings": {"index": {}}}})
-
-    with pytest.raises(DocumentStoreError, match="is an alias"):
-        await store.delete_all_documents_async(recreate_index=True)
-
-    mock_client.indices.delete.assert_not_called()
-    mock_client.indices.create.assert_not_called()
-
-
-@pytest.mark.asyncio
-@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
-@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
-async def test_delete_all_documents_async_recreate_works_for_concrete_index(_mock_sync_client, _mock_async_client):
-    """delete_all_documents_async(recreate_index=True) proceeds normally when self._index is a concrete index."""
-    store = OpenSearchDocumentStore(hosts="testhost", index="my-index", http_auth=("a", "b"))
-    mock_client = AsyncMock()
-    store._async_client = mock_client
-    mock_client.indices.get = AsyncMock(return_value={"my-index": {"mappings": {}, "settings": {"index": {}}}})
-
-    await store.delete_all_documents_async(recreate_index=True)
 
     mock_client.indices.delete.assert_called_once_with(index="my-index")
     mock_client.indices.create.assert_called_once()

--- a/integrations/opensearch/tests/test_document_store_async.py
+++ b/integrations/opensearch/tests/test_document_store_async.py
@@ -948,3 +948,17 @@ class TestDocumentStoreAsync(
         )
         assert set(unique_topics_value_only) == {"needle-in-haystack"}
         assert total_topics_value_only == 1
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_field_unique_values_with_filters_async(self, document_store: OpenSearchDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await document_store.get_metadata_field_unique_values_async("meta.category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2

--- a/integrations/opensearch/tests/test_document_store_async.py
+++ b/integrations/opensearch/tests/test_document_store_async.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from haystack.dataclasses import Document
@@ -53,6 +53,110 @@ async def test_close_async_is_exception_safe():
     await store.close_async()
 
     assert store._async_client is None
+
+
+@pytest.mark.asyncio
+@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
+@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+async def test_ensure_index_exists_async_direct_index(_mock_sync_client, _mock_async_client):
+    """Async: When an index exists and is referenced directly, mappings are loaded without error."""
+    store = OpenSearchDocumentStore(hosts="testhost", index="my-index", http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+    mock_client.indices.exists = AsyncMock(return_value=True)
+    mock_client.indices.get_mapping = AsyncMock(
+        return_value={"my-index": {"mappings": {"properties": {"content": {"type": "text"}}}}}
+    )
+
+    await store._ensure_index_exists_async()
+
+    mock_client.indices.exists.assert_called_once_with(index="my-index")
+    mock_client.indices.get_mapping.assert_called_once_with(index="my-index")
+    mock_client.indices.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
+@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+async def test_ensure_index_exists_async_with_alias(_mock_sync_client, _mock_async_client):
+    """Async: When self._index is an alias, get_mapping keys by real index name; no KeyError."""
+    store = OpenSearchDocumentStore(hosts="testhost", index="my-alias", http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+    mock_client.indices.exists = AsyncMock(return_value=True)
+    mock_client.indices.get_mapping = AsyncMock(
+        return_value={"my-real-index-v1": {"mappings": {"properties": {"content": {"type": "text"}}}}}
+    )
+
+    await store._ensure_index_exists_async()  # must not raise KeyError
+
+    mock_client.indices.get_mapping.assert_called_once_with(index="my-alias")
+    mock_client.indices.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
+@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+async def test_ensure_index_exists_async_creates_index_when_not_exists(_mock_sync_client, _mock_async_client):
+    """Async: When the index does not exist and create_index=True, the index is created."""
+    store = OpenSearchDocumentStore(hosts="testhost", index="new-index", http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+    mock_client.indices.exists = AsyncMock(return_value=False)
+
+    await store._ensure_index_exists_async()
+
+    mock_client.indices.create.assert_called_once()
+    mock_client.indices.get_mapping.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
+@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+async def test_ensure_index_exists_async_no_create_when_disabled(_mock_sync_client, _mock_async_client):
+    """Async: When the index does not exist and create_index=False, no index is created."""
+    store = OpenSearchDocumentStore(hosts="testhost", index="new-index", create_index=False, http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+    mock_client.indices.exists = AsyncMock(return_value=False)
+
+    await store._ensure_index_exists_async()
+
+    mock_client.indices.create.assert_not_called()
+    mock_client.indices.get_mapping.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
+@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+async def test_delete_all_documents_async_recreate_raises_for_alias(_mock_sync_client, _mock_async_client):
+    """delete_all_documents_async(recreate_index=True) raises DocumentStoreError when self._index is an alias."""
+    store = OpenSearchDocumentStore(hosts="testhost", index="my-alias", http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+    mock_client.indices.get = AsyncMock(return_value={"my-real-index-v1": {"mappings": {}, "settings": {"index": {}}}})
+
+    with pytest.raises(DocumentStoreError, match="is an alias"):
+        await store.delete_all_documents_async(recreate_index=True)
+
+    mock_client.indices.delete.assert_not_called()
+    mock_client.indices.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("haystack_integrations.document_stores.opensearch.document_store.AsyncOpenSearch")
+@patch("haystack_integrations.document_stores.opensearch.document_store.OpenSearch")
+async def test_delete_all_documents_async_recreate_works_for_concrete_index(_mock_sync_client, _mock_async_client):
+    """delete_all_documents_async(recreate_index=True) proceeds normally when self._index is a concrete index."""
+    store = OpenSearchDocumentStore(hosts="testhost", index="my-index", http_auth=("a", "b"))
+    mock_client = AsyncMock()
+    store._async_client = mock_client
+    mock_client.indices.get = AsyncMock(return_value={"my-index": {"mappings": {}, "settings": {"index": {}}}})
+
+    await store.delete_all_documents_async(recreate_index=True)
+
+    mock_client.indices.delete.assert_called_once_with(index="my-index")
+    mock_client.indices.create.assert_called_once()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Proposed Changes:

- adding filters param to unique_metadata_values

### How did you test it?

- added new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
