### PR TITLE
fix(rankers): honor falsy run() overrides in SentenceTransformersSimilarityRanker

### DIFF
--- a/integrations/sentence_transformers/src/haystack_integrations/components/rankers/sentence_transformers/sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/src/haystack_integrations/components/rankers/sentence_transformers/sentence_transformers_similarity.py
@@ -250,9 +250,9 @@ class SentenceTransformersSimilarityRanker:
         if not documents:
             return {"documents": []}
 
-        top_k = top_k or self.top_k
-        scale_score = scale_score or self.scale_score
-        score_threshold = score_threshold or self.score_threshold
+        top_k = self.top_k if top_k is None else top_k
+        scale_score = self.scale_score if scale_score is None else scale_score
+        score_threshold = self.score_threshold if score_threshold is None else score_threshold
 
         if top_k <= 0:
             msg = f"top_k must be > 0, but got {top_k}"

--- a/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
+++ b/integrations/sentence_transformers/tests/test_sentence_transformers_similarity.py
@@ -281,6 +281,39 @@ class TestSentenceTransformersSimilarityRanker:
         with pytest.raises(ValueError):
             ranker.run(query="test", documents=[Document(content="document")], top_k=-1)
 
+    def test_run_falsy_scale_score_override(self):
+        ranker = SentenceTransformersSimilarityRanker(model="model")  # scale_score=True by default
+        mock_cross_encoder = MagicMock()
+        ranker._cross_encoder = mock_cross_encoder
+
+        ranker.run(query="test", documents=[Document(content="document")], scale_score=False)
+
+        _, kwargs = mock_cross_encoder.rank.call_args
+        assert isinstance(kwargs["activation_fn"], torch.nn.Identity)
+
+    def test_run_falsy_score_threshold_override(self):
+        ranker = SentenceTransformersSimilarityRanker(model="model", score_threshold=0.5)
+        mock_cross_encoder = MagicMock()
+        mock_cross_encoder.rank.return_value = [
+            {"score": 0.1, "corpus_id": 0},
+            {"score": -0.1, "corpus_id": 1},
+        ]
+        ranker._cross_encoder = mock_cross_encoder
+
+        out = ranker.run(
+            query="test", documents=[Document(content="doc 0"), Document(content="doc 1")], score_threshold=0.0
+        )
+
+        assert len(out["documents"]) == 1
+        assert out["documents"][0].score == pytest.approx(0.1, abs=1e-4)
+
+    def test_run_top_k_zero_raises(self):
+        ranker = SentenceTransformersSimilarityRanker()
+        ranker._cross_encoder = MagicMock()
+
+        with pytest.raises(ValueError):
+            ranker.run(query="test", documents=[Document(content="document")], top_k=0)
+
     def test_returns_empty_list_if_no_documents_are_provided(self):
         ranker = SentenceTransformersSimilarityRanker()
         ranker._cross_encoder = MagicMock()


### PR DESCRIPTION
Fixes #3854

`run()` previously resolved overrides with `or`, so falsy arguments (`scale_score=False`, `score_threshold=0.0`, `top_k=0`) were silently replaced by the init values. This PR switches to explicit `None` checks.

Changes:
- Use `self.top_k if top_k is None else top_k`, etc.
- Add regression tests for `scale_score=False`, `score_threshold=0.0`, and `top_k=0`.

Verification:
- `hatch run test:unit` in `integrations/sentence_transformers` passes (165 passed, 14 deselected).
- `hatch run fmt` passes.