### PR TITLE
ci: remove unnecessary docker/setup-buildx-action from MCP worflow

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -81,10 +81,6 @@ jobs:
           # (e.g. `uvx mcp-server-time`). Installed on every OS so those tests run everywhere.
           pip install uv
 
-      - name: Set up Docker
-        if: runner.os == 'Linux'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
       # we need to pull the mcp/brave-search image to run the test
       # on the actual mcp server as an example of real life usage
       # We also need to set the BRAVE_API_KEY environment variable


### PR DESCRIPTION
### Related Issues

When reviewing https://github.com/deepset-ai/haystack-core-integrations/pull/3817, I realized that `docker/setup-buildx-action` is not needed here.

Here we just need `docker pull` (available out of the box in Ubuntu latest GitHub workers)

### Proposed Changes:
- remove the unnecessary action from MCP workflow

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
