### PR TITLE
feat(azure_ai_search): improve handling of unknown metadata fields

### DIFF
--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -421,14 +421,20 @@ class AzureAISearchDocumentStore:
         index_fields = self._index_client.get_index(self._index_name).fields
         return {field.name: field for field in index_fields}
 
-    def _validate_index_fields(self, field_names: list[str]) -> None:
+    def _is_index_field(self, field_name: str) -> bool:
         """
-        Validates that all provided field names exist in the index schema.
+        Returns whether the given field name is defined in the index schema.
         """
         if not self._index_fields:
             self._index_fields = list(self._get_index_schema_fields().keys())
 
-        missing_fields = [field for field in field_names if field not in self._index_fields]
+        return field_name in self._index_fields
+
+    def _validate_index_fields(self, field_names: list[str]) -> None:
+        """
+        Validates that all provided field names exist in the index schema.
+        """
+        missing_fields = [field for field in field_names if not self._is_index_field(field)]
         if missing_fields:
             msg = f"Fields {missing_fields} are not defined in index schema. Available fields: {self._index_fields}"
             raise ValueError(msg)
@@ -576,9 +582,15 @@ class AzureAISearchDocumentStore:
         :param size: Number of values to return.
         :param filters: Optional filters to restrict the documents considered.
         :returns: Tuple of (list of unique values in their original type, total count of matching values).
+            A field that is not defined in the index schema has no values, so it returns `([], 0)`.
         """
         field_name = _normalize_metadata_field_name(metadata_field)
-        self._validate_index_fields([field_name])
+        # Azure AI Search fixes the index schema at creation time, so a metadata field that is not part
+        # of it can never hold values, and selecting it would be rejected by the service. Return an
+        # empty result rather than raising, which is how the other document stores answer for a field
+        # no document has.
+        if not self._is_index_field(field_name):
+            return [], 0
 
         documents = self._fetch_raw_documents(filters=filters, select=[field_name])
         unique_values = sorted(self._collect_unique_values(documents, field_name))

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -380,6 +380,20 @@ def test_get_metadata_field_unique_values_preserves_non_string_types():
     assert total_count == 2
 
 
+def test_get_metadata_field_unique_values_unknown_field_returns_empty():
+    index_fields = [
+        SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+    ]
+    document_store, search_client, _ = _build_mock_document_store_with_schema(index_fields)
+
+    values, total_count = document_store.get_metadata_field_unique_values(metadata_field="missing_field")
+
+    assert values == []
+    assert total_count == 0
+    search_client.search.assert_not_called()
+
+
 def test_query_sql_raises_not_implemented():
     document_store = AzureAISearchDocumentStore(
         api_key=Secret.from_token("fake-api-key"),
@@ -819,6 +833,98 @@ class TestDocumentStore(
 
     @pytest.mark.parametrize(
         "document_store",
+        [{"metadata_fields": {"category": str}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_meta_prefix(self, document_store: AzureAISearchDocumentStore):
+        """Override to use a document_store with required metadata fields."""
+        GetMetadataFieldUniqueValuesTest.test_get_metadata_field_unique_values_meta_prefix(document_store)
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_search_term(self, document_store: AzureAISearchDocumentStore):
+        """Override to use a document_store with required metadata fields."""
+        GetMetadataFieldUniqueValuesTest.test_get_metadata_field_unique_values_search_term(document_store)
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_pagination(self, document_store: AzureAISearchDocumentStore):
+        """Override to use a document_store with required metadata fields."""
+        GetMetadataFieldUniqueValuesTest.test_get_metadata_field_unique_values_pagination(document_store)
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"category": str}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_empty_store(self, document_store: AzureAISearchDocumentStore):
+        """Override to use a document_store with required metadata fields."""
+        GetMetadataFieldUniqueValuesTest.test_get_metadata_field_unique_values_empty_store(document_store)
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [{"metadata_fields": {"priority": int}}],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_preserves_type(self, document_store: AzureAISearchDocumentStore):
+        """Override to use a document_store with required metadata fields."""
+        GetMetadataFieldUniqueValuesTest.test_get_metadata_field_unique_values_preserves_type(document_store)
+
+    @pytest.mark.parametrize(
+        "document_store",
+        [
+            {
+                "metadata_fields": {
+                    "priority_int": int,
+                    "priority_str": str,
+                    "priority_float": float,
+                    "priority_bool": bool,
+                }
+            }
+        ],
+        indirect=True,
+    )
+    def test_get_metadata_field_unique_values_distinct_types(self, document_store: AzureAISearchDocumentStore):
+        """
+        Override: the base mixin test stores int, float, str and bool under the *same* metadata field
+        name and expects all four back as distinct values. Azure AI Search fixes the index schema at
+        creation time and binds every field to a single Edm.* type, so one field cannot hold values of
+        four different types - the writes for the mismatched types are rejected by the service.
+
+        This adapts the same intent - int, float, str and bool must come back as distinct, unmangled
+        types via get_metadata_field_unique_values() - using one field per type instead of one shared
+        field, which is what Azure AI Search can actually support.
+
+        The float value is a non-whole number (1.5, not 1.0) to keep the value unambiguous, matching
+        the pattern used by the other document stores hitting this limitation.
+        """
+        docs = [
+            Document(content="Doc 1", meta={"priority_int": 1}),
+            Document(content="Doc 2", meta={"priority_str": "1"}),
+            Document(content="Doc 3", meta={"priority_float": 1.5}),
+            Document(content="Doc 4", meta={"priority_bool": True}),
+        ]
+        document_store.write_documents(docs)
+
+        int_values, int_count = document_store.get_metadata_field_unique_values(metadata_field="priority_int")
+        str_values, str_count = document_store.get_metadata_field_unique_values(metadata_field="priority_str")
+        float_values, float_count = document_store.get_metadata_field_unique_values(metadata_field="priority_float")
+        bool_values, bool_count = document_store.get_metadata_field_unique_values(metadata_field="priority_bool")
+
+        assert (int_count, str_count, float_count, bool_count) == (1, 1, 1, 1)
+        assert int_values == [1] and type(int_values[0]) is int
+        assert str_values == ["1"] and type(str_values[0]) is str
+        assert float_values == [1.5] and type(float_values[0]) is float
+        assert bool_values == [True] and type(bool_values[0]) is bool
+
+    @pytest.mark.parametrize(
+        "document_store",
         [{"metadata_fields": {"category": str, "status": str, "priority": int}}],
         indirect=True,
     )
@@ -886,45 +992,12 @@ class TestDocumentStore(
 
     @pytest.mark.parametrize(
         "document_store",
-        [{"metadata_fields": {"category": str, "status": str, "priority": int}}],
-        indirect=True,
-    )
-    def test_get_metadata_field_unique_values_integration(self, document_store: AzureAISearchDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "news", "status": "draft", "priority": 1}),
-            Document(content="Doc 2", meta={"category": "guides", "status": "published", "priority": 8}),
-            Document(content="Doc 3", meta={"category": "docs", "status": "draft", "priority": 3}),
-            Document(content="Doc 4", meta={"category": "news", "status": "archived", "priority": 10}),
-        ]
-        document_store.write_documents(docs)
-
-        values, total_count = document_store.get_metadata_field_unique_values(
-            metadata_field="meta.category",
-            search_term="d",
-            from_=0,
-            size=10,
-        )
-
-        assert values == ["docs", "guides"]
-        assert total_count == 2
-
-    @pytest.mark.parametrize(
-        "document_store",
         [{"metadata_fields": {"category": str, "status": str}}],
         indirect=True,
     )
     def test_get_metadata_field_unique_values_with_filters(self, document_store: AzureAISearchDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
-            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
-            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
-        ]
-        document_store.write_documents(docs)
-
-        filters = {"field": "meta.status", "operator": "==", "value": "active"}
-        values, total = document_store.get_metadata_field_unique_values("meta.category", filters=filters)
-        assert set(values) == {"A", "B"}
-        assert total == 2
+        """Override to use a document_store with required metadata fields."""
+        GetMetadataFieldUniqueValuesTest.test_get_metadata_field_unique_values_with_filters(document_store)
 
     def test_query_sql_integration(self, document_store: AzureAISearchDocumentStore):
         with pytest.raises(NotImplementedError, match="does not support SQL queries"):


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-private/issues/501
- fixes the failing nightly: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/33029891446

### Proposed Changes:

- `haystack-ai` 3.1.0 grew `GetMetadataFieldUniqueValuesTest` from 1 test to 9. `azure_ai_search` inherited the 8 new tests unguarded and the nightly has been red since 2026-08-25 with `ValueError: Fields ['category'] are not defined in index schema`. 

- Azure AI Search fixes the index schema at index creation time, so metadata fields have to be declared up front via `metadata_fields=`. Added overrides that parametrize the `document_store` fixture with the fields each Mixin test needs.

- `test_get_metadata_field_unique_values_distinct_types` expects int, float, str and bool sharing the same metadata field name to all come back as distinct. Azure AI Search binds every index field to a single `Edm.*` type, so a field declared `Edm.Int32` rejects the str/float/bool writes outright. Adapted the test to use one metadata field per type instead of one shared field.

- Unknown field no longer raises: `get_metadata_field_unique_values()` used to raise `ValueError` for a field absent from the index schema, while the Mixin's `_missing_field` test expects `([], 0)`. 

- Removed duplicated tests, now relying on the Mixin: `test_get_metadata_field_unique_values_integration` duplicated `_search_term` and was deleted, and the hand-written `_with_filters` — which was silently shadowing the new Mixin test of the same name — is now a delegating override.


### How did you test it?

- `hatch run fmt-check`, `hatch run test:types`, `hatch run test:unit` — green, 94 unit tests, one added for the new unknown-field behaviour
- `hatch run test:integration` against a live Azure AI Search index

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
