### PR TITLE
fix: fix finish reason mapping for streaming Gemini models

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/chat_generator.py
@@ -329,11 +329,17 @@ class GoogleGenAIChatGenerator:
 
         try:
             chunks = []
+            tool_calls_seen = False
 
             for i, chunk in enumerate(response_stream):
                 streaming_chunk = _convert_google_chunk_to_streaming_chunk(
-                    chunk=chunk, index=i, component_info=component_info, model=self._model
+                    chunk=chunk,
+                    index=i,
+                    component_info=component_info,
+                    model=self._model,
+                    tool_calls_seen=tool_calls_seen,
                 )
+                tool_calls_seen = tool_calls_seen or bool(streaming_chunk.tool_calls)
                 chunks.append(streaming_chunk)
 
                 # Stream the chunk
@@ -361,13 +367,19 @@ class GoogleGenAIChatGenerator:
 
         try:
             chunks = []
+            tool_calls_seen = False
 
             i = 0
             chunk = None
             async for chunk in response_stream:
                 streaming_chunk = _convert_google_chunk_to_streaming_chunk(
-                    chunk=chunk, index=i, component_info=component_info, model=self._model
+                    chunk=chunk,
+                    index=i,
+                    component_info=component_info,
+                    model=self._model,
+                    tool_calls_seen=tool_calls_seen,
                 )
+                tool_calls_seen = tool_calls_seen or bool(streaming_chunk.tool_calls)
                 chunks.append(streaming_chunk)
 
                 # Stream the chunk

--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/utils.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/utils.py
@@ -590,6 +590,8 @@ def _convert_google_chunk_to_streaming_chunk(
     index: int,
     component_info: ComponentInfo,
     model: str,
+    *,
+    tool_calls_seen: bool = False,
 ) -> StreamingChunk:
     """
     Convert a chunk from Google Gen AI to a Haystack StreamingChunk.
@@ -598,6 +600,8 @@ def _convert_google_chunk_to_streaming_chunk(
     :param index: The index of the chunk.
     :param component_info: The component info.
     :param model: The model name.
+    :param tool_calls_seen: Whether an earlier chunk of the same stream already carried a tool call. Needed to
+        report the correct finish reason, since Gemini 3 models send the terminal finish reason in its own chunk.
     :returns: A StreamingChunk object.
     """
     content = ""
@@ -627,7 +631,7 @@ def _convert_google_chunk_to_streaming_chunk(
     if cached_content_token_count is not None:
         usage["cached_content_token_count"] = cached_content_token_count
 
-    if candidate.content and candidate.content.parts:
+    if chunk.candidates and candidate.content and candidate.content.parts:
         tc_index = -1
         for part_index, part in enumerate(candidate.content.parts):
             # Check for thought signature on this part (for multi-turn context)
@@ -685,8 +689,10 @@ def _convert_google_chunk_to_streaming_chunk(
 
     # Remap finish_reason to "tool_calls" when tool calls are present, since Google GenAI returns
     # "STOP" for both normal completions and tool calls (no dedicated FUNCTION_CALL finish reason).
+    # Gemini 3 models send the finish reason in its own chunk, after the one holding the tool call, so we also
+    # consider tool calls from earlier chunks of the same stream.
     mapped_finish_reason = FINISH_REASON_MAPPING.get(finish_reason or "")
-    if mapped_finish_reason == "stop" and tool_calls:
+    if mapped_finish_reason == "stop" and (tool_calls or tool_calls_seen):
         mapped_finish_reason = "tool_calls"
 
     return StreamingChunk(

--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -8,6 +8,7 @@ import os
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from google.genai import types
 from haystack.components.agents import Agent
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import (
@@ -335,6 +336,39 @@ class TestGoogleGenAIChatGeneratorRun:
         assert "Hello" in results["replies"][0].text
         assert " world" in results["replies"][0].text
         assert len(callback_chunks) == 2
+
+    def test_run_streaming_gemini_3_tool_call_finish_reason(self, monkeypatch):
+        """
+        Gemini 3 models send the terminal "STOP" in its own chunk, after the one holding the function call.
+        Both the streamed chunk and the aggregated reply must report "tool_calls".
+        """
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        component = GoogleGenAIChatGenerator(model="gemini-3.7-flash")
+
+        def google_chunk(parts, finish_reason=None):
+            return types.GenerateContentResponse(
+                candidates=[
+                    types.Candidate(content=types.Content(role="model", parts=parts), finish_reason=finish_reason)
+                ]
+            )
+
+        raw_chunks = [
+            google_chunk([types.Part(text="Checking the weather", thought=True)]),
+            google_chunk([types.Part(function_call=types.FunctionCall(name="weather", args={"city": "Paris"}))]),
+            google_chunk([], finish_reason=types.FinishReason.STOP),
+        ]
+        component._client.models.generate_content_stream = Mock(return_value=iter(raw_chunks))
+
+        callback_chunks = []
+        results = component.run(
+            [ChatMessage.from_user("What's the weather in Paris?")],
+            streaming_callback=callback_chunks.append,
+        )
+
+        # The terminal chunk handed to the callback carries the remapped finish reason
+        assert callback_chunks[-1].finish_reason == "tool_calls"
+        assert results["replies"][0].meta["finish_reason"] == "tool_calls"
+        assert results["replies"][0].tool_calls[0].tool_name == "weather"
 
     def test_run_extracts_system_message(self, monkeypatch, mock_response):
         monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")

--- a/integrations/google_genai/tests/test_chat_generator_utils.py
+++ b/integrations/google_genai/tests/test_chat_generator_utils.py
@@ -772,6 +772,21 @@ class TestStreamingChunkConversion:
         assert result.text == "Hello world"
         assert result.meta["usage"]["cached_content_token_count"] == 800
 
+    def test_convert_google_chunk_to_streaming_chunk_without_candidates(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        component_info = ComponentInfo.from_component(GoogleGenAIChatGenerator())
+
+        chunk = _convert_google_chunk_to_streaming_chunk(
+            chunk=types.GenerateContentResponse(candidates=[]),
+            index=3,
+            component_info=component_info,
+            model="gemini-3.7-flash",
+        )
+
+        assert chunk.content == ""
+        assert chunk.tool_calls == []
+        assert chunk.finish_reason is None
+
 
 class TestConvertMessageToGoogleGenAI:
     def test_convert_message_to_google_genai_format_complex(self):


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Some Gemini models stream their finish reason in a separate chunk from the last content part. This broke our existing finish reason mapping in our streaming code which assumed a streamed tool call chunk also carried its finish reason. This isn't guaranteed so we now support both cases where a finish reason could be sent on its own or with a tool call content part. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New and existing tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
