### PR TITLE
fix: Azure Document Intelligence - fix default model

### DIFF
--- a/.github/workflows/azure_doc_intelligence.yml
+++ b/.github/workflows/azure_doc_intelligence.yml
@@ -104,7 +104,7 @@ jobs:
         if: matrix.python-version == '3.10' && runner.os == 'Linux'
         env:
           AZURE_DI_ENDPOINT: ${{ secrets.AZURE_DI_ENDPOINT }}
-          AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
+          AZURE_DI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
         run: hatch run test:integration-cov-append-retry
 
       - name: Store combined coverage

--- a/integrations/azure_doc_intelligence/src/haystack_integrations/components/converters/azure_doc_intelligence/converter.py
+++ b/integrations/azure_doc_intelligence/src/haystack_integrations/components/converters/azure_doc_intelligence/converter.py
@@ -65,7 +65,7 @@ class AzureDocumentIntelligenceConverter:
         endpoint: str,
         *,
         api_key: Secret = Secret.from_env_var("AZURE_DI_API_KEY"),
-        model_id: str = "prebuilt-document",
+        model_id: str = "prebuilt-layout",
         store_full_path: bool = False,
     ) -> None:
         """
@@ -79,9 +79,8 @@ class AzureDocumentIntelligenceConverter:
             to load from AZURE_DI_API_KEY environment variable.
         :param model_id:
             Azure model to use for analysis. Options:
-            - "prebuilt-document": General document analysis (default)
+            - "prebuilt-layout": Layout analysis with table and structure detection (default)
             - "prebuilt-read": Fast OCR for text extraction
-            - "prebuilt-layout": Enhanced layout analysis with better table/structure detection
             - Custom model IDs from your Azure resource
         :param store_full_path:
             If True, stores complete file path in metadata.

--- a/integrations/azure_doc_intelligence/tests/test_azure_document_intelligence_converter.py
+++ b/integrations/azure_doc_intelligence/tests/test_azure_document_intelligence_converter.py
@@ -41,7 +41,7 @@ class TestAzureDocumentIntelligenceConverter:
         )
 
         assert converter.endpoint == "https://test.cognitiveservices.azure.com/"
-        assert converter.model_id == "prebuilt-document"
+        assert converter.model_id == "prebuilt-layout"
         assert converter.store_full_path is False
 
     def test_init_custom_params(self):
@@ -49,12 +49,12 @@ class TestAzureDocumentIntelligenceConverter:
         converter = AzureDocumentIntelligenceConverter(
             endpoint="https://test.cognitiveservices.azure.com/",
             api_key=Secret.from_token("test_api_key"),
-            model_id="prebuilt-layout",
+            model_id="prebuilt-read",
             store_full_path=True,
         )
 
         assert converter.endpoint == "https://test.cognitiveservices.azure.com/"
-        assert converter.model_id == "prebuilt-layout"
+        assert converter.model_id == "prebuilt-read"
         assert converter.store_full_path is True
 
     def test_to_dict(self):
@@ -62,7 +62,7 @@ class TestAzureDocumentIntelligenceConverter:
         converter = AzureDocumentIntelligenceConverter(
             endpoint="https://test.cognitiveservices.azure.com/",
             api_key=Secret.from_env_var("AZURE_DI_API_KEY"),
-            model_id="prebuilt-layout",
+            model_id="prebuilt-read",
             store_full_path=True,
         )
 
@@ -77,7 +77,7 @@ class TestAzureDocumentIntelligenceConverter:
             "init_parameters": {
                 "api_key": {"type": "env_var", "env_vars": ["AZURE_DI_API_KEY"], "strict": True},
                 "endpoint": "https://test.cognitiveservices.azure.com/",
-                "model_id": "prebuilt-layout",
+                "model_id": "prebuilt-read",
                 "store_full_path": True,
             },
         }
@@ -92,7 +92,7 @@ class TestAzureDocumentIntelligenceConverter:
         data = converter.to_dict()
 
         assert data["init_parameters"]["endpoint"] == "https://test.cognitiveservices.azure.com/"
-        assert data["init_parameters"]["model_id"] == "prebuilt-document"
+        assert data["init_parameters"]["model_id"] == "prebuilt-layout"
         assert data["init_parameters"]["store_full_path"] is False
 
     def test_from_dict(self):
@@ -106,7 +106,7 @@ class TestAzureDocumentIntelligenceConverter:
             "init_parameters": {
                 "api_key": {"type": "env_var", "env_vars": ["AZURE_DI_API_KEY"], "strict": True},
                 "endpoint": "https://test.cognitiveservices.azure.com/",
-                "model_id": "prebuilt-layout",
+                "model_id": "prebuilt-read",
                 "store_full_path": False,
             },
         }
@@ -114,7 +114,7 @@ class TestAzureDocumentIntelligenceConverter:
         converter = AzureDocumentIntelligenceConverter.from_dict(data)
 
         assert converter.endpoint == "https://test.cognitiveservices.azure.com/"
-        assert converter.model_id == "prebuilt-layout"
+        assert converter.model_id == "prebuilt-read"
         assert converter.store_full_path is False
 
     def test_warm_up_initializes_client_only_once(self):
@@ -158,7 +158,7 @@ class TestAzureDocumentIntelligenceConverter:
         assert len(result["documents"]) == 1
         doc = result["documents"][0]
         assert doc.content == "# Heading\n\nHello"
-        assert doc.meta["model_id"] == "prebuilt-document"
+        assert doc.meta["model_id"] == "prebuilt-layout"
         assert doc.meta["page_count"] == 3
 
     def test_run_returns_raw_azure_response(self, warmed_converter):
@@ -263,7 +263,7 @@ class TestAzureDocumentIntelligenceConverterIntegration:
         assert "documents" in results
         assert len(results["documents"]) == 1
         assert len(results["documents"][0].content) > 0
-        assert results["documents"][0].meta["model_id"] == "prebuilt-document"
+        assert results["documents"][0].meta["model_id"] == "prebuilt-layout"
 
     @pytest.mark.skipif(not os.environ.get("AZURE_DI_ENDPOINT"), reason="Azure endpoint not available")
     @pytest.mark.skipif(not os.environ.get("AZURE_DI_API_KEY"), reason="Azure credentials not available")


### PR DESCRIPTION
### Related Issues
Due to a mismatch in CI environment variable names, the integration tests for this integration have always been skipped. 

Now they fail for a good reason: with `azure-ai-documentintelligence>=1.0.0`, `prebuilt-document` is no longer usable.

I searched a lot to find a good source of info, but this seems reliable: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/documentintelligence/azure-ai-documentintelligence/MIGRATION_GUIDE.md

In other pages I found, the model is just "deprecated" but I have actually verified that with `azure-ai-documentintelligence>=1.0.0`, it's not reachable.

### Proposed Changes:
- change the default model to `prebuilt-layout`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
