### PR TITLE
chore: clarify how generation_kwargs passed in run are handled

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -572,7 +572,9 @@ class AmazonBedrockChatGenerator:
         :param messages: A list of `ChatMessage` objects forming the chat history.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: Optional callback for handling streaming outputs.
-        :param generation_kwargs: Optional dictionary of generation parameters. Some common parameters are:
+        :param generation_kwargs: Optional dictionary of generation parameters. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only at
+            initialization are kept. Some common parameters are:
             - `maxTokens`: Maximum number of tokens to generate.
             - `stopSequences`: List of stop sequences to stop generation.
             - `temperature`: Sampling temperature.
@@ -636,7 +638,9 @@ class AmazonBedrockChatGenerator:
         :param messages: A list of `ChatMessage` objects forming the chat history.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: Optional async-compatible callback for handling streaming outputs.
-        :param generation_kwargs: Optional dictionary of generation parameters. Some common parameters are:
+        :param generation_kwargs: Optional dictionary of generation parameters. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only at
+            initialization are kept. Some common parameters are:
             - `maxTokens`: Maximum number of tokens to generate.
             - `stopSequences`: List of stop sequences to stop generation.
             - `temperature`: Sampling temperature.

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -824,6 +824,23 @@ class TestAmazonBedrockChatGenerator:
         assert len(result["replies"]) == 1
         assert result["replies"][0].text == "Paris"
 
+    def test_run_with_generation_kwargs(self, mock_boto3_session, set_env_variables):
+        generator = AmazonBedrockChatGenerator(
+            model="global.anthropic.claude-sonnet-4-6",
+            generation_kwargs={"maxTokens": 100, "temperature": 0.5},
+        )
+        generator.client = MagicMock()
+        generator.client.converse.return_value = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Paris"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5},
+            "metrics": {"latencyMs": 100},
+        }
+        generator.run([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = generator.client.converse.call_args
+        assert kwargs["inferenceConfig"] == {"maxTokens": 100, "temperature": 0.9}
+
     def test_run_client_error(self, mock_boto3_session, set_env_variables):
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")
         generator.client = MagicMock()
@@ -878,6 +895,33 @@ class TestAmazonBedrockChatGenerator:
         result = await generator.run_async([ChatMessage.from_user("What's the capital of France?")])
         assert len(result["replies"]) == 1
         assert result["replies"][0].text == "Paris"
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(self, mock_boto3_session, set_env_variables):
+        generator = AmazonBedrockChatGenerator(
+            model="global.anthropic.claude-sonnet-4-6",
+            generation_kwargs={"maxTokens": 100, "temperature": 0.5},
+        )
+        mock_async_client = AsyncMock()
+        mock_async_client.converse.return_value = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Paris"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5},
+            "metrics": {"latencyMs": 100},
+        }
+
+        mock_session = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_session.create_client.return_value = mock_cm
+
+        generator.async_session = mock_session
+
+        await generator.run_async([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_async_client.converse.call_args
+        assert kwargs["inferenceConfig"] == {"maxTokens": 100, "temperature": 0.9}
 
     def test_run_with_string_input(self, mock_boto3_session, set_env_variables):
         generator = AmazonBedrockChatGenerator(model="global.anthropic.claude-sonnet-4-6")

--- a/integrations/amazon_sagemaker/src/haystack_integrations/components/generators/amazon_sagemaker/sagemaker.py
+++ b/integrations/amazon_sagemaker/src/haystack_integrations/components/generators/amazon_sagemaker/sagemaker.py
@@ -199,8 +199,9 @@ class SagemakerGenerator:
         Invoke the text generation inference based on the provided prompt and generation parameters.
 
         :param prompt: The string prompt to use for text generation.
-        :param generation_kwargs: Additional keyword arguments for text generation. These parameters will
-            potentially override the parameters passed in the `__init__` method.
+        :param generation_kwargs: Additional keyword arguments for text generation.
+            These are merged per key with the `generation_kwargs` passed at initialization: keys provided here
+            take precedence, keys set only at initialization are kept.
         :raises ValueError: If the model response type is not a list of dictionaries or a single dictionary.
         :raises SagemakerNotReadyError: If the SageMaker model is not ready to accept requests.
         :raises SagemakerInferenceError: If the SageMaker Inference returns an error.
@@ -208,7 +209,7 @@ class SagemakerGenerator:
             - `replies`: A list of strings containing the generated responses
             - `meta`: A list of dictionaries containing the metadata for each response.
         """
-        generation_kwargs = generation_kwargs or self.generation_kwargs
+        generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
         custom_attributes = ";".join(
             f"{k}={str(v).lower() if isinstance(v, bool) else str(v)}" for k, v in self.aws_custom_attributes.items()
         )

--- a/integrations/amazon_sagemaker/tests/test_sagemaker.py
+++ b/integrations/amazon_sagemaker/tests/test_sagemaker.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from unittest.mock import Mock
@@ -192,6 +193,20 @@ def test_run_raises_inference_error_on_other_http_error(set_env_variables, mock_
         ),
     ):
         component.run("What's Natural Language Processing?")
+
+
+def test_run_with_generation_kwargs(set_env_variables, mock_boto3_session):  # noqa: ARG001
+    client_mock = Mock()
+    client_mock.invoke_endpoint.return_value = {"Body": Mock(read=lambda: b'{"generated_text": "ok"}')}
+    component = SagemakerGenerator(
+        model="test-model",
+        generation_kwargs={"max_new_tokens": 100, "temperature": 0.5},
+    )
+    component.client = client_mock
+    component.run("prompt", generation_kwargs={"temperature": 0.9})
+
+    body = json.loads(client_mock.invoke_endpoint.call_args.kwargs["Body"])
+    assert body["parameters"] == {"max_new_tokens": 100, "temperature": 0.9}
 
 
 def test_run_passes_custom_attributes_and_generation_kwargs(set_env_variables, mock_boto3_session):  # noqa: ARG001

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -533,7 +533,9 @@ class AnthropicChatGenerator:
         :param messages: A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint. These are merged
+        per key with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+        only at initialization are kept.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
         Each tool should have a unique name. If set, it will override the `tools` parameter set during component
         initialization.
@@ -577,7 +579,9 @@ class AnthropicChatGenerator:
         :param messages: A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint. These are merged
+        per key with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+        only at initialization are kept.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
         Each tool should have a unique name. If set, it will override the `tools` parameter set during component
         initialization.

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -229,7 +229,9 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         :param messages: A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint. These are merged
+            per key with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys
+            set only at initialization are kept.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
             Each tool should have a unique name. If set, it will override the `tools` parameter set during component
             initialization.
@@ -257,7 +259,9 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
         :param messages: A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint.
+        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint. These are merged
+            per key with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys
+            set only at initialization are kept.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
             Each tool should have a unique name. If set, it will override the `tools` parameter set during component
             initialization.

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -358,6 +358,16 @@ class TestRun:
         assert response["replies"][0].meta["model"] == "claude-sonnet-4-5"
         assert response["replies"][0].meta["finish_reason"] == "stop"
 
+    def test_run_with_generation_kwargs(self, chat_messages, mock_chat_completion):
+        component = AnthropicChatGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
+        )
+        component.run(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.9
+
     @pytest.mark.parametrize(
         "generation_kwargs,expected_kwargs",
         [

--- a/integrations/anthropic/tests/test_chat_generator_async.py
+++ b/integrations/anthropic/tests/test_chat_generator_async.py
@@ -77,6 +77,16 @@ class TestUnit:
         assert response["replies"][0].meta["finish_reason"] == "stop"
         assert "completion_tokens" in response["replies"][0].meta["usage"]
 
+    async def test_run_async_with_generation_kwargs(self, chat_messages, mock_anthropic_completion_async):
+        component = AnthropicChatGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
+        )
+        await component.run_async(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_anthropic_completion_async.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.9
+
 
 @pytest.mark.integration
 @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set")

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -652,8 +652,9 @@ class CohereChatGenerator:
 
         :param messages: list of `ChatMessage` instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
-        :param generation_kwargs: additional keyword arguments for chat generation. These parameters will
-            potentially override the parameters passed in the __init__ method.
+        :param generation_kwargs: additional keyword arguments for chat generation. These are merged per key
+            with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+            only at initialization are kept.
             For more details on the parameters supported by the Cohere API, refer to the
             Cohere [documentation](https://docs.cohere.com/reference/chat).
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
@@ -720,8 +721,9 @@ class CohereChatGenerator:
 
         :param messages: list of `ChatMessage` instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
-        :param generation_kwargs: additional keyword arguments for chat generation. These parameters will
-            potentially override the parameters passed in the __init__ method.
+        :param generation_kwargs: additional keyword arguments for chat generation. These are merged per key
+            with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+            only at initialization are kept.
             For more details on the parameters supported by the Cohere API, refer to the
             Cohere [documentation](https://docs.cohere.com/reference/chat).
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.

--- a/integrations/cohere/tests/test_chat_generator.py
+++ b/integrations/cohere/tests/test_chat_generator.py
@@ -546,6 +546,51 @@ class TestCohereChatGenerator:
         assert len(result["replies"]) == 1
         assert isinstance(result["replies"][0], ChatMessage)
 
+    def test_run_with_generation_kwargs(self):
+        generator = CohereChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            generation_kwargs={"max_tokens": 100, "temperature": 0.5},
+        )
+
+        mock_response = MagicMock()
+        mock_response.message.content = [MagicMock()]
+        mock_response.message.content[0].text = "Paris"
+        mock_response.message.content[0].type = "text"
+        mock_response.message.tool_calls = None
+        mock_response.finish_reason = "COMPLETE"
+        mock_response.usage = None
+
+        generator.client.chat = MagicMock(return_value=mock_response)
+
+        generator.run([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = generator.client.chat.call_args
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["temperature"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(self):
+        generator = CohereChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            generation_kwargs={"max_tokens": 100, "temperature": 0.5},
+        )
+
+        mock_response = MagicMock()
+        mock_response.message.content = [MagicMock()]
+        mock_response.message.content[0].text = "Paris"
+        mock_response.message.content[0].type = "text"
+        mock_response.message.tool_calls = None
+        mock_response.finish_reason = "COMPLETE"
+        mock_response.usage = None
+
+        generator.async_client.chat = AsyncMock(return_value=mock_response)
+
+        await generator.run_async([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = generator.async_client.chat.call_args
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["temperature"] == 0.9
+
 
 @pytest.mark.skipif(
     not os.environ.get("COHERE_API_KEY", None) and not os.environ.get("CO_API_KEY", None),

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -25,10 +25,8 @@ classifiers = [
 dependencies = [
     "haystack-ai>=2.22.0",
     "dspy>=3.1.3",
-    # litellm 1.83.8+ ships a Rust extension with no cp314 wheels and caps requires-python at
-    # <3.14, so on Python 3.14 pin to the last pure-Python release. Other versions stay unpinned.
-    "litellm!=1.82.7,!=1.82.8; python_version < '3.14'",
-    "litellm!=1.82.7,!=1.82.8,<1.83.8; python_version >= '3.14'",
+    # https://github.com/BerriAI/litellm/issues/36384
+    "litellm<1.97.0",
 ]
 
 [project.urls]

--- a/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
+++ b/integrations/dspy/src/haystack_integrations/components/generators/dspy/chat/chat_generator.py
@@ -270,7 +270,9 @@ class DSPySignatureChatGenerator:
         Run the DSPy module on the given messages.
 
         :param messages: List of chat messages. The last user message is used as input.
-        :param generation_kwargs: Optional runtime generation parameters.
+        :param generation_kwargs: Optional runtime generation parameters. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only at
+            initialization are kept.
         :param kwargs: Additional keyword arguments mapped to signature input fields.
         :returns: A dictionary with `replies` (list of ChatMessage).
         """
@@ -305,7 +307,9 @@ class DSPySignatureChatGenerator:
         Uses DSPy's native `acall` for true async I/O.
 
         :param messages: List of chat messages. The last user message is used as input.
-        :param generation_kwargs: Optional runtime generation parameters.
+        :param generation_kwargs: Optional runtime generation parameters. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only at
+            initialization are kept.
         :param kwargs: Additional keyword arguments mapped to signature input fields.
         :returns: A dictionary with `replies` (list of ChatMessage).
         """

--- a/integrations/dspy/tests/test_chat_generator.py
+++ b/integrations/dspy/tests/test_chat_generator.py
@@ -49,6 +49,7 @@ def mock_dspy_module():
 
         mock_module = MagicMock()
         mock_module.return_value = MagicMock(answer="Hello world!")
+        mock_module.lm_class = mock_lm_class
         mock_cot_class.return_value = mock_module
         mock_predict_class.return_value = mock_module
         mock_react_class.return_value = mock_module
@@ -395,6 +396,10 @@ class TestDSPySignatureChatGenerator:
             generation_kwargs={"max_tokens": 10, "temperature": 0.5},
         )
         response = component.run(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        lm_kwargs = mock_dspy_module.lm_class.call_args.kwargs
+        assert lm_kwargs["max_tokens"] == 10
+        assert lm_kwargs["temperature"] == 0.5
 
         _, kwargs = mock_dspy_module.call_args
         assert kwargs["config"] == {"temperature": 0.9}

--- a/integrations/dspy/tests/test_chat_generator_async.py
+++ b/integrations/dspy/tests/test_chat_generator_async.py
@@ -27,6 +27,7 @@ def mock_dspy_module():
         mock_module = MagicMock()
         mock_module.return_value = MagicMock(answer="Hello world!")
         mock_module.acall = AsyncMock(return_value=MagicMock(answer="Hello world!"))
+        mock_module.lm_class = mock_lm_class
 
         mock_cot_class.return_value = mock_module
         mock_predict_class.return_value = mock_module
@@ -71,14 +72,19 @@ class TestDSPySignatureChatGeneratorAsync:
         assert kwargs["config"] == {}
 
     @pytest.mark.asyncio
-    async def test_run_async_with_params(self, chat_messages, mock_dspy_module):
+    async def test_run_async_with_generation_kwargs(self, chat_messages, mock_dspy_module):
         component = DSPySignatureChatGenerator(
             signature="question -> answer",
+            generation_kwargs={"max_tokens": 10, "temperature": 0.5},
         )
         response = await component.run_async(
             messages=chat_messages,
             generation_kwargs={"temperature": 0.9},
         )
+
+        lm_kwargs = mock_dspy_module.lm_class.call_args.kwargs
+        assert lm_kwargs["max_tokens"] == 10
+        assert lm_kwargs["temperature"] == 0.5
 
         _, kwargs = mock_dspy_module.acall.call_args
         assert kwargs["config"] == {"temperature": 0.9}

--- a/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
@@ -505,7 +505,9 @@ class HuggingFaceAPIChatGenerator:
             A list of ChatMessage objects representing the input messages. If a string is provided, it is converted
             to a list containing a ChatMessage with user role.
         :param generation_kwargs:
-            Additional keyword arguments for text generation.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param tools:
             A list of tools or a Toolset for which the model can prepare calls. If set, it will override
             the `tools` parameter set during component initialization. This parameter can accept either a
@@ -565,7 +567,9 @@ class HuggingFaceAPIChatGenerator:
             A list of ChatMessage objects representing the input messages. If a string is provided, it is converted
             to a list containing a ChatMessage with user role.
         :param generation_kwargs:
-            Additional keyword arguments for text generation.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param tools:
             A list of tools or a Toolset for which the model can prepare calls. If set, it will override the `tools`
             parameter set during component initialization. This parameter can accept either a list of `Tool` objects

--- a/integrations/huggingface_api/tests/test_chat_generator.py
+++ b/integrations/huggingface_api/tests/test_chat_generator.py
@@ -374,6 +374,19 @@ class TestHuggingFaceAPIChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    def test_run_with_generation_kwargs(self, mock_check_valid_model, mock_chat_completion, chat_messages):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "meta-llama/Llama-2-13b-chat-hf"},
+            generation_kwargs={"max_tokens": 100, "temperature": 0.5},
+        )
+
+        generator.run(messages=chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["temperature"] == 0.9
+
     def test_run_with_string_input(self, mock_check_valid_model, mock_chat_completion):
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
@@ -913,6 +926,22 @@ class TestHuggingFaceAPIChatGenerator:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(
+        self, mock_check_valid_model, mock_chat_completion_async, chat_messages
+    ):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "meta-llama/Llama-2-13b-chat-hf"},
+            generation_kwargs={"max_tokens": 100, "temperature": 0.5},
+        )
+
+        await generator.run_async(messages=chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_chat_completion_async.call_args
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["temperature"] == 0.9
 
     @pytest.mark.asyncio
     async def test_run_async_with_string_input(self, mock_check_valid_model, mock_chat_completion_async):

--- a/integrations/litellm/src/haystack_integrations/components/generators/litellm/chat/chat_generator.py
+++ b/integrations/litellm/src/haystack_integrations/components/generators/litellm/chat/chat_generator.py
@@ -149,7 +149,9 @@ class LiteLLMChatGenerator:
         :param messages: Input messages as ChatMessage instances.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: Override the streaming callback for this call.
-        :param generation_kwargs: Override generation parameters for this call.
+        :param generation_kwargs: Additional parameters for this call. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param tools: Override tools for this call.
         :returns: A dict with key ``replies`` containing ChatMessage instances.
         """
@@ -186,7 +188,9 @@ class LiteLLMChatGenerator:
         :param messages: Input messages as ChatMessage instances.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param streaming_callback: Override the streaming callback for this call.
-        :param generation_kwargs: Override generation parameters for this call.
+        :param generation_kwargs: Additional parameters for this call. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param tools: Override tools for this call.
         :returns: A dict with key ``replies`` containing ChatMessage instances.
         """

--- a/integrations/litellm/tests/test_litellm_chat_generator.py
+++ b/integrations/litellm/tests/test_litellm_chat_generator.py
@@ -201,18 +201,20 @@ class TestRun:
             call_kwargs = fake_litellm.completion.call_args
             assert call_kwargs.kwargs["api_base"] == "https://proxy.local"
 
-    def test_generation_kwargs_merged(self):
-        gen = LiteLLMChatGenerator(model="openai/gpt-4o", generation_kwargs={"temperature": 0.5})
+    def test_run_with_generation_kwargs(self):
+        gen = LiteLLMChatGenerator(
+            model="openai/gpt-4o", generation_kwargs={"temperature": 0.5, "max_completion_tokens": 100}
+        )
         mock_resp = _make_mock_response()
 
         fake_litellm = types.ModuleType("litellm")
         fake_litellm.completion = MagicMock(return_value=mock_resp)
 
         with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
-            gen.run(messages=[ChatMessage.from_user("hi")], generation_kwargs={"max_tokens": 100})
+            gen.run(messages=[ChatMessage.from_user("hi")], generation_kwargs={"temperature": 0.9})
             call_kwargs = fake_litellm.completion.call_args
-            assert call_kwargs.kwargs["temperature"] == 0.5
-            assert call_kwargs.kwargs["max_tokens"] == 100
+            assert call_kwargs.kwargs["temperature"] == 0.9
+            assert call_kwargs.kwargs["max_completion_tokens"] == 100
 
     def test_empty_messages_returns_empty(self):
         gen = LiteLLMChatGenerator()
@@ -462,6 +464,27 @@ class TestAsync:
             assert isinstance(result["replies"], list)
             assert len(result["replies"]) == 1
             assert isinstance(result["replies"][0], ChatMessage)
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(self):
+        gen = LiteLLMChatGenerator(
+            model="openai/gpt-4o", generation_kwargs={"temperature": 0.5, "max_completion_tokens": 100}
+        )
+        mock_resp = _make_mock_response()
+
+        fake_litellm = types.ModuleType("litellm")
+        captured_kwargs = {}
+
+        async def _acompletion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_resp
+
+        fake_litellm.acompletion = _acompletion
+
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            await gen.run_async(messages=[ChatMessage.from_user("hi")], generation_kwargs={"temperature": 0.9})
+            assert captured_kwargs["temperature"] == 0.9
+            assert captured_kwargs["max_completion_tokens"] == 100
 
     @pytest.mark.asyncio
     async def test_run_async_empty_messages(self):

--- a/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
+++ b/integrations/llama_cpp/src/haystack_integrations/components/generators/llama_cpp/chat/chat_generator.py
@@ -350,6 +350,8 @@ class LlamaCppChatGenerator:
             A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs:  A dictionary containing keyword arguments to customize text generation.
+            These are merged per key with the `generation_kwargs` passed at initialization: keys provided here
+            take precedence, keys set only at initialization are kept.
             For more information on the available kwargs, see
             [llama.cpp documentation](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.create_chat_completion).
         :param tools:
@@ -441,6 +443,8 @@ class LlamaCppChatGenerator:
             A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs:  A dictionary containing keyword arguments to customize text generation.
+            These are merged per key with the `generation_kwargs` passed at initialization: keys provided here
+            take precedence, keys set only at initialization are kept.
             For more information on the available kwargs, see
             [llama.cpp documentation](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.create_chat_completion).
         :param tools:

--- a/integrations/llama_cpp/tests/test_chat_generator.py
+++ b/integrations/llama_cpp/tests/test_chat_generator.py
@@ -963,11 +963,12 @@ class TestLlamaCppChatGenerator:
         assert result["replies"][0].text == "Generated text"
         assert result["replies"][0].role == ChatRole.ASSISTANT
 
-    def test_run_with_generation_kwargs(self, generator_mock):
-        """
-        Test that a valid message and generation kwargs returns a list of replies.
-        """
-        generator, mock_model = generator_mock
+    def test_run_with_generation_kwargs(self):
+        mock_model = MagicMock()
+        generator = LlamaCppChatGenerator(
+            model="test_model.gguf", generation_kwargs={"max_tokens": 128, "temperature": 0.5}
+        )
+        generator._model = mock_model
         mock_output = {
             "id": "unique-id-123",
             "model": "Test Model Path",
@@ -978,8 +979,11 @@ class TestLlamaCppChatGenerator:
             "usage": {"prompt_tokens": 14, "completion_tokens": 57, "total_tokens": 71},
         }
         mock_model.create_chat_completion.return_value = mock_output
-        generation_kwargs = {"max_tokens": 128}
-        result = generator.run([ChatMessage.from_system("Write a 200 word paragraph.")], generation_kwargs)
+        result = generator.run([ChatMessage.from_system("Write a 200 word paragraph.")], {"temperature": 0.9})
+
+        call_kwargs = mock_model.create_chat_completion.call_args[1]
+        assert call_kwargs["max_tokens"] == 128
+        assert call_kwargs["temperature"] == 0.9
         assert result["replies"][0].text == "Generated text"
         assert result["replies"][0].meta["finish_reason"] == "length"
 
@@ -1227,9 +1231,12 @@ class TestLlamaCppChatGeneratorAsync:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) == 0
 
-    async def test_run_async_with_params(self, generator_mock):
-        """Test that run_async passes generation_kwargs correctly."""
-        generator, mock_model = generator_mock
+    async def test_run_async_with_generation_kwargs(self):
+        mock_model = MagicMock()
+        generator = LlamaCppChatGenerator(
+            model="test_model.gguf", generation_kwargs={"max_tokens": 128, "temperature": 0.5}
+        )
+        generator._model = mock_model
         mock_output = {
             "id": "unique-id-123",
             "model": "Test Model Path",
@@ -1243,15 +1250,15 @@ class TestLlamaCppChatGeneratorAsync:
 
         response = await generator.run_async(
             messages=[ChatMessage.from_system("Write a 200 word paragraph.")],
-            generation_kwargs={"max_tokens": 128, "temperature": 0.5},
+            generation_kwargs={"temperature": 0.9},
         )
 
-        assert response["replies"][0].text == "Generated text"
-        assert response["replies"][0].meta["finish_reason"] == "length"
         mock_model.create_chat_completion.assert_called_once()
         call_kwargs = mock_model.create_chat_completion.call_args[1]
         assert call_kwargs["max_tokens"] == 128
-        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["temperature"] == 0.9
+        assert response["replies"][0].text == "Generated text"
+        assert response["replies"][0].meta["finish_reason"] == "length"
 
     async def test_run_async_with_string_input(self, generator_mock):
         """Test that a string input is converted to a user ChatMessage and returns a list of replies."""

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -343,8 +343,9 @@ class MistralChatGenerator(OpenAIChatGenerator):
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
             For details on Mistral API parameters, see
             [Mistral docs](https://docs.mistral.ai/api/).
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
@@ -417,7 +418,9 @@ class MistralChatGenerator(OpenAIChatGenerator):
             A callback function that is called when a new token is received from the stream.
             Must be a coroutine.
         :param generation_kwargs:
-            Additional keyword arguments for text generation.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset.
         :param tools_strict:
             Whether to enable strict schema adherence for tool calls.

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -498,6 +498,15 @@ class TestMistralChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    def test_run_with_generation_kwargs(self, chat_messages, mock_chat_completion, monkeypatch):
+        monkeypatch.setenv("MISTRAL_API_KEY", "fake-api-key")
+        component = MistralChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        component.run(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.9
+
     @pytest.mark.skipif(
         not os.environ.get("MISTRAL_API_KEY", None),
         reason="Export an env var called MISTRAL_API_KEY containing the Mistral API key to run this test.",

--- a/integrations/mistral/tests/test_mistral_chat_generator_async.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator_async.py
@@ -121,6 +121,16 @@ class TestMistralChatGeneratorAsync:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(self, chat_messages, mock_async_chat_completion, monkeypatch):
+        monkeypatch.setenv("MISTRAL_API_KEY", "fake-api-key")
+        component = MistralChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        await component.run_async(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_async_chat_completion.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.9
+
     @pytest.mark.skipif(
         not os.environ.get("MISTRAL_API_KEY", None),
         reason="Export an env var called MISTRAL_API_KEY containing the OpenAI API key to run this test.",

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -1040,6 +1040,49 @@ class TestOllamaChatGeneratorRun:
         assert len(result["replies"]) == 1
         assert isinstance(result["replies"][0], ChatMessage)
 
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
+    def test_run_with_generation_kwargs(self, mock_client):
+        generator = OllamaChatGenerator(generation_kwargs={"num_predict": 100, "temperature": 0.5})
+
+        mock_response = ChatResponse(
+            model="qwen3:0.6b",
+            created_at="2023-12-12T14:13:43.416799Z",
+            message={"role": "assistant", "content": "Paris"},
+            done=True,
+            prompt_eval_count=1,
+            eval_count=1,
+        )
+
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.chat.return_value = mock_response
+
+        generator.run(messages=[ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_client_instance.chat.call_args
+        assert kwargs["options"] == {"num_predict": 100, "temperature": 0.9}
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.AsyncClient")
+    async def test_run_async_with_generation_kwargs(self, mock_async_client):
+        generator = OllamaChatGenerator(generation_kwargs={"num_predict": 100, "temperature": 0.5})
+
+        mock_response = ChatResponse(
+            model="qwen3:0.6b",
+            created_at="2023-12-12T14:13:43.416799Z",
+            message={"role": "assistant", "content": "Paris"},
+            done=True,
+            prompt_eval_count=1,
+            eval_count=1,
+        )
+
+        mock_async_client_instance = mock_async_client.return_value
+        mock_async_client_instance.chat = AsyncMock(return_value=mock_response)
+
+        await generator.run_async(messages=[ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_async_client_instance.chat.call_args
+        assert kwargs["options"] == {"num_predict": 100, "temperature": 0.9}
+
     @pytest.mark.asyncio
     @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.AsyncClient")
     async def test_run_async_with_string_input(self, mock_async_client):

--- a/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
+++ b/integrations/openrouter/src/haystack_integrations/components/generators/openrouter/chat/chat_generator.py
@@ -340,8 +340,9 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
             For details on OpenRouter API parameters, see
             [OpenRouter docs](https://openrouter.ai/docs/quickstart).
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
@@ -419,7 +420,9 @@ class OpenRouterChatGenerator(OpenAIChatGenerator):
             A callback function that is called when a new token is received from the stream.
             Must be a coroutine.
         :param generation_kwargs:
-            Additional keyword arguments for text generation.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset.
         :param tools_strict:
             Whether to enable strict schema adherence for tool calls.

--- a/integrations/openrouter/tests/test_openrouter_chat_generator.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator.py
@@ -261,6 +261,15 @@ class TestOpenRouterChatGeneratorUnit:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    def test_run_with_generation_kwargs(self, chat_messages, mock_chat_completion, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
+        component = OpenRouterChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        component.run(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_chat_completion.call_args
+        assert kwargs["extra_body"]["max_tokens"] == 10
+        assert kwargs["extra_body"]["temperature"] == 0.9
+
     def test_prepare_api_call_with_tools_strict(self, chat_messages, tools, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
         component = OpenRouterChatGenerator(tools=tools)

--- a/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
+++ b/integrations/openrouter/tests/test_openrouter_chat_generator_async.py
@@ -124,6 +124,15 @@ class TestOpenRouterChatGeneratorAsyncUnit:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    async def test_run_async_with_generation_kwargs(self, chat_messages, mock_async_chat_completion, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
+        component = OpenRouterChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        await component.run_async(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_async_chat_completion.call_args
+        assert kwargs["extra_body"]["max_tokens"] == 10
+        assert kwargs["extra_body"]["temperature"] == 0.9
+
     async def test_run_async_with_reasoning(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "fake-api-key")
 

--- a/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
+++ b/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
@@ -353,7 +353,9 @@ class TransformersChatGenerator:
 
         :param messages: A list of ChatMessage objects representing the input messages. If a string is provided,
             it is converted to a list containing a ChatMessage with user role.
-        :param generation_kwargs: Additional keyword arguments for text generation.
+        :param generation_kwargs: Additional keyword arguments for text generation. These are merged per key with
+            the `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only at
+            initialization are kept.
         :param streaming_callback: An optional callable for handling streaming responses.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
             If set, it will override the `tools` parameter provided during initialization.
@@ -472,7 +474,9 @@ class TransformersChatGenerator:
         and return values but can be used with `await` in an async code.
 
         :param messages: A list of ChatMessage objects representing the input messages.
-        :param generation_kwargs: Additional keyword arguments for text generation.
+        :param generation_kwargs: Additional keyword arguments for text generation. These are merged per key with
+            the `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only at
+            initialization are kept.
         :param streaming_callback: An optional callable for handling streaming responses.
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
             If set, it will override the `tools` parameter provided during initialization.

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -440,6 +440,19 @@ class TestTransformersChatGenerator:
         assert chat_message.is_from(ChatRole.ASSISTANT)
         assert chat_message.text == "Berlin is cool"
 
+    def test_run_with_generation_kwargs(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+        generator = TransformersChatGenerator(
+            model="meta-llama/Llama-2-13b-chat-hf",
+            generation_kwargs={"max_new_tokens": 100, "temperature": 0.5},
+        )
+        generator.pipeline = mock_pipeline_with_tokenizer
+
+        generator.run(messages=chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = generator.pipeline.call_args
+        assert kwargs["max_new_tokens"] == 100
+        assert kwargs["temperature"] == 0.9
+
     def test_run_with_streaming_callback(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
         # Define the streaming callback function
         def streaming_callback_fn(chunk: StreamingChunk): ...
@@ -703,6 +716,21 @@ class TestTransformersChatGeneratorAsync:
         chat_message = results["replies"][0]
         assert chat_message.is_from(ChatRole.ASSISTANT)
         assert chat_message.text == "Berlin is cool"
+        generator.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+        generator = TransformersChatGenerator(
+            model="meta-llama/Llama-2-13b-chat-hf",
+            generation_kwargs={"max_new_tokens": 100, "temperature": 0.5},
+        )
+        generator.pipeline = mock_pipeline_with_tokenizer
+
+        await generator.run_async(messages=chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = generator.pipeline.call_args
+        assert kwargs["max_new_tokens"] == 100
+        assert kwargs["temperature"] == 0.9
         generator.shutdown()
 
     @pytest.mark.asyncio

--- a/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
+++ b/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
@@ -451,8 +451,9 @@ class VLLMChatGenerator:
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
             For details on vLLM API parameters, see
             [vLLM documentation](https://docs.vllm.ai/en/stable/serving/openai_compatible_server/).
         :param tools:
@@ -509,8 +510,9 @@ class VLLMChatGenerator:
             A callback function that is called when a new token is received from the stream.
             Must be a coroutine.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
             For details on vLLM API parameters, see
             [vLLM documentation](https://docs.vllm.ai/en/stable/serving/openai_compatible_server/).
         :param tools:

--- a/integrations/vllm/tests/test_chat_generator.py
+++ b/integrations/vllm/tests/test_chat_generator.py
@@ -369,16 +369,16 @@ class TestVLLMChatGeneratorRun:
         assert reply.reasoning is not None
         assert "capital of France" in reply.reasoning.reasoning_text
 
-    def test_run_passes_generation_kwargs(self, mock_chat_completion):
+    def test_run_with_generation_kwargs(self, mock_chat_completion):
         component = VLLMChatGenerator(
             model=MODEL,
             generation_kwargs={"max_tokens": 100, "temperature": 0.5},
         )
-        component.run([ChatMessage.from_user("Hello")])
+        component.run([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
 
         _, kwargs = mock_chat_completion.call_args
         assert kwargs["max_tokens"] == 100
-        assert kwargs["temperature"] == 0.5
+        assert kwargs["temperature"] == 0.9
 
     def test_run_with_string_input(self, mock_chat_completion):
         component = VLLMChatGenerator(model=MODEL)
@@ -465,6 +465,17 @@ class TestVLLMChatGeneratorRunAsync:
         assert isinstance(result["replies"], list)
         assert len(result["replies"]) == 1
         assert isinstance(result["replies"][0], ChatMessage)
+
+    async def test_run_async_with_generation_kwargs(self, mock_async_chat_completion):
+        component = VLLMChatGenerator(
+            model=MODEL,
+            generation_kwargs={"max_tokens": 100, "temperature": 0.5},
+        )
+        await component.run_async([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = mock_async_chat_completion.call_args
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["temperature"] == 0.9
 
     async def test_run_async(self, mock_async_chat_completion):  # noqa: ARG002
         component = VLLMChatGenerator(model=MODEL)

--- a/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
+++ b/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
@@ -272,8 +272,9 @@ class WatsonxChatGenerator:
             A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will potentially override the parameters
-            passed in the `__init__` method.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
             If provided this will override the `streaming_callback` set in the `__init__` method.
@@ -315,8 +316,9 @@ class WatsonxChatGenerator:
             A list of ChatMessage instances representing the input messages.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will potentially override the parameters
-            passed in the `__init__` method.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only
+            at initialization are kept.
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
             If provided this will override the `streaming_callback` set in the `__init__` method.

--- a/integrations/watsonx/tests/test_chat_generator.py
+++ b/integrations/watsonx/tests/test_chat_generator.py
@@ -314,20 +314,20 @@ class TestWatsonxChatGenerator:
             messages=[{"role": "user", "content": "Test prompt"}], params={}, tools=None
         )
 
-    def test_run_with_generation_params(self, mock_watsonx):
+    def test_run_with_generation_kwargs(self, mock_watsonx):
         generator = WatsonxChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             project_id=Secret.from_token("test-project"),
-            generation_kwargs={"max_tokens": 100, "temperature": 0.7, "top_p": 0.9},
+            generation_kwargs={"max_completion_tokens": 100, "temperature": 0.7, "top_p": 0.9},
         )
 
         messages = [ChatMessage.from_user("Test prompt")]
-        result = generator.run(messages=messages)
+        result = generator.run(messages=messages, generation_kwargs={"temperature": 0.9})
 
         assert len(result["replies"]) == 1
         mock_watsonx["model_instance"].chat.assert_called_once_with(
             messages=[{"role": "user", "content": "Test prompt"}],
-            params={"max_tokens": 100, "temperature": 0.7, "top_p": 0.9},
+            params={"max_completion_tokens": 100, "temperature": 0.9, "top_p": 0.9},
             tools=None,
         )
 
@@ -441,6 +441,24 @@ class TestWatsonxChatGenerator:
         assert len(result["replies"]) == 1
         assert result["replies"][0].text == "Async generated response"
         assert result["replies"][0].meta["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_generation_kwargs(self, mock_watsonx):
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            project_id=Secret.from_token("test-project"),
+            generation_kwargs={"max_completion_tokens": 100, "temperature": 0.7, "top_p": 0.9},
+        )
+
+        messages = [ChatMessage.from_user("Test prompt")]
+        result = await generator.run_async(messages=messages, generation_kwargs={"temperature": 0.9})
+
+        assert len(result["replies"]) == 1
+        mock_watsonx["model_instance"].achat.assert_called_once_with(
+            messages=[{"role": "user", "content": "Test prompt"}],
+            params={"max_completion_tokens": 100, "temperature": 0.9, "top_p": 0.9},
+            tools=None,
+        )
 
     @pytest.mark.asyncio
     async def test_run_async_streaming(self, mock_watsonx):


### PR DESCRIPTION
### Related Issues

See https://github.com/deepset-ai/haystack/pull/12384 for an explanation

### Proposed Changes:
- better explain the `generation_kwargs` merging logic in the docstrings
- test this behavior

### How did you test it?
CI, new tests

Failing integration tests are unrelated

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
