### PR TITLE
test: replace retired Qwen2.5 models in `huggingface_api` live tests

### DIFF
--- a/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
@@ -280,7 +280,7 @@ class HuggingFaceAPIChatGenerator:
     api_type = "serverless_inference_api" # this is equivalent to the above
 
     generator = HuggingFaceAPIChatGenerator(api_type=api_type,
-                                            api_params={"model": "Qwen/Qwen2.5-7B-Instruct",
+                                            api_params={"model": "Qwen/Qwen3.5-9B",
                                                         "provider": "together"},
                                             token=Secret.from_token("<your-api-key>"))
 
@@ -305,8 +305,8 @@ class HuggingFaceAPIChatGenerator:
     generator = HuggingFaceAPIChatGenerator(
         api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
         api_params={
-            "model": "Qwen/Qwen2.5-VL-7B-Instruct",  # Vision Language Model
-            "provider": "hyperbolic"
+            "model": "Qwen/Qwen3.5-9B",  # Vision Language Model
+            "provider": "together"
         },
         token=Secret.from_token("<your-api-key>")
     )

--- a/integrations/huggingface_api/tests/test_chat_generator.py
+++ b/integrations/huggingface_api/tests/test_chat_generator.py
@@ -763,8 +763,8 @@ class TestHuggingFaceAPIChatGenerator:
     def test_live_run_serverless(self):
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen2.5-7B-Instruct", "provider": "together"},
-            generation_kwargs={"max_tokens": 20},
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
         )
 
         # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
@@ -785,7 +785,7 @@ class TestHuggingFaceAPIChatGenerator:
         assert meta["usage"]["prompt_tokens"] > 0
         assert "completion_tokens" in meta["usage"]
         assert meta["usage"]["completion_tokens"] > 0
-        assert meta["model"] == "Qwen/Qwen2.5-7B-Instruct"
+        assert meta["model"] == "Qwen/Qwen3.5-9B"
         assert meta["finish_reason"] is not None
 
     @pytest.mark.integration
@@ -796,8 +796,8 @@ class TestHuggingFaceAPIChatGenerator:
     def test_live_run_serverless_streaming(self):
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen2.5-7B-Instruct", "provider": "together"},
-            generation_kwargs={"max_tokens": 20},
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
             streaming_callback=streaming_callback_handler,
         )
 
@@ -822,8 +822,7 @@ class TestHuggingFaceAPIChatGenerator:
         assert response_meta["usage"]["prompt_tokens"] >= 0
         assert "completion_tokens" in response_meta["usage"]
         assert response_meta["usage"]["completion_tokens"] >= 0
-        # internally, Together calls this "Qwen/Qwen2.5-7B-Instruct-Turbo"
-        assert "Qwen/Qwen2.5-7B-Instruct" in response_meta["model"]
+        assert response_meta["model"] == "Qwen/Qwen3.5-9B"
         assert response_meta["finish_reason"] is not None
 
     @pytest.mark.integration
@@ -1089,8 +1088,8 @@ class TestHuggingFaceAPIChatGenerator:
     async def test_live_run_async_serverless(self):
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen2.5-7B-Instruct", "provider": "together"},
-            generation_kwargs={"max_tokens": 20},
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
         )
 
         messages = [
@@ -1111,7 +1110,7 @@ class TestHuggingFaceAPIChatGenerator:
             assert meta["usage"]["prompt_tokens"] > 0
             assert "completion_tokens" in meta["usage"]
             assert meta["usage"]["completion_tokens"] > 0
-            assert meta["model"] == "Qwen/Qwen2.5-7B-Instruct"
+            assert meta["model"] == "Qwen/Qwen3.5-9B"
             assert meta["finish_reason"] is not None
         finally:
             await generator._async_client.close()


### PR DESCRIPTION
### Related Issues

None — found via the nightly `main` failure in [run 33136428425](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/33136428425/job/98775492175).

The nightly `huggingface_api` integration job fails because Together retired the model behind `Qwen/Qwen2.5-7B-Instruct`:

```
Unable to access non-serverless model Qwen/Qwen2.5-7B-Instruct-Turbo.
… 'type': 'invalid_request_error', 'code': 'model_not_available'
```

`Qwen/Qwen2.5-7B-Instruct` + `provider="together"` routes to `Qwen2.5-7B-Instruct-Turbo`, which is no longer served as serverless

### Proposed Changes:

- Swap `Qwen/Qwen2.5-7B-Instruct` → **`Qwen/Qwen3.5-9B`** 
- Pass `extra_body={"chat_template_kwargs": {"enable_thinking": False}}` in those tests
- Update two stale docstring examples in `HuggingFaceAPIChatGenerator`


### How did you test it?

- existing tests

### Notes for the reviewer

Why `Qwen/Qwen3.5-9B`: recent, small, cheap, live on `together`, and already used by two other live tests in this file.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes — n/a, no issue
- I added unit tests and updated the docstrings — updated existing integration tests and two docstring examples; no new unit tests, this is a test/docs fix
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
