### PR TITLE
fix: MariaDB - use 127.0.0.1 as default host

### DIFF
--- a/integrations/mariadb/src/haystack_integrations/components/retrievers/mariadb/embedding_retriever.py
+++ b/integrations/mariadb/src/haystack_integrations/components/retrievers/mariadb/embedding_retriever.py
@@ -26,7 +26,7 @@ class MariaDBEmbeddingRetriever:
     from haystack_integrations.document_stores.mariadb import MariaDBDocumentStore
     from haystack_integrations.components.retrievers.mariadb import MariaDBEmbeddingRetriever
 
-    store = MariaDBDocumentStore(host="localhost", database="haystack", embedding_dimension=768)
+    store = MariaDBDocumentStore(host="127.0.0.1", database="haystack", embedding_dimension=768)
     retriever = MariaDBEmbeddingRetriever(document_store=store, top_k=5)
     result = retriever.run(query_embedding=[0.1] * 768)
     documents = result["documents"]

--- a/integrations/mariadb/src/haystack_integrations/components/retrievers/mariadb/keyword_retriever.py
+++ b/integrations/mariadb/src/haystack_integrations/components/retrievers/mariadb/keyword_retriever.py
@@ -26,7 +26,7 @@ class MariaDBKeywordRetriever:
     from haystack_integrations.document_stores.mariadb import MariaDBDocumentStore
     from haystack_integrations.components.retrievers.mariadb import MariaDBKeywordRetriever
 
-    store = MariaDBDocumentStore(host="localhost", database="haystack", embedding_dimension=768)
+    store = MariaDBDocumentStore(host="127.0.0.1", database="haystack", embedding_dimension=768)
     retriever = MariaDBKeywordRetriever(document_store=store, top_k=5)
     result = retriever.run(query="climate change")
     documents = result["documents"]

--- a/integrations/mariadb/src/haystack_integrations/document_stores/mariadb/document_store.py
+++ b/integrations/mariadb/src/haystack_integrations/document_stores/mariadb/document_store.py
@@ -113,7 +113,7 @@ class MariaDBDocumentStore:
     from haystack_integrations.document_stores.mariadb import MariaDBDocumentStore
 
     store = MariaDBDocumentStore(
-        host="localhost",
+        host="127.0.0.1",
         port=3306,
         database="haystack",
         embedding_dimension=768,
@@ -125,7 +125,7 @@ class MariaDBDocumentStore:
     def __init__(
         self,
         *,
-        host: str = "localhost",
+        host: str = "127.0.0.1",
         port: int = 3306,
         database: str = "haystack",
         user: Secret = Secret.from_env_var("MARIADB_USER"),

--- a/integrations/mariadb/tests/test_document_store.py
+++ b/integrations/mariadb/tests/test_document_store.py
@@ -46,7 +46,7 @@ class TestSerialization:
         d = MariaDBDocumentStore().to_dict()
         assert d["type"] == "haystack_integrations.document_stores.mariadb.document_store.MariaDBDocumentStore"
         params = d["init_parameters"]
-        assert params["host"] == "localhost"
+        assert params["host"] == "127.0.0.1"
         assert params["embedding_dimension"] == 768
         assert params["distance"] == "cosine"
 
@@ -54,7 +54,7 @@ class TestSerialization:
         store = MariaDBDocumentStore(embedding_dimension=512, distance="euclidean")
         restored = MariaDBDocumentStore.from_dict(store.to_dict())
         assert restored.embedding_dimension == 512
-        assert restored.host == "localhost"
+        assert restored.host == "127.0.0.1"
         assert restored.distance == "euclidean"
 
     def test_invalid_table_name_raises(self):


### PR DESCRIPTION
### Related Issues

Our `MariaDBDocumentStore` adopts `host="localhost"` by default.

Unfortunately, this has a special meaning: connect through a local Unix socket, ignore `port`.

So if one spins up a MariaDB Docker container (as we recommend doing), and tries connecting with the default `MariaDBDocumentStore`, he gets this error:
> Can't connect to local server through socket '/tmp/mysql.sock' (2)
DocumentStoreError: Failed to connect to MariaDB at localhost:3306/haystack.

This is a [documented behavior](https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client#specify-which-protocol-to-use) but confuses users: https://bugs.mysql.com/bug.php?id=31577; https://github.com/rails/rails/issues/50824.

I think that for Haystack users, it's better to switch to a clearer default. User will still be able to use `"localhost"` if they want to use the local Unix Socket instead of TCP.

### Proposed Changes:
- use 127.0.0.1 as the default host: this works both with Docker and a local MariaDB via TCP connection

### How did you test it?
CI
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
