### PR TITLE
ci: ask for adoption signals before adding a new integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-integration-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-integration-proposal.md
@@ -14,10 +14,9 @@ Briefly explain the request: why do we need this integration? What use cases doe
 ## Adoption signals
 
 Every integration we merge has to be maintained, tested nightly, and released, so we prioritize integrations for
-technologies with a healthy and growing user base. Please share whatever signals you can find for the software you
-want to integrate with — you don't need all of them, but the more you provide, the easier it is for us to decide.
+technologies with a healthy and growing user base. Please share adoption signals for the software you want to integrate with. The more info you provide, the easier it is for us to decide.
 
-- **GitHub stars** of the main repository (and roughly how fast it is growing):
+- **GitHub stars** of the main repository:
 - **PyPI downloads in the last 30 days** of the Python client/SDK (see [pypistats.org](https://pypistats.org/)):
 - **Release activity**: date of the latest release and rough release cadence:
 - **Maintenance**: is the project actively maintained (recent commits, issues being answered)? Is there a company or
@@ -28,17 +27,14 @@ want to integrate with — you don't need all of them, but the more you provide,
   other frameworks):
 
 > Example: [`elasticsearch-py`](https://github.com/elastic/elasticsearch-py) has 4.4k GitHub stars and
-> [54 million PyPI downloads in the last 30 days](https://pypistats.org/packages/elasticsearch), with releases every
-> few weeks and Elastic maintaining it.
+> [54 million monthly PyPI downloads](https://pypistats.org/packages/elasticsearch), with releases every
+> few weeks and Elastic maintaining it. A similar integration is available for (other frameworks)[https://github.com/langchain-ai/langchain-elastic].
 
-If the technology is very new and these numbers are still small, tell us why you expect it to grow — that is useful
-context too.
+If the technology is very new and these numbers are still small, please tell us when and why you expect community interest to grow.
 
 ## Detailed design
 
-Explain the design in enough detail for somebody familiar with Haystack to understand, and for somebody familiar with
-the implementation to implement. Get into specifics and corner-cases, and include examples of how the feature is used.
-Also, if there's any new terminology involved, define it here.
+Explain the design in enough detail for somebody familiar with Haystack to understand, and for somebody familiar with the implementation to build it. Get into specifics, mention corner-cases, and include examples of how the feature is used.
 
 ## Checklist
 

--- a/.github/ISSUE_TEMPLATE/new-integration-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-integration-proposal.md
@@ -28,7 +28,7 @@ technologies with a healthy and growing user base. Please share adoption signals
 
 > Example: [`elasticsearch-py`](https://github.com/elastic/elasticsearch-py) has 4.4k GitHub stars and
 > [54 million monthly PyPI downloads](https://pypistats.org/packages/elasticsearch), with releases every
-> few weeks and Elastic maintaining it. A similar integration is available for (other frameworks)[https://github.com/langchain-ai/langchain-elastic].
+> few weeks and Elastic maintaining it. A similar integration is available for [other frameworks](https://github.com/langchain-ai/langchain-elastic).
 
 If the technology is very new and these numbers are still small, please tell us when and why you expect community interest to grow.
 

--- a/.github/ISSUE_TEMPLATE/new-integration-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-integration-proposal.md
@@ -11,6 +11,29 @@ assignees: ''
 
 Briefly explain the request: why do we need this integration? What use cases does it support?
 
+## Adoption signals
+
+Every integration we merge has to be maintained, tested nightly, and released, so we prioritize integrations for
+technologies with a healthy and growing user base. Please share whatever signals you can find for the software you
+want to integrate with — you don't need all of them, but the more you provide, the easier it is for us to decide.
+
+- **GitHub stars** of the main repository (and roughly how fast it is growing):
+- **PyPI downloads in the last 30 days** of the Python client/SDK (see [pypistats.org](https://pypistats.org/)):
+- **Release activity**: date of the latest release and rough release cadence:
+- **Maintenance**: is the project actively maintained (recent commits, issues being answered)? Is there a company or
+  foundation behind it?
+- **Haystack community demand**: links to Discord threads, GitHub issues, or other requests asking for this
+  integration:
+- **Anything else** that shows adoption (enterprise usage, conference talks, blog posts, comparable integrations in
+  other frameworks):
+
+> Example: [`elasticsearch-py`](https://github.com/elastic/elasticsearch-py) has 4.4k GitHub stars and
+> [54 million PyPI downloads in the last 30 days](https://pypistats.org/packages/elasticsearch), with releases every
+> few weeks and Elastic maintaining it.
+
+If the technology is very new and these numbers are still small, tell us why you expect it to grow — that is useful
+context too.
+
 ## Detailed design
 
 Explain the design in enough detail for somebody familiar with Haystack to understand, and for somebody familiar with

--- a/.github/workflows/CI_new_integration_proposal.yml
+++ b/.github/workflows/CI_new_integration_proposal.yml
@@ -132,8 +132,8 @@ jobs:
             and fill it out? The **Adoption signals** section (GitHub stars, PyPI downloads over the last 30 days,
             release activity, community demand) is what helps us decide whether to add the integration to Haystack.
 
-            Then link the issue from this PR — for example by adding `Related to #<issue-number>` to the PR description —
-            and this comment will disappear automatically.
+            Then reference the issue in this PR's description (for example, by adding `Related to #<issue-number>`)
+           and this comment will disappear automatically.
 
       - name: Remove stale comment
         if: steps.check.outputs.missing != 'true'

--- a/.github/workflows/CI_new_integration_proposal.yml
+++ b/.github/workflows/CI_new_integration_proposal.yml
@@ -13,7 +13,7 @@ name: Core / New integration proposal check
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [opened, reopened, synchronize, edited, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -83,7 +83,7 @@ jobs:
                 .map((issue) => issue.number),
             );
             const body = pr.body ?? "";
-            for (const m of body.matchAll(/(?:^|\s)#(\d+)\b/g)) referenced.add(Number(m[1]));
+            for (const m of body.matchAll(/(?:^|[^\w])#(\d+)\b/g)) referenced.add(Number(m[1]));
             const urlPattern = new RegExp(
               `https://github\\.com/${owner}/${repo}/issues/(\\d+)`, "g",
             );

--- a/.github/workflows/CI_new_integration_proposal.yml
+++ b/.github/workflows/CI_new_integration_proposal.yml
@@ -132,7 +132,7 @@ jobs:
             and fill it out? The **Adoption signals** section (GitHub stars, PyPI downloads over the last 30 days,
             release activity, community demand) is what helps us decide whether to add the integration to Haystack.
 
-            Then link the issue from this PR — for example by adding `Fixes #<issue-number>` to the PR description —
+            Then link the issue from this PR — for example by adding `Related to #<issue-number>` to the PR description —
             and this comment will disappear automatically.
 
       - name: Remove stale comment

--- a/.github/workflows/CI_new_integration_proposal.yml
+++ b/.github/workflows/CI_new_integration_proposal.yml
@@ -133,7 +133,7 @@ jobs:
             release activity, community demand) is what helps us decide whether to add the integration to Haystack.
 
             Then reference the issue in this PR's description (for example, by adding `Related to #<issue-number>`)
-           and this comment will disappear automatically.
+            and this comment will disappear automatically.
 
       - name: Remove stale comment
         if: steps.check.outputs.missing != 'true'

--- a/.github/workflows/CI_new_integration_proposal.yml
+++ b/.github/workflows/CI_new_integration_proposal.yml
@@ -1,0 +1,144 @@
+name: Core / New integration proposal check
+
+# When a PR adds a brand-new integration (a new `integrations/<name>/pyproject.toml`),
+# check that it links an issue labeled `new integration` in this repo. That issue is
+# where we collect the adoption signals (GitHub stars, PyPI downloads, ...) we need to
+# decide whether Haystack should maintain the integration long-term.
+#
+# If no such issue is linked, ask the PR author to open one from the template. The
+# comment is sticky and gets removed again as soon as a proposal issue is linked.
+#
+# Uses pull_request_target so it can comment on fork PRs; this is safe because the
+# workflow never checks out or executes PR code.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: new-integration-proposal-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check for a linked new integration proposal
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const PROPOSAL_LABEL = "new integration";
+            // Maintainers can opt a PR out (e.g. a rename or a split of an existing
+            // integration that shows up as a new package).
+            const EXEMPT_LABEL = "skip-integration-proposal";
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            if (pr.user?.type === "Bot") return;
+            if (pr.labels.some((l) => l.name === EXEMPT_LABEL)) {
+              core.info(`PR is labeled ${EXEMPT_LABEL}, skipping.`);
+              return;
+            }
+
+            // 1. Does this PR add a new integration package?
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const added = files
+              .filter((f) => f.status === "added")
+              .map((f) => f.filename.match(/^integrations\/([^/]+)\/pyproject\.toml$/))
+              .filter(Boolean)
+              .map((m) => m[1]);
+            const newIntegrations = [...new Set(added)].sort();
+            if (!newIntegrations.length) {
+              core.info("PR does not add a new integration.");
+              return;
+            }
+            core.info(`PR adds new integration(s): ${newIntegrations.join(", ")}`);
+
+            // 2. Collect the issues this PR references: both proper closing
+            // references ("Fixes #123") and plain mentions in the body, since
+            // contributors often only write "Related to #123".
+            const result = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 20) {
+                      nodes { number repository { nameWithOwner } }
+                    }
+                  }
+                }
+              }`,
+              { owner, repo, number: pr.number },
+            );
+            const referenced = new Set(
+              result.repository.pullRequest.closingIssuesReferences.nodes
+                .filter((issue) => issue.repository.nameWithOwner === `${owner}/${repo}`)
+                .map((issue) => issue.number),
+            );
+            const body = pr.body ?? "";
+            for (const m of body.matchAll(/(?:^|\s)#(\d+)\b/g)) referenced.add(Number(m[1]));
+            const urlPattern = new RegExp(
+              `https://github\\.com/${owner}/${repo}/issues/(\\d+)`, "g",
+            );
+            for (const m of body.matchAll(urlPattern)) referenced.add(Number(m[1]));
+
+            // 3. Is any of them a new integration proposal?
+            for (const number of referenced) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner, repo, issue_number: number,
+                });
+                // Pull requests share the issue numbering space.
+                if (issue.pull_request) continue;
+                if (issue.labels.some((l) => (l.name ?? l) === PROPOSAL_LABEL)) {
+                  core.info(`Found proposal issue #${number}, nothing to do.`);
+                  return;
+                }
+              } catch (error) {
+                core.info(`Could not read issue #${number}: ${error.message}`);
+              }
+            }
+
+            core.info("No linked issue labeled 'new integration' found.");
+            core.setOutput("author", pr.user.login);
+            core.setOutput(
+              "integrations",
+              newIntegrations.map((name) => `\`${name}\``).join(", "),
+            );
+            core.setOutput("missing", "true");
+
+      - name: Ask the author for a proposal issue
+        if: steps.check.outputs.missing == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: new-integration-proposal
+          number: ${{ github.event.pull_request.number }}
+          message: |
+            Hi @${{ steps.check.outputs.author }}, thanks a lot for contributing a new integration! :pray:
+
+            This PR looks like it adds a new integration (${{ steps.check.outputs.integrations }}), but we couldn't
+            find a linked issue labeled `new integration`.
+
+            Every integration we merge is maintained, tested nightly, and released by us, so before reviewing the code
+            we'd like to understand the adoption of the technology you're integrating with. Could you please
+            [open a New Integration Proposal](https://github.com/deepset-ai/haystack-core-integrations/issues/new?template=new-integration-proposal.md)
+            and fill it out? The **Adoption signals** section (GitHub stars, PyPI downloads over the last 30 days,
+            release activity, community demand) is what helps us decide whether to add the integration to Haystack.
+
+            Then link the issue from this PR — for example by adding `Fixes #<issue-number>` to the PR description —
+            and this comment will disappear automatically.
+
+      - name: Remove stale comment
+        if: steps.check.outputs.missing != 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: new-integration-proposal
+          number: ${{ github.event.pull_request.number }}
+          delete: true


### PR DESCRIPTION
### Related Issues

- Fixes https://github.com/deepset-ai/haystack-private/issues/537

### Proposed Changes:

- **`.github/ISSUE_TEMPLATE/new-integration-proposal.md`**: new **Adoption signals** section asking for GitHub stars, PyPI downloads etc. includes `elasticsearch-py` example 
- **`.github/workflows/CI_new_integration_proposal.yml`** (new): on `pull_request_target` (`opened`, `reopened`, `synchronize`, `edited`, `ready_for_review`) it
  - detects a new integration by a newly **added** `integrations/<name>/pyproject.toml`,
  - resolves the issues the PR references via proper closing references (`Fixes #123`) via GraphQL or plain `#123` / issue-URL mentions in the body
  - checks whether any of them is an issue labeled `new integration`,
  - if not, posts a sticky comment tagging the PR author with a link to the proposal template and an explanation of why we ask for it. The comment is deleted again as soon as a proposal issue is linked.
  - Maintainers can opt a PR out with a `skip-integration-proposal` label

Follows the existing `CI_comment_fork_prs.yml` conventions: `pull_request_target` without checking out PR code, pinned action SHAs, `marocchino/sticky-pull-request-comment` for idempotent comments.

### How did you test it?

### Notes for the reviewer

We could mark PRs adding a new integration as draft if they are not linked to an issue. Then we could postpone the review similar to our CLA gate. I didn't want to make this PR larger than it is though. It's a much less frequent problem than what we see with the CLA gate.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes — n/a, no related issue
- I added unit tests and updated the docstrings — n/a, CI configuration and issue-template change only
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `ci:`
