### PR TITLE
fix: ValidationException on invalid bedrock tool result json

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -197,10 +197,16 @@ def _format_tool_result_message(tool_call_result_message: ChatMessage) -> dict[s
     # Assuming tool call result messages will only contain tool results
     tool_results = []
     for tool_call_result in tool_call_result_message.tool_call_results:
+        content: list[dict[str, Any]]
         if isinstance(tool_call_result.result, str):
             try:
                 json_result = json.loads(tool_call_result.result)
-                content = [{"json": json_result}]
+                # Bedrock's toolResult.content[].json field requires a JSON object, not an arbitrary JSON value
+                # (e.g. a bare number, string, boolean, null or array is rejected with a ValidationException).
+                if isinstance(json_result, dict):
+                    content = [{"json": json_result}]
+                else:
+                    content = [{"text": tool_call_result.result}]
             except json.JSONDecodeError:
                 content = [{"text": tool_call_result.result}]
         elif isinstance(tool_call_result.result, list):

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -22,6 +22,7 @@ from haystack_integrations.components.generators.amazon_bedrock.chat.utils impor
     _convert_streaming_chunks_to_chat_message,
     _format_messages,
     _format_textual_assistant_message,
+    _format_tool_result_message,
     _format_tools,
     _format_user_message,
     _parse_completion_response,
@@ -246,6 +247,47 @@ class TestAmazonBedrockChatGeneratorUtils:
                 "content": [{"text": "The weather in Paris is sunny and 25°C."}],
             },
         ]
+
+    def test_format_tool_result_message_json_object(self):
+        # a tool result string that parses as a JSON object is sent as a Bedrock "json" content block
+        message = ChatMessage.from_tool(
+            tool_result='{"city": "Paris", "temperature": 25}',
+            origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"}),
+        )
+        formatted_message = _format_tool_result_message(message)
+        assert formatted_message == {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [{"json": {"city": "Paris", "temperature": 25}}],
+                    }
+                }
+            ],
+        }
+
+    @pytest.mark.parametrize("tool_result", ["42", "true", "null", "[1, 2, 3]"])
+    def test_format_tool_result_message_non_object_json_falls_back_to_text(self, tool_result):
+        # Bedrock's toolResult.content[].json field requires a JSON object; a string that parses to a
+        # non-object JSON value (number, bool, null, array) must fall back to a "text" content block,
+        # otherwise Bedrock rejects the request with a ValidationException.
+        message = ChatMessage.from_tool(
+            tool_result=tool_result,
+            origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"}),
+        )
+        formatted_message = _format_tool_result_message(message)
+        assert formatted_message == {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [{"text": tool_result}],
+                    }
+                }
+            ],
+        }
 
     def test_format_messages_with_cache_point(self):
         meta = {"cachePoint": {"type": "default"}}


### PR DESCRIPTION
### Related Issues

```python
AmazonBedrockInferenceError
Could not perform inference for Amazon Bedrock model eu.anthropic.claude-sonnet-4-6 due to: · An error occurred (ValidationException) when calling the ConverseStream operation: The format of the value at messages.28.content.0.toolResult.content.0.json is invalid. Provide a json object for the field and try again.
```

Whenever a tool returns its result as a plain string, Haystack tries json.loads() on it. If that succeeds, it wraps the parsed value under {"json": ...} and sends it to Bedrock's Converse API as toolResult.content[0].json.

The problem: json.loads() succeeds not just for JSON objects, but for any valid JSON value — numbers, booleans, null, strings, and arrays. For example, if a tool's string result is:

"42" → parses to 42 (an int)
"true" → parses to True
"[1, 2, 3]" → parses to a list
"null" → parses to None
...then content becomes [{"json": 42}] or [{"json": [1, 2, 3]}], etc. But Bedrock's toolResult.content[].json field (the Document type) specifically requires a JSON object, not an arbitrary JSON value.

### Proposed Changes:

_format_tool_result_message now only wraps a parsed JSON string as a Bedrock {"json": ...} content block when it's actually a JSON object (dict). If a tool's string result parses to a number, boolean, null, or array, it falls back to a {"text": ...} block — avoiding the ValidationException.

### How did you test it?
- Added two regression tests in test_chat_generator_utils.py covering the JSON-object case (still uses json) and the non-object cases ("42", "true", "null", "[1, 2, 3]" — now fall back to text).
- besides unit tests, I ran into this issue having a tool that returns a list of strings. Tested against this too

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
