### PR TITLE
chore: remove releasing warning from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,3 @@ GitHub. The GitHub Actions workflow will take care of the rest.
 3. Wait for the CI to do its magic
 
    If the release is successful, the HaystackBot will push a commit on main to update the changelog.
-
-> [!IMPORTANT]
-> To ensure the changelog is accurate, it's recommended to tag a commit that includes the actual changes for the
-> integration (usually the PR merge commit). Tagging a commit that doesn't contain those changes can lead to an
-> incorrect changelog.


### PR DESCRIPTION
### Proposed Changes:

- remove the warning from readme that suggests to "tag a commit that includes the actual changes for the integration". Fixed in https://github.com/deepset-ai/haystack-core-integrations/pull/3883

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
