### PR TITLE
feat(deepeval): support custom metric instances in evaluator

### DIFF
--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/evaluator.py
@@ -13,6 +13,8 @@ from .metrics import (
     METRIC_DESCRIPTORS,
     DeepEvalMetric,
     InputConverters,
+    MetricDescriptor,
+    _metric_name,
 )
 
 
@@ -22,7 +24,14 @@ class DeepEvalEvaluator:
     A component that uses DeepEval to evaluate inputs against a specific metric.
 
     Uses the [DeepEval framework](https://docs.confident-ai.com/docs/evaluation-introduction).
-    Supported metrics are defined by `DeepEvalMetric`.
+    Supported built-in metrics are defined by `DeepEvalMetric`. Alternatively, any
+    initialized DeepEval metric can be passed directly, which makes it possible to use
+    custom metrics that subclass `deepeval.metrics.BaseMetric`.
+
+    Note that a component configured with an already initialized metric cannot be
+    serialized: a metric instance carries runtime state that cannot be reliably
+    reconstructed. Use one of the `DeepEvalMetric` built-ins if the pipeline needs
+    to survive `to_dict`/`from_dict`.
 
     Usage example:
     ```python
@@ -46,30 +55,80 @@ class DeepEvalEvaluator:
     )
     print(output["results"])
     ```
+
+    Usage example with a custom metric:
+    ```python
+    from deepeval.metrics import BaseMetric
+    from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+    class ResponseLengthMetric(BaseMetric):
+        _required_params = [SingleTurnParams.INPUT, SingleTurnParams.ACTUAL_OUTPUT]
+
+        def __init__(self, max_words: int = 20) -> None:
+            self.max_words = max_words
+
+        def measure(self, test_case: LLMTestCase) -> float:
+            words = len((test_case.actual_output or "").split())
+            self.score = min(1.0, words / self.max_words)
+            self.reason = f"The response contains {words} words"
+            return self.score
+
+        async def a_measure(self, test_case: LLMTestCase) -> float:
+            return self.measure(test_case)
+
+        @property
+        def __name__(self) -> str:
+            return "Response Length"
+
+    evaluator = DeepEvalEvaluator(metric=ResponseLengthMetric(max_words=10))
+    output = evaluator.run(
+        questions=["Which is the most popular global sport?"],
+        responses=["Football"],
+    )
+    print(output["results"])
+    ```
     """
 
+    metric: DeepEvalMetric | BaseMetric
+    descriptor: MetricDescriptor
     _backend_metric: BaseMetric
     # Wrapped for easy mocking.
     _backend_callable: Callable[[list[LLMTestCase], BaseMetric], EvaluationResult]
 
     def __init__(
         self,
-        metric: str | DeepEvalMetric,
+        metric: str | DeepEvalMetric | BaseMetric,
         metric_params: dict[str, Any] | None = None,
     ) -> None:
         """
         Construct a new DeepEval evaluator.
 
         :param metric:
-            The metric to use for evaluation.
+            The metric to use for evaluation. Either one of the built-in metrics
+            defined by `DeepEvalMetric` (or its string value), or an already
+            initialized DeepEval metric such as a custom subclass of
+            `deepeval.metrics.BaseMetric`. In the latter case, the inputs expected
+            by the component are derived from the test case parameters that the
+            metric declares as required.
         :param metric_params:
             Parameters to pass to the metric's constructor.
-            Refer to the `RagasMetric` class for more details
-            on required parameters.
+            Refer to the `DeepEvalMetric` class for more details
+            on required parameters. Not supported when `metric` is an
+            already initialized metric, which is expected to be fully configured.
         """
-        self.metric = metric if isinstance(metric, DeepEvalMetric) else DeepEvalMetric.from_str(metric)
+        if isinstance(metric, BaseMetric):
+            if metric_params is not None:
+                msg = (
+                    f"DeepEval metric '{_metric_name(metric)}' is already initialized, "
+                    f"'metric_params' must not be provided"
+                )
+                raise ValueError(msg)
+            self.metric = metric
+            self.descriptor = MetricDescriptor.for_custom_metric(metric)
+        else:
+            self.metric = metric if isinstance(metric, DeepEvalMetric) else DeepEvalMetric.from_str(metric)
+            self.descriptor = METRIC_DESCRIPTORS[self.metric]
         self.metric_params = metric_params
-        self.descriptor = METRIC_DESCRIPTORS[self.metric]
 
         self._init_backend()
         expected_inputs = self.descriptor.input_parameters
@@ -107,6 +166,9 @@ class DeepEvalEvaluator:
         """
         Serializes the component to a dictionary.
 
+        Only evaluators using a built-in metric can be serialized; metric instances
+        provided by the user cannot be reconstructed from a dictionary.
+
         :returns:
             Dictionary with serialized data.
         :raises DeserializationError:
@@ -119,6 +181,13 @@ class DeepEvalEvaluator:
                 return True
             except (TypeError, OverflowError):
                 return False
+
+        if isinstance(self.metric, BaseMetric):
+            msg = (
+                f"DeepEval evaluator cannot serialize the metric instance '{_metric_name(self.metric)}'. "
+                f"Use one of the built-in metrics defined by 'DeepEvalMetric' to serialize the component"
+            )
+            raise DeserializationError(msg)
 
         if not check_serializable(self.metric_params):
             msg = "DeepEval evaluator cannot serialize the metric parameters"
@@ -150,6 +219,14 @@ class DeepEvalEvaluator:
         """
         Initialize the DeepEval backend.
         """
+        self._backend_callable = DeepEvalEvaluator._invoke_deepeval
+
+        if isinstance(self.metric, BaseMetric):
+            # Metrics provided by the user are already initialized, so we use them as-is
+            # instead of instantiating the backend ourselves.
+            self._backend_metric = self.metric
+            return
+
         if self.descriptor.init_parameters is not None:
             if self.metric_params is None:
                 msg = f"DeepEval metric '{self.metric}' expected init parameters but got none"
@@ -166,4 +243,3 @@ class DeepEvalEvaluator:
         # This shouldn't matter at all as we aren't asserting the outputs, but just in case...
         backend_metric_params["threshold"] = 0.0
         self._backend_metric = self.descriptor.backend(**backend_metric_params)
-        self._backend_callable = DeepEvalEvaluator._invoke_deepeval

--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
@@ -1,6 +1,6 @@
 import dataclasses
 import inspect
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Collection, Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
@@ -15,7 +15,7 @@ from deepeval.metrics import (
     ContextualRelevancyMetric,
     FaithfulnessMetric,
 )
-from deepeval.test_case import LLMTestCase
+from deepeval.test_case import LLMTestCase, SingleTurnParams
 
 
 class DeepEvalMetric(Enum):
@@ -70,6 +70,86 @@ class DeepEvalMetric(Enum):
         return metric
 
 
+#: Evaluator inputs that can be mapped onto a DeepEval test case parameter, in the
+#: order in which they are exposed by the component. Used to derive the expected
+#: inputs of a user-provided metric from the parameters it declares as required.
+CUSTOM_METRIC_INPUT_PARAMETERS: Mapping[SingleTurnParams, tuple[str, Any]] = {
+    SingleTurnParams.INPUT: ("questions", list[str]),
+    SingleTurnParams.ACTUAL_OUTPUT: ("responses", list[str]),
+    SingleTurnParams.RETRIEVAL_CONTEXT: ("contexts", list[list[str]]),
+    SingleTurnParams.EXPECTED_OUTPUT: ("ground_truths", list[str]),
+}
+
+#: Reverse of `CUSTOM_METRIC_INPUT_PARAMETERS`, mapping an evaluator input to the
+#: keyword argument of `LLMTestCase` that it populates.
+_TEST_CASE_KEYWORDS: Mapping[str, str] = {
+    name: param.value for param, (name, _) in CUSTOM_METRIC_INPUT_PARAMETERS.items()
+}
+
+#: Fallback for metrics that don't declare their required parameters. Matches the
+#: inputs of the built-in RAG metrics.
+_DEFAULT_CUSTOM_METRIC_PARAMETERS = (
+    SingleTurnParams.INPUT,
+    SingleTurnParams.ACTUAL_OUTPUT,
+    SingleTurnParams.RETRIEVAL_CONTEXT,
+)
+
+
+def _metric_name(metric: "DeepEvalMetric | BaseMetric") -> str:
+    """
+    Return a human-readable name for a metric, used in error messages.
+
+    :param metric:
+        A built-in metric or a DeepEval metric instance.
+    :returns:
+        The value of the metric for built-in metrics, the class name otherwise.
+    """
+    # `BaseMetric` overrides `__name__` on instances, so we read it off the class.
+    return str(metric) if isinstance(metric, DeepEvalMetric) else type(metric).__qualname__
+
+
+def _custom_metric_input_parameters(metric: BaseMetric) -> dict[str, Any]:
+    """
+    Determine the inputs that the evaluator should expose for a user-provided metric.
+
+    :param metric:
+        An initialized DeepEval metric.
+    :returns:
+        Dictionary of input parameter names to their types.
+    :raises ValueError:
+        If the metric requires a test case parameter that the evaluator cannot provide.
+    """
+    declared = getattr(metric, "_required_params", None)
+    if (
+        isinstance(declared, Collection)
+        and not isinstance(declared, (str, bytes))
+        and all(isinstance(p, SingleTurnParams) for p in declared)
+    ):
+        # Accept any collection of params, not just `list`: DeepEval does not promise a
+        # concrete container, and silently discarding a tuple/set declaration would map
+        # the component's inputs to the RAG defaults without telling the user.
+        required_params = list(declared)
+    else:
+        # `BaseMetric` only annotates `_required_params` without assigning a value, so on
+        # a metric that doesn't declare it `getattr` returns the typing alias
+        # (`typing.List[SingleTurnParams]`) rather than `None`. Treat that -- and anything
+        # else we can't interpret as params -- as "undeclared" and assume RAG inputs.
+        required_params = list(_DEFAULT_CUSTOM_METRIC_PARAMETERS)
+
+    unsupported = [p for p in required_params if p not in CUSTOM_METRIC_INPUT_PARAMETERS]
+    if unsupported:
+        msg = (
+            f"DeepEval metric '{_metric_name(metric)}' requires test case parameters that the evaluator "
+            f"cannot provide: {sorted(p.value for p in unsupported)}. "
+            f"Supported: {sorted(p.value for p in CUSTOM_METRIC_INPUT_PARAMETERS)}"
+        )
+        raise ValueError(msg)
+
+    # `LLMTestCase` always needs an input, even if the metric doesn't ask for it.
+    selected = {SingleTurnParams.INPUT, *required_params}
+    return {name: type_ for param, (name, type_) in CUSTOM_METRIC_INPUT_PARAMETERS.items() if param in selected}
+
+
 @dataclass(frozen=True)
 class MetricResult:
     """
@@ -103,7 +183,7 @@ class MetricDescriptor:
     Descriptor for a metric.
 
     :param metric:
-        The metric.
+        The metric. Either a built-in metric or the user-provided metric instance.
     :param backend:
         The associated DeepEval metric class.
     :param input_parameters:
@@ -118,7 +198,7 @@ class MetricDescriptor:
         Additional parameters that need to be passed to the metric class during initialization.
     """
 
-    metric: DeepEvalMetric
+    metric: DeepEvalMetric | BaseMetric
     backend: type[BaseMetric]
     input_parameters: dict[str, type]
     input_converter: Callable[[Any], Iterable[LLMTestCase]]
@@ -170,6 +250,32 @@ class MetricDescriptor:
             init_parameters=init_parameters,
         )
 
+    @classmethod
+    def for_custom_metric(cls, metric: BaseMetric) -> "MetricDescriptor":
+        """
+        Create a metric descriptor for an initialized DeepEval metric provided by the user.
+
+        The inputs expected by the evaluator are derived from the test case parameters that
+        the metric declares as required through `BaseMetric._required_params`. Metrics that
+        don't declare them expect the same inputs as the built-in RAG metrics, namely
+        `questions`, `contexts` and `responses`.
+
+        :param metric:
+            A fully initialized DeepEval metric, for example a subclass of `BaseMetric`.
+        :returns:
+            A new `MetricDescriptor` instance.
+        :raises ValueError:
+            If the metric requires a test case parameter that the evaluator cannot provide.
+        """
+        input_parameters = _custom_metric_input_parameters(metric)
+        return cls(
+            metric=metric,
+            backend=type(metric),
+            input_parameters=input_parameters,
+            input_converter=InputConverters.custom(input_parameters),  # type: ignore[arg-type]
+            output_converter=OutputConverters.custom,
+        )
+
 
 class InputConverters:
     """
@@ -199,7 +305,9 @@ class InputConverters:
             raise ValueError(msg)
 
     @staticmethod
-    def validate_input_parameters(metric: DeepEvalMetric, expected: dict[str, Any], received: dict[str, Any]) -> None:
+    def validate_input_parameters(
+        metric: DeepEvalMetric | BaseMetric, expected: dict[str, Any], received: dict[str, Any]
+    ) -> None:
         """
         Validate that all expected input parameters are present in the received inputs.
 
@@ -214,7 +322,7 @@ class InputConverters:
         """
         for param, _ in expected.items():
             if param not in received:
-                msg = f"DeepEval evaluator expected input parameter '{param}' for metric '{metric}'"
+                msg = f"DeepEval evaluator expected input parameter '{param}' for metric '{_metric_name(metric)}'"
                 raise ValueError(msg)
 
     @staticmethod
@@ -263,6 +371,29 @@ class InputConverters:
             test_case = LLMTestCase(input=q, actual_output=r, retrieval_context=c, expected_output=gt)  # type: ignore[arg-type]
             yield test_case
 
+    @staticmethod
+    def custom(input_parameters: Iterable[str]) -> Callable[..., Iterable[LLMTestCase]]:
+        """
+        Create a converter for a user-provided metric that expects the given inputs.
+
+        :param input_parameters:
+            Names of the evaluator inputs to convert. Each of them must be a key of
+            `CUSTOM_METRIC_INPUT_PARAMETERS`.
+        :returns:
+            Callable that converts the inputs to DeepEval test cases.
+        """
+        names = list(input_parameters)
+
+        def inner(**inputs: Any) -> Iterable[LLMTestCase]:
+            selected = {name: inputs[name] for name in names}
+            InputConverters._validate_input_elements(**selected)
+            for values in zip(*selected.values(), strict=True):
+                kwargs = {_TEST_CASE_KEYWORDS[name]: value for name, value in zip(names, values, strict=True)}
+                # for retrieval_context, deepeval expects list[str | RetrievedContextData]; we pass list[str]
+                yield LLMTestCase(**kwargs)
+
+        return inner
+
 
 class OutputConverters:
     """
@@ -293,6 +424,24 @@ class OutputConverters:
             return out
 
         return partial(inner, metric=metric)
+
+    @staticmethod
+    def custom(output: TestResult) -> list[MetricResult]:
+        """
+        Convert the result of a user-provided metric.
+
+        Unlike the built-in metrics, the name is taken from the result reported by
+        DeepEval since it's determined by the metric itself.
+
+        :param output:
+            The result of a single test case.
+        :returns:
+            A list with the result of the metric.
+        """
+        assert output.metrics_data
+        assert len(output.metrics_data) == 1
+        metric_result = output.metrics_data[0]
+        return [MetricResult(name=metric_result.name, score=metric_result.score, explanation=metric_result.reason)]
 
 
 METRIC_DESCRIPTORS = {

--- a/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
+++ b/integrations/deepeval/src/haystack_integrations/components/evaluators/deepeval/metrics.py
@@ -15,7 +15,12 @@ from deepeval.metrics import (
     ContextualRelevancyMetric,
     FaithfulnessMetric,
 )
-from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.test_case import LLMTestCase
+
+try:  # deepeval >= 4 renamed this enum; keep working on the >=2.9.0 floor
+    from deepeval.test_case import SingleTurnParams
+except ImportError:  # pragma: no cover - exercised only on older deepeval
+    from deepeval.test_case import LLMTestCaseParams as SingleTurnParams  # type: ignore[no-redef]
 
 
 class DeepEvalMetric(Enum):

--- a/integrations/deepeval/tests/test_evaluator.py
+++ b/integrations/deepeval/tests/test_evaluator.py
@@ -6,12 +6,16 @@ from typing import ClassVar
 import pytest
 from deepeval.evaluate.types import EvaluationResult, TestResult
 from deepeval.metrics import BaseMetric, FaithfulnessMetric
-from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.test_case import LLMTestCase
 from deepeval.test_run import MetricData
 from haystack import DeserializationError
 
 from haystack_integrations.components.evaluators.deepeval import DeepEvalEvaluator
-from haystack_integrations.components.evaluators.deepeval.metrics import DeepEvalMetric, InputConverters
+from haystack_integrations.components.evaluators.deepeval.metrics import (
+    DeepEvalMetric,
+    InputConverters,
+    SingleTurnParams,
+)
 
 DEFAULT_QUESTIONS = [
     "Which is the most popular global sport?",
@@ -148,10 +152,21 @@ def measure_locally(test_cases, metric) -> EvaluationResult:
     out = []
     for test_case in test_cases:
         score = metric.measure(test_case)
+        threshold = getattr(metric, "threshold", 0.0)
         r = TestResult(
             name=test_case.name or "",
             success=False,
-            metrics_data=[MetricData(name=metric.__name__, score=score, reason=metric.reason)],
+            # `threshold` and `success` are required by deepeval < 4 and optional after,
+            # so pass them explicitly to keep this double valid across the version floor.
+            metrics_data=[
+                MetricData(
+                    name=metric.__name__,
+                    score=score,
+                    reason=metric.reason,
+                    threshold=threshold,
+                    success=score >= threshold,
+                )
+            ],
             conversational=False,
             input=test_case.input,
             actual_output=test_case.actual_output,

--- a/integrations/deepeval/tests/test_evaluator.py
+++ b/integrations/deepeval/tests/test_evaluator.py
@@ -1,10 +1,13 @@
 import copy
 import os
 from dataclasses import dataclass
+from typing import ClassVar
 
 import pytest
 from deepeval.evaluate.types import EvaluationResult, TestResult
-from deepeval.metrics import BaseMetric
+from deepeval.metrics import BaseMetric, FaithfulnessMetric
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.test_run import MetricData
 from haystack import DeserializationError
 
 from haystack_integrations.components.evaluators.deepeval import DeepEvalEvaluator
@@ -84,6 +87,80 @@ class MockBackend:
             )
             out.append(r)
         return EvaluationResult(test_results=out, confident_link=None, test_run_id=None)
+
+
+# A custom metric that doesn't need an LLM, so that it can be measured locally.
+# The subclasses below only differ in the test case parameters they require.
+class LengthMetric(BaseMetric):
+    def __init__(self, max_words: int = 10) -> None:
+        self.max_words = max_words
+        self.threshold = 0.0
+
+    def measure(self, test_case: LLMTestCase) -> float:
+        words = len((test_case.actual_output or "").split())
+        self.score = min(1.0, words / self.max_words)
+        self.reason = f"The response to '{test_case.input}' contains {words} words"
+        return self.score
+
+    async def a_measure(self, test_case: LLMTestCase) -> float:
+        return self.measure(test_case)
+
+
+class ResponseLengthMetric(LengthMetric):
+    _required_params: ClassVar = [SingleTurnParams.INPUT, SingleTurnParams.ACTUAL_OUTPUT]
+
+    @property
+    def __name__(self) -> str:
+        return "Response Length"
+
+
+class GroundTruthMetric(LengthMetric):
+    _required_params: ClassVar = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+        SingleTurnParams.RETRIEVAL_CONTEXT,
+        SingleTurnParams.EXPECTED_OUTPUT,
+    ]
+
+
+class UndeclaredParamsMetric(LengthMetric):
+    """Doesn't declare `_required_params`, so the built-in RAG inputs are expected."""
+
+
+class TupleParamsMetric(LengthMetric):
+    """Declares `_required_params` as a tuple; DeepEval promises no concrete container."""
+
+    _required_params: ClassVar = (SingleTurnParams.INPUT, SingleTurnParams.ACTUAL_OUTPUT)
+
+
+class BadParamsMetric(LengthMetric):
+    """Declares `_required_params` as something we cannot read as params."""
+
+    _required_params: ClassVar = 42
+
+
+class UnsupportedParamsMetric(LengthMetric):
+    _required_params: ClassVar = [SingleTurnParams.INPUT, SingleTurnParams.TOOLS_CALLED]
+
+
+# Measures the metric locally, mimicking the results returned by `deepeval.evaluate`.
+def measure_locally(test_cases, metric) -> EvaluationResult:
+    out = []
+    for test_case in test_cases:
+        score = metric.measure(test_case)
+        r = TestResult(
+            name=test_case.name or "",
+            success=False,
+            metrics_data=[MetricData(name=metric.__name__, score=score, reason=metric.reason)],
+            conversational=False,
+            input=test_case.input,
+            actual_output=test_case.actual_output,
+            expected_output=test_case.expected_output,
+            context=test_case.context,
+            retrieval_context=test_case.retrieval_context,
+        )
+        out.append(r)
+    return EvaluationResult(test_results=out, confident_link=None, test_run_id=None)
 
 
 def test_evaluator_metric_init_params(monkeypatch):
@@ -282,6 +359,132 @@ def test_evaluator_outputs(metric, inputs, expected_outputs, metric_params, monk
         expected = {(name if name is not None else str(metric), score, exp) for name, score, exp in o}
         got = {(x["name"], x["score"], x["explanation"]) for x in r}
         assert got == expected
+
+
+def test_evaluator_custom_metric_backend():
+    metric = ResponseLengthMetric(max_words=5)
+    evaluator = DeepEvalEvaluator(metric)
+
+    assert evaluator.metric is metric
+    assert evaluator.metric_params is None
+    # The user-provided instance is used as-is, including its threshold.
+    assert evaluator._backend_metric is metric
+    assert evaluator._backend_metric.threshold == 0.0
+    assert evaluator._backend_metric.max_words == 5
+    assert evaluator.descriptor.backend is ResponseLengthMetric
+
+
+def test_evaluator_custom_metric_params_not_allowed():
+    with pytest.raises(ValueError, match="'metric_params' must not be provided"):
+        DeepEvalEvaluator(ResponseLengthMetric(), metric_params={"model": "gpt-4o"})
+
+
+@pytest.mark.parametrize(
+    "metric, expected_inputs",
+    [
+        (ResponseLengthMetric(), ["questions", "responses"]),
+        (UndeclaredParamsMetric(), ["questions", "responses", "contexts"]),
+        (TupleParamsMetric(), ["questions", "responses"]),
+        (GroundTruthMetric(), ["questions", "responses", "contexts", "ground_truths"]),
+    ],
+)
+def test_evaluator_custom_metric_expected_inputs(metric, expected_inputs):
+    evaluator = DeepEvalEvaluator(metric)
+
+    assert list(evaluator.descriptor.input_parameters) == expected_inputs
+    assert list(evaluator.__haystack_input__._sockets_dict) == expected_inputs
+
+
+def test_evaluator_custom_metric_unsupported_params():
+    with pytest.raises(ValueError, match="cannot provide: \\['tools_called'\\]"):
+        DeepEvalEvaluator(UnsupportedParamsMetric())
+
+
+def test_evaluator_custom_metric_uninterpretable_params():
+    # An unreadable declaration is treated the same as not declaring it at all: fall back
+    # to the built-in RAG inputs rather than crashing on a private-attribute quirk.
+    evaluator = DeepEvalEvaluator(BadParamsMetric())
+
+    assert list(evaluator.descriptor.input_parameters) == ["questions", "responses", "contexts"]
+
+
+def test_evaluator_custom_metric_missing_inputs():
+    evaluator = DeepEvalEvaluator(ResponseLengthMetric())
+
+    with pytest.raises(ValueError, match="expected input parameter 'responses' for metric 'ResponseLengthMetric'"):
+        evaluator.run(questions=DEFAULT_QUESTIONS)
+
+
+def test_evaluator_custom_metric_invalid_inputs():
+    evaluator = DeepEvalEvaluator(ResponseLengthMetric())
+
+    with pytest.raises(ValueError, match="to be a collection of type 'list'"):
+        evaluator.run(questions={}, responses=DEFAULT_RESPONSES)
+
+    with pytest.raises(ValueError, match="Mismatching counts "):
+        evaluator.run(questions=DEFAULT_QUESTIONS, responses=DEFAULT_RESPONSES[:1])
+
+
+def test_evaluator_custom_metric_outputs():
+    evaluator = DeepEvalEvaluator(ResponseLengthMetric(max_words=10))
+    evaluator._backend_callable = measure_locally
+
+    results = evaluator.run(questions=DEFAULT_QUESTIONS, responses=DEFAULT_RESPONSES)["results"]
+
+    assert results == [
+        [
+            {
+                "name": "Response Length",
+                "score": 1.0,
+                "explanation": "The response to 'Which is the most popular global sport?' contains 12 words",
+            }
+        ],
+        [
+            {
+                "name": "Response Length",
+                "score": 0.8,
+                "explanation": "The response to 'Who created the Python language?' contains 8 words",
+            }
+        ],
+    ]
+
+
+def test_evaluator_custom_metric_test_case_conversion():
+    metric = GroundTruthMetric()
+    evaluator = DeepEvalEvaluator(metric)
+    test_cases = list(
+        evaluator.descriptor.input_converter(
+            questions=DEFAULT_QUESTIONS,
+            contexts=DEFAULT_CONTEXTS,
+            responses=DEFAULT_RESPONSES,
+            ground_truths=DEFAULT_GROUND_TRUTHS,
+        )
+    )
+
+    assert len(test_cases) == len(DEFAULT_QUESTIONS)
+    for i, test_case in enumerate(test_cases):
+        assert test_case.input == DEFAULT_QUESTIONS[i]
+        assert test_case.actual_output == DEFAULT_RESPONSES[i]
+        assert test_case.retrieval_context == DEFAULT_CONTEXTS[i]
+        assert test_case.expected_output == DEFAULT_GROUND_TRUTHS[i]
+
+
+def test_evaluator_custom_metric_not_serializable():
+    evaluator = DeepEvalEvaluator(ResponseLengthMetric())
+
+    with pytest.raises(DeserializationError, match=r"cannot serialize the metric instance 'ResponseLengthMetric'"):
+        evaluator.to_dict()
+
+
+def test_evaluator_builtin_metric_instance(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
+    metric = FaithfulnessMetric(model="gpt-4o", threshold=0.75)
+    evaluator = DeepEvalEvaluator(metric)
+
+    assert list(evaluator.descriptor.input_parameters) == ["questions", "responses", "contexts"]
+    assert evaluator._backend_metric is metric
+    assert evaluator._backend_metric.threshold == 0.75
 
 
 # This integration test validates the evaluator by running it against the


### PR DESCRIPTION
Fixes #3838

## What

`DeepEvalEvaluator` now accepts an already initialized DeepEval metric, so any subclass
of `deepeval.metrics.BaseMetric` can be used for evaluation:

```python
class ResponseLengthMetric(BaseMetric):
    _required_params = [SingleTurnParams.INPUT, SingleTurnParams.ACTUAL_OUTPUT]

    def measure(self, test_case: LLMTestCase) -> float:
        words = len((test_case.actual_output or "").split())
        self.score = min(1.0, words / self.max_words)
        self.reason = f"The response contains {words} words"
        return self.score


evaluator = DeepEvalEvaluator(metric=ResponseLengthMetric(max_words=20))
```

The inputs the component exposes are derived from the test case parameters the metric
declares, and results come back in the same `name`/`score`/`explanation` shape as the
built-ins.

## Backwards compatibility

Purely additive. `metric` widens from `str | DeepEvalMetric` to
`str | DeepEvalMetric | BaseMetric`; the built-in branch, its init validation, its input
validation and its serde are untouched. Existing tests still pass unchanged.

## Two design points worth your call

**1. Parameter discovery reads `_required_params`.** DeepEval exposes no public way to
ask a metric which test case params it needs, so this reads the private attribute. Two
details:

- Any collection of `SingleTurnParams` is accepted, not just `list` — DeepEval does not
  promise a concrete container type, and silently discarding a `tuple`/`set` declaration
  would map the component's inputs to the RAG defaults without telling the user.
- `BaseMetric` only *annotates* `_required_params` without assigning it, so on a metric
  that never declares it `getattr` returns the typing alias
  `typing.List[SingleTurnParams]` rather than `None`. That case — and anything else that
  cannot be read as params — falls back to the built-in RAG inputs.

If you would rather not depend on a private attribute, the alternative is an explicit
constructor argument for the expected inputs. Happy to switch.

**2. A metric instance cannot be serialized.** `to_dict` raises for that case, since an
instance carries runtime state that cannot be reliably reconstructed. The class docstring
points at the built-in metrics when a pipeline has to survive a `to_dict`/`from_dict`
round trip. Tell me if you would prefer a warning plus a degraded dict instead of a hard
error.

Also note this supports a *single* metric instance, matching the current DeepEval
evaluator shape. `RagasEvaluator` takes a list of metrics — say the word and I will align
this one to that API.

## Tests

`integrations/deepeval/tests/test_evaluator.py` gains coverage for input derivation
(declared as list, declared as tuple, undeclared, unreadable, unsupported params), the
`measure()` call path, output shape, `LLMTestCase` conversion, and passing a built-in
metric as an instance. Locally: 32 passed, 5 skipped (the skips need `OPENAI_API_KEY`).
`ruff check` and `ruff format --check` are clean.

Two notes so they don't surprise you in review:

- I did not touch `CHANGELOG.md` — it looks like `HaystackBot` generates it via
  `cliff.toml` during the release workflow. Let me know if contributors are expected to
  add an entry.
- `mypy src` reports 8 errors in this integration, but they are identical before and
  after this change (only one line number shifts, because the docstring grew). They come
  from `deepeval.metrics` attribute resolution against the installed deepeval version, so
  I left them alone rather than widening the diff.
