### PR TITLE
fix: respect falsy run() overrides in `SentenceTransformersSimilarityRanker`

### DIFF
--- a/integrations/sentence_transformers/src/haystack_integrations/components/rankers/sentence_transformers/sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/src/haystack_integrations/components/rankers/sentence_transformers/sentence_transformers_similarity.py
@@ -250,13 +250,13 @@ class SentenceTransformersSimilarityRanker:
         if not documents:
             return {"documents": []}
 
-        top_k = top_k or self.top_k
-        scale_score = scale_score or self.scale_score
-        score_threshold = score_threshold or self.score_threshold
-
-        if top_k <= 0:
+        if top_k is not None and top_k <= 0:
             msg = f"top_k must be > 0, but got {top_k}"
             raise ValueError(msg)
+
+        top_k = self.top_k if top_k is None else top_k
+        scale_score = self.scale_score if scale_score is None else scale_score
+        score_threshold = self.score_threshold if score_threshold is None else score_threshold
 
         deduplicated_documents = _deduplicate_documents(documents)
         prepared_query = self.query_prefix + query + self.query_suffix

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
@@ -281,6 +281,35 @@ class TestSentenceTransformersSimilarityRanker:
         with pytest.raises(ValueError):
             ranker.run(query="test", documents=[Document(content="document")], top_k=-1)
 
+    def test_run_top_k_zero_raises(self):
+        ranker = SentenceTransformersSimilarityRanker()
+        ranker._cross_encoder = MagicMock()
+
+        with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
+            ranker.run(query="test", documents=[Document(content="document")], top_k=0)
+
+    def test_run_scale_score_false_overrides_init(self):
+        ranker = SentenceTransformersSimilarityRanker()  # scale_score=True by default
+        mock_cross_encoder = MagicMock()
+        mock_cross_encoder.rank.return_value = [{"corpus_id": 0, "score": 1.0}]
+        ranker._cross_encoder = mock_cross_encoder
+
+        ranker.run(query="test", documents=[Document(content="document")], scale_score=False)
+
+        _, kwargs = mock_cross_encoder.rank.call_args
+        assert isinstance(kwargs["activation_fn"], torch.nn.Identity)
+
+    def test_run_score_threshold_zero_overrides_init(self):
+        ranker = SentenceTransformersSimilarityRanker(score_threshold=0.5)
+        mock_cross_encoder = MagicMock()
+        mock_cross_encoder.rank.return_value = [{"corpus_id": 0, "score": 0.2}, {"corpus_id": 1, "score": -0.4}]
+        ranker._cross_encoder = mock_cross_encoder
+
+        documents = [Document(content="first"), Document(content="second")]
+        result = ranker.run(query="test", documents=documents, score_threshold=0.0)
+
+        assert [doc.score for doc in result["documents"]] == [0.2]
+
     def test_returns_empty_list_if_no_documents_are_provided(self):
         ranker = SentenceTransformersSimilarityRanker()
         ranker._cross_encoder = MagicMock()


### PR DESCRIPTION
### Related Issues

- fixes #3854

### Proposed Changes:

`run()` resolved its overrides with `or`, which falls back on any falsy value, not just `None`. So `run(scale_score=False)` never disabled scaling, `run(score_threshold=0.0)` was replaced by the init value, and `run(top_k=0)` silently used the init `top_k` instead of raising the documented ValueError. This validates `top_k` before the fallback and switches the three fallbacks to `None` checks, the same change #3745 and #3746 made for the fastembed rankers. Behavior now matches the run() docstring, which already says "If set, overrides the value set at initialization."

### How did you test it?

Added 3 regression tests, one per parameter. They fail on main and pass with the fix. Also verified with a real cross-encoder model that `run(scale_score=False)` now returns raw logits instead of sigmoid-scaled scores, and that the unit and integration suites both pass (23 + 3 tests).

### Notes for the reviewer

Behavior change: `run(top_k=0)` now raises instead of silently using the init value, same as the fastembed rankers fix.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
