### PR TITLE
fix: `LibreOfficeFileConverter` sources type should be `list` instead of `Iterable`

### DIFF
--- a/integrations/libreoffice/src/haystack_integrations/components/converters/libreoffice/converter.py
+++ b/integrations/libreoffice/src/haystack_integrations/components/converters/libreoffice/converter.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import subprocess
 from asyncio import create_subprocess_exec
-from collections.abc import Iterable
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, Literal, TypedDict, get_args
@@ -254,7 +253,7 @@ class LibreOfficeFileConverter:
     @component.output_types(output=list[ByteStream])
     def run(
         self,
-        sources: Iterable[str | Path | ByteStream],
+        sources: list[str | Path | ByteStream],
         output_file_type: OUTPUT_FILE_TYPE | None = None,
     ) -> LibreOfficeFileConverterOutput:
         """
@@ -320,7 +319,7 @@ class LibreOfficeFileConverter:
     @component.output_types(output=list[ByteStream])
     async def run_async(
         self,
-        sources: Iterable[str | Path | ByteStream],
+        sources: list[str | Path | ByteStream],
         output_file_type: OUTPUT_FILE_TYPE | None = None,
     ) -> LibreOfficeFileConverterOutput:
         """


### PR DESCRIPTION
### Related Issues

- fixes #3832

### Proposed Changes:

Change sources type to be `list` instead of `Iterable`.

### How did you test it?

Ran existing unit and integration tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
