### PR TITLE
fix: serialize missing init params in to_dict (transformers, huggingface_api, ragas)

### DIFF
--- a/integrations/huggingface_api/src/haystack_integrations/components/rankers/huggingface_api/ranker.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/rankers/huggingface_api/ranker.py
@@ -108,6 +108,7 @@ class HuggingFaceTEIRanker:
             self,
             url=self.url,
             top_k=self.top_k,
+            raw_scores=self.raw_scores,
             timeout=self.timeout,
             token=self.token,
             max_retries=self.max_retries,

--- a/integrations/huggingface_api/tests/test_ranker.py
+++ b/integrations/huggingface_api/tests/test_ranker.py
@@ -60,6 +60,14 @@ class TestHuggingFaceTEIRanker:
         assert data["init_parameters"]["max_retries"] == 4
         assert data["init_parameters"]["retry_status_codes"] == [500, 502]
 
+    def test_raw_scores_survives_a_serialization_round_trip(self, del_hf_env_vars_if_empty):
+        """raw_scores goes into the request payload, so losing it changes what the API returns."""
+        ranker = HuggingFaceTEIRanker(url="https://api.my-tei-service.com", raw_scores=True)
+
+        restored = HuggingFaceTEIRanker.from_dict(ranker.to_dict())
+
+        assert restored.raw_scores is True
+
     def test_from_dict(self, del_hf_env_vars_if_empty):
         """Test deserialization from dict with environment variable token"""
         data = {

--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -85,7 +85,11 @@ class RagasEvaluator:
         :returns:
             Dictionary with serialized data.
         """
-        return default_to_dict(self, ragas_metrics=[_serialize_metric(m) for m in self.metrics])
+        return default_to_dict(
+            self,
+            ragas_metrics=[_serialize_metric(m) for m in self.metrics],
+            concurrency_limit=self.concurrency_limit,
+        )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "RagasEvaluator":

--- a/integrations/ragas/tests/test_evaluator.py
+++ b/integrations/ragas/tests/test_evaluator.py
@@ -316,9 +316,19 @@ class TestSerialization:
                         "llm": {"model": "gpt-4o-mini", "provider": "openai"},
                     },
                     {"type": "tests.test_evaluator.ConcreteMetric", "name": "another_metric"},
-                ]
+                ],
+                "concurrency_limit": 4,
             },
         }
+
+    def test_concurrency_limit_survives_a_serialization_round_trip(self, monkeypatch):
+        """concurrency_limit caps how many metric evaluations run at once in run_async."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        evaluator = RagasEvaluator(ragas_metrics=[ConcreteMetric(name="a_metric")], concurrency_limit=16)
+
+        restored = RagasEvaluator.from_dict(evaluator.to_dict())
+
+        assert restored.concurrency_limit == 16
 
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test")

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
@@ -156,7 +156,11 @@ class TransformersZeroShotTextRouter:
             Dictionary with serialized data.
         """
         serialization_dict = default_to_dict(
-            self, labels=self.labels, huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs, token=self.token
+            self,
+            labels=self.labels,
+            multi_label=self.multi_label,
+            huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
+            token=self.token,
         )
 
         huggingface_pipeline_kwargs = serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]

--- a/integrations/transformers/tests/test_zero_shot_text_router.py
+++ b/integrations/transformers/tests/test_zero_shot_text_router.py
@@ -22,6 +22,7 @@ class TestTransformersZeroShotTextRouter:
             "type": COMPONENT_TYPE,
             "init_parameters": {
                 "labels": ["query", "passage"],
+                "multi_label": False,
                 "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
                 "huggingface_pipeline_kwargs": {
                     "model": "MoritzLaurer/deberta-v3-base-zeroshot-v1.1-all-33",
@@ -30,6 +31,14 @@ class TestTransformersZeroShotTextRouter:
                 },
             },
         }
+
+    def test_multi_label_survives_a_serialization_round_trip(self, del_hf_env_vars_if_empty):
+        """`multi_label` changes how the pipeline normalizes scores, so losing it changes routing decisions."""
+        router = TransformersZeroShotTextRouter(labels=["query", "passage"], multi_label=True)
+
+        restored = TransformersZeroShotTextRouter.from_dict(router.to_dict())
+
+        assert restored.multi_label is True
 
     def test_from_dict(self, del_hf_env_vars_if_empty):
         data = {


### PR DESCRIPTION
### Related Issues

- No issue; found while auditing `to_dict` against `__init__` across the integrations.

### Proposed Changes:

Three components accept an `__init__` parameter, store it, and use it at run time, but leave it out of `to_dict`. In each case the value silently falls back to its default after a `to_dict` / `from_dict` round trip, and nothing in the serialized dict shows that the setting was ever there. `from_dict` needed no change in any of them — `default_from_dict` passes `init_parameters` straight through to `__init__`.

**`TransformersZeroShotTextRouter.multi_label`** — passed to the Hugging Face pipeline in `run`:

```python
self.pipeline([text], candidate_labels=self.labels, multi_label=self.multi_label)
```

The flag decides whether label scores are normalized to sum to 1 across labels, or whether each label is scored independently against its own contradiction score. The router picks its output branch from those scores, so the same text can route to a different branch after a pipeline is saved and reloaded. `model` and `device` are absent from `to_dict` too, but correctly so: `_resolve_hf_pipeline_kwargs` folds them into `huggingface_pipeline_kwargs`, which is serialized. `multi_label` is the only one that goes nowhere. The sibling component in this same integration, `TransformersZeroShotDocumentClassifier`, has the same shape and already serializes it — which is what suggests an oversight rather than a decision.

**`HuggingFaceTEIRanker.raw_scores`** — goes directly into the request payload, on both the sync and async paths:

```python
payload: dict[str, Any] = {"query": query, "texts": texts, "raw_scores": self.raw_scores}
```

After a reload the ranker silently stops asking the TEI endpoint for raw relevance scores: the request body changes with nothing to show why. Everything else `__init__` takes (`url`, `top_k`, `timeout`, `token`, `max_retries`, `retry_status_codes`) is already serialized; `raw_scores` is the only one missing.

**`RagasEvaluator.concurrency_limit`** — sizes the semaphore bounding how many metrics are evaluated at once in `run_async`:

```python
sem = Semaphore(max(1, self.concurrency_limit))
```

`to_dict` serialized only `ragas_metrics`, so an evaluator built with `concurrency_limit=16` comes back at the default of `4`. Every one of those concurrent evaluations is an LLM call, so the value decides whether an evaluation run finishes in a quarter of the time or hits the judge model's rate limit.

### How did you test it?

One new round-trip regression test per component, each asserting the value survives `to_dict` → `from_dict`:

| Component | Test | Suite |
|---|---|---|
| `TransformersZeroShotTextRouter` | `test_multi_label_survives_a_serialization_round_trip` | `hatch run test:pytest tests/test_zero_shot_text_router.py` — 9 passed |
| `HuggingFaceTEIRanker` | `test_raw_scores_survives_a_serialization_round_trip` | `hatch run test:pytest tests/test_ranker.py` — 16 passed |
| `RagasEvaluator` | `test_concurrency_limit_survives_a_serialization_round_trip` | `hatch run test:pytest tests/test_evaluator.py` — 27 passed, 8 skipped (integration tests needing an API key) |

`hatch run test:types` and `hatch run fmt-check` are clean in all three integrations.

I checked each regression test is not vacuous — with the production file reverted to `main`, each fails for the reason the bug describes rather than on an incidental assertion mismatch:

- router: `assert False is True` on the restored component's `multi_label`
- ranker: `assert False is True` on the restored component's `raw_scores`
- evaluator: `assert 4 == 16` — the round trip falling back to the default

`test_to_dict` in the transformers and ragas suites compares the whole dict, so both needed the new key added in the same commit. The huggingface_api `test_to_dict` asserts key by key, which is also why that gap survived: a full-dict assertion would have flagged the missing key when `raw_scores` was added.

### Notes for the reviewer

This supersedes #3809 (`raw_scores`) and #3810 (`concurrency_limit`), which I have closed in favour of this one. Those PRs said I would keep the fixes separate because each integration ships on its own; I have grouped them here instead, since it is one class of bug found by one sweep and it reads better reviewed as a whole than as three near-identical PRs. Releases are unaffected — `CI_pypi_release.yml` generates each changelog with `git-cliff --include-path "<integration>/**/*"`, so the entry is partitioned by file path, not by the commit scope in the title.

The three commits are kept separate and per-integration, so the change can still be split back apart if you would rather take them one at a time.

`concurrency_limit` is documented as only affecting `run_async`, so that round trip is silent on the sync path — part of why it is easy to miss.

I used an AI assistant while writing this change. I have reviewed it, reproduced the behaviour, and run the tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have run pre-commit hooks and fixed any issue.
