### PR TITLE
test: MCP - refactor test_toolset_combination for Toolset.__add__ removal

### DIFF
--- a/integrations/mcp/tests/test_mcp_toolset.py
+++ b/integrations/mcp/tests/test_mcp_toolset.py
@@ -249,11 +249,11 @@ class TestMCPToolset:
             },
         )
 
-        combined_tools = toolset + [multiply_tool]
+        toolset.add(multiply_tool)
 
-        assert len(combined_tools) == 4  # add, subtract, divide_by_zero, multiply
+        assert len(toolset) == 4  # add, subtract, divide_by_zero, multiply
 
-        tool_names = [tool.name for tool in combined_tools.tools]
+        tool_names = [tool.name for tool in toolset.tools]
         assert "add" in tool_names
         assert "subtract" in tool_names
         assert "divide_by_zero" in tool_names


### PR DESCRIPTION
### Related Issues

- `Toolset.__add__` (`+`) was removed in https://github.com/deepset-ai/haystack/pull/12525

### Proposed Changes:
- refactor MCP `test_toolset_combination` to work without using `+`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
