### PR TITLE
fix(tika): update tests to use Tika 3 server and pin sdk to v3

### DIFF
--- a/.github/workflows/tika.yml
+++ b/.github/workflows/tika.yml
@@ -106,9 +106,8 @@ jobs:
       - name: Start Tika server
         if: runner.os == 'Linux'
         run: |
-          # Pinned to the last 3.x image: the tika client is pinned to 3.x, which supports the
-          # 3.x server line, and a 4.x server renames the metadata key that client reads
-          # (TIKA-4816).
+          # Pinned to the last 3.x image because the tika Python client does not yet support
+          # Tika Server 4.x (TIKA-4816).
           docker run -d -p 127.0.0.1:9998:9998 apache/tika:3.3.1.0
           for i in $(seq 1 30); do
             if curl -sf http://localhost:9998/tika > /dev/null 2>&1; then

--- a/.github/workflows/tika.yml
+++ b/.github/workflows/tika.yml
@@ -106,7 +106,10 @@ jobs:
       - name: Start Tika server
         if: runner.os == 'Linux'
         run: |
-          docker run -d -p 127.0.0.1:9998:9998 apache/tika:latest
+          # Pinned to the last 3.x image: the tika client is pinned to 3.x, which supports the
+          # 3.x server line, and a 4.x server renames the metadata key that client reads
+          # (TIKA-4816).
+          docker run -d -p 127.0.0.1:9998:9998 apache/tika:3.3.1.0
           for i in $(seq 1 30); do
             if curl -sf http://localhost:9998/tika > /dev/null 2>&1; then
               echo "Tika is ready"

--- a/integrations/tika/README.md
+++ b/integrations/tika/README.md
@@ -15,5 +15,8 @@ Refer to the general [Contribution Guidelines](https://github.com/deepset-ai/hay
 Integration tests require a running Tika server. Start one with:
 
 ```shell
-docker run -d -p 127.0.0.1:9998:9998 apache/tika:latest
+docker run -d -p 127.0.0.1:9998:9998 apache/tika:3.3.1.0
 ```
+
+Use a 3.x image, not `apache/tika:latest`: this integration pins the `tika` client to 3.x, and a
+4.x server renames the metadata key that client reads (TIKA-4816). `3.3.1.0` is the last 3.x image.

--- a/integrations/tika/README.md
+++ b/integrations/tika/README.md
@@ -18,5 +18,5 @@ Integration tests require a running Tika server. Start one with:
 docker run -d -p 127.0.0.1:9998:9998 apache/tika:3.3.1.0
 ```
 
-Use a 3.x image, not `apache/tika:latest`: this integration pins the `tika` client to 3.x, and a
-4.x server renames the metadata key that client reads (TIKA-4816). `3.3.1.0` is the last 3.x image.
+Use a 3.x image, not `apache/tika:latest`: the `tika` Python client does not yet support Tika Server
+4.x (TIKA-4816). `3.3.1.0` is the last 3.x image.

--- a/integrations/tika/pyproject.toml
+++ b/integrations/tika/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.9.0", "tika==3.1.0"]
+dependencies = ["haystack-ai>=2.9.0", "tika>=3.1.0,<4.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/tika#readme"

--- a/integrations/tika/src/haystack_integrations/components/converters/tika/converter.py
+++ b/integrations/tika/src/haystack_integrations/components/converters/tika/converter.py
@@ -73,6 +73,11 @@ class TikaDocumentConverter:
     For more options on running Tika,
     see the [official documentation](https://github.com/apache/tika-docker/blob/main/README.md#usage).
 
+    **Requires a Tika 3.x server.** The `tika` client's major version tracks the server line it
+    supports, and this integration pins the client to 3.x. A 4.x server renames the metadata key
+    that client reads (TIKA-4816), so the client returns no content and this component produces no
+    Documents. Use a 3.x image, for example `apache/tika:3.3.1.0`.
+
     Usage example:
     ```python
     from haystack_integrations.components.converters.tika import TikaDocumentConverter
@@ -94,7 +99,7 @@ class TikaDocumentConverter:
         """
         Create a TikaDocumentConverter component.
 
-        :param tika_url: Tika server URL.
+        :param tika_url: Tika server URL. Must be a Tika 3.x server; see the class docstring.
         :param store_full_path:
             If True, the full path of the file is stored in the metadata of the document.
             If False, only the file name is stored.
@@ -133,9 +138,21 @@ class TikaDocumentConverter:
             try:
                 # we extract the content as XHTML to preserve the structure of the document as much as possible
                 # this works for PDFs, but does not work for other file types (DOCX)
-                xhtml_content = tika_parser.from_buffer(
+                response = tika_parser.from_buffer(
                     io.BytesIO(bytestream.data), serverEndpoint=self.tika_url, xmlContent=True
-                )["content"]
+                )
+                if (status := response.get("status")) != 200:  # noqa: PLR2004
+                    msg = f"Tika server at {self.tika_url} returned status {status}."
+                    raise RuntimeError(msg)
+                xhtml_content = response["content"]
+                if xhtml_content is None:
+                    # Most likely a 4.x server: it reports content under a key the pinned 3.x
+                    # `tika` client does not read, so the client hands back None.
+                    msg = (
+                        f"Tika returned no content. This component requires a Tika 3.x server, "
+                        f"matching the 3.x tika client it pins; check the server at {self.tika_url}."
+                    )
+                    raise RuntimeError(msg)
                 xhtml_parser = XHTMLParser()
                 xhtml_parser.feed(xhtml_content)
                 text = "\f".join(xhtml_parser.pages)

--- a/integrations/tika/src/haystack_integrations/components/converters/tika/converter.py
+++ b/integrations/tika/src/haystack_integrations/components/converters/tika/converter.py
@@ -70,13 +70,9 @@ class TikaDocumentConverter:
 
     This component uses [Apache Tika](https://tika.apache.org/) for parsing the files and, therefore,
     requires a running Tika server.
+    Use a Tika 3.x server; the `tika` Python client does not yet support Tika Server 4.x.
     For more options on running Tika,
     see the [official documentation](https://github.com/apache/tika-docker/blob/main/README.md#usage).
-
-    **Requires a Tika 3.x server.** The `tika` client's major version tracks the server line it
-    supports, and this integration pins the client to 3.x. A 4.x server renames the metadata key
-    that client reads (TIKA-4816), so the client returns no content and this component produces no
-    Documents. Use a 3.x image, for example `apache/tika:3.3.1.0`.
 
     Usage example:
     ```python
@@ -99,7 +95,7 @@ class TikaDocumentConverter:
         """
         Create a TikaDocumentConverter component.
 
-        :param tika_url: Tika server URL. Must be a Tika 3.x server; see the class docstring.
+        :param tika_url: Tika server URL.
         :param store_full_path:
             If True, the full path of the file is stored in the metadata of the document.
             If False, only the file name is stored.
@@ -138,21 +134,9 @@ class TikaDocumentConverter:
             try:
                 # we extract the content as XHTML to preserve the structure of the document as much as possible
                 # this works for PDFs, but does not work for other file types (DOCX)
-                response = tika_parser.from_buffer(
+                xhtml_content = tika_parser.from_buffer(
                     io.BytesIO(bytestream.data), serverEndpoint=self.tika_url, xmlContent=True
-                )
-                if (status := response.get("status")) != 200:  # noqa: PLR2004
-                    msg = f"Tika server at {self.tika_url} returned status {status}."
-                    raise RuntimeError(msg)
-                xhtml_content = response["content"]
-                if xhtml_content is None:
-                    # Most likely a 4.x server: it reports content under a key the pinned 3.x
-                    # `tika` client does not read, so the client hands back None.
-                    msg = (
-                        f"Tika returned no content. This component requires a Tika 3.x server, "
-                        f"matching the 3.x tika client it pins; check the server at {self.tika_url}."
-                    )
-                    raise RuntimeError(msg)
+                )["content"]
                 xhtml_parser = XHTMLParser()
                 xhtml_parser.feed(xhtml_content)
                 text = "\f".join(xhtml_parser.pages)

--- a/integrations/tika/tests/test_tika_document_converter.py
+++ b/integrations/tika/tests/test_tika_document_converter.py
@@ -13,11 +13,6 @@ from haystack_integrations.components.converters.tika import TikaDocumentConvert
 TIKA_PARSER_PATH = "haystack_integrations.components.converters.tika.converter.tika_parser"
 
 
-def tika_response(xhtml, status=200):
-    """Build what tika_parser.from_buffer() returns for an xmlContent call."""
-    return {"status": status, "content": xhtml, "metadata": {"Content-Type": "text/plain"}}
-
-
 @pytest.fixture
 def test_files_path():
     return Path(__file__).parent / "test_files"
@@ -26,7 +21,7 @@ def test_files_path():
 class TestTikaDocumentConverter:
     @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run(self, mock_tika_parser):
-        mock_tika_parser.return_value = tika_response("<div><p>Content of mock source</p></div>")
+        mock_tika_parser.return_value = {"content": "<div><p>Content of mock source</p></div>"}
 
         component = TikaDocumentConverter()
         source = ByteStream(data=b"placeholder data")
@@ -36,56 +31,38 @@ class TestTikaDocumentConverter:
         assert documents[0].content == "Content of mock source"
 
     @patch(TIKA_PARSER_PATH + ".from_buffer")
-    def test_run_with_non_200_status(self, mock_tika_parser, caplog):
-        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>", status=500)
-
-        with caplog.at_level("WARNING"):
-            output = TikaDocumentConverter().run(sources=[ByteStream(data=b"test")])
-
-        assert output["documents"] == []
-        assert "returned status 500" in caplog.text
-
-    @patch(TIKA_PARSER_PATH + ".from_buffer")
-    def test_run_with_no_content(self, mock_tika_parser, caplog):
-        """A 4.x server reports content under a key the pinned 3.x client does not read."""
-        mock_tika_parser.return_value = {"status": 200, "content": None}
-
-        with caplog.at_level("WARNING"):
-            output = TikaDocumentConverter().run(sources=[ByteStream(data=b"test")])
-
-        assert output["documents"] == []
-        assert "requires a Tika 3.x server" in caplog.text
-
-    @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run_with_meta(self, mock_tika_parser):
-        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>")
+        mock_tika_parser.return_value = {"content": "<div><p>text</p></div>"}
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})
 
         converter = TikaDocumentConverter()
-        output = converter.run(sources=[bytestream], meta={"language": "it"})
+        with patch(TIKA_PARSER_PATH + ".from_buffer"):
+            output = converter.run(sources=[bytestream], meta={"language": "it"})
 
         assert output["documents"][0].meta["author"] == "test_author"
         assert output["documents"][0].meta["language"] == "it"
 
     @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run_with_store_full_path_false(self, mock_tika_parser):
-        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>")
+        mock_tika_parser.return_value = {"content": "<div><p>text</p></div>"}
         bytestream = ByteStream(data=b"test")
         bytestream.meta["file_path"] = "/some/path/to/doc_3.txt"
 
         converter = TikaDocumentConverter(store_full_path=False)
-        output = converter.run(sources=[bytestream])
+        with patch(TIKA_PARSER_PATH + ".from_buffer"):
+            output = converter.run(sources=[bytestream])
 
         assert output["documents"][0].meta["file_path"] == "doc_3.txt"
 
     @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run_with_store_full_path_true(self, mock_tika_parser):
-        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>")
+        mock_tika_parser.return_value = {"content": "<div><p>text</p></div>"}
         bytestream = ByteStream(data=b"test")
         bytestream.meta["file_path"] = "/some/path/to/doc_3.txt"
 
         converter = TikaDocumentConverter(store_full_path=True)
-        output = converter.run(sources=[bytestream])
+        with patch(TIKA_PARSER_PATH + ".from_buffer"):
+            output = converter.run(sources=[bytestream])
 
         assert output["documents"][0].meta["file_path"] == "/some/path/to/doc_3.txt"
 

--- a/integrations/tika/tests/test_tika_document_converter.py
+++ b/integrations/tika/tests/test_tika_document_converter.py
@@ -13,6 +13,11 @@ from haystack_integrations.components.converters.tika import TikaDocumentConvert
 TIKA_PARSER_PATH = "haystack_integrations.components.converters.tika.converter.tika_parser"
 
 
+def tika_response(xhtml, status=200):
+    """Build what tika_parser.from_buffer() returns for an xmlContent call."""
+    return {"status": status, "content": xhtml, "metadata": {"Content-Type": "text/plain"}}
+
+
 @pytest.fixture
 def test_files_path():
     return Path(__file__).parent / "test_files"
@@ -21,7 +26,7 @@ def test_files_path():
 class TestTikaDocumentConverter:
     @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run(self, mock_tika_parser):
-        mock_tika_parser.return_value = {"content": "<div><p>Content of mock source</p></div>"}
+        mock_tika_parser.return_value = tika_response("<div><p>Content of mock source</p></div>")
 
         component = TikaDocumentConverter()
         source = ByteStream(data=b"placeholder data")
@@ -31,38 +36,56 @@ class TestTikaDocumentConverter:
         assert documents[0].content == "Content of mock source"
 
     @patch(TIKA_PARSER_PATH + ".from_buffer")
+    def test_run_with_non_200_status(self, mock_tika_parser, caplog):
+        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>", status=500)
+
+        with caplog.at_level("WARNING"):
+            output = TikaDocumentConverter().run(sources=[ByteStream(data=b"test")])
+
+        assert output["documents"] == []
+        assert "returned status 500" in caplog.text
+
+    @patch(TIKA_PARSER_PATH + ".from_buffer")
+    def test_run_with_no_content(self, mock_tika_parser, caplog):
+        """A 4.x server reports content under a key the pinned 3.x client does not read."""
+        mock_tika_parser.return_value = {"status": 200, "content": None}
+
+        with caplog.at_level("WARNING"):
+            output = TikaDocumentConverter().run(sources=[ByteStream(data=b"test")])
+
+        assert output["documents"] == []
+        assert "requires a Tika 3.x server" in caplog.text
+
+    @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run_with_meta(self, mock_tika_parser):
-        mock_tika_parser.return_value = {"content": "<div><p>text</p></div>"}
+        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>")
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})
 
         converter = TikaDocumentConverter()
-        with patch(TIKA_PARSER_PATH + ".from_buffer"):
-            output = converter.run(sources=[bytestream], meta={"language": "it"})
+        output = converter.run(sources=[bytestream], meta={"language": "it"})
 
         assert output["documents"][0].meta["author"] == "test_author"
         assert output["documents"][0].meta["language"] == "it"
 
     @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run_with_store_full_path_false(self, mock_tika_parser):
-        mock_tika_parser.return_value = {"content": "<div><p>text</p></div>"}
+        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>")
         bytestream = ByteStream(data=b"test")
         bytestream.meta["file_path"] = "/some/path/to/doc_3.txt"
 
         converter = TikaDocumentConverter(store_full_path=False)
-        with patch(TIKA_PARSER_PATH + ".from_buffer"):
-            output = converter.run(sources=[bytestream])
+        output = converter.run(sources=[bytestream])
 
         assert output["documents"][0].meta["file_path"] == "doc_3.txt"
 
     @patch(TIKA_PARSER_PATH + ".from_buffer")
     def test_run_with_store_full_path_true(self, mock_tika_parser):
-        mock_tika_parser.return_value = {"content": "<div><p>text</p></div>"}
+        mock_tika_parser.return_value = tika_response("<div><p>text</p></div>")
         bytestream = ByteStream(data=b"test")
         bytestream.meta["file_path"] = "/some/path/to/doc_3.txt"
 
         converter = TikaDocumentConverter(store_full_path=True)
-        with patch(TIKA_PARSER_PATH + ".from_buffer"):
-            output = converter.run(sources=[bytestream])
+        output = converter.run(sources=[bytestream])
 
         assert output["documents"][0].meta["file_path"] == "/some/path/to/doc_3.txt"
 


### PR DESCRIPTION
### Related Issues

- fixes failing tika tests

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

We pin the tika python sdk to less than 4 (a new major version), and restrict the tests to use the latest 3.X server image. 

Tika has released a new 4.X server image which is now what `:latest` points to. This is not compatible with any tika python sdk version which is why we are restricting the tika docker image to 3.X and adding api docstrings to warn users not to use the 4.X docker image. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
