### PR TITLE
fix(cognee): cap litellm below 1.97.0 on Python 3.10

### DIFF
--- a/integrations/cognee/pyproject.toml
+++ b/integrations/cognee/pyproject.toml
@@ -28,8 +28,15 @@ dependencies = [
   "cognee>=1.0.9",
   # litellm (pulled in transitively by cognee) ships a Rust extension from 1.83.8+ with no cp314
   # wheels and caps requires-python at <3.14, so on Python 3.14 constrain to the last pure-Python
-  # release. Other Python versions stay unpinned.
+  # release.
   "litellm<1.83.8; python_version >= '3.14'",
+  # On Python 3.10, litellm 1.98.0 imports `NotRequired` from `typing` (3.11+ only), so `import
+  # litellm` fails outright even though litellm still declares requires-python >=3.10. 1.97.0
+  # imports, but leaves the `Message` pydantic model with an unresolved forward reference, so every
+  # completion raises (BerriAI/litellm#36384). 1.96.2 is the last release that works on 3.10; both
+  # regressions are fixed for 3.11+ in 1.98.0, so only 3.10 needs the cap. Drop it once a release
+  # imports and completes on 3.10 again.
+  "litellm<1.97.0; python_version < '3.11'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues

- fixes failing tests

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

The cognee nightly has been red since 2026-08-17, with two different errors that are both upstream litellm regressions on Python 3.10:

- litellm 1.97.0 (16 Aug) leaves the `Message` pydantic model with an unresolved forward reference to `ChatCompletionReasoningSummaryTextBlock`, so constructing a `ModelResponse` raises `PydanticUserError`. Every completion fails, cognee retries with backoff, and its LLM connection test gives up: `TimeoutError: LLM connection test timed out after 30s`. That took out `test_remember_then_recall` from 17-23 Aug (BerriAI/litellm#36384).

- litellm 1.98.0 (22 Aug) imports `NotRequired` from `typing`, which only exists on 3.11+, while still declaring `requires-python >=3.10`. From 24 Aug `import litellm` fails outright, so collecting tests/test_integration.py errors and the unit step dies too - masking the timeout above.

1.96.2 is the last release that imports and completes on 3.10. Both regressions are fixed for 3.11+ in 1.98.0, so the cap is scoped to 3.10 and leaves 3.11-3.13 unpinned; the existing 3.14 cap is untouched.

Verified on Python 3.10: `import litellm`, `ModelResponse()` and `import cognee` all succeed again, and the unit suite that CI was failing to collect runs 37 passed, 3 deselected. Resolution checked on 3.10-3.14 (1.96.2 / 1.98.0 / 1.98.0 / 1.98.0 / 1.83.7).

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
