### PR TITLE
feat (google-genai): add file content support in tool result

### DIFF
--- a/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/utils.py
+++ b/integrations/google_genai/src/haystack_integrations/components/generators/google_genai/chat/utils.py
@@ -367,10 +367,18 @@ def _convert_message_to_google_genai_format(message: ChatMessage) -> types.Conte
                                 ),
                             )
                         )
+                    elif isinstance(item, FileContent):
+                        tool_call_result_parts.append(
+                            types.FunctionResponsePart(
+                                inline_data=types.FunctionResponseBlob(
+                                    data=base64.b64decode(item.base64_data), mime_type=item.mime_type
+                                ),
+                            )
+                        )
                     else:
                         msg = (
                             "Unsupported content type in tool call result list. "
-                            "Only TextContent and ImageContent are supported."
+                            "Only TextContent, ImageContent, and FileContent are supported."
                         )
                         raise ValueError(msg)
                 parts.append(

--- a/integrations/google_genai/tests/test_chat_generator.py
+++ b/integrations/google_genai/tests/test_chat_generator.py
@@ -954,28 +954,36 @@ class TestGoogleGenAIChatGeneratorInference:
         assert "name" in parsed
         assert "country" in parsed
 
-    def test_live_run_agent_with_images_in_tool_result(self, test_files_path):
-        def retrieve_image():
+    def test_live_run_agent_with_multimodal_content_in_tool_result(self, test_files_path):
+        def retrieve_multimodal_content():
             return [
-                TextContent("Here is the retrieved image."),
-                ImageContent.from_file_path(test_files_path / "apple.jpg", size=(100, 100)),
+                TextContent("Here are the retrieved image and document."),
+                ImageContent.from_file_path(file_path=test_files_path / "apple.jpg", size=(100, 100)),
+                FileContent.from_file_path(file_path=test_files_path / "sample_pdf_3.pdf"),
             ]
 
-        image_retriever_tool = create_tool_from_function(
-            name="retrieve_image", description="Tool to retrieve an image", function=retrieve_image
+        multimodal_retriever_tool = create_tool_from_function(
+            name="retrieve_multimodal_content",
+            description="Tool to retrieve an image and a document",
+            function=retrieve_multimodal_content,
+            outputs_to_string={"raw_result": True},
         )
-        image_retriever_tool.outputs_to_string = {"raw_result": True}
 
         agent = Agent(
             chat_generator=GoogleGenAIChatGenerator(model="gemini-3-flash-preview"),
-            system_prompt="You are an Agent that can retrieve images and describe them.",
-            tools=[image_retriever_tool],
+            system_prompt="You are an Agent that can retrieve and analyze images and documents.",
+            tools=[multimodal_retriever_tool],
         )
 
-        user_message = ChatMessage.from_user("Retrieve the image and describe it in max 5 words.")
+        user_message = ChatMessage.from_user(
+            "Retrieve the image and document. Describe what is shown in the image in no more than 5 words. Then "
+            "determine whether the document is a paper about Large Language Models and answer that part with exactly "
+            "'yes' or 'no'."
+        )
         result = agent.run(messages=[user_message])
 
         assert "apple" in result["last_message"].text.lower()
+        assert "no" in result["last_message"].text.lower()
 
 
 @pytest.mark.skipif(

--- a/integrations/google_genai/tests/test_chat_generator_utils.py
+++ b/integrations/google_genai/tests/test_chat_generator_utils.py
@@ -1005,11 +1005,16 @@ class TestConvertMessageToGoogleGenAI:
         assert google_content.parts[0].function_response.response == {"result": "22° C"}
         assert google_content.parts[0].function_response.parts is None
 
-    def test_convert_message_to_google_genai_format_image_in_tool_result(self):
-        tool_call = ToolCall(id="123", tool_name="image_retriever", arguments={})
+    def test_convert_message_to_google_genai_format_multimodal_content_in_tool_result(self):
+        tool_call = ToolCall(id="123", tool_name="multimodal_retriever", arguments={})
 
-        base64_str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII="
-        tool_result = [TextContent("Here is the image"), ImageContent(base64_image=base64_str, mime_type="image/jpeg")]
+        base64_image = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII="
+        base64_pdf = base64.b64encode(b"This is a test document.").decode()
+        tool_result = [
+            TextContent("Here are the image and document"),
+            ImageContent(base64_image=base64_image, mime_type="image/jpeg"),
+            FileContent(base64_data=base64_pdf, mime_type="application/pdf", validation=False),
+        ]
 
         message = ChatMessage.from_tool(tool_result=tool_result, origin=tool_call)
         google_content = _convert_message_to_google_genai_format(message)
@@ -1017,16 +1022,19 @@ class TestConvertMessageToGoogleGenAI:
         assert len(google_content.parts) == 1
         assert isinstance(google_content.parts[0].function_response, types.FunctionResponse)
         assert google_content.parts[0].function_response.id == "123"
-        assert google_content.parts[0].function_response.name == "image_retriever"
+        assert google_content.parts[0].function_response.name == "multimodal_retriever"
         assert google_content.parts[0].function_response.response == {"result": ""}
-        assert len(google_content.parts[0].function_response.parts) == 2
+        assert len(google_content.parts[0].function_response.parts) == 3
         assert isinstance(google_content.parts[0].function_response.parts[0], types.FunctionResponsePart)
         assert google_content.parts[0].function_response.parts[0].inline_data.mime_type == "text/plain"
-        assert google_content.parts[0].function_response.parts[0].inline_data.data == b"Here is the image"
+        assert google_content.parts[0].function_response.parts[0].inline_data.data == b"Here are the image and document"
         assert isinstance(google_content.parts[0].function_response.parts[1], types.FunctionResponsePart)
         assert google_content.parts[0].function_response.parts[1].inline_data.mime_type == "image/jpeg"
-        assert google_content.parts[0].function_response.parts[1].inline_data.data == base64.b64decode(base64_str)
+        assert google_content.parts[0].function_response.parts[1].inline_data.data == base64.b64decode(base64_image)
         assert len(google_content.parts[0].function_response.parts[1].inline_data.data) > 0
+        assert isinstance(google_content.parts[0].function_response.parts[2], types.FunctionResponsePart)
+        assert google_content.parts[0].function_response.parts[2].inline_data.mime_type == "application/pdf"
+        assert google_content.parts[0].function_response.parts[2].inline_data.data == b"This is a test document."
 
     def test_convert_message_empty_content_raises(self):
         message = ChatMessage.from_user("hello")
@@ -1079,7 +1087,7 @@ class TestConvertMessageToGoogleGenAI:
             ValueError,
             match=(
                 r"Unsupported content type in tool call result list. "
-                "Only TextContent and ImageContent are supported."
+                "Only TextContent, ImageContent, and FileContent are supported."
             ),
         ):
             _convert_message_to_google_genai_format(message)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/423

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add support for file content in a tool result. 

Google’s multimodal function-response documentation (https://ai.google.dev/gemini-api/docs/generate-content/function-calling#multimodal) confirms Gemini 3 accepts nested inlineData, including PDFs and plain-text documents.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Expanded existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
