### PR TITLE
fix!: standardize generation_kwargs handling in GoogleGenAIChatGenerator

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -396,8 +396,10 @@ class GoogleGenAIChatGenerator:
 
         :param messages: A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
-        :param generation_kwargs: Configuration for generation. If provided, it will override
-        the default config. Supports `thinking_budget` for Gemini 2.5 series thinking configuration.
+        :param generation_kwargs: Configuration for generation. These are merged per key with the
+        `generation_kwargs` passed during component initialization: keys provided here take precedence,
+        keys set only at initialization are kept. Supports `thinking_budget` for Gemini 2.5 series
+        thinking configuration.
         :param safety_settings: Safety settings for content filtering. If provided, it will override the
         default settings.
         :param streaming_callback: A callback function that is called when a new token is
@@ -412,8 +414,8 @@ class GoogleGenAIChatGenerator:
         ToolCallResult or if the role in ChatMessage is different from User, System, Assistant.
         """
         messages = _normalize_messages(messages)
-        # Use provided configs or fall back to instance defaults
-        generation_kwargs = generation_kwargs or self._generation_kwargs
+        # Merge generation_kwargs with instance defaults; other configs fall back to instance defaults
+        generation_kwargs = {**self._generation_kwargs, **(generation_kwargs or {})}
         safety_settings = safety_settings or self._safety_settings
         tools = tools or self._tools
 
@@ -508,8 +510,10 @@ class GoogleGenAIChatGenerator:
 
         :param messages: A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
-        :param generation_kwargs: Configuration for generation. If provided, it will override
-        the default config. Supports `thinking_budget` for Gemini 2.5 series thinking configuration.
+        :param generation_kwargs: Configuration for generation. These are merged per key with the
+        `generation_kwargs` passed during component initialization: keys provided here take precedence,
+        keys set only at initialization are kept. Supports `thinking_budget` for Gemini 2.5 series
+        thinking configuration.
         See https://ai.google.dev/gemini-api/docs/thinking for possible values.
         :param safety_settings: Safety settings for content filtering. If provided, it will override the
         default settings.
@@ -525,8 +529,8 @@ class GoogleGenAIChatGenerator:
         ToolCallResult or if the role in ChatMessage is different from User, System, Assistant.
         """
         messages = _normalize_messages(messages)
-        # Use provided configs or fall back to instance defaults
-        generation_kwargs = generation_kwargs or self._generation_kwargs
+        # Merge generation_kwargs with instance defaults; other configs fall back to instance defaults
+        generation_kwargs = {**self._generation_kwargs, **(generation_kwargs or {})}
         safety_settings = safety_settings or self._safety_settings
         tools = tools or self._tools
 

--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -378,9 +378,9 @@ class TestGoogleGenAIChatGeneratorRun:
         assert len(config.safety_settings) == 1
         assert config.safety_settings[0].category == "HARM_CATEGORY_HARASSMENT"
 
-    def test_run_with_generation_kwargs_override(self, monkeypatch, mock_response):
+    def test_run_with_generation_kwargs(self, monkeypatch, mock_response):
         monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
-        component = GoogleGenAIChatGenerator(generation_kwargs={"temperature": 0.5})
+        component = GoogleGenAIChatGenerator(generation_kwargs={"temperature": 0.5, "max_output_tokens": 100})
         component._client.models.generate_content = Mock(return_value=mock_response)
 
         component.run([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
@@ -388,6 +388,7 @@ class TestGoogleGenAIChatGeneratorRun:
         call_kwargs = component._client.models.generate_content.call_args
         config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
         assert config.temperature == 0.9
+        assert config.max_output_tokens == 100
 
     def test_run_thinking_error_raises_helpful_message(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
@@ -474,6 +475,19 @@ class TestGoogleGenAIChatGeneratorRun:
         assert isinstance(result["replies"], list)
         assert len(result["replies"]) == 1
         assert isinstance(result["replies"][0], ChatMessage)
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(self, monkeypatch, mock_response):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        component = GoogleGenAIChatGenerator(generation_kwargs={"temperature": 0.5, "max_output_tokens": 100})
+        component._client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+
+        await component.run_async([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        call_kwargs = component._client.aio.models.generate_content.call_args
+        config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+        assert config.temperature == 0.9
+        assert config.max_output_tokens == 100
 
     @pytest.mark.asyncio
     async def test_run_async_streaming(self, monkeypatch, mock_streaming_chunk):


### PR DESCRIPTION
### Related Issues

I realized that `GoogleGenAIChatGenerator` is the only Chat Generators that uses `generation_kwargs` passed at `run` to completely override those passed at init. All the other Chat Generators do this:
- at init: `generation_kwargs= {"max_completion_tokens": 10, "temperature": 0.5}`
- at run: `generation_kwargs={"temperature":0.9}`
- result: `generation_kwargs= {"max_completion_tokens": 10, "temperature": 0.9}`

### Proposed Changes:
- make `GoogleGenAIChatGenerator` behave consistently with other Chat Generators

### How did you test it?
CI, new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
