### PR TITLE
feat: add GoogleGenAITokenCounter to google-genai integration

### DIFF
--- a/integrations/google_genai/pydoc/config_docusaurus.yml
+++ b/integrations/google_genai/pydoc/config_docusaurus.yml
@@ -4,6 +4,7 @@ loaders:
       - haystack_integrations.components.embedders.google_genai.document_embedder
       - haystack_integrations.components.embedders.google_genai.text_embedder
       - haystack_integrations.components.embedders.google_genai.multimodal_document_embedder
+      - haystack_integrations.token_counters.google_genai.token_counter
     search_path: [../src]
 processors:
   - type: filter

--- a/integrations/google_genai/pyproject.toml
+++ b/integrations/google_genai/pyproject.toml
@@ -73,7 +73,8 @@ integration-cov-append-retry = 'pytest --cov=haystack_integrations --cov-append 
 
 types = """mypy -p haystack_integrations.components.generators.google_genai \
 -p haystack_integrations.components.embedders.google_genai \
--p haystack_integrations.common.google_genai {args}"""
+-p haystack_integrations.common.google_genai \
+-p haystack_integrations.token_counters.google_genai {args}"""
 
 [tool.mypy]
 install_types = true

--- a/integrations/google_genai/src/haystack_integrations/token_counters/google_genai/__init__.py
+++ b/integrations/google_genai/src/haystack_integrations/token_counters/google_genai/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from .token_counter import GoogleGenAITokenCounter
+
+__all__ = ["GoogleGenAITokenCounter"]

--- a/integrations/google_genai/src/haystack_integrations/token_counters/google_genai/token_counter.py
+++ b/integrations/google_genai/src/haystack_integrations/token_counters/google_genai/token_counter.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Literal
+
+from google.genai import Client, types
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.dataclasses.chat_message import ChatMessage, ChatRole
+from haystack.tools import ToolsType
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+from haystack_integrations.common.google_genai.utils import _get_client
+from haystack_integrations.components.generators.google_genai.chat.utils import (
+    _convert_message_to_google_genai_format,
+    _convert_tools_to_google_genai_format,
+)
+
+
+class GoogleGenAITokenCounter:
+    """
+    Counts input tokens for Gemini models with Google's token counting API.
+
+    Unlike local token counters, this counter sends the input to the `countTokens` endpoint of the Google Gen AI
+    SDK, so the returned count includes the model-specific formatting Gemini applies to messages.
+
+    Inputs are assembled exactly as `GoogleGenAIChatGenerator` sends them: a leading system message becomes the
+    system instruction and the remaining messages become the request contents.
+
+    ### Backend support for system instructions and tools
+
+    The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client
+    targets Vertex AI. On the Gemini Developer API it rejects both, so this counter raises a `ValueError` instead
+    of silently returning a count that omits them. Counting plain messages works on either backend.
+
+    ## Usage Example:
+    ```python
+    from haystack.dataclasses import ChatMessage
+    from haystack_integrations.token_counters.google_genai import GoogleGenAITokenCounter
+
+    counter = GoogleGenAITokenCounter("gemini-3.7-flash")
+    messages = [ChatMessage.from_user("Hello, how are you?")]
+    token_count = counter.count(messages)
+    print(f"Token count: {token_count}")
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: Secret = Secret.from_env_var(["GOOGLE_API_KEY", "GEMINI_API_KEY"], strict=False),
+        api: Literal["gemini", "vertex"] = "gemini",
+        vertex_ai_project: str | None = None,
+        vertex_ai_location: str | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+    ) -> None:
+        """
+        Initialize the counter.
+
+        :param model: The model whose tokenization should be used. Token counts are model-specific, so count
+            against the same model you intend to generate with.
+        :param api_key: Google API key, defaults to the `GOOGLE_API_KEY` and `GEMINI_API_KEY` environment
+            variables. Not needed if using Vertex AI with Application Default Credentials.
+        :param api: Which API to use. Either `gemini` for the Gemini Developer API or `vertex` for Vertex AI.
+        :param vertex_ai_project: Google Cloud project ID for Vertex AI. Required when using Vertex AI with
+            Application Default Credentials.
+        :param vertex_ai_location: Google Cloud location for Vertex AI (e.g., `us-central1`, `europe-west1`).
+            Required when using Vertex AI with Application Default Credentials.
+        :param timeout: Timeout for Google Gen AI client calls. If not set, it defaults to the default set by the
+            Google Gen AI client.
+        :param max_retries: Maximum number of retries to attempt for failed requests. If not set, it defaults to
+            the default set by the Google Gen AI client.
+        """
+        self.model = model
+        self.api_key = api_key
+        self.api = api
+        self.vertex_ai_project = vertex_ai_project
+        self.vertex_ai_location = vertex_ai_location
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+        self.client: Client | None = None
+
+    def warm_up(self) -> None:
+        """Initialize the Google Gen AI client."""
+        if self.client is not None:
+            return
+
+        self.client = _get_client(
+            api_key=self.api_key,
+            api=self.api,
+            vertex_ai_project=self.vertex_ai_project,
+            vertex_ai_location=self.vertex_ai_location,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        )
+
+    def count(self, messages: list[ChatMessage], tools: ToolsType | None = None) -> int:
+        """
+        Return the number of input tokens Gemini will use for the given messages and tools.
+
+        :param messages: The messages to measure. A leading system message is measured as the system instruction.
+        :param tools: Tools whose schemas are sent alongside the messages, and so consume tokens too.
+        :returns: The token count, or `0` when there is nothing to measure.
+        :raises ValueError: If a system message or tools are passed while targeting the Gemini Developer API,
+            which cannot measure either.
+        """
+        if not messages and not tools:
+            return 0
+
+        # Mirror how GoogleGenAIChatGenerator splits the request: a leading system message is sent separately.
+        chat_messages = messages
+        system_instruction = None
+        if messages and messages[0].is_from(ChatRole.SYSTEM):
+            system_instruction = messages[0].text or ""
+            chat_messages = messages[1:]
+
+        config_params: dict[str, Any] = {}
+        if system_instruction:
+            config_params["system_instruction"] = system_instruction
+        if tools:
+            config_params["tools"] = _convert_tools_to_google_genai_format(tools)
+
+        # Rejected before the client is built, so an unsupported request fails the same way with or without
+        # credentials.
+        if config_params and self.api != "vertex":
+            unsupported = " and ".join(
+                name for name, present in (("a system message", system_instruction), ("tools", tools)) if present
+            )
+            msg = (
+                f"Counting tokens for {unsupported} is only supported when targeting Vertex AI, because the "
+                "Google Gen AI SDK rejects them on the Gemini Developer API. Initialize this counter with "
+                'api="vertex", or count only the non-system messages.'
+            )
+            raise ValueError(msg)
+
+        self.warm_up()
+        client = self.client
+        if client is None:
+            msg = "The Google Gen AI client was not initialized."
+            raise RuntimeError(msg)
+
+        contents: list[types.ContentUnion] = [_convert_message_to_google_genai_format(msg) for msg in chat_messages]
+        config = types.CountTokensConfig(**config_params) if config_params else None
+
+        response = client.models.count_tokens(model=self.model, contents=contents, config=config)
+        return response.total_tokens or 0
+
+    def close(self) -> None:
+        """Close the Google Gen AI client and its underlying HTTP resources."""
+        if self.client is not None:
+            self.client.close()
+            self.client = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the counter.
+
+        :returns: A dictionary representation of the counter.
+        """
+        return default_to_dict(
+            self,
+            model=self.model,
+            api_key=self.api_key.to_dict(),
+            api=self.api,
+            vertex_ai_project=self.vertex_ai_project,
+            vertex_ai_location=self.vertex_ai_location,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GoogleGenAITokenCounter":
+        """
+        Deserialize the counter.
+
+        :param data: The dictionary to deserialize from.
+        :returns: The deserialized counter.
+        """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        return default_from_dict(cls, data)

--- a/integrations/google_genai/src/haystack_integrations/token_counters/google_genai/token_counter.py
+++ b/integrations/google_genai/src/haystack_integrations/token_counters/google_genai/token_counter.py
@@ -30,8 +30,9 @@ class GoogleGenAITokenCounter:
     ### Backend support for system instructions and tools
 
     The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client
-    targets Vertex AI. On the Gemini Developer API it rejects both, so this counter raises a `ValueError` instead
-    of silently returning a count that omits them. Counting plain messages works on either backend.
+    targets Vertex AI. On the Gemini Developer API, a leading system message is therefore measured as a user turn,
+    which gives a close approximation rather than the exact count, and tools raise a `ValueError` instead of
+    silently returning a count that omits their schemas. Counting plain messages works on either backend.
 
     ## Usage Example:
     ```python
@@ -101,14 +102,24 @@ class GoogleGenAITokenCounter:
         """
         Return the number of input tokens Gemini will use for the given messages and tools.
 
-        :param messages: The messages to measure. A leading system message is measured as the system instruction.
+        :param messages: The messages to measure. A leading system message is measured as the system instruction on
+            Vertex AI and as a user turn on the Gemini Developer API, which cannot measure system instructions.
         :param tools: Tools whose schemas are sent alongside the messages, and so consume tokens too.
         :returns: The token count, or `0` when there is nothing to measure.
-        :raises ValueError: If a system message or tools are passed while targeting the Gemini Developer API,
-            which cannot measure either.
+        :raises ValueError: If tools are passed while targeting the Gemini Developer API, which cannot measure them.
         """
         if not messages and not tools:
             return 0
+
+        # Rejected before the client is built, so an unsupported request fails the same way with or without
+        # credentials.
+        if tools and self.api != "vertex":
+            msg = (
+                "Counting tokens for tools is only supported when targeting Vertex AI, because the Google Gen AI SDK "
+                'rejects them on the Gemini Developer API. Initialize this counter with api="vertex", or count only '
+                "the messages."
+            )
+            raise ValueError(msg)
 
         # Mirror how GoogleGenAIChatGenerator splits the request: a leading system message is sent separately.
         chat_messages = messages
@@ -117,24 +128,17 @@ class GoogleGenAITokenCounter:
             system_instruction = messages[0].text or ""
             chat_messages = messages[1:]
 
+        contents: list[types.ContentUnion] = [_convert_message_to_google_genai_format(m) for m in chat_messages]
         config_params: dict[str, Any] = {}
         if system_instruction:
-            config_params["system_instruction"] = system_instruction
+            if self.api == "vertex":
+                config_params["system_instruction"] = system_instruction
+            else:
+                # The Gemini Developer API rejects a system instruction on countTokens, so measure its text as a
+                # user turn. This is a close approximation, not the exact count.
+                contents.insert(0, types.Content(role="user", parts=[types.Part.from_text(text=system_instruction)]))
         if tools:
             config_params["tools"] = _convert_tools_to_google_genai_format(tools)
-
-        # Rejected before the client is built, so an unsupported request fails the same way with or without
-        # credentials.
-        if config_params and self.api != "vertex":
-            unsupported = " and ".join(
-                name for name, present in (("a system message", system_instruction), ("tools", tools)) if present
-            )
-            msg = (
-                f"Counting tokens for {unsupported} is only supported when targeting Vertex AI, because the "
-                "Google Gen AI SDK rejects them on the Gemini Developer API. Initialize this counter with "
-                'api="vertex", or count only the non-system messages.'
-            )
-            raise ValueError(msg)
 
         self.warm_up()
         client = self.client
@@ -142,7 +146,6 @@ class GoogleGenAITokenCounter:
             msg = "The Google Gen AI client was not initialized."
             raise RuntimeError(msg)
 
-        contents: list[types.ContentUnion] = [_convert_message_to_google_genai_format(msg) for msg in chat_messages]
         config = types.CountTokensConfig(**config_params) if config_params else None
 
         response = client.models.count_tokens(model=self.model, contents=contents, config=config)

--- a/integrations/google_genai/tests/test_token_counter.py
+++ b/integrations/google_genai/tests/test_token_counter.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.tools import Tool
+from haystack.utils.auth import Secret
+
+from haystack_integrations.token_counters.google_genai import GoogleGenAITokenCounter
+
+
+def weather(city: str):
+    """Get weather information for a city."""
+    return f"Weather in {city}: 22°C, sunny"
+
+
+@pytest.fixture
+def tools():
+    return [
+        Tool(
+            name="weather",
+            description="useful to determine the weather in a given location",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=weather,
+        )
+    ]
+
+
+def _counter_with_mock_client(total_tokens, **kwargs):
+    """Build a counter whose client is already set, so `warm_up` never builds a real one."""
+    counter = GoogleGenAITokenCounter("gemini-3.7-flash", **kwargs)
+    client = Mock()
+    client.models.count_tokens.return_value = Mock(total_tokens=total_tokens)
+    counter.client = client
+    return counter
+
+
+class TestGoogleGenAITokenCounterInitSerDe:
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        counter = GoogleGenAITokenCounter("gemini-3.7-flash")
+
+        assert counter.model == "gemini-3.7-flash"
+        assert counter.api == "gemini"
+        assert counter.vertex_ai_project is None
+        assert counter.vertex_ai_location is None
+        assert counter.timeout is None
+        assert counter.max_retries is None
+        # The client is built lazily, so constructing the counter never touches the network.
+        assert counter.client is None
+
+    def test_serde_round_trip(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-api-key")
+        counter = GoogleGenAITokenCounter(
+            "gemini-3.7-flash",
+            api="vertex",
+            vertex_ai_project="my-project",
+            vertex_ai_location="us-central1",
+            timeout=10.0,
+            max_retries=2,
+        )
+
+        data = counter.to_dict()
+        assert data == {
+            "type": "haystack_integrations.token_counters.google_genai.token_counter.GoogleGenAITokenCounter",
+            "init_parameters": {
+                "model": "gemini-3.7-flash",
+                "api_key": {"type": "env_var", "env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"], "strict": False},
+                "api": "vertex",
+                "vertex_ai_project": "my-project",
+                "vertex_ai_location": "us-central1",
+                "timeout": 10.0,
+                "max_retries": 2,
+            },
+        }
+
+        restored = GoogleGenAITokenCounter.from_dict(data)
+        assert restored.model == counter.model
+        assert restored.api == counter.api
+        assert restored.vertex_ai_project == counter.vertex_ai_project
+        assert restored.vertex_ai_location == counter.vertex_ai_location
+        assert restored.timeout == counter.timeout
+        assert restored.max_retries == counter.max_retries
+        assert restored.api_key == Secret.from_env_var(["GOOGLE_API_KEY", "GEMINI_API_KEY"], strict=False)
+
+
+class TestGoogleGenAITokenCounterCount:
+    def test_count_without_messages_or_tools_returns_zero(self):
+        counter = GoogleGenAITokenCounter("gemini-3.7-flash")
+
+        assert counter.count([]) == 0
+        # Nothing to measure means nothing to connect to either.
+        assert counter.client is None
+
+    def test_count_sends_messages_and_returns_total(self):
+        counter = _counter_with_mock_client(42)
+
+        assert counter.count([ChatMessage.from_user("How many tokens is this?")]) == 42
+
+        _, kwargs = counter.client.models.count_tokens.call_args
+        assert kwargs["model"] == "gemini-3.7-flash"
+        assert len(kwargs["contents"]) == 1
+        assert kwargs["config"] is None
+
+    def test_count_returns_zero_when_the_api_reports_no_total(self):
+        counter = _counter_with_mock_client(None)
+
+        assert counter.count([ChatMessage.from_user("Hello")]) == 0
+
+    @pytest.mark.parametrize(
+        ("messages", "expected_in_error"),
+        [
+            ([ChatMessage.from_system("You are helpful."), ChatMessage.from_user("Hi")], "a system message"),
+            ([ChatMessage.from_user("Hi")], "tools"),
+        ],
+        ids=["system_message", "tools"],
+    )
+    def test_count_rejects_what_the_gemini_developer_api_cannot_measure(self, messages, expected_in_error, tools):
+        counter = GoogleGenAITokenCounter("gemini-3.7-flash")
+        passed_tools = tools if expected_in_error == "tools" else None
+
+        with pytest.raises(ValueError, match=expected_in_error) as exc_info:
+            counter.count(messages, tools=passed_tools)
+
+        # The error has to point at the way out, not just at the failure.
+        assert 'api="vertex"' in str(exc_info.value)
+        # Rejected before any client is built, so it fails the same way without credentials.
+        assert counter.client is None
+
+    def test_count_on_vertex_sends_the_system_instruction_and_tools(self, tools):
+        counter = _counter_with_mock_client(99, api="vertex", vertex_ai_project="p", vertex_ai_location="l")
+        messages = [
+            ChatMessage.from_system("You are helpful."),
+            ChatMessage.from_user("What is the weather in Paris?"),
+        ]
+
+        assert counter.count(messages, tools=tools) == 99
+
+        _, kwargs = counter.client.models.count_tokens.call_args
+        # The system message is measured as the system instruction, not as one of the contents.
+        assert len(kwargs["contents"]) == 1
+        assert kwargs["config"].system_instruction == "You are helpful."
+        assert len(kwargs["config"].tools) == 1
+
+    def test_close_closes_the_client(self):
+        counter = _counter_with_mock_client(1)
+        client = counter.client
+
+        counter.close()
+
+        # Dropping the reference is not enough: the client holds a pooled HTTP connection.
+        client.close.assert_called_once()
+        assert counter.client is None
+
+
+@pytest.mark.integration
+class TestGoogleGenAITokenCounterInference:
+    def test_live_count(self, tools):
+        """
+        Counts a conversation that carries a user turn, an assistant tool call and a tool result.
+
+        A system message and tools are left out on purpose: the Google Gen AI SDK rejects both on the Gemini
+        Developer API, which is the backend these tests authenticate against.
+        """
+        tool_call = ToolCall(tool_name="weather", arguments={"city": "Paris"})
+        messages = [
+            ChatMessage.from_user("What is the weather in Paris?"),
+            ChatMessage.from_assistant(tool_calls=[tool_call]),
+            ChatMessage.from_tool(tool_result="22°C, sunny", origin=tool_call),
+        ]
+
+        counter = GoogleGenAITokenCounter("gemini-3.7-flash")
+        token_count = counter.count(messages)
+
+        assert isinstance(token_count, int)
+        assert token_count > 0

--- a/integrations/google_genai/tests/test_token_counter.py
+++ b/integrations/google_genai/tests/test_token_counter.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from unittest.mock import Mock
 
 import pytest
@@ -156,6 +157,10 @@ class TestGoogleGenAITokenCounterCount:
         assert counter.client is None
 
 
+@pytest.mark.skipif(
+    not os.environ.get("GOOGLE_API_KEY", None) and not os.environ.get("GEMINI_API_KEY", None),
+    reason="Export an env var called GOOGLE_API_KEY or GEMINI_API_KEY containing the Google API key to run this test.",
+)
 @pytest.mark.integration
 class TestGoogleGenAITokenCounterInference:
     def test_live_count(self, tools):

--- a/integrations/google_genai/tests/test_token_counter.py
+++ b/integrations/google_genai/tests/test_token_counter.py
@@ -111,25 +111,29 @@ class TestGoogleGenAITokenCounterCount:
 
         assert counter.count([ChatMessage.from_user("Hello")]) == 0
 
-    @pytest.mark.parametrize(
-        ("messages", "expected_in_error"),
-        [
-            ([ChatMessage.from_system("You are helpful."), ChatMessage.from_user("Hi")], "a system message"),
-            ([ChatMessage.from_user("Hi")], "tools"),
-        ],
-        ids=["system_message", "tools"],
-    )
-    def test_count_rejects_what_the_gemini_developer_api_cannot_measure(self, messages, expected_in_error, tools):
+    def test_count_rejects_tools_on_the_gemini_developer_api(self, tools):
         counter = GoogleGenAITokenCounter("gemini-3.7-flash")
-        passed_tools = tools if expected_in_error == "tools" else None
 
-        with pytest.raises(ValueError, match=expected_in_error) as exc_info:
-            counter.count(messages, tools=passed_tools)
+        with pytest.raises(ValueError, match="tools") as exc_info:
+            counter.count([ChatMessage.from_user("Hi")], tools=tools)
 
         # The error has to point at the way out, not just at the failure.
         assert 'api="vertex"' in str(exc_info.value)
         # Rejected before any client is built, so it fails the same way without credentials.
         assert counter.client is None
+
+    def test_count_on_the_gemini_developer_api_measures_the_system_message_as_a_user_turn(self):
+        counter = _counter_with_mock_client(7)
+        messages = [ChatMessage.from_system("You are helpful."), ChatMessage.from_user("Hi")]
+
+        assert counter.count(messages) == 7
+
+        _, kwargs = counter.client.models.count_tokens.call_args
+        # The Developer API cannot take a system instruction, so the text is folded into the contents instead.
+        assert kwargs["config"] is None
+        assert len(kwargs["contents"]) == 2
+        assert kwargs["contents"][0].role == "user"
+        assert kwargs["contents"][0].parts[0].text == "You are helpful."
 
     def test_count_on_vertex_sends_the_system_instruction_and_tools(self, tools):
         counter = _counter_with_mock_client(99, api="vertex", vertex_ai_project="p", vertex_ai_location="l")
@@ -165,13 +169,14 @@ class TestGoogleGenAITokenCounterCount:
 class TestGoogleGenAITokenCounterInference:
     def test_live_count(self, tools):
         """
-        Counts a conversation that carries a user turn, an assistant tool call and a tool result.
+        Counts a conversation that carries a system message, a user turn, an assistant tool call and a tool result.
 
-        A system message and tools are left out on purpose: the Google Gen AI SDK rejects both on the Gemini
-        Developer API, which is the backend these tests authenticate against.
+        Tools are left out on purpose: the Google Gen AI SDK rejects them on the Gemini Developer API, which is the
+        backend these tests authenticate against.
         """
         tool_call = ToolCall(tool_name="weather", arguments={"city": "Paris"})
         messages = [
+            ChatMessage.from_system("You are a helpful weather assistant."),
             ChatMessage.from_user("What is the weather in Paris?"),
             ChatMessage.from_assistant(tool_calls=[tool_call]),
             ChatMessage.from_tool(tool_result="22°C, sunny", origin=tool_call),


### PR DESCRIPTION
### Related Issues

- fixes #3857

### Proposed Changes:

Adds `GoogleGenAITokenCounter` to the `google_genai` integration, implementing the `TokenCounter` protocol introduced in Haystack 3.1 on top of Google's [`countTokens`](https://ai.google.dev/api/tokens#method:-models.counttokens) endpoint — the Gemini analogue of `OpenAITokenCounter`.

It follows the `OpenAITokenCounter` pattern: `model` is required and never assumed, everything after it is keyword-only, the client is built lazily in `warm_up()`, `count()` auto-warms, and there is a `close()` lifecycle method. The constructor mirrors `GoogleGenAIChatGenerator` (`api`, `vertex_ai_project`, `vertex_ai_location`, `timeout`, `max_retries`) so a counter can be configured exactly like the generator it measures.

Inputs are assembled the way `GoogleGenAIChatGenerator` sends them: a leading system message becomes the system instruction, the remaining messages become the request contents.

```python
from haystack.dataclasses import ChatMessage
from haystack_integrations.token_counters.google_genai import GoogleGenAITokenCounter

counter = GoogleGenAITokenCounter("gemini-3.7-flash")
print(counter.count([ChatMessage.from_user("Hello, how are you?")]))
```

### One design decision I'd like your call on

The Google Gen AI SDK **cannot** measure a system instruction or tool schemas on the Gemini Developer API. It is not a silent drop — `_CountTokensConfig_to_mldev` raises explicitly:

```python
if getv(from_object, ['tools']) is not None:
    raise ValueError(
        'tools parameter is only supported in Gemini Enterprise Agent Platform'
        ' mode, not in Gemini Developer API mode.'
    )
```

`_CountTokensConfig_to_vertex` maps both, so Vertex is fine. Worth noting the REST API itself *could* do it via `generateContentRequest`, which accepts system instructions and function declarations — but the Python SDK does not expose that field anywhere, so there is no supported path to it today.

Since `count(messages, tools)` has to answer for both, I chose to **raise a `ValueError` naming the limitation and pointing at `api="vertex"`**, rather than return a count that silently omits tool schemas — those can be worth hundreds of tokens, and a counter that quietly under-reports seemed worse than one that refuses. Counting plain messages works on either backend.

Happy to switch to a warning plus a partial count if you'd rather the component always return a number.

### How did you test it?

- `hatch run test:unit` — 9 new unit tests pass. They cover serde round-trip, the empty-input short circuit, the `total_tokens: None` case, the rejection path for both a system message and tools, that Vertex actually forwards the system instruction and tool schemas, and `close()`.
- `hatch run test:integration` — the live test passes against the real Gemini API.
- `hatch run test:types` — mypy clean (the new package is registered in the `types` command).
- `hatch run fmt-check` — clean.

Two failures in the full unit run (`test_init_fail_wo_api_key`, `test_extract_sources_info_rejects_symlink_escaping_root`) are unrelated to this change: they reproduce identically on a clean checkout of `main` on my machine — the first because I have `GEMINI_API_KEY` exported and the test only clears `GOOGLE_API_KEY`, the second because of Windows symlink permissions.

The live test deliberately covers a user turn, an assistant tool call and a tool result, but not a system message or tools, since the Gemini Developer API these tests authenticate against cannot measure those.
