### PR TITLE
fix: confine GoogleGenAIMultimodalDocumentEmbedder file paths to root_path

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -77,8 +77,7 @@ def _extract_sources_info(documents: list[Document], file_path_meta_field: str, 
 
         # When root_path is set, ensure the resolved path stays within it to block path-traversal
         # payloads (e.g. "../../etc/passwd") coming from document metadata. When root_path is unset,
-        # file paths are treated as absolute by design and no containment check is applied; callers that
-        # process untrusted metadata should configure root_path (see component docstrings).
+        # file paths are treated as absolute by design and no containment check is applied.
         if root_path:
             resolved_file_path = resolved_file_path.resolve()
             resolved_root = Path(root_path).resolve()
@@ -217,10 +216,8 @@ class GoogleGenAIMultimodalDocumentEmbedder:
             The root directory path where document files are located. If provided, file paths in
             document metadata will be resolved relative to this path and are guaranteed to stay within it.
             If None, file paths are treated as absolute paths with no containment check.
-            Security: this component reads the file referenced by `file_path_meta_field` from the host filesystem
-            and sends its content to the Google API. If document metadata may be influenced by untrusted input,
-            set `root_path` to a dedicated data directory so that path-traversal payloads (e.g. absolute paths
-            or `../`) are rejected instead of read.
+            If document metadata, in particular `file_path_meta_field`, may be influenced by untrusted input,
+            set `root_path` to a dedicated data directory so that path-traversal beyond it is rejected.
         :param image_size:
             Only used for images and PDF pages. If provided, resizes the image to fit within the specified dimensions
             (width, height) while maintaining aspect ratio. This reduces file size, memory usage, and processing time,

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -316,6 +316,9 @@ class GoogleGenAIMultimodalDocumentEmbedder:
 
         :raises TypeError:
             If the input is not a list of `Documents`.
+        :raises ValueError:
+            If a document is missing the file path metadata field, its file path escapes `root_path`, or its
+            MIME type is not supported.
         :raises RuntimeError:
             If the conversion of some documents fails.
         """
@@ -472,6 +475,14 @@ class GoogleGenAIMultimodalDocumentEmbedder:
             A dictionary with the following keys:
             - `documents`: A list of documents with embeddings.
             - `meta`: Information about the usage of the model.
+
+        :raises TypeError:
+            If the input is not a list of `Documents`.
+        :raises ValueError:
+            If a document is missing the file path metadata field, its file path escapes `root_path`, or its
+            MIME type is not supported.
+        :raises RuntimeError:
+            If the conversion of some documents fails.
         """
 
         parts_to_embed = self._extract_parts_to_embed(documents=documents)
@@ -497,6 +508,14 @@ class GoogleGenAIMultimodalDocumentEmbedder:
             A dictionary with the following keys:
             - `documents`: A list of documents with embeddings.
             - `meta`: Information about the usage of the model.
+
+        :raises TypeError:
+            If the input is not a list of `Documents`.
+        :raises ValueError:
+            If a document is missing the file path metadata field, its file path escapes `root_path`, or its
+            MIME type is not supported.
+        :raises RuntimeError:
+            If the conversion of some documents fails.
         """
 
         parts_to_embed = self._extract_parts_to_embed(documents=documents)

--- a/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
+++ b/integrations/google_genai/src/haystack_integrations/components/embedders/google_genai/multimodal_document_embedder.py
@@ -60,8 +60,8 @@ def _extract_sources_info(documents: list[Document], file_path_meta_field: str, 
         If the file is a PDF and a page number is provided, the dictionary also contains the page number.
         Files that are not images, or PDFs without a page number, have `send_raw` set to True,
         meaning they will be sent as raw bytes without image processing.
-    :raises ValueError: If the document is missing the file_path_meta_field key in its metadata or the file path is
-        invalid.
+    :raises ValueError: If the document is missing the file_path_meta_field key in its metadata, the file path
+        escapes the configured root path, or the file path is invalid.
     """
     sources_info: list[_SourceInfo] = []
     for doc in documents:
@@ -74,6 +74,21 @@ def _extract_sources_info(documents: list[Document], file_path_meta_field: str, 
             raise ValueError(err_msg)
 
         resolved_file_path = Path(root_path, file_path)
+
+        # When root_path is set, ensure the resolved path stays within it to block path-traversal
+        # payloads (e.g. "../../etc/passwd") coming from document metadata. When root_path is unset,
+        # file paths are treated as absolute by design and no containment check is applied; callers that
+        # process untrusted metadata should configure root_path (see component docstrings).
+        if root_path:
+            resolved_file_path = resolved_file_path.resolve()
+            resolved_root = Path(root_path).resolve()
+            if not resolved_file_path.is_relative_to(resolved_root):
+                err_msg = (
+                    f"Document with ID '{doc.id}' has a file path '{file_path}' that escapes the "
+                    f"configured root '{root_path}'. Resolved path: '{resolved_file_path}'."
+                )
+                raise ValueError(err_msg)
+
         if not resolved_file_path.is_file():
             err_msg = (
                 f"Document with ID '{doc.id}' has an invalid file path '{resolved_file_path}'. "
@@ -200,7 +215,12 @@ class GoogleGenAIMultimodalDocumentEmbedder:
             The metadata field in the Document that contains the file path to the file to embed.
         :param root_path:
             The root directory path where document files are located. If provided, file paths in
-            document metadata will be resolved relative to this path. If None, file paths are treated as absolute paths.
+            document metadata will be resolved relative to this path and are guaranteed to stay within it.
+            If None, file paths are treated as absolute paths with no containment check.
+            Security: this component reads the file referenced by `file_path_meta_field` from the host filesystem
+            and sends its content to the Google API. If document metadata may be influenced by untrusted input,
+            set `root_path` to a dedicated data directory so that path-traversal payloads (e.g. absolute paths
+            or `../`) are rejected instead of read.
         :param image_size:
             Only used for images and PDF pages. If provided, resizes the image to fit within the specified dimensions
             (width, height) while maintaining aspect ratio. This reduces file size, memory usage, and processing time,

--- a/integrations/google_genai/tests/test_multimodal_document_embedder.py
+++ b/integrations/google_genai/tests/test_multimodal_document_embedder.py
@@ -64,6 +64,45 @@ class TestExtractSourcesInfo:
         with pytest.raises(ValueError, match="has an unsupported MIME type"):
             _extract_sources_info(documents=[document], file_path_meta_field="file_path", root_path="")
 
+    def test_extract_sources_info_rejects_path_traversal(self, test_files_path):
+        # Attacker-controlled document metadata attempts to escape the configured root.
+        document = Document(content="test", meta={"file_path": "../../../../../../etc/passwd"})
+        with pytest.raises(ValueError, match="escapes the configured root"):
+            _extract_sources_info(
+                documents=[document], file_path_meta_field="file_path", root_path=str(test_files_path)
+            )
+
+    def test_extract_sources_info_rejects_absolute_outside_root(self, test_files_path, tmp_path):
+        # Absolute path that lies outside the configured root must be rejected before any IO.
+        outside_file = tmp_path / "secret.png"
+        outside_file.write_bytes(b"secret")
+        document = Document(content="test", meta={"file_path": str(outside_file)})
+        with pytest.raises(ValueError, match="escapes the configured root"):
+            _extract_sources_info(
+                documents=[document], file_path_meta_field="file_path", root_path=str(test_files_path)
+            )
+
+    def test_extract_sources_info_rejects_symlink_escaping_root(self, tmp_path):
+        # A symlink inside the root pointing outside of it must not be followed.
+        outside_file = tmp_path / "secret.png"
+        outside_file.write_bytes(b"secret")
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "link.png").symlink_to(outside_file)
+        document = Document(content="test", meta={"file_path": "link.png"})
+        with pytest.raises(ValueError, match="escapes the configured root"):
+            _extract_sources_info(documents=[document], file_path_meta_field="file_path", root_path=str(root))
+
+    def test_extract_sources_info_accepts_path_inside_root(self, test_files_path):
+        # When the resolved path is inside the configured root, processing must succeed.
+        document = Document(content="test", meta={"file_path": "banana.png"})
+        sources_info = _extract_sources_info(
+            documents=[document], file_path_meta_field="file_path", root_path=str(test_files_path)
+        )
+        assert len(sources_info) == 1
+        assert sources_info[0]["mime_type"] == "image/png"
+        assert sources_info[0]["path"] == (test_files_path / "banana.png").resolve()
+
 
 class TestGoogleGenAIMultimodalDocumentEmbedder:
     def test_init_with_parameters(self):


### PR DESCRIPTION
### Related Issues

- Part of deepset-ai/haystack-private#533

A file path coming from document metadata was not confined to `root_path` and and the resolved file's bytes were sent to the Google embedding API.

### Proposed Changes:

- Added a containment check: when `root_path` is set, the path is `resolve()`d and must be `is_relative_to()` the resolved root, otherwise a `ValueError` is raised before any file IO. Symlinks that point outside the root are rejected too, since `resolve()` follows them.
- Documented the exceptions that escape: the new `ValueError` propagates unwrapped through `_extract_parts_to_embed`, which listed only `TypeError` and `RuntimeError`, and `run()`/`run_async()` documented no exceptions at all.
- Behaviour is unchanged when `root_path` is unset (the default)

### How did you test it?

- Added four unit tests

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes — n/a, issue already describes the fix
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
