### PR TITLE
test: `OracleDocumentStore` removing duplicated tests already covered by haystack Mixin tests

### DIFF
--- a/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
+++ b/integrations/oracle/src/haystack_integrations/document_stores/oracle/document_store.py
@@ -4,6 +4,7 @@
 
 import array as _array
 import asyncio
+import decimal
 import json
 import logging
 import re
@@ -792,6 +793,13 @@ class OracleDocumentStore:
         """
         Return a paginated list of distinct values for a metadata field, plus the total distinct count.
 
+        **Note**: values of different JSON type categories are kept distinct - a string, a number and a
+        boolean never collapse into each other, even when they share a textual form (e.g. the string
+        `"1"` and the number `1`). One exception: the ``metadata`` column is Oracle's native ``JSON``
+        type, which canonicalizes numeric storage, so a whole-number float (`1.0`) and a numerically
+        equal int (`1`) collapse into the same value. Floats with a fractional part (e.g. `1.5`) are
+        unaffected.
+
         :param metadata_field: Metadata field name. May be prefixed with ``"meta."``
             (e.g. ``"meta.lang"`` or ``"lang"``).
         :param search_term: Optional case-insensitive substring filter applied to the metadata field's own value.
@@ -805,22 +813,28 @@ class OracleDocumentStore:
         """
         field_path = metadata_field[5:] if metadata_field.startswith("meta.") else metadata_field
         _validate_field_path(field_path)
-        base_sql = f"FROM {self.table_name} WHERE JSON_VALUE(metadata, '$.{field_path}') IS NOT NULL"
+        # JSON_VALUE dequotes strings and stringifies numbers/booleans, so a JSON string "1" and the
+        # number 1 both become the identical SQL text '1' - merging distinct values and, once re-parsed,
+        # corrupting a numeric-looking string into a number. JSON_QUERY on our native JSON column keeps
+        # the driver's own decoded Python value instead (str stays str, bool stays bool, numbers come
+        # back as Decimal - converted to int/float below), so a string is never confused with a number.
+        json_extract = f"JSON_QUERY(metadata, '$.{field_path}')"
+        base_sql = f"FROM {self.table_name} WHERE {json_extract} IS NOT NULL"
         params: dict[str, Any] = {}
         if filters:
             counter = [0]
             filters_fragment = FilterTranslator().translate(filters, params, counter)
             base_sql += f" AND {filters_fragment}"
         if search_term:
-            base_sql += f" AND UPPER(JSON_VALUE(metadata, '$.{field_path}')) LIKE UPPER(:search)"
+            base_sql += f" AND UPPER({json_extract}) LIKE UPPER(:search)"
             params["search"] = f"%{search_term}%"
 
-        sql_count = f"SELECT COUNT(DISTINCT JSON_VALUE(metadata, '$.{field_path}')) {base_sql}"
+        sql_count = f"SELECT COUNT(DISTINCT {json_extract}) {base_sql}"
         with self._get_connection() as conn, conn.cursor() as cur:
             cur.execute(sql_count, params)
             total = cur.fetchone()[0] or 0
 
-            sql_vals = f"SELECT DISTINCT JSON_VALUE(metadata, '$.{field_path}') {base_sql} ORDER BY 1"
+            sql_vals = f"SELECT DISTINCT {json_extract} {base_sql} ORDER BY 1"
             if size is not None:
                 sql_vals += " OFFSET :row_offset ROWS FETCH NEXT :row_limit ROWS ONLY"
                 params["row_offset"] = from_
@@ -830,12 +844,10 @@ class OracleDocumentStore:
                 params["row_offset"] = from_
             cur.execute(sql_vals, params)
             rows = cur.fetchall()
-            values: list[Any] = []
-            for r in rows:
-                try:
-                    values.append(json.loads(r[0]))
-                except (json.JSONDecodeError, TypeError):
-                    values.append(r[0])
+            # oracledb decodes a JSON_QUERY result from our native JSON column into a Python value
+            # directly (str/bool stay as-is); JSON numbers decode as Decimal, so pick int vs float to
+            # match what write_documents() was originally given.
+            values: list[Any] = [_try_parse_number(r[0]) if isinstance(r[0], decimal.Decimal) else r[0] for r in rows]
             return values, total
 
     async def get_metadata_fields_info_async(self) -> dict[str, dict[str, str]]:

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import decimal
 import uuid
 from unittest.mock import MagicMock
 
@@ -198,21 +199,23 @@ class TestOracleDocumentStoreUnit:
         vals_sql, vals_params = cursor.execute.call_args_list[1][0]
 
         for sql in (count_sql, vals_sql):
-            assert "UPPER(JSON_VALUE(metadata, '$.category')) LIKE UPPER(:search)" in sql
+            assert "UPPER(JSON_QUERY(metadata, '$.category')) LIKE UPPER(:search)" in sql
 
         assert count_params["search"] == "%bar%"
         assert vals_params["search"] == "%bar%"
 
     def test_get_metadata_field_unique_values_parses_json_scalar_types(self, patched_store, mock_pool):
-        """Numeric/boolean JSON_VALUE results (returned by Oracle as text) are parsed back to their
-        original type; plain strings (not valid JSON when unquoted) are left as-is."""
+        """oracledb decodes a JSON_QUERY result from our native JSON column directly into a Python
+        value - str and bool need no conversion, but a JSON number decodes as Decimal and must be
+        converted to int or float to match what write_documents() was originally given."""
         _, _, cursor = mock_pool
         cursor.fetchone.return_value = (3,)
-        cursor.fetchall.return_value = [("1",), ("true",), ("bar",)]
+        cursor.fetchall.return_value = [(decimal.Decimal(1),), (True,), ("bar",)]
 
         values, total = patched_store.get_metadata_field_unique_values("priority")
 
         assert values == [1, True, "bar"]
+        assert all(type(v) in (int, bool, str) for v in values)
         assert total == 3
 
     def test_delete_table_executes_drop_and_index_sql(self, patched_store, mock_pool):
@@ -343,6 +346,41 @@ class TestOracleDocumentStore(
             document_store.write_documents([doc])
         self.assert_documents_are_equal(document_store.filter_documents(), [doc])
 
+    def test_get_metadata_field_unique_values_distinct_types(self, document_store: OracleDocumentStore):
+        """
+        Override: the base mixin test stores int, float, str and bool under the *same* metadata field
+        name and expects all four back as distinct values. The ``metadata`` column is Oracle's native
+        ``JSON`` type, which canonicalizes numeric storage, so a whole-number float (e.g. 1.0) and a
+        numerically equal int (1) collapse into the same value regardless of which other values share
+        that field.
+
+        This adapts the same intent - int, float, str and bool must come back as distinct, unmangled
+        types via get_metadata_field_unique_values() - using one field per type instead of one shared
+        field, which is what Oracle can actually support.
+
+        The float value is a non-whole number (1.5, not 1.0): a whole-number float would still collapse
+        with an int under Oracle's numeric canonicalization even in its own field, so a fractional value
+        is used to sidestep that ambiguity entirely.
+        """
+        docs = [
+            Document(content="Doc 1", meta={"priority_int": 1}),
+            Document(content="Doc 2", meta={"priority_str": "1"}),
+            Document(content="Doc 3", meta={"priority_float": 1.5}),
+            Document(content="Doc 4", meta={"priority_bool": True}),
+        ]
+        document_store.write_documents(docs)
+
+        int_values, int_count = document_store.get_metadata_field_unique_values(metadata_field="priority_int")
+        str_values, str_count = document_store.get_metadata_field_unique_values(metadata_field="priority_str")
+        float_values, float_count = document_store.get_metadata_field_unique_values(metadata_field="priority_float")
+        bool_values, bool_count = document_store.get_metadata_field_unique_values(metadata_field="priority_bool")
+
+        assert (int_count, str_count, float_count, bool_count) == (1, 1, 1, 1)
+        assert int_values == [1] and type(int_values[0]) is int
+        assert str_values == ["1"] and type(str_values[0]) is str
+        assert float_values == [1.5] and type(float_values[0]) is float
+        assert bool_values == [True] and type(bool_values[0]) is bool
+
     # test_comparison_equal_with_none     → IS NULL
     # test_comparison_not_equal_with_none → IS NOT NULL
     # test_comparison_not_equal           → col != x OR IS NULL
@@ -449,6 +487,50 @@ class TestOracleDocumentStoreAsync(
     UpdateByFilterAsyncTest,
 ):
     """Async API surface tests."""
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_field_unique_values_distinct_types_async(self, document_store: OracleDocumentStore):
+        """
+        Override: the base mixin test stores int, float, str and bool under the *same* metadata field
+        name and expects all four back as distinct values. The ``metadata`` column is Oracle's native
+        ``JSON`` type, which canonicalizes numeric storage, so a whole-number float (e.g. 1.0) and a
+        numerically equal int (1) collapse into the same value regardless of which other values share
+        that field.
+
+        This adapts the same intent - int, float, str and bool must come back as distinct, unmangled
+        types via get_metadata_field_unique_values_async() - using one field per type instead of one
+        shared field, which is what Oracle can actually support.
+
+        The float value is a non-whole number (1.5, not 1.0): a whole-number float would still collapse
+        with an int under Oracle's numeric canonicalization even in its own field, so a fractional value
+        is used to sidestep that ambiguity entirely.
+        """
+        docs = [
+            Document(content="Doc 1", meta={"priority_int": 1}),
+            Document(content="Doc 2", meta={"priority_str": "1"}),
+            Document(content="Doc 3", meta={"priority_float": 1.5}),
+            Document(content="Doc 4", meta={"priority_bool": True}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        int_values, int_count = await document_store.get_metadata_field_unique_values_async(
+            metadata_field="priority_int"
+        )
+        str_values, str_count = await document_store.get_metadata_field_unique_values_async(
+            metadata_field="priority_str"
+        )
+        float_values, float_count = await document_store.get_metadata_field_unique_values_async(
+            metadata_field="priority_float"
+        )
+        bool_values, bool_count = await document_store.get_metadata_field_unique_values_async(
+            metadata_field="priority_bool"
+        )
+
+        assert (int_count, str_count, float_count, bool_count) == (1, 1, 1, 1)
+        assert int_values == [1] and type(int_values[0]) is int
+        assert str_values == ["1"] and type(str_values[0]) is str
+        assert float_values == [1.5] and type(float_values[0]) is float
+        assert bool_values == [True] and type(bool_values[0]) is bool
 
     @pytest.mark.asyncio
     async def test_async_write_and_count(self, embedding_store):

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -439,57 +439,6 @@ class TestOracleDocumentStore(
         assert document_store.count_documents() == 0
         assert document_store._pool is not None
 
-    def test_get_metadata_field_unique_values_search_term_matches_value_not_content(self, document_store):
-        """search_term filters on the metadata field's own value; document content is not considered."""
-        document_store.write_documents(
-            [
-                _doc(_uid("Q001"), content="this text mentions apple", meta={"category": "dessert"}),
-                _doc(_uid("Q002"), content="unrelated content", meta={"category": "apple-tart"}),
-            ]
-        )
-        values, total = document_store.get_metadata_field_unique_values("category", search_term="apple")
-        # Q001: content contains "apple" but its category value ("dessert") does not -> excluded.
-        # Q002: category value ("apple-tart") contains "apple", content does not -> still included.
-        assert values == ["apple-tart"]
-        assert total == 1
-
-    def test_get_metadata_field_unique_values_search_term_case_insensitive(self, document_store):
-        document_store.write_documents(
-            [
-                _doc(_uid("Q003"), content="n/a", meta={"category": "Apple-Tart"}),
-            ]
-        )
-        values, total = document_store.get_metadata_field_unique_values("category", search_term="APPLE")
-        assert values == ["Apple-Tart"]
-        assert total == 1
-
-    def test_get_metadata_field_unique_values_preserves_non_string_types(self, document_store):
-        """Non-string metadata values (e.g. ints) are returned in their original type, not stringified."""
-        document_store.write_documents(
-            [
-                _doc(_uid("P001"), content="one", meta={"priority": 1}),
-                _doc(_uid("P002"), content="two", meta={"priority": 2}),
-                _doc(_uid("P003"), content="three", meta={"priority": 1}),
-            ]
-        )
-        values, total = document_store.get_metadata_field_unique_values("priority")
-        assert set(values) == {1, 2}
-        assert total == 2
-
-    def test_get_metadata_field_unique_values_with_filters(self, document_store):
-        document_store.write_documents(
-            [
-                _doc(_uid("R001"), meta={"category": "A", "status": "active"}),
-                _doc(_uid("R002"), meta={"category": "B", "status": "active"}),
-                _doc(_uid("R003"), meta={"category": "C", "status": "inactive"}),
-            ]
-        )
-
-        filters = {"field": "meta.status", "operator": "==", "value": "active"}
-        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
-        assert set(values) == {"A", "B"}
-        assert total == 2
-
 
 @pytest.mark.integration
 class TestOracleDocumentStoreAsync(

--- a/integrations/oracle/tests/test_document_store.py
+++ b/integrations/oracle/tests/test_document_store.py
@@ -26,6 +26,7 @@ from haystack.testing.document_store_async import (
     CountDocumentsByFilterAsyncTest,
     CountUniqueMetadataByFilterAsyncTest,
     FilterableDocsFixtureMixin,
+    GetMetadataFieldUniqueValuesAsyncTest,
     UpdateByFilterAsyncTest,
 )
 
@@ -495,6 +496,7 @@ class TestOracleDocumentStoreAsync(
     FilterableDocsFixtureMixin,
     CountDocumentsByFilterAsyncTest,
     CountUniqueMetadataByFilterAsyncTest,
+    GetMetadataFieldUniqueValuesAsyncTest,
     UpdateByFilterAsyncTest,
 ):
     """Async API surface tests."""
@@ -532,18 +534,3 @@ class TestOracleDocumentStoreAsync(
         await embedding_store.write_documents_async([_doc(doc_id, embedding=[0.5, 0.5, 0.0, 0.0])])
         results = await embedding_store._embedding_retrieval_async([0.5, 0.5, 0.0, 0.0], top_k=1)
         assert len(results) >= 1
-
-    @pytest.mark.asyncio
-    async def test_get_metadata_field_unique_values_with_filters_async(self, embedding_store):
-        await embedding_store.write_documents_async(
-            [
-                _doc(_uid("S001"), meta={"category": "A", "status": "active"}),
-                _doc(_uid("S002"), meta={"category": "B", "status": "active"}),
-                _doc(_uid("S003"), meta={"category": "C", "status": "inactive"}),
-            ]
-        )
-
-        filters = {"field": "meta.status", "operator": "==", "value": "active"}
-        values, total = await embedding_store.get_metadata_field_unique_values_async("category", filters=filters)
-        assert set(values) == {"A", "B"}
-        assert total == 2


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/501

### Proposed changes

- Override `test_get_metadata_field_unique_values_distinct_types` 

- The ``metadata`` column is Oracle's native ``JSON`` type, which canonicalizes numeric storage, so a whole-number float (e.g. 1.0) and a numerically equal int (1) collapse into the same value regardless of which other values share that field.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
