### PR TITLE
!fix: `BedrockKnowledgeBaseRetriever` → `AmazonBedrockKnowledgeBaseRetriever`

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/retrievers/amazon_bedrock/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/retrievers/amazon_bedrock/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack_integrations.components.retrievers.amazon_bedrock.knowledge_base_retriever import (
-    BedrockKnowledgeBaseRetriever,
+    AmazonBedrockKnowledgeBaseRetriever,
 )
 
-__all__ = ["BedrockKnowledgeBaseRetriever"]
+__all__ = ["AmazonBedrockKnowledgeBaseRetriever"]

--- a/integrations/amazon_bedrock/src/haystack_integrations/components/retrievers/amazon_bedrock/knowledge_base_retriever.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/retrievers/amazon_bedrock/knowledge_base_retriever.py
@@ -39,7 +39,7 @@ def _get_source_uri(result: dict) -> str:
 
 
 @component
-class BedrockKnowledgeBaseRetriever:
+class AmazonBedrockKnowledgeBaseRetriever:
     """
     Retrieves documents from an Amazon Bedrock Managed Knowledge Base.
 
@@ -48,9 +48,9 @@ class BedrockKnowledgeBaseRetriever:
     Usage example:
     ```python
     from haystack.utils import Secret
-    from haystack_integrations.components.retrievers.amazon_bedrock import BedrockKnowledgeBaseRetriever
+    from haystack_integrations.components.retrievers.amazon_bedrock import AmazonBedrockKnowledgeBaseRetriever
 
-    retriever = BedrockKnowledgeBaseRetriever(
+    retriever = AmazonBedrockKnowledgeBaseRetriever(
         knowledge_base_id="ABCDEFGHIJ",
         aws_region_name=Secret.from_token("eu-central-1"),
     )
@@ -62,7 +62,7 @@ class BedrockKnowledgeBaseRetriever:
         print(doc.score)
     ```
 
-    BedrockKnowledgeBaseRetriever uses AWS for authentication. You can use the AWS CLI to authenticate through
+    AmazonBedrockKnowledgeBaseRetriever uses AWS for authentication. You can use the AWS CLI to authenticate through
     your IAM. For more information on setting up an IAM identity-based policy, see [Amazon Bedrock documentation]
     (https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html).
 
@@ -87,7 +87,7 @@ class BedrockKnowledgeBaseRetriever:
         use_agentic_retrieval: bool | None = None,
     ) -> None:
         """
-        Create the BedrockKnowledgeBaseRetriever component.
+        Create the AmazonBedrockKnowledgeBaseRetriever component.
 
         :param knowledge_base_id: The ID of the Bedrock Knowledge Base. Falls back to the AWS_KNOWLEDGE_BASE_ID
             environment variable.
@@ -244,7 +244,7 @@ class BedrockKnowledgeBaseRetriever:
         )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "BedrockKnowledgeBaseRetriever":
+    def from_dict(cls, data: dict[str, Any]) -> "AmazonBedrockKnowledgeBaseRetriever":
         """
         Deserializes the component from a dictionary.
 

--- a/integrations/amazon_bedrock/tests/test_knowledge_base_retriever.py
+++ b/integrations/amazon_bedrock/tests/test_knowledge_base_retriever.py
@@ -10,7 +10,7 @@ from haystack import Document
 
 from haystack_integrations.common.amazon_bedrock.errors import AmazonBedrockInferenceError
 from haystack_integrations.components.retrievers.amazon_bedrock.knowledge_base_retriever import (
-    BedrockKnowledgeBaseRetriever,
+    AmazonBedrockKnowledgeBaseRetriever,
 )
 
 
@@ -24,16 +24,16 @@ def mock_aws_session():
         yield mock_client
 
 
-class TestBedrockKnowledgeBaseRetriever:
+class TestAmazonBedrockKnowledgeBaseRetriever:
     def test_init_defaults(self, mock_aws_session):
-        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        retriever = AmazonBedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
         assert retriever.knowledge_base_id == "TEST123456"
         assert retriever.number_of_results == 5
         assert retriever.knowledge_base_type == "MANAGED"
 
     @patch.dict("os.environ", {"AWS_KNOWLEDGE_BASE_ID": "ENV_KB", "AWS_DEFAULT_REGION": "eu-west-1"})
     def test_init_from_env(self, mock_aws_session):
-        retriever = BedrockKnowledgeBaseRetriever()
+        retriever = AmazonBedrockKnowledgeBaseRetriever()
         assert retriever.knowledge_base_id == "ENV_KB"
         assert retriever.aws_region_name.resolve_value() == "eu-west-1"
 
@@ -53,7 +53,7 @@ class TestBedrockKnowledgeBaseRetriever:
             ]
         }
 
-        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        retriever = AmazonBedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
         result = retriever.run(query="What is managed KB?")
 
         # Verify correct API call
@@ -74,7 +74,7 @@ class TestBedrockKnowledgeBaseRetriever:
     def test_run_top_k_override(self, mock_aws_session):
         mock_aws_session.retrieve.return_value = {"retrievalResults": []}
 
-        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456", number_of_results=5)
+        retriever = AmazonBedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456", number_of_results=5)
         retriever.run(query="test", top_k=10)
 
         call_kwargs = mock_aws_session.retrieve.call_args.kwargs
@@ -83,7 +83,7 @@ class TestBedrockKnowledgeBaseRetriever:
     def test_run_empty_results(self, mock_aws_session):
         mock_aws_session.retrieve.return_value = {"retrievalResults": []}
 
-        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        retriever = AmazonBedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
         result = retriever.run(query="no match")
 
         assert result["documents"] == []
@@ -91,13 +91,13 @@ class TestBedrockKnowledgeBaseRetriever:
     def test_run_error_handling(self, mock_aws_session):
         mock_aws_session.retrieve.side_effect = Exception("Service unavailable")
 
-        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        retriever = AmazonBedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
 
         with pytest.raises(AmazonBedrockInferenceError):
             retriever.run(query="test")
 
     def test_to_dict(self, mock_aws_session):
-        retriever = BedrockKnowledgeBaseRetriever(
+        retriever = AmazonBedrockKnowledgeBaseRetriever(
             knowledge_base_id="TEST123456",
             number_of_results=10,
         )
@@ -106,7 +106,7 @@ class TestBedrockKnowledgeBaseRetriever:
         assert serialized == {
             "type": (
                 "haystack_integrations.components.retrievers.amazon_bedrock."
-                "knowledge_base_retriever.BedrockKnowledgeBaseRetriever"
+                "knowledge_base_retriever.AmazonBedrockKnowledgeBaseRetriever"
             ),
             "init_parameters": {
                 "knowledge_base_id": "TEST123456",
@@ -128,7 +128,7 @@ class TestBedrockKnowledgeBaseRetriever:
         data = {
             "type": (
                 "haystack_integrations.components.retrievers.amazon_bedrock."
-                "knowledge_base_retriever.BedrockKnowledgeBaseRetriever"
+                "knowledge_base_retriever.AmazonBedrockKnowledgeBaseRetriever"
             ),
             "init_parameters": {
                 "knowledge_base_id": "TEST123456",
@@ -141,7 +141,7 @@ class TestBedrockKnowledgeBaseRetriever:
                 "use_agentic_retrieval": False,
             },
         }
-        retriever = BedrockKnowledgeBaseRetriever.from_dict(data)
+        retriever = AmazonBedrockKnowledgeBaseRetriever.from_dict(data)
         assert retriever.knowledge_base_id == "TEST123456"
         assert retriever.number_of_results == 10
         assert retriever.use_agentic_retrieval is False
@@ -152,12 +152,12 @@ class TestBedrockKnowledgeBaseRetriever:
     not os.environ.get("AWS_KNOWLEDGE_BASE_ID"),
     reason="Set AWS_KNOWLEDGE_BASE_ID env var to run integration tests",
 )
-class TestBedrockKnowledgeBaseRetrieverIntegration:
-    """Integration tests for BedrockKnowledgeBaseRetriever against a live managed KB."""
+class TestAmazonBedrockKnowledgeBaseRetrieverIntegration:
+    """Integration tests for AmazonBedrockKnowledgeBaseRetriever against a live managed KB."""
 
     def test_standard_retrieve(self):
         """Test standard Retrieve API on a managed knowledge base."""
-        retriever = BedrockKnowledgeBaseRetriever(
+        retriever = AmazonBedrockKnowledgeBaseRetriever(
             knowledge_base_id=os.environ["AWS_KNOWLEDGE_BASE_ID"],
             aws_region_name=os.environ["AWS_REGION"],
             use_agentic_retrieval=False,
@@ -173,7 +173,7 @@ class TestBedrockKnowledgeBaseRetrieverIntegration:
 
     def test_agentic_retrieve(self):
         """Test AgenticRetrieveStream on a managed knowledge base."""
-        retriever = BedrockKnowledgeBaseRetriever(
+        retriever = AmazonBedrockKnowledgeBaseRetriever(
             knowledge_base_id=os.environ["AWS_KNOWLEDGE_BASE_ID"],
             aws_region_name=os.environ["AWS_REGION"],
             use_agentic_retrieval=True,
@@ -188,7 +188,7 @@ class TestBedrockKnowledgeBaseRetrieverIntegration:
 
     def test_user_agent(self):
         """Verify user-agent header is set correctly."""
-        retriever = BedrockKnowledgeBaseRetriever(
+        retriever = AmazonBedrockKnowledgeBaseRetriever(
             knowledge_base_id=os.environ["AWS_KNOWLEDGE_BASE_ID"],
             aws_region_name=os.environ["AWS_REGION"],
         )


### PR DESCRIPTION
### Proposed Changes:

-  BedrockKnowledgeBaseRetriever → AmazonBedrockKnowledgeBaseRetriever

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
