### PR TITLE
feat: Amazon Textract - add lifecycle handling

### DIFF
--- a/integrations/amazon_textract/pyproject.toml
+++ b/integrations/amazon_textract/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=2.24.1",
+    "haystack-ai>=3.0.0",
     "boto3>=1.42.84,<2",
 ]
 

--- a/integrations/amazon_textract/pyproject.toml
+++ b/integrations/amazon_textract/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "haystack-ai>=3.0.0",
+    "haystack-ai>=2.24.1",
     "boto3>=1.42.84,<2",
 ]
 

--- a/integrations/amazon_textract/src/haystack_integrations/components/converters/amazon_textract/converter.py
+++ b/integrations/amazon_textract/src/haystack_integrations/components/converters/amazon_textract/converter.py
@@ -129,6 +129,14 @@ class AmazonTextractConverter:
             )
             raise AmazonTextractConfigurationError(msg) from e
 
+    def close(self) -> None:
+        """Closes the AWS Textract client."""
+        if self._client is None:
+            return
+
+        self._client.close()
+        self._client = None
+
     @component.output_types(documents=list[Document], raw_textract_response=list[dict])
     def run(
         self,
@@ -157,8 +165,7 @@ class AmazonTextractConverter:
             - `documents`: List of created Documents with extracted text as content.
             - `raw_textract_response`: List of raw Textract API responses.
         """
-        if self._client is None:
-            self.warm_up()
+        self.warm_up()
 
         documents: list[Document] = []
         raw_responses: list[dict[str, Any]] = []

--- a/integrations/amazon_textract/tests/test_amazon_textract_converter.py
+++ b/integrations/amazon_textract/tests/test_amazon_textract_converter.py
@@ -45,6 +45,7 @@ class TestAmazonTextractConverterInit:
         assert converter.feature_types is None
         assert converter.store_full_path is False
         assert converter.boto3_config is None
+        assert converter._client is None
 
     def test_init_custom_params(self):
         converter = AmazonTextractConverter(
@@ -153,41 +154,76 @@ class TestAmazonTextractConverterSerialization:
         assert restored.boto3_config == converter.boto3_config
 
 
-class TestAmazonTextractConverterWarmUp:
+class TestComponentLifecycle:
     @patch("haystack_integrations.components.converters.amazon_textract.converter.boto3.Session")
-    def test_warm_up_creates_client(self, mock_session_cls):
-        mock_session = MagicMock()
-        mock_client = MagicMock()
-        mock_session.client.return_value = mock_client
-        mock_session_cls.return_value = mock_session
-
+    def test_warm_up_uses_resolved_credentials(self, mock_session_cls):
         converter = AmazonTextractConverter(
             aws_access_key_id=Secret.from_token("fake_id"),
             aws_secret_access_key=Secret.from_token("fake_secret"),
+            aws_session_token=Secret.from_token("fake_token"),
             aws_region_name=Secret.from_token("us-east-1"),
+            aws_profile_name=Secret.from_token("fake_profile"),
         )
+
         converter.warm_up()
 
-        mock_session_cls.assert_called_once()
-        mock_session.client.assert_called_once()
-        call_args = mock_session.client.call_args
-        assert call_args[0][0] == "textract"
-        assert converter._client is mock_client
+        mock_session_cls.assert_called_once_with(
+            aws_access_key_id="fake_id",
+            aws_secret_access_key="fake_secret",
+            aws_session_token="fake_token",
+            region_name="us-east-1",
+            profile_name="fake_profile",
+        )
+
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        env_var = "AMAZON_TEXTRACT_TEST_ACCESS_KEY"
+        monkeypatch.delenv(env_var, raising=False)
+
+        converter = AmazonTextractConverter(aws_access_key_id=Secret.from_env_var(env_var))
+
+        with pytest.raises(ValueError, match=env_var):
+            converter.warm_up()
 
     @patch("haystack_integrations.components.converters.amazon_textract.converter.boto3.Session")
-    def test_warm_up_idempotent(self, mock_session_cls):
-        mock_session = MagicMock()
-        mock_session.client.return_value = MagicMock()
-        mock_session_cls.return_value = mock_session
-
+    def test_sync_lifecycle(self, mock_session_cls):
         converter = AmazonTextractConverter(
             aws_access_key_id=Secret.from_token("fake"),
             aws_secret_access_key=Secret.from_token("fake"),
         )
+        client = mock_session_cls.return_value.client.return_value
+
+        converter.warm_up()
+
+        assert converter._client is client
+
+        converter.close()
+
+        client.close.assert_called_once_with()
+        assert converter._client is None
+
+        converter.warm_up()
+
+        assert mock_session_cls.call_count == 2
+
+    @patch("haystack_integrations.components.converters.amazon_textract.converter.boto3.Session")
+    def test_warm_up_is_idempotent(self, mock_session_cls):
+        converter = AmazonTextractConverter(
+            aws_access_key_id=Secret.from_token("fake"),
+            aws_secret_access_key=Secret.from_token("fake"),
+        )
+
         converter.warm_up()
         converter.warm_up()
 
         mock_session_cls.assert_called_once()
+        mock_session_cls.return_value.client.assert_called_once()
+
+    def test_close_is_safe_without_warm_up(self):
+        converter = AmazonTextractConverter()
+
+        converter.close()
+
+        assert converter._client is None
 
     @patch(
         "haystack_integrations.components.converters.amazon_textract.converter.boto3.Session",


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- add `close` method to close the sync client
- make `run` always call `warm_up`: then `warm_up` only creates the client if needed (aligned with Haystack 3.0 refactoring)
- ~pin `haystack-ai>=3.0.0`~

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
