### PR TITLE
feat (bedrock): add support for file content in a tool result

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -215,7 +215,15 @@ def _format_tool_result_message(tool_call_result_message: ChatMessage) -> dict[s
                 if isinstance(item, TextContent):
                     content.append({"text": item.text})
                 elif isinstance(item, ImageContent):
-                    content.append(_convert_image_content_to_bedrock_format(item))
+                    content.append(_convert_image_content_to_bedrock_format(image_content=item))
+                elif isinstance(item, FileContent):
+                    content.append(_convert_file_content_to_bedrock_format(file_content=item))
+                else:
+                    err_msg = (
+                        "Unsupported content type in tool call result list. "
+                        "Only TextContent, ImageContent, and FileContent are supported."
+                    )
+                    raise ValueError(err_msg)
         else:
             err_msg = "Unsupported content type in tool call result"
             raise ValueError(err_msg)

--- a/integrations/amazon_bedrock/tests/test_chat_generator.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator.py
@@ -55,7 +55,7 @@ MODELS_TO_TEST_WITH_IMAGE_INPUT = [
     "qwen.qwen3-vl-235b-a22b",
 ]
 
-MODELS_TO_TEST_WITH_IMAGE_TOOL_OUTPUT = [
+MODELS_TO_TEST_WITH_MULTIMODAL_TOOL_OUTPUT = [
     "global.anthropic.claude-sonnet-4-6",
 ]
 
@@ -1085,31 +1085,36 @@ class TestAmazonBedrockChatGeneratorInference:
         assert first_reply.text
         assert "earth" in first_reply.text.lower()
 
-    @pytest.mark.parametrize("model_name", MODELS_TO_TEST_WITH_IMAGE_TOOL_OUTPUT)
-    def test_live_run_agent_with_images_in_tool_result(self, model_name, test_files_path):
-        def retrieve_image():
+    @pytest.mark.parametrize("model_name", MODELS_TO_TEST_WITH_MULTIMODAL_TOOL_OUTPUT)
+    def test_live_run_agent_with_multimodal_content_in_tool_result(self, model_name, test_files_path):
+        def retrieve_multimodal_content():
             return [
-                TextContent("Here is the retrieved image."),
+                TextContent("Here are the retrieved image and document."),
                 ImageContent.from_file_path(test_files_path / "apple.jpg", size=(100, 100)),
+                FileContent.from_file_path(test_files_path / "sample_pdf_1.pdf"),
             ]
 
-        image_retriever_tool = create_tool_from_function(
-            name="retrieve_image",
-            description="Tool to retrieve an image",
-            function=retrieve_image,
+        multimodal_retriever_tool = create_tool_from_function(
+            name="retrieve_multimodal_content",
+            description="Tool to retrieve an image and a document",
+            function=retrieve_multimodal_content,
+            outputs_to_string={"raw_result": True},
         )
-        image_retriever_tool.outputs_to_string = {"raw_result": True}
 
         agent = Agent(
             chat_generator=AmazonBedrockChatGenerator(model=model_name),
-            system_prompt="You are an Agent that can retrieve images and describe them.",
-            tools=[image_retriever_tool],
+            system_prompt="You are an Agent that can retrieve and analyze images and documents.",
+            tools=[multimodal_retriever_tool],
         )
 
-        user_message = ChatMessage.from_user("Retrieve the image and describe it in max 5 words.")
+        user_message = ChatMessage.from_user(
+            "Retrieve the image and document. Identify what is shown in the image. Then determine whether the document "
+            "is a paper about Large Language Models and answer that part with exactly 'yes' or 'no'. Respond briefly."
+        )
         result = agent.run(messages=[user_message])
 
         assert "apple" in result["last_message"].text.lower()
+        assert "no" in result["last_message"].text.lower()
 
     @pytest.mark.parametrize("model_name", MODELS_TO_TEST)
     def test_default_inference_with_streaming(self, model_name, chat_messages):

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -460,6 +460,56 @@ class TestAmazonBedrockChatGeneratorUtils:
             },
         ]
 
+    def test_format_tool_result_message_with_file_content(self):
+        file_content = FileContent(
+            base64_data=base64.b64encode(b"This is a test document."),
+            mime_type="application/pdf",
+            filename="test document.pdf",
+            validation=False,
+        )
+        message = ChatMessage.from_tool(
+            tool_result=[TextContent("Here's the retrieved document"), file_content],
+            origin=ToolCall(id="123", tool_name="file_retriever", arguments={"path": "test document.pdf"}),
+        )
+
+        formatted_message = _format_tool_result_message(message)
+
+        assert formatted_message == {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "123",
+                        "content": [
+                            {"text": "Here's the retrieved document"},
+                            {
+                                "document": {
+                                    "format": "pdf",
+                                    "source": {"bytes": b"This is a test document."},
+                                    "name": "test document",
+                                }
+                            },
+                        ],
+                    }
+                }
+            ],
+        }
+
+    def test_format_tool_result_message_with_unsupported_list_item_raises(self):
+        message = ChatMessage.from_tool(
+            tool_result=[TextContent("This is supported"), 256],
+            origin=ToolCall(id="123", tool_name="test_tool", arguments={}),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"Unsupported content type in tool call result list. "
+                "Only TextContent, ImageContent, and FileContent are supported."
+            ),
+        ):
+            _format_tool_result_message(message)
+
     def test_format_message_thinking(self):
         assistant_message = ChatMessage.from_assistant(
             "This is a test message.",


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/422

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add support for file content in a tool result which the bedrock converse api accepts.

The primary AWS reference is ToolResultContentBlock (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultContentBlock.html). Its document member is explicitly described as a tool result containing a document.

AWS’s DocumentBlock reference (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html) lists supported formats: PDF, CSV, DOC/DOCX, XLS/XLSX, HTML, TXT, and Markdown.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests and updated existing tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
