### PR TITLE
feat (anthropic): add file content support to tool result

### DIFF
--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/utils.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/utils.py
@@ -180,7 +180,7 @@ def _update_anthropic_message_with_tool_call_results(
             msg = "`ToolCall` must have a non-null `id` attribute to be used with Anthropic."
             raise ValueError(msg)
 
-        tool_result_block_content: list[TextBlockParam | ImageBlockParam] = []
+        tool_result_block_content: list[TextBlockParam | ImageBlockParam | DocumentBlockParam] = []
         if isinstance(tool_call_result.result, str):
             tool_result_block_content.append(TextBlockParam(type="text", text=tool_call_result.result))
         elif isinstance(tool_call_result.result, list):
@@ -188,7 +188,9 @@ def _update_anthropic_message_with_tool_call_results(
                 if isinstance(item, TextContent):
                     tool_result_block_content.append(TextBlockParam(type="text", text=item.text))
                 elif isinstance(item, ImageContent):
-                    tool_result_block_content.append(_convert_image_content_to_anthropic_format(item))
+                    tool_result_block_content.append(_convert_image_content_to_anthropic_format(image_content=item))
+                elif isinstance(item, FileContent):
+                    tool_result_block_content.append(_convert_file_content_to_anthropic_format(file_content=item))
                 else:
                     msg = "Unsupported content type in tool call result"
                     raise ValueError(msg)

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -1205,28 +1205,35 @@ class TestIntegration:
         _, non_system = _convert_messages_to_anthropic_format([message])
         assert non_system[0]["content"] == raw_content
 
-    def test_live_run_agent_with_images_in_tool_result(self, test_files_path):
-        def retrieve_image():
+    def test_live_run_agent_with_multimodal_content_in_tool_result(self, test_files_path):
+        def retrieve_multimodal_content():
             return [
-                TextContent("Here is the retrieved image."),
-                ImageContent.from_file_path(test_files_path / "apple.jpg", size=(100, 100)),
+                TextContent("Here are the retrieved image and document."),
+                ImageContent.from_file_path(file_path=test_files_path / "apple.jpg", size=(100, 100)),
+                FileContent.from_file_path(file_path=test_files_path / "sample_pdf_3.pdf"),
             ]
 
-        image_retriever_tool = create_tool_from_function(
-            name="retrieve_image", description="Tool to retrieve an image", function=retrieve_image
+        multimodal_retriever_tool = create_tool_from_function(
+            name="retrieve_multimodal_content",
+            description="Tool to retrieve an image and a document",
+            function=retrieve_multimodal_content,
+            outputs_to_string={"raw_result": True},
         )
-        image_retriever_tool.outputs_to_string = {"raw_result": True}
 
         agent = Agent(
             chat_generator=AnthropicChatGenerator(model="claude-haiku-4-5"),
-            system_prompt="You are an Agent that can retrieve images and describe them.",
-            tools=[image_retriever_tool],
+            system_prompt="You are an Agent that can retrieve and analyze images and documents.",
+            tools=[multimodal_retriever_tool],
         )
 
-        user_message = ChatMessage.from_user("Retrieve the image and describe it in max 5 words.")
+        user_message = ChatMessage.from_user(
+            "Retrieve the image and document. Identify what is shown in the image. Then determine whether the document "
+            "is a paper about Large Language Models and answer that part with exactly 'yes' or 'no'. Respond briefly."
+        )
         result = agent.run(messages=[user_message])
 
         assert "apple" in result["last_message"].text.lower()
+        assert "no" in result["last_message"].text.lower()
 
     @pytest.mark.parametrize("streaming", [False, True])
     def test_live_run_agent_with_local_and_anthropic_server_tools(self, streaming):

--- a/integrations/anthropic/tests/test_utils.py
+++ b/integrations/anthropic/tests/test_utils.py
@@ -1089,10 +1089,16 @@ class TestConvertMessagesToAnthropicFormat:
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
         )
+        base64_pdf = "JVBERi0xLjEKMSAwIG9iago8PC9UeXBlL0NhdGFsb2c+PgplbmRvYmoKdHJhaWxlcgo8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
 
         tool_result = [
-            TextContent("Here's the retrieved image"),
+            TextContent("Here are the retrieved image and document"),
             ImageContent(base64_image=base64_image, mime_type="image/png"),
+            FileContent(
+                base64_data=base64_pdf,
+                mime_type="application/pdf",
+                extra={"context": "This document contains a table", "title": "A nice PDF"},
+            ),
         ]
         messages = [
             ChatMessage.from_tool(
@@ -1109,10 +1115,20 @@ class TestConvertMessagesToAnthropicFormat:
                             "type": "tool_result",
                             "tool_use_id": "123",
                             "content": [
-                                {"type": "text", "text": "Here's the retrieved image"},
+                                {"type": "text", "text": "Here are the retrieved image and document"},
                                 {
                                     "type": "image",
                                     "source": {"type": "base64", "media_type": "image/png", "data": base64_image},
+                                },
+                                {
+                                    "type": "document",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "application/pdf",
+                                        "data": base64_pdf,
+                                    },
+                                    "context": "This document contains a table",
+                                    "title": "A nice PDF",
                                 },
                             ],
                             "is_error": False,


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/421

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add support for file content being returned in a tool result which is supported by anthropics api. 

Anthropic support is confirmed by its OpenAPI-generated SDK type (https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/tool_result_block_param.py), where ToolResultBlockParam.content includes DocumentBlockParam.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests and expanded existing integration test. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
