### PR TITLE
fix(ragas): serialize concurrency_limit in RagasEvaluator

### DIFF
--- a/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
+++ b/integrations/ragas/src/haystack_integrations/components/evaluators/ragas/evaluator.py
@@ -85,7 +85,11 @@ class RagasEvaluator:
         :returns:
             Dictionary with serialized data.
         """
-        return default_to_dict(self, ragas_metrics=[_serialize_metric(m) for m in self.metrics])
+        return default_to_dict(
+            self,
+            ragas_metrics=[_serialize_metric(m) for m in self.metrics],
+            concurrency_limit=self.concurrency_limit,
+        )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "RagasEvaluator":

--- a/integrations/ragas/tests/test_evaluator.py
+++ b/integrations/ragas/tests/test_evaluator.py
@@ -316,9 +316,19 @@ class TestSerialization:
                         "llm": {"model": "gpt-4o-mini", "provider": "openai"},
                     },
                     {"type": "tests.test_evaluator.ConcreteMetric", "name": "another_metric"},
-                ]
+                ],
+                "concurrency_limit": 4,
             },
         }
+
+    def test_concurrency_limit_survives_a_serialization_round_trip(self, monkeypatch):
+        """concurrency_limit caps how many metric evaluations run at once in run_async."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        evaluator = RagasEvaluator(ragas_metrics=[ConcreteMetric(name="a_metric")], concurrency_limit=16)
+
+        restored = RagasEvaluator.from_dict(evaluator.to_dict())
+
+        assert restored.concurrency_limit == 16
 
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test")


### PR DESCRIPTION
### Related Issues

- No issue; found while auditing `to_dict` against `__init__` across the integrations.

### Proposed Changes:

`RagasEvaluator.__init__` takes `concurrency_limit`, stores it, and uses it in `run_async` to size the semaphore that bounds how many metrics are evaluated at once:

```python
sem = Semaphore(max(1, self.concurrency_limit))
```

`to_dict` serialized only `ragas_metrics`:

```python
return default_to_dict(self, ragas_metrics=[_serialize_metric(m) for m in self.metrics])
```

So an evaluator constructed with, say, `concurrency_limit=16` comes back from `from_dict` at the default of `4`. Every one of those concurrent evaluations is an LLM call, so the value is what decides whether an evaluation run finishes in a quarter of the time or hits the judge model's rate limit. A pipeline saved and reloaded runs at a concurrency nobody chose, and the serialized dict gives no hint that the setting was ever there.

`from_dict` needed no change: it rebuilds the metrics and hands the rest of `init_parameters` to `default_from_dict`, which passes the new key straight through to `__init__`.

### How did you test it?

- New unit test `test_concurrency_limit_survives_a_serialization_round_trip`: builds the evaluator with `concurrency_limit=16`, runs it through `to_dict` then `from_dict`, and asserts it is still `16`.
- Updated `test_to_dict`, which compares the whole dict, to expect the new key.
- I checked the regression test is not vacuous: with `evaluator.py` reverted to `main` it fails with `assert 4 == 16` — the round trip falling back to the default, not an incidental assertion mismatch.
- `hatch run test:pytest tests/test_evaluator.py` — 27 passed, 8 skipped (the skips are the integration tests that need an API key).
- `hatch run test:types` clean (3 source files), `hatch run fmt-check` clean.

### Notes for the reviewer

`concurrency_limit` is documented as only affecting `run_async`, so the round trip is silent on the sync path — which is part of why it is easy to miss.

This came out of a sweep comparing every component's `to_dict` against its `__init__` signature. The same class of gap turned up in a few other packages; since each integration ships separately I am opening those as their own PRs rather than one cross-package change.

I used an AI assistant while writing this change. I have reviewed it, reproduced the behaviour, and run the tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have run pre-commit hooks and fixed any issue.
