### PR TITLE
chore: AmazonBedrockChatGenerator - support sync streaming callbacks in async contexts

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/chat_generator.py
@@ -637,7 +637,7 @@ class AmazonBedrockChatGenerator:
 
         :param messages: A list of `ChatMessage` objects forming the chat history.
             If a string is provided, it is converted to a list containing a ChatMessage with user role.
-        :param streaming_callback: Optional async-compatible callback for handling streaming outputs.
+        :param streaming_callback: Optional callback for handling streaming outputs. Async callbacks are preferred.
         :param generation_kwargs: Optional dictionary of generation parameters. These are merged per key with the
             `generation_kwargs` passed at initialization: keys provided here take precedence, keys set only at
             initialization are kept. Some common parameters are:
@@ -691,10 +691,9 @@ class AmazonBedrockChatGenerator:
                     if not response_stream:
                         msg = "No stream found in the response."
                         raise AmazonBedrockInferenceError(msg)
-                    # the type of streaming callback is checked in _prepare_request_params, but mypy doesn't know
                     replies = await _parse_streaming_response_async(
                         response_stream=response_stream,
-                        streaming_callback=callback,  # type: ignore[arg-type]
+                        streaming_callback=callback,
                         model=self.model,
                         component_info=component_info,
                     )

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/generators/amazon_bedrock/chat/utils.py
@@ -1,5 +1,6 @@
 import base64
 import dataclasses
+import inspect
 import json
 import os
 import re
@@ -10,7 +11,6 @@ from botocore.eventstream import EventStream
 from haystack import logging
 from haystack.components.generators.utils import _convert_streaming_chunks_to_chat_message
 from haystack.dataclasses import (
-    AsyncStreamingCallbackT,
     ChatMessage,
     ChatRole,
     ComponentInfo,
@@ -18,6 +18,7 @@ from haystack.dataclasses import (
     FinishReason,
     ImageContent,
     ReasoningContent,
+    StreamingCallbackT,
     StreamingChunk,
     SyncStreamingCallbackT,
     TextContent,
@@ -707,7 +708,7 @@ def _convert_chunks_to_messages(chunks: list[StreamingChunk]) -> list[ChatMessag
 
 async def _parse_streaming_response_async(
     response_stream: EventStream,
-    streaming_callback: AsyncStreamingCallbackT,
+    streaming_callback: StreamingCallbackT,
     model: str,
     component_info: ComponentInfo,
 ) -> list[ChatMessage]:
@@ -728,7 +729,10 @@ async def _parse_streaming_response_async(
         if content_block_idx is not None and content_block_idx not in content_block_idxs:
             streaming_chunk.start = True
             content_block_idxs.add(content_block_idx)
-        await streaming_callback(streaming_chunk)
+        # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+        callback_result = streaming_callback(streaming_chunk)
+        if inspect.isawaitable(callback_result):
+            await callback_result
         chunks.append(streaming_chunk)
 
     replies = _convert_chunks_to_messages(chunks)

--- a/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
+++ b/integrations/amazon_bedrock/tests/test_chat_generator_utils.py
@@ -27,6 +27,7 @@ from haystack_integrations.components.generators.amazon_bedrock.chat.utils impor
     _format_user_message,
     _parse_completion_response,
     _parse_streaming_response,
+    _parse_streaming_response_async,
     _validate_and_format_cache_point,
     _validate_guardrail_config,
 )
@@ -1935,6 +1936,39 @@ class TestAmazonBedrockChatGeneratorUtils:
             )
         ]
         assert replies == expected_messages
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_async_callback", [True, False])
+    async def test_parse_streaming_response_async_with_sync_and_async_callback(self, use_async_callback):
+        model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "Hello"}, "contentBlockIndex": 0}},
+            {"contentBlockDelta": {"delta": {"text": " world"}, "contentBlockIndex": 0}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+
+        async def event_stream():
+            for event in events:
+                yield event
+
+        collected = []
+
+        async def async_callback(chunk: StreamingChunk) -> None:
+            collected.append(chunk)
+
+        def sync_callback(chunk: StreamingChunk) -> None:
+            collected.append(chunk)
+
+        callback = async_callback if use_async_callback else sync_callback
+
+        replies = await _parse_streaming_response_async(event_stream(), callback, model, ComponentInfo(type="test"))
+
+        assert len(collected) == len(events)
+        assert "".join(chunk.content for chunk in collected) == "Hello world"
+        assert len(replies) == 1
+        assert replies[0].text == "Hello world"
+        assert replies[0].meta["finish_reason"] == "stop"
 
     def test_convert_streaming_chunks_to_chat_message_tool_call_with_empty_arguments(
         self,


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/395

### Proposed Changes:
- make `AmazonBedrockChatGenerator` accept sync callbacks in `run_async` and handle them properly

### How did you test it?
CI + new tests

### Notes for the reviewer
No need to bump Haystack, as explained in https://github.com/deepset-ai/haystack-private/issues/395#issuecomment-5370836694

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
