### PR TITLE
fix(oauth): rebuild the OAuthRefreshTokenSource refresh lock per event loop

### DIFF
--- a/integrations/oauth/src/haystack_integrations/utils/oauth/sources.py
+++ b/integrations/oauth/src/haystack_integrations/utils/oauth/sources.py
@@ -121,7 +121,10 @@ class OAuthRefreshTokenSource:
 
         # Runtime state — never serialized.
         self._sync_lock = Lock()
+        # `_async_lock_guard` only guards the creation of `_async_lock`; see `_get_async_lock`.
+        self._async_lock_guard = Lock()
         self._async_lock: asyncio.Lock | None = None
+        self._async_lock_loop: asyncio.AbstractEventLoop | None = None
         self._cached_token: str | None = None
         self._expires_at: float = 0.0
         self._current_refresh_token: str | None = None
@@ -178,13 +181,29 @@ class OAuthRefreshTokenSource:
             )
             return self._handle_response(response)
 
+    def _get_async_lock(self) -> asyncio.Lock:
+        """
+        Return the refresh lock for the running event loop, building it if there isn't one yet.
+
+        The lock cannot be created in `__init__`, which is synchronous and may run with no loop. It also cannot be
+        created once and kept for the lifetime of the source: an `asyncio.Lock` binds itself to the loop that first
+        awaits it under contention, and raises `RuntimeError` when awaited from any other one. A source routinely
+        outlives the loop that first used it — one `asyncio.run` per request is a common deployment — so the lock is
+        rebuilt whenever the running loop changes.
+
+        `_async_lock_guard` is held for the check and the assignment only, never across an await, so that two threads
+        driving separate event loops cannot each install a lock and lose mutual exclusion between them.
+        """
+        loop = asyncio.get_running_loop()
+        with self._async_lock_guard:
+            if self._async_lock is None or self._async_lock_loop is not loop:
+                self._async_lock = asyncio.Lock()
+                self._async_lock_loop = loop
+            return self._async_lock
+
     async def resolve_async(self) -> str:
         """Asynchronous counterpart of `resolve`. Use a single instance in either sync or async mode, not both."""
-        # Create the asyncio.Lock lazily (not in __init__): it must bind to the running event loop, but __init__
-        # is sync and may run without one.
-        if self._async_lock is None:
-            self._async_lock = asyncio.Lock()
-        async with self._async_lock:
+        async with self._get_async_lock():
             cached = self._cached_if_valid()
             if cached is not None:
                 return cached

--- a/integrations/oauth/tests/test_sources.py
+++ b/integrations/oauth/tests/test_sources.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from unittest.mock import patch
 
 import httpx
@@ -147,6 +148,45 @@ class TestOAuthRefreshTokenSource:
             await source.resolve_async()
         assert token == "acc-async"
         assert mp.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_resolve_async_refreshes_once(self):
+        """The refresh lock exists to collapse a burst of concurrent callers into a single network refresh."""
+        source = self._source()
+        with patch("httpx.AsyncClient.post", side_effect=self._slow_post("acc-async")) as mp:
+            tokens = await asyncio.gather(*(source.resolve_async() for _ in range(4)))
+        assert tokens == ["acc-async"] * 4
+        assert mp.call_count == 1
+
+    def test_resolve_async_works_in_a_second_event_loop(self):
+        """
+        A source outlives the loop that first used it: one `asyncio.run` per request is a common deployment.
+
+        An `asyncio.Lock` binds to the loop that first awaits it *under contention* and rejects every other one, so
+        a lock built once and cached on the instance made the second loop's first contended refresh raise
+        `RuntimeError: ... is bound to a different event loop`. Both halves of this test must contend for the lock,
+        otherwise the lock is never bound and the bug does not reproduce.
+        """
+        source = self._source()
+
+        async def two_concurrent_callers() -> list[str]:
+            # expires_in=0 keeps the cache from serving the second round, so both rounds really refresh.
+            with patch("httpx.AsyncClient.post", side_effect=self._slow_post("acc-async", expires_in=0)):
+                return list(await asyncio.gather(source.resolve_async(), source.resolve_async()))
+
+        assert asyncio.run(two_concurrent_callers()) == ["acc-async"] * 2
+        # Same source, brand new event loop.
+        assert asyncio.run(two_concurrent_callers()) == ["acc-async"] * 2
+
+    @staticmethod
+    def _slow_post(access_token: str, expires_in: int = 3600):
+        """A patched `post` that yields to the loop, so a second caller reaches the lock while the first holds it."""
+
+        async def _post(*_args, **_kwargs):
+            await asyncio.sleep(0)
+            return _json(access_token=access_token, expires_in=expires_in)
+
+        return _post
 
 
 class TestOAuthTokenExchangeSource:


### PR DESCRIPTION
### Related Issues

- fixes #3789

### Proposed Changes:

`OAuthRefreshTokenSource.resolve_async` built its `asyncio.Lock` lazily and then kept it for the lifetime of the source. An `asyncio.Lock` binds to the loop that first awaits it under contention and raises `RuntimeError` when awaited from another one, so a source reused across event loops — one `asyncio.run` per request is a common deployment — failed on the second loop's first contended refresh:

```text
RuntimeError: <asyncio.locks.Lock object> is bound to a different event loop
```

Contention is not an edge case here: collapsing a burst of concurrent callers into a single network refresh is the only reason the lock exists.

`_get_async_lock` now returns the lock for the running loop and rebuilds it when the loop changes. A dedicated `_async_lock_guard` (a `threading.Lock`) covers the check and the assignment, never an await, so two threads driving separate loops cannot each install a lock and lose mutual exclusion between them.

`_sync_lock` was deliberately not reused for that guard: `resolve` holds it across a blocking network call, so an async caller waiting on it would stall its own event loop for the duration of a token refresh.

`OAuthTokenExchangeSource` needed no change — it holds a `threading.Lock` only around cache access and never across the network call, as its own comment says.

### How did you test it?

Two tests added to `TestOAuthRefreshTokenSource`:

- `test_resolve_async_works_in_a_second_event_loop` is the regression pin: it drives two concurrent callers under `asyncio.run`, then does it again on a fresh loop with the same source.
- `test_concurrent_resolve_async_refreshes_once` pins the property the lock exists for — four concurrent callers, one network refresh. It passes before and after; it is there so a future change to the locking cannot quietly drop the coalescing.

I checked the regression test is not vacuous: with `sources.py` reverted to `main` it fails with the `RuntimeError` above, raised from `asyncio/mixins.py:20` — the bug itself, not an incidental assertion mismatch. The standalone reproduction in #3789 was run both ways too (fails on `main`, passes on this branch).

Both halves of the test have to contend for the lock or it proves nothing: an uncontended `Lock.acquire()` returns before it ever calls `_get_loop()`, so the loop is never bound. That is exactly why the existing `test_resolve_async_success_and_caches` did not catch this, and the `_slow_post` helper exists to force the overlap.

`hatch run test:unit tests/test_sources.py` → 33 passed. `hatch run test:types` and `hatch run fmt-check .` clean.

### Notes for the reviewer

Two judgement calls worth a look:

1. **Rebuilding on loop change rather than keeping a lock per loop.** If two event loops in two threads use the same source *simultaneously*, each one rebuilds the lock and mutual exclusion between them is lost. A `WeakKeyDictionary` keyed by loop would hold in that case too. I did not do it because the class is documented as single-identity and "use a single instance in either sync or async mode, not both", so the realistic pattern is sequential loops, not simultaneous ones — but say the word and I will switch it.

2. **The extra `threading.Lock`.** It is one more attribute on a class that already has one lock. Without it, the check-and-set is not atomic across threads. Happy to drop it if you consider cross-thread use out of scope.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
