### PR TITLE
fix(chroma): reject trust_remote_code in embedding_function_params

### DIFF
--- a/integrations/chroma/src/haystack_integrations/document_stores/chroma/utils.py
+++ b/integrations/chroma/src/haystack_integrations/document_stores/chroma/utils.py
@@ -43,8 +43,12 @@ def get_embedding_function(function_name: str, **kwargs: Any) -> EmbeddingFuncti
     :param function_name: the name of the embedding function.
     :param kwargs: additional arguments to pass to the embedding function.
     :returns: the loaded embedding function.
-    :raises ChromaDocumentStoreConfigError: if the function name is invalid.
+    :raises ChromaDocumentStoreConfigError: if the function name is invalid or `trust_remote_code` is set.
     """
+    if kwargs.get("trust_remote_code"):
+        # CVE-2026-45829/45833: trust_remote_code lets a model repo run arbitrary code on load.
+        msg = "Setting 'trust_remote_code=True' in embedding_function_params is not allowed."
+        raise ChromaDocumentStoreConfigError(msg)
     try:
         return FUNCTION_REGISTRY[function_name](**kwargs)
     except KeyError:

--- a/integrations/chroma/tests/test_document_store.py
+++ b/integrations/chroma/tests/test_document_store.py
@@ -49,6 +49,11 @@ def test_get_embedding_function_invalid_name_raises():
         get_embedding_function("NonExistentEmbeddingFunction")
 
 
+def test_get_embedding_function_trust_remote_code_raises():
+    with pytest.raises(ChromaDocumentStoreConfigError, match="trust_remote_code"):
+        get_embedding_function("SentenceTransformerEmbeddingFunction", trust_remote_code=True)
+
+
 class TestDocumentStoreUnit:
     def test_init_in_memory(self):
         store = ChromaDocumentStore()


### PR DESCRIPTION
## Summary
- Fixes ECO-964 (Socket CVE-2026-45833 / GHSA-36p7-vc44-83pf, chromadb code injection).
- No upstream chromadb fix exists yet — PyPI's latest release is 1.5.9, the same version flagged, and the advisory lists no patched version. The CVE's actual attack surface (chromadb server's `/collections/{id}` UPDATE_COLLECTION REST endpoint) also isn't reachable through this repo, since `chroma-haystack` only uses chromadb as a client SDK.
- This is defense-in-depth for the adjacent, real risk in our code: `ChromaDocumentStore` forwards user-supplied `embedding_function_params` directly into chromadb's embedding function constructors (e.g. `SentenceTransformerEmbeddingFunction`). A `trust_remote_code=True` there lets a malicious/attacker-controlled model repo execute arbitrary code on load — the same bug class as CVE-2026-45829, whose chromadb-side fix (chroma-core/chroma#7237) also hasn't shipped to PyPI.
- Guard added once in the shared `get_embedding_function()` so every caller is covered.

## Test plan
- [x] `pytest tests/test_document_store.py -k test_get_embedding_function` — new test asserts `trust_remote_code=True` raises `ChromaDocumentStoreConfigError`
- [x] Full unit suite (`pytest -m "not integration" tests`) — 54 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)