### PR TITLE
feat: add set_langfuse_context helpers for trace metadata

### DIFF
--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/__init__.py
@@ -2,6 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .tracer import DefaultSpanHandler, LangfuseSpan, LangfuseTracer, SpanContext, SpanHandler
+from .tracer import (
+    DefaultSpanHandler,
+    LangfuseContextToken,
+    LangfuseSpan,
+    LangfuseTracer,
+    SpanContext,
+    SpanHandler,
+    reset_langfuse_context,
+    set_langfuse_context,
+)
 
-__all__ = ["DefaultSpanHandler", "LangfuseSpan", "LangfuseTracer", "SpanContext", "SpanHandler"]
+__all__ = [
+    "DefaultSpanHandler",
+    "LangfuseContextToken",
+    "LangfuseSpan",
+    "LangfuseTracer",
+    "SpanContext",
+    "SpanHandler",
+    "reset_langfuse_context",
+    "set_langfuse_context",
+]

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -52,6 +52,71 @@ tracing_context_var: ContextVar[dict[Any, Any]] = ContextVar("tracing_context")
 span_stack_var: ContextVar[list["LangfuseSpan"] | None] = ContextVar("span_stack", default=None)
 
 
+class LangfuseContextToken:
+    """
+    Opaque token returned by :func:`set_langfuse_context`.
+
+    Pass it to :func:`reset_langfuse_context` to restore the previous tracing context.
+    """
+
+    def __init__(self, token: Any) -> None:
+        self._token = token
+
+
+def set_langfuse_context(
+    trace_id: Any | None = None,
+    user_id: Any | None = None,
+    session_id: Any | None = None,
+    tags: list[str] | None = None,
+    version: Any | None = None,
+) -> LangfuseContextToken:
+    """
+    Set Langfuse trace-level context for the current execution context.
+
+    The values are picked up by :class:`LangfuseTracer` when the next root trace is created
+    and propagated to all child spans in that trace. Use :func:`reset_langfuse_context` with
+    the returned token to restore the previous context.
+
+    :param trace_id: Custom trace ID to use for the next root trace.
+    :param user_id: User ID to attach to the trace.
+    :param session_id: Session ID to attach to the trace.
+    :param tags: Tags to attach to the trace.
+    :param version: Version to attach to the trace.
+    :returns: A token that can be passed to :func:`reset_langfuse_context` to undo this change.
+
+    Example:
+        >>> from haystack_integrations.tracing.langfuse import set_langfuse_context, reset_langfuse_context
+        >>> token = set_langfuse_context(user_id="user-456", tags=["production"])
+        >>> response = pipe.run(...)
+        >>> reset_langfuse_context(token)
+    """
+    new_ctx = tracing_context_var.get({}).copy()
+    if trace_id is not None:
+        new_ctx["trace_id"] = trace_id
+    if user_id is not None:
+        new_ctx["user_id"] = user_id
+    if session_id is not None:
+        new_ctx["session_id"] = session_id
+    if tags is not None:
+        new_ctx["tags"] = tags
+    if version is not None:
+        new_ctx["version"] = version
+    return LangfuseContextToken(tracing_context_var.set(new_ctx))
+
+
+def reset_langfuse_context(token: LangfuseContextToken | None = None) -> None:
+    """
+    Reset the Langfuse trace-level context for the current execution context.
+
+    :param token: The token returned by :func:`set_langfuse_context`. If omitted, the context is
+        cleared entirely.
+    """
+    if token is not None:
+        tracing_context_var.reset(token._token)
+    else:
+        tracing_context_var.set({})
+
+
 class LangfuseSpan(Span):
     """
     Internal class representing a bridge between the Haystack span tracing API and Langfuse.

--- a/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
+++ b/integrations/langfuse/src/haystack_integrations/tracing/langfuse/tracer.py
@@ -54,9 +54,9 @@ span_stack_var: ContextVar[list["LangfuseSpan"] | None] = ContextVar("span_stack
 
 class LangfuseContextToken:
     """
-    Opaque token returned by :func:`set_langfuse_context`.
+    Opaque token returned by `set_langfuse_context`.
 
-    Pass it to :func:`reset_langfuse_context` to restore the previous tracing context.
+    Pass it to `reset_langfuse_context` to restore the previous tracing context.
     """
 
     def __init__(self, token: Any) -> None:
@@ -64,31 +64,43 @@ class LangfuseContextToken:
 
 
 def set_langfuse_context(
-    trace_id: Any | None = None,
-    user_id: Any | None = None,
-    session_id: Any | None = None,
+    *,
+    trace_id: str | None = None,
+    user_id: str | None = None,
+    session_id: str | None = None,
     tags: list[str] | None = None,
-    version: Any | None = None,
+    version: str | None = None,
 ) -> LangfuseContextToken:
     """
     Set Langfuse trace-level context for the current execution context.
 
-    The values are picked up by :class:`LangfuseTracer` when the next root trace is created
-    and propagated to all child spans in that trace. Use :func:`reset_langfuse_context` with
+    The values are picked up by `LangfuseTracer` when the next root trace is created
+    and propagated to all child spans in that trace. Use `reset_langfuse_context` with
     the returned token to restore the previous context.
+
+    ### Usage example
+
+    ```python
+    from haystack_integrations.tracing.langfuse import (
+        reset_langfuse_context,
+        set_langfuse_context,
+    )
+
+    token = set_langfuse_context(
+        user_id="user-456", session_id="session-123", tags=["production"]
+    )
+    try:
+        response = pipe.run(...)
+    finally:
+        reset_langfuse_context(token)
+    ```
 
     :param trace_id: Custom trace ID to use for the next root trace.
     :param user_id: User ID to attach to the trace.
     :param session_id: Session ID to attach to the trace.
     :param tags: Tags to attach to the trace.
     :param version: Version to attach to the trace.
-    :returns: A token that can be passed to :func:`reset_langfuse_context` to undo this change.
-
-    Example:
-        >>> from haystack_integrations.tracing.langfuse import set_langfuse_context, reset_langfuse_context
-        >>> token = set_langfuse_context(user_id="user-456", tags=["production"])
-        >>> response = pipe.run(...)
-        >>> reset_langfuse_context(token)
+    :returns: A token that can be passed to `reset_langfuse_context` to undo this change.
     """
     new_ctx = tracing_context_var.get({}).copy()
     if trace_id is not None:
@@ -108,7 +120,7 @@ def reset_langfuse_context(token: LangfuseContextToken | None = None) -> None:
     """
     Reset the Langfuse trace-level context for the current execution context.
 
-    :param token: The token returned by :func:`set_langfuse_context`. If omitted, the context is
+    :param token: The token returned by `set_langfuse_context`. If omitted, the context is
         cleared entirely.
     """
     if token is not None:

--- a/integrations/langfuse/tests/test_tracer.py
+++ b/integrations/langfuse/tests/test_tracer.py
@@ -14,10 +14,13 @@ from haystack.dataclasses import ChatMessage, ToolCall
 from haystack_integrations.tracing.langfuse.tracer import (
     _COMPONENT_OUTPUT_KEY,
     DefaultSpanHandler,
+    LangfuseContextToken,
     LangfuseSpan,
     LangfuseTracer,
     SpanContext,
     _sanitize_usage_data,
+    reset_langfuse_context,
+    set_langfuse_context,
     tracing_context_var,
 )
 
@@ -1008,3 +1011,70 @@ class TestLangfuseTracer:
 
         # Test 3: Verify span stack is cleaned up after exception
         assert tracer.current_span() is None
+
+
+class TestLangfuseContextHelpers:
+    def test_set_langfuse_context_sets_all_values(self):
+        token = tracing_context_var.set({"existing": "value"})
+        try:
+            new_token = set_langfuse_context(
+                trace_id="trace-123",
+                user_id="user-456",
+                session_id="session-789",
+                tags=["production"],
+                version="v1.0",
+            )
+            assert isinstance(new_token, LangfuseContextToken)
+
+            ctx = tracing_context_var.get()
+            assert ctx["trace_id"] == "trace-123"
+            assert ctx["user_id"] == "user-456"
+            assert ctx["session_id"] == "session-789"
+            assert ctx["tags"] == ["production"]
+            assert ctx["version"] == "v1.0"
+            assert ctx["existing"] == "value"
+        finally:
+            tracing_context_var.reset(token)
+
+    def test_set_langfuse_context_partial_update_preserves_existing(self):
+        token = tracing_context_var.set({"user_id": "existing-user", "tags": ["old"]})
+        try:
+            new_token = set_langfuse_context(session_id="session-abc")
+            ctx = tracing_context_var.get()
+            assert ctx["user_id"] == "existing-user"
+            assert ctx["tags"] == ["old"]
+            assert ctx["session_id"] == "session-abc"
+            assert "trace_id" not in ctx
+        finally:
+            reset_langfuse_context(new_token)
+            tracing_context_var.reset(token)
+
+    def test_reset_langfuse_context_with_token_restores_previous_context(self):
+        first_token = tracing_context_var.set({"user_id": "first"})
+        try:
+            second_token = set_langfuse_context(user_id="second")
+            assert tracing_context_var.get()["user_id"] == "second"
+
+            reset_langfuse_context(second_token)
+            assert tracing_context_var.get()["user_id"] == "first"
+        finally:
+            tracing_context_var.reset(first_token)
+
+    def test_reset_langfuse_context_without_token_clears_context(self):
+        token = tracing_context_var.set({"user_id": "user", "tags": ["prod"]})
+        try:
+            reset_langfuse_context()
+            assert tracing_context_var.get() == {}
+        finally:
+            tracing_context_var.reset(token)
+
+    def test_set_langfuse_context_none_values_do_not_overwrite(self):
+        token = tracing_context_var.set({"user_id": "user", "version": "v1"})
+        try:
+            new_token = set_langfuse_context(user_id=None, version=None)
+            ctx = tracing_context_var.get()
+            assert ctx["user_id"] == "user"
+            assert ctx["version"] == "v1"
+            reset_langfuse_context(new_token)
+        finally:
+            tracing_context_var.reset(token)


### PR DESCRIPTION
Adds convenience helpers to set/reset Langfuse trace-level context without manually touching the internal context variable.

New exports in `haystack_integrations.tracing.langfuse`:
- `set_langfuse_context(trace_id, user_id, session_id, tags, version)`
- `reset_langfuse_context(token)`
- `LangfuseContextToken`

These wrap the existing `tracing_context_var` plumbing that `LangfuseTracer` already reads when creating a root trace. They make it easier to attach `user_id`, `session_id`, `tags`, `version`, and `trace_id` to the next pipeline run, as discussed in #1279 and #1264.

Closes #1279
Relates to #1264

### How did you test it?
- Added unit tests covering full/partial updates, token-based reset, and clearing.
- Ran `hatch run test:unit` and `hatch run test:types` for the langfuse integration.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- [x] I added unit tests and updated the docstrings