### PR TITLE
fix: Sentence Transformers - fix types for 6.0

### DIFF
--- a/integrations/sentence_transformers/src/haystack_integrations/components/embedders/sentence_transformers/embedding_backend/backend.py
+++ b/integrations/sentence_transformers/src/haystack_integrations/components/embedders/sentence_transformers/embedding_backend/backend.py
@@ -112,5 +112,9 @@ class _SentenceTransformersEmbeddingBackend:
         if quantization_ranges is not None and precision in ("int8", "uint8"):
             kwargs["precision"] = "float32"
             embeddings = self.model.encode(data, **kwargs)
-            return quantize_embeddings(embeddings, precision=precision, ranges=np.asarray(quantization_ranges)).tolist()
+            quantized = quantize_embeddings(embeddings, precision=precision, ranges=np.asarray(quantization_ranges))
+            if isinstance(quantized, list):
+                msg = "Unexpected multi-vector output from quantize_embeddings"
+                raise TypeError(msg)
+            return quantized.tolist()
         return self.model.encode(data, **kwargs).tolist()


### PR DESCRIPTION
### Related Issues

Failing mypy: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/32316063335/job/96268427054

This happens because `sentence-transformers==6.0.0` added support for multi-vector embeddings and the signature of `quantize_embeddings` changed:

```python
# before
def quantize_embeddings(embeddings: Tensor | np.ndarray, ...) -> np.ndarray

# 6.0.0
def quantize_embeddings(
    embeddings: Tensor | np.ndarray | list[Tensor] | list[np.ndarray], ...
) -> np.ndarray | list[np.ndarray]
```

### Proposed Changes:
- our embedding backend only handles single-vector embeddings at the moment -> narrow the type and fail loudly if the type reflects a multi-vector embedding instead

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
