### PR TITLE
feat(fastembed): add Python 3.14 support

### DIFF
--- a/.github/workflows/fastembed.yml
+++ b/.github/workflows/fastembed.yml
@@ -24,7 +24,7 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   TEST_MATRIX_OS: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-  TEST_MATRIX_PYTHON: '["3.10", "3.13"]'
+  TEST_MATRIX_PYTHON: '["3.10", "3.14"]'
 
 jobs:
   compute-test-matrix:

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/integrations/fastembed/pyproject.toml
+++ b/integrations/fastembed/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "fastembed>=0.4.2"]
+dependencies = ["haystack-ai>=2.24.1", "fastembed>=0.8.0"]
 
 [project.urls]
 Source = "https://github.com/deepset-ai/haystack-core-integrations"


### PR DESCRIPTION
FastEmbed 0.8.0 added Python 3.14 support (tracked in qdrant/fastembed#576). This PR adds the 3.14 classifier to `pyproject.toml` and updates the CI matrix to test on 3.14 instead of 3.13.

Closes #3035