### PR TITLE
fix(huggingface_api): serialize raw_scores in HuggingFaceTEIRanker

### DIFF
--- a/integrations/huggingface_api/src/haystack_integrations/components/rankers/huggingface_api/ranker.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/rankers/huggingface_api/ranker.py
@@ -108,6 +108,7 @@ class HuggingFaceTEIRanker:
             self,
             url=self.url,
             top_k=self.top_k,
+            raw_scores=self.raw_scores,
             timeout=self.timeout,
             token=self.token,
             max_retries=self.max_retries,

--- a/integrations/huggingface_api/tests/test_ranker.py
+++ b/integrations/huggingface_api/tests/test_ranker.py
@@ -60,6 +60,14 @@ class TestHuggingFaceTEIRanker:
         assert data["init_parameters"]["max_retries"] == 4
         assert data["init_parameters"]["retry_status_codes"] == [500, 502]
 
+    def test_raw_scores_survives_a_serialization_round_trip(self, del_hf_env_vars_if_empty):
+        """raw_scores goes into the request payload, so losing it changes what the API returns."""
+        ranker = HuggingFaceTEIRanker(url="https://api.my-tei-service.com", raw_scores=True)
+
+        restored = HuggingFaceTEIRanker.from_dict(ranker.to_dict())
+
+        assert restored.raw_scores is True
+
     def test_from_dict(self, del_hf_env_vars_if_empty):
         """Test deserialization from dict with environment variable token"""
         data = {


### PR DESCRIPTION
### Related Issues

- No issue; found while auditing `to_dict` against `__init__` across the integrations.

### Proposed Changes:

`HuggingFaceTEIRanker.__init__` accepts `raw_scores`, stores it, and puts it directly into the request payload — on both paths:

```python
payload: dict[str, Any] = {"query": query, "texts": texts, "raw_scores": self.raw_scores}
```

`to_dict` does not serialize it, so a ranker built with `raw_scores=True` comes back from `from_dict` with the `False` default. Save a pipeline containing that ranker, reload it, and it silently stops asking the TEI endpoint for raw relevance scores — the request body changes, and nothing in the serialized dict shows why.

Everything else `__init__` takes (`url`, `top_k`, `timeout`, `token`, `max_retries`, `retry_status_codes`) is already serialized; `raw_scores` is the only one missing.

`from_dict` needed no change — `default_from_dict` passes `init_parameters` through to `__init__`.

### How did you test it?

- New unit test `test_raw_scores_survives_a_serialization_round_trip`: builds the ranker with `raw_scores=True`, runs it through `to_dict` then `from_dict`, and asserts the flag is still `True`.
- I checked it is not vacuous: with `ranker.py` reverted to `main` it fails with `assert False is True` on the restored component — the round trip losing the flag, not an incidental assertion mismatch.
- `hatch run test:pytest tests/test_ranker.py` — 16 passed.
- `hatch run test:types` clean (10 source files), `hatch run fmt-check` clean.

### Notes for the reviewer

The existing `test_to_dict` asserts key by key rather than comparing the whole dict, so it did not need changing — which is also why the gap survived: a full-dict assertion would have flagged the missing key when `raw_scores` was added.

This came out of a sweep comparing every component's `to_dict` against its `__init__` signature. It found the same class of gap in a few other packages, and since each integration ships separately I am opening those as their own PRs rather than one cross-package change.

I used an AI assistant while writing this change. I have reviewed it, reproduced the behaviour, and run the tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have run pre-commit hooks and fixed any issue.
