### PR TITLE
fix: confine S3Downloader downloads to file_root_path

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -153,7 +153,8 @@ class S3Downloader:
             - `documents`: The downloaded `Document`s; each has `meta['file_path']`. Documents whose file name
               is missing, or resolves outside of `file_root_path`, are logged and skipped.
         :raises S3Error: If a download attempt fails or the file does not exist in the S3 bucket.
-        :raises ValueError: If the path where files will be downloaded is not set.
+        :raises ValueError: If the component has not been warmed up yet and the environment variable naming the
+            S3 bucket (`s3_bucket_name_env`, by default `S3_DOWNLOADER_BUCKET`) is not set.
         """
 
         if self._storage is None:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -160,9 +160,6 @@ class S3Downloader:
             - `documents`: The downloaded `Document`s; each has `meta['file_path']`. Documents whose file name
               is missing, or resolves outside of `file_root_path`, are logged and skipped.
         :raises S3Error: If a download attempt fails or the file does not exist in the S3 bucket.
-        :raises ValueError: If the environment variable naming the S3 bucket (`s3_bucket_name_env`, by default
-            `S3_DOWNLOADER_BUCKET`) is not set. `run()` warms the component up on first use, so this surfaces
-            from the implicit `warm_up()` call.
         """
 
         if self._storage is None:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -87,6 +87,7 @@ class S3Downloader:
             By default, the value is `"S3_DOWNLOADER_BUCKET"`.
         :raises ValueError: If the `file_root_path` is not set through
             the constructor or the `FILE_ROOT_PATH` environment variable.
+        :raises AWSConfigurationError: If the provided AWS credentials are invalid.
 
         """
 
@@ -132,7 +133,13 @@ class S3Downloader:
         )
 
     def warm_up(self) -> None:
-        """Warm up the component by initializing the settings and storage."""
+        """
+        Warm up the component by initializing the settings and storage.
+
+        :raises ValueError: If the environment variable naming the S3 bucket (`s3_bucket_name_env`, by default
+            `S3_DOWNLOADER_BUCKET`) is not set.
+        :raises S3ConfigurationError: If the S3 client cannot be created.
+        """
         if self._storage is None:
             self.file_root_path.mkdir(parents=True, exist_ok=True)
             self._storage = S3Storage.from_env(
@@ -218,8 +225,9 @@ class S3Downloader:
 
         :param document: `Document` with the name of the file to download in the meta field.
         :returns:
-            The same `Document` with `meta` containing the `file_path` of the
-            downloaded file, or `None` if the document has no usable file name.
+            The same `Document` with `meta` containing the `file_path` of the downloaded file, or `None` if the
+            document has no file name in its metadata or its file name resolves outside of `file_root_path`.
+            Both cases are logged and skipped rather than raised.
         :raises S3Error: If the download or head request fails or the file does not exist in the S3 bucket.
         """
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -68,12 +68,14 @@ class S3Downloader:
         :param file_root_path: The path where the file will be downloaded.
             Can be set through this parameter or the `FILE_ROOT_PATH` environment variable.
             If none of them is set, a `ValueError` is raised.
+            Downloads are confined to this directory: a file name from document metadata that resolves outside
+            of it (for example an absolute path or one containing `..`) is rejected instead of written.
         :param file_extensions: The file extensions that are permitted to be downloaded.
             By default, all file extensions are allowed.
         :param max_workers: The maximum number of workers to use for concurrent downloads.
         :param max_cache_size: The maximum number of files to cache.
         :param file_name_meta_key: The name of the meta key that contains the file name to download. The file name
-            will also be used to create local file path for download.
+            will also be used to create local file path for download, relative to `file_root_path`.
             By default, the `Document.meta["file_name"]` is used. If you want to use a
             different key in `Document.meta`, you can set it here.
         :param s3_key_generation_function: An optional function that generates the S3 key for the file to download.
@@ -150,7 +152,8 @@ class S3Downloader:
         :returns: A dictionary with:
             - `documents`: The downloaded `Document`s; each has `meta['file_path']`.
         :raises S3Error: If a download attempt fails or the file does not exist in the S3 bucket.
-        :raises ValueError: If the path where files will be downloaded is not set.
+        :raises ValueError: If the path where files will be downloaded is not set, or if the file name of one of
+            the documents resolves outside of `file_root_path`.
         """
 
         if self._storage is None:
@@ -181,6 +184,33 @@ class S3Downloader:
             if Path(doc.meta.get(self.file_name_meta_key, "")).suffix.lower() in self.file_extensions
         ]
 
+    def _resolve_local_file_path(self, file_name: str) -> Path:
+        """
+        Resolve the local download path for a file name and ensure it stays inside `file_root_path`.
+
+        The file name comes from document metadata, which may be influenced by untrusted input. Without this
+        check an absolute file name or one containing `..` segments would escape the download directory, and
+        the S3 object would be written anywhere the process can write.
+
+        :param file_name: The file name taken from the document metadata.
+        :returns: The resolved local path, guaranteed to be inside the resolved `file_root_path`.
+        :raises ValueError: If the resolved path is outside `file_root_path` or is the root directory itself.
+        """
+        root = self.file_root_path.resolve()
+        candidate = (root / file_name).resolve()
+
+        if not candidate.is_relative_to(root):
+            msg = (
+                f"Refusing to download to a path outside of 'file_root_path': {file_name!r}. "
+                f"Resolved path: '{candidate}', configured root: '{root}'."
+            )
+            raise ValueError(msg)
+        if candidate == root:
+            msg = f"Refusing to overwrite the download root directory with the file {file_name!r}."
+            raise ValueError(msg)
+
+        return candidate
+
     def _download_file(self, document: Document) -> Document | None:
         """
         Download a single file from AWS S3 Bucket to local filesystem.
@@ -190,6 +220,7 @@ class S3Downloader:
             The same `Document` with `meta` containing the `file_path` of the
             downloaded file.
         :raises S3Error: If the download or head request fails or the file does not exist in the S3 bucket.
+        :raises ValueError: If the file name in the document metadata resolves outside of `file_root_path`.
         """
 
         file_name = document.meta.get(self.file_name_meta_key)
@@ -199,7 +230,7 @@ class S3Downloader:
             )
             return None
 
-        file_path = self.file_root_path / Path(file_name)
+        file_path = self._resolve_local_file_path(str(file_name))
 
         # if the file exists, avoid downloading it and just update the timestamp
         try:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -160,8 +160,9 @@ class S3Downloader:
             - `documents`: The downloaded `Document`s; each has `meta['file_path']`. Documents whose file name
               is missing, or resolves outside of `file_root_path`, are logged and skipped.
         :raises S3Error: If a download attempt fails or the file does not exist in the S3 bucket.
-        :raises ValueError: If the component has not been warmed up yet and the environment variable naming the
-            S3 bucket (`s3_bucket_name_env`, by default `S3_DOWNLOADER_BUCKET`) is not set.
+        :raises ValueError: If the environment variable naming the S3 bucket (`s3_bucket_name_env`, by default
+            `S3_DOWNLOADER_BUCKET`) is not set. `run()` warms the component up on first use, so this surfaces
+            from the implicit `warm_up()` call.
         """
 
         if self._storage is None:

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -68,8 +68,8 @@ class S3Downloader:
         :param file_root_path: The path where the file will be downloaded.
             Can be set through this parameter or the `FILE_ROOT_PATH` environment variable.
             If none of them is set, a `ValueError` is raised.
-            Downloads are confined to this directory: a file name from document metadata that resolves outside
-            of it (for example an absolute path or one containing `..`) is rejected instead of written.
+            Downloads are confined to this directory: a document whose file name resolves outside of it
+            (for example an absolute path or one containing `..`) is logged and skipped instead of written.
         :param file_extensions: The file extensions that are permitted to be downloaded.
             By default, all file extensions are allowed.
         :param max_workers: The maximum number of workers to use for concurrent downloads.
@@ -150,10 +150,10 @@ class S3Downloader:
         Return enriched `Document`s with the path of the downloaded file.
         :param documents: Document containing the name of the file to download in the meta field.
         :returns: A dictionary with:
-            - `documents`: The downloaded `Document`s; each has `meta['file_path']`.
+            - `documents`: The downloaded `Document`s; each has `meta['file_path']`. Documents whose file name
+              is missing, or resolves outside of `file_root_path`, are logged and skipped.
         :raises S3Error: If a download attempt fails or the file does not exist in the S3 bucket.
-        :raises ValueError: If the path where files will be downloaded is not set, or if the file name of one of
-            the documents resolves outside of `file_root_path`.
+        :raises ValueError: If the path where files will be downloaded is not set.
         """
 
         if self._storage is None:
@@ -218,9 +218,8 @@ class S3Downloader:
         :param document: `Document` with the name of the file to download in the meta field.
         :returns:
             The same `Document` with `meta` containing the `file_path` of the
-            downloaded file.
+            downloaded file, or `None` if the document has no usable file name.
         :raises S3Error: If the download or head request fails or the file does not exist in the S3 bucket.
-        :raises ValueError: If the file name in the document metadata resolves outside of `file_root_path`.
         """
 
         file_name = document.meta.get(self.file_name_meta_key)
@@ -230,7 +229,11 @@ class S3Downloader:
             )
             return None
 
-        file_path = self._resolve_local_file_path(str(file_name))
+        try:
+            file_path = self._resolve_local_file_path(str(file_name))
+        except ValueError as error:
+            logger.warning("Skipping download of {file_name}: {error}", file_name=repr(file_name), error=str(error))
+            return None
 
         # if the file exists, avoid downloading it and just update the timestamp
         try:

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -331,50 +331,33 @@ class TestS3Downloader:
         assert final_path.exists()
         assert final_path.read_bytes() == b"complete content"
 
-    def test_run_skips_file_name_escaping_root(self, tmp_path, mock_s3_storage, mock_boto3_session, caplog):
+    @pytest.mark.parametrize(
+        ("file_name", "expected_warning"),
+        [
+            ("../escaped.txt", "outside of 'file_root_path'"),
+            ("{tmp_path}/absolute.txt", "outside of 'file_root_path'"),
+            ("sub/..", "Refusing to overwrite the download root directory"),
+        ],
+        ids=["traversal", "absolute", "root_itself"],
+    )
+    def test_run_skips_file_name_escaping_root(
+        self, tmp_path, mock_s3_storage, mock_boto3_session, caplog, file_name, expected_warning
+    ):
         # Attacker-controlled document metadata must not be able to write outside of file_root_path.
         root = tmp_path / "root"
         root.mkdir()
         d = S3Downloader(file_root_path=str(root))
         d._storage = mock_s3_storage
 
-        out = d.run(documents=[Document(meta={"file_name": "../escaped.txt"})])
+        out = d.run(documents=[Document(meta={"file_name": file_name.format(tmp_path=tmp_path)})])
 
         assert out["documents"] == []
-        assert not (tmp_path / "escaped.txt").exists()
+        assert list(tmp_path.iterdir()) == [root]  # nothing was written outside of the root
         mock_s3_storage.download.assert_not_called()
-        assert "outside of 'file_root_path'" in caplog.text
-
-    def test_run_skips_absolute_file_name(self, tmp_path, mock_s3_storage, mock_boto3_session, caplog):
-        # An absolute file name would otherwise discard file_root_path entirely.
-        root = tmp_path / "root"
-        root.mkdir()
-        target = tmp_path / "absolute.txt"
-        d = S3Downloader(file_root_path=str(root))
-        d._storage = mock_s3_storage
-
-        out = d.run(documents=[Document(meta={"file_name": str(target)})])
-
-        assert out["documents"] == []
-        assert not target.exists()
-        mock_s3_storage.download.assert_not_called()
-        assert "outside of 'file_root_path'" in caplog.text
-
-    def test_run_skips_file_name_resolving_to_root(self, tmp_path, mock_s3_storage, mock_boto3_session, caplog):
-        # A file name that resolves to the download directory itself must not be written to.
-        root = tmp_path / "root"
-        root.mkdir()
-        d = S3Downloader(file_root_path=str(root))
-        d._storage = mock_s3_storage
-
-        out = d.run(documents=[Document(meta={"file_name": "sub/.."})])
-
-        assert out["documents"] == []
-        mock_s3_storage.download.assert_not_called()
-        assert "Refusing to overwrite the download root directory" in caplog.text
+        assert expected_warning in caplog.text
 
     def test_run_skips_only_the_escaping_document(self, tmp_path, mock_s3_storage, mock_boto3_session):
-        # A single malicious document must not stop the rest of the batch from being downloaded.
+        # One malicious document must not stop the batch, and nested names inside the root keep working.
         root = tmp_path / "root"
         root.mkdir()
         d = S3Downloader(file_root_path=str(root))
@@ -383,24 +366,12 @@ class TestS3Downloader:
         out = d.run(
             documents=[
                 Document(meta={"file_name": "../escaped.txt"}),
-                Document(meta={"file_name": "legit.txt"}),
+                Document(meta={"file_name": "nested/dir/file.txt"}),
             ]
         )
 
-        assert [doc.meta["file_path"] for doc in out["documents"]] == [str(root / "legit.txt")]
+        assert [doc.meta["file_path"] for doc in out["documents"]] == [str(root / "nested" / "dir" / "file.txt")]
         assert not (tmp_path / "escaped.txt").exists()
-
-    def test_run_allows_file_name_in_subdirectory_of_root(self, tmp_path, mock_s3_storage, mock_boto3_session):
-        # Nested file names stay supported as long as they remain inside the root.
-        root = tmp_path / "root"
-        root.mkdir()
-        d = S3Downloader(file_root_path=str(root))
-        d._storage = mock_s3_storage
-
-        out = d.run(documents=[Document(meta={"file_name": "nested/dir/file.txt"})])
-
-        assert out["documents"][0].meta["file_path"] == str(root / "nested" / "dir" / "file.txt")
-        mock_s3_storage.download.assert_called_once()
 
     def test_cleanup_cache_evicts_old_files(self, tmp_path, mock_s3_storage, mock_boto3_session):
         d = S3Downloader(file_root_path=str(tmp_path), max_cache_size=1)

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -331,6 +331,57 @@ class TestS3Downloader:
         assert final_path.exists()
         assert final_path.read_bytes() == b"complete content"
 
+    def test_run_rejects_file_name_escaping_root(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        # Attacker-controlled document metadata must not be able to write outside of file_root_path.
+        root = tmp_path / "root"
+        root.mkdir()
+        d = S3Downloader(file_root_path=str(root))
+        d._storage = mock_s3_storage
+
+        with pytest.raises(ValueError, match="outside of 'file_root_path'"):
+            d.run(documents=[Document(meta={"file_name": "../escaped.txt"})])
+
+        assert not (tmp_path / "escaped.txt").exists()
+        mock_s3_storage.download.assert_not_called()
+
+    def test_run_rejects_absolute_file_name(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        # An absolute file name would otherwise discard file_root_path entirely.
+        root = tmp_path / "root"
+        root.mkdir()
+        target = tmp_path / "absolute.txt"
+        d = S3Downloader(file_root_path=str(root))
+        d._storage = mock_s3_storage
+
+        with pytest.raises(ValueError, match="outside of 'file_root_path'"):
+            d.run(documents=[Document(meta={"file_name": str(target)})])
+
+        assert not target.exists()
+        mock_s3_storage.download.assert_not_called()
+
+    def test_run_rejects_file_name_resolving_to_root(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        # A file name that resolves to the download directory itself must not be written to.
+        root = tmp_path / "root"
+        root.mkdir()
+        d = S3Downloader(file_root_path=str(root))
+        d._storage = mock_s3_storage
+
+        with pytest.raises(ValueError, match="Refusing to overwrite the download root directory"):
+            d.run(documents=[Document(meta={"file_name": "sub/.."})])
+
+        mock_s3_storage.download.assert_not_called()
+
+    def test_run_allows_file_name_in_subdirectory_of_root(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        # Nested file names stay supported as long as they remain inside the root.
+        root = tmp_path / "root"
+        root.mkdir()
+        d = S3Downloader(file_root_path=str(root))
+        d._storage = mock_s3_storage
+
+        out = d.run(documents=[Document(meta={"file_name": "nested/dir/file.txt"})])
+
+        assert out["documents"][0].meta["file_path"] == str(root / "nested" / "dir" / "file.txt")
+        mock_s3_storage.download.assert_called_once()
+
     def test_cleanup_cache_evicts_old_files(self, tmp_path, mock_s3_storage, mock_boto3_session):
         d = S3Downloader(file_root_path=str(tmp_path), max_cache_size=1)
         d._storage = mock_s3_storage

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -331,20 +331,21 @@ class TestS3Downloader:
         assert final_path.exists()
         assert final_path.read_bytes() == b"complete content"
 
-    def test_run_rejects_file_name_escaping_root(self, tmp_path, mock_s3_storage, mock_boto3_session):
+    def test_run_skips_file_name_escaping_root(self, tmp_path, mock_s3_storage, mock_boto3_session, caplog):
         # Attacker-controlled document metadata must not be able to write outside of file_root_path.
         root = tmp_path / "root"
         root.mkdir()
         d = S3Downloader(file_root_path=str(root))
         d._storage = mock_s3_storage
 
-        with pytest.raises(ValueError, match="outside of 'file_root_path'"):
-            d.run(documents=[Document(meta={"file_name": "../escaped.txt"})])
+        out = d.run(documents=[Document(meta={"file_name": "../escaped.txt"})])
 
+        assert out["documents"] == []
         assert not (tmp_path / "escaped.txt").exists()
         mock_s3_storage.download.assert_not_called()
+        assert "outside of 'file_root_path'" in caplog.text
 
-    def test_run_rejects_absolute_file_name(self, tmp_path, mock_s3_storage, mock_boto3_session):
+    def test_run_skips_absolute_file_name(self, tmp_path, mock_s3_storage, mock_boto3_session, caplog):
         # An absolute file name would otherwise discard file_root_path entirely.
         root = tmp_path / "root"
         root.mkdir()
@@ -352,23 +353,42 @@ class TestS3Downloader:
         d = S3Downloader(file_root_path=str(root))
         d._storage = mock_s3_storage
 
-        with pytest.raises(ValueError, match="outside of 'file_root_path'"):
-            d.run(documents=[Document(meta={"file_name": str(target)})])
+        out = d.run(documents=[Document(meta={"file_name": str(target)})])
 
+        assert out["documents"] == []
         assert not target.exists()
         mock_s3_storage.download.assert_not_called()
+        assert "outside of 'file_root_path'" in caplog.text
 
-    def test_run_rejects_file_name_resolving_to_root(self, tmp_path, mock_s3_storage, mock_boto3_session):
+    def test_run_skips_file_name_resolving_to_root(self, tmp_path, mock_s3_storage, mock_boto3_session, caplog):
         # A file name that resolves to the download directory itself must not be written to.
         root = tmp_path / "root"
         root.mkdir()
         d = S3Downloader(file_root_path=str(root))
         d._storage = mock_s3_storage
 
-        with pytest.raises(ValueError, match="Refusing to overwrite the download root directory"):
-            d.run(documents=[Document(meta={"file_name": "sub/.."})])
+        out = d.run(documents=[Document(meta={"file_name": "sub/.."})])
 
+        assert out["documents"] == []
         mock_s3_storage.download.assert_not_called()
+        assert "Refusing to overwrite the download root directory" in caplog.text
+
+    def test_run_skips_only_the_escaping_document(self, tmp_path, mock_s3_storage, mock_boto3_session):
+        # A single malicious document must not stop the rest of the batch from being downloaded.
+        root = tmp_path / "root"
+        root.mkdir()
+        d = S3Downloader(file_root_path=str(root))
+        d._storage = mock_s3_storage
+
+        out = d.run(
+            documents=[
+                Document(meta={"file_name": "../escaped.txt"}),
+                Document(meta={"file_name": "legit.txt"}),
+            ]
+        )
+
+        assert [doc.meta["file_path"] for doc in out["documents"]] == [str(root / "legit.txt")]
+        assert not (tmp_path / "escaped.txt").exists()
 
     def test_run_allows_file_name_in_subdirectory_of_root(self, tmp_path, mock_s3_storage, mock_boto3_session):
         # Nested file names stay supported as long as they remain inside the root.


### PR DESCRIPTION
### Related Issues

- Fixes deepset-ai/haystack-private#533

`S3Downloader._download_file` builds the local destination in a way that does not confine it to `file_root_path`

### Proposed Changes:
- Added `_resolve_local_file_path()`, which resolves the destination and requires it to be `is_relative_to()` the resolved `file_root_path`. It also refuses a file name that resolves to the root directory itself (e.g. `"sub/.."`), which would otherwise be handed to `os.utime`/`os.replace`.
- A document that fails the check is logged at warning level and skipped, exactly like a document missing the file name metadata key. 
- Docstrings for `file_root_path`, `file_name_meta_key`, `run()` and `_download_file()` now state the confinement and the skip behaviour.
- Updated some `:raises:`:
  - `run()` documented `:raises ValueError: If the path where files will be downloaded is not set.`, but `file_root_path` is validated in `__init__` and `run()` can never raise for it. 
  - `__init__` now documents the `AWSConfigurationError` that `get_aws_session` raises on invalid credentials, matching what sibling Bedrock components already document.
  - `warm_up()` documented nothing, but raises `ValueError` when the bucket environment variable is unset and `S3ConfigurationError` when the S3 client cannot be created.

### How did you test it?

- Added two unit tests

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes — n/a, issue already describes the fix
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
