### PR TITLE
feat!: Anthropic - lifecycle handling

### DIFF
--- a/integrations/anthropic/pyproject.toml
+++ b/integrations/anthropic/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "anthropic>=0.74.0"]
+dependencies = ["haystack-ai>=3.0.0", "anthropic>=0.74.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/anthropic#readme"

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/chat_generator.py
@@ -193,20 +193,45 @@ class AnthropicChatGenerator:
         self.timeout = timeout
         self.max_retries = max_retries
 
-        client_kwargs: dict[str, Any] = {"api_key": api_key.resolve_value()}
-        # We do this since timeout=None is not the same as not setting it in Anthropic
-        if timeout is not None:
-            client_kwargs["timeout"] = timeout
-        # We do this since max_retries must be an int when passing to Anthropic
-        if max_retries is not None:
-            client_kwargs["max_retries"] = max_retries
-
-        self.client = Anthropic(**client_kwargs)
-        self.async_client = AsyncAnthropic(**client_kwargs)
+        self.client: Anthropic | None = None
+        self.async_client: AsyncAnthropic | None = None
 
         self.ignore_tools_thinking_messages = ignore_tools_thinking_messages
         self.tools = tools
         self.anthropic_server_tools = anthropic_server_tools
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments used to create Anthropic clients."""
+        client_kwargs: dict[str, Any] = {"api_key": self.api_key.resolve_value()}
+        # We do this since timeout=None is not the same as not setting it in Anthropic
+        if self.timeout is not None:
+            client_kwargs["timeout"] = self.timeout
+        # We do this since max_retries must be an int when passing to Anthropic
+        if self.max_retries is not None:
+            client_kwargs["max_retries"] = self.max_retries
+        return client_kwargs
+
+    def warm_up(self) -> None:
+        """Create the synchronous Anthropic client."""
+        if self.client is None:
+            self.client = Anthropic(**self._client_kwargs())
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Anthropic client."""
+        if self.async_client is None:
+            self.async_client = AsyncAnthropic(**self._client_kwargs())
+
+    def close(self) -> None:
+        """Close the synchronous Anthropic client."""
+        if self.client is not None:
+            self.client.close()
+            self.client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous Anthropic client."""
+        if self.async_client is not None:
+            await self.async_client.close()
+            self.async_client = None
 
     def _get_telemetry_data(self) -> dict[str, Any]:
         """
@@ -542,6 +567,9 @@ class AnthropicChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: The responses from the model
         """
+        self.warm_up()
+        assert self.client is not None  # noqa: S101
+
         messages = _normalize_messages(messages)
         system_messages, non_system_messages, generation_kwargs, anthropic_tools = self._prepare_request_params(
             messages, generation_kwargs, tools
@@ -588,6 +616,9 @@ class AnthropicChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: The responses from the model
         """
+        await self.warm_up_async()
+        assert self.async_client is not None  # noqa: S101
+
         messages = _normalize_messages(messages)
         system_messages, non_system_messages, generation_kwargs, anthropic_tools = self._prepare_request_params(
             messages, generation_kwargs, tools

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/foundry_chat_generator.py
@@ -7,9 +7,7 @@ from collections.abc import Callable
 from typing import Any, ClassVar
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.components.generators.utils import _normalize_messages
-from haystack.dataclasses import ChatMessage, StreamingChunk
-from haystack.dataclasses.streaming_chunk import StreamingCallbackT
+from haystack.dataclasses import StreamingChunk
 from haystack.tools import (
     ToolsType,
     _check_duplicate_tool_names,
@@ -179,20 +177,12 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
             )
             raise ValueError(msg)
 
-        # Clients are created lazily in warm_up()
+        # mypy is not happy that the Foundry clients differ from the base Anthropic client types
         self.client = None  # type: ignore[assignment]
         self.async_client = None  # type: ignore[assignment]
-        self._is_warmed_up = False
 
-    def warm_up(self) -> None:
-        """
-        Create the AnthropicFoundry clients.
-
-        This method is idempotent — it only creates clients once.
-        """
-        if self._is_warmed_up:
-            return
-
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments used to create Anthropic Foundry clients."""
         client_kwargs: dict[str, Any] = {}
 
         if self.azure_ad_token_provider:
@@ -210,70 +200,17 @@ class AnthropicFoundryChatGenerator(AnthropicChatGenerator):
 
         if self.max_retries is not None:
             client_kwargs["max_retries"] = self.max_retries
+        return client_kwargs
 
-        self.client = AnthropicFoundry(**client_kwargs)  # type: ignore[assignment]
-        self.async_client = AsyncAnthropicFoundry(**client_kwargs)  # type: ignore[assignment]
-        self._is_warmed_up = True
+    def warm_up(self) -> None:
+        """Create the synchronous Anthropic Foundry client."""
+        if self.client is None:
+            self.client = AnthropicFoundry(**self._client_kwargs())  # type: ignore[assignment]
 
-    @component.output_types(replies=list[ChatMessage])
-    def run(
-        self,
-        messages: list[ChatMessage] | str,
-        streaming_callback: StreamingCallbackT | None = None,
-        generation_kwargs: dict[str, Any] | None = None,
-        tools: ToolsType | None = None,
-    ) -> dict[str, list[ChatMessage]]:
-        """
-        Invokes the AnthropicFoundry API with the given messages and generation kwargs.
-
-        :param messages: A list of ChatMessage instances representing the input messages.
-            If a string is provided, it is converted to a list containing a ChatMessage with user role.
-        :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint. These are merged
-            per key with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys
-            set only at initialization are kept.
-        :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
-            Each tool should have a unique name. If set, it will override the `tools` parameter set during component
-            initialization.
-        :returns: A dictionary with the following keys:
-            - `replies`: The responses from the model
-        """
-        messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
-            self.warm_up()
-        return super(AnthropicFoundryChatGenerator, self).run(  # noqa: UP008
-            messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
-        )
-
-    @component.output_types(replies=list[ChatMessage])
-    async def run_async(
-        self,
-        messages: list[ChatMessage] | str,
-        streaming_callback: StreamingCallbackT | None = None,
-        generation_kwargs: dict[str, Any] | None = None,
-        tools: ToolsType | None = None,
-    ) -> dict[str, list[ChatMessage]]:
-        """
-        Async version of the run method. Invokes the AnthropicFoundry API with the given messages and generation kwargs.
-
-        :param messages: A list of ChatMessage instances representing the input messages.
-            If a string is provided, it is converted to a list containing a ChatMessage with user role.
-        :param streaming_callback: A callback function that is called when a new token is received from the stream.
-        :param generation_kwargs: Optional arguments to pass to the Anthropic generation endpoint. These are merged
-            per key with the `generation_kwargs` passed at initialization: keys provided here take precedence, keys
-            set only at initialization are kept.
-        :param tools: A list of Tool and/or Toolset objects, or a single Toolset, that the model can use.
-            Each tool should have a unique name. If set, it will override the `tools` parameter set during component
-            initialization.
-        :returns: A dictionary with the following keys:
-            - `replies`: The responses from the model
-        """
-        messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
-            self.warm_up()
-        return await super(AnthropicFoundryChatGenerator, self).run_async(  # noqa: UP008
-            messages=messages, streaming_callback=streaming_callback, generation_kwargs=generation_kwargs, tools=tools
-        )
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Anthropic Foundry client."""
+        if self.async_client is None:
+            self.async_client = AsyncAnthropicFoundry(**self._client_kwargs())  # type: ignore[assignment]
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
+++ b/integrations/anthropic/src/haystack_integrations/components/generators/anthropic/chat/vertex_chat_generator.py
@@ -146,17 +146,30 @@ class AnthropicVertexChatGenerator(AnthropicChatGenerator):
         self.timeout = timeout
         self.max_retries = max_retries
 
+        # mypy is not happy that the Vertex clients differ from the base Anthropic client types
+        self.client = None  # type: ignore[assignment]
+        self.async_client = None  # type: ignore[assignment]
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments used to create Anthropic Vertex clients."""
         client_kwargs: dict[str, Any] = {"region": self.region, "project_id": self.project_id}
         # We do this since timeout=None is not the same as not setting it in Anthropic
-        if timeout is not None:
-            client_kwargs["timeout"] = timeout
+        if self.timeout is not None:
+            client_kwargs["timeout"] = self.timeout
         # We do this since max_retries must be an int when passing to Anthropic
-        if max_retries is not None:
-            client_kwargs["max_retries"] = max_retries
+        if self.max_retries is not None:
+            client_kwargs["max_retries"] = self.max_retries
+        return client_kwargs
 
-        # mypy is not happy that we override the type of the clients
-        self.client = AnthropicVertex(**client_kwargs)  # type: ignore[assignment]
-        self.async_client = AsyncAnthropicVertex(**client_kwargs)  # type: ignore[assignment]
+    def warm_up(self) -> None:
+        """Create the synchronous Anthropic Vertex client."""
+        if self.client is None:
+            self.client = AnthropicVertex(**self._client_kwargs())  # type: ignore[assignment]
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Anthropic Vertex client."""
+        if self.async_client is None:
+            self.async_client = AsyncAnthropicVertex(**self._client_kwargs())  # type: ignore[assignment]
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -285,6 +285,89 @@ class TestSerialization:
         assert new_pipeline == pipeline
 
 
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_ANTHROPIC_API_KEY", raising=False)
+        component = AnthropicChatGenerator(api_key=Secret.from_env_var("MISSING_ANTHROPIC_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_ANTHROPIC_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
+    def test_sync_lifecycle(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        client = mock_client_cls.return_value
+
+        component.warm_up()
+        assert component.client is client
+        assert component.async_client is None
+
+        component.close()
+        client.close.assert_called_once_with()
+        assert component.client is None
+
+        component.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
+    async def test_async_lifecycle(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await component.warm_up_async()
+        assert component.async_client is client
+        assert component.client is None
+
+        await component.close_async()
+        client.close.assert_awaited_once_with()
+        assert component.async_client is None
+
+        await component.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"), timeout=10.0, max_retries=1)
+        component.warm_up()
+        component.warm_up()
+        mock_client_cls.assert_called_once_with(api_key="test-api-key", timeout=10.0, max_retries=1)
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        await component.warm_up_async()
+        await component.warm_up_async()
+        mock_client_cls.assert_called_once_with(api_key="test-api-key")
+
+    async def test_close_is_safe_without_warm_up(self):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component.close()
+        await component.close_async()
+        assert component.client is None
+        assert component.async_client is None
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        sync_client = MagicMock()
+        async_client = MagicMock(close=AsyncMock())
+        mock_sync_cls.return_value = sync_client
+        mock_async_cls.return_value = async_client
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component.warm_up()
+        await component.warm_up_async()
+
+        component.close()
+        assert component.client is None
+        assert component.async_client is async_client
+        async_client.close.assert_not_awaited()
+
+        await component.close_async()
+        assert component.async_client is None
+        sync_client.close.assert_called_once_with()
+
+
 class TestRun:
     @pytest.mark.parametrize(
         "messages",
@@ -701,89 +784,6 @@ class TestPromptCaching:
 
         assert sys_blocks[0]["cache_control"] == {"type": "ephemeral", "example_key": "example_val"}
         assert non_sys[0]["content"][0]["cache_control"]["type"] == "ephemeral"
-
-
-class TestComponentLifecycle:
-    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
-        monkeypatch.delenv("MISSING_ANTHROPIC_API_KEY", raising=False)
-        component = AnthropicChatGenerator(api_key=Secret.from_env_var("MISSING_ANTHROPIC_API_KEY"))
-
-        with pytest.raises(ValueError, match="MISSING_ANTHROPIC_API_KEY"):
-            component.warm_up()
-
-    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
-    def test_sync_lifecycle(self, mock_client_cls):
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        client = mock_client_cls.return_value
-
-        component.warm_up()
-        assert component.client is client
-        assert component.async_client is None
-
-        component.close()
-        client.close.assert_called_once_with()
-        assert component.client is None
-
-        component.warm_up()
-        assert mock_client_cls.call_count == 2
-
-    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
-    async def test_async_lifecycle(self, mock_client_cls):
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        client = mock_client_cls.return_value
-        client.close = AsyncMock()
-
-        await component.warm_up_async()
-        assert component.async_client is client
-        assert component.client is None
-
-        await component.close_async()
-        client.close.assert_awaited_once_with()
-        assert component.async_client is None
-
-        await component.warm_up_async()
-        assert mock_client_cls.call_count == 2
-
-    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
-    def test_warm_up_is_idempotent(self, mock_client_cls):
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"), timeout=10.0, max_retries=1)
-        component.warm_up()
-        component.warm_up()
-        mock_client_cls.assert_called_once_with(api_key="test-api-key", timeout=10.0, max_retries=1)
-
-    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
-    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        await component.warm_up_async()
-        await component.warm_up_async()
-        mock_client_cls.assert_called_once_with(api_key="test-api-key")
-
-    async def test_close_is_safe_without_warm_up(self):
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        component.close()
-        await component.close_async()
-        assert component.client is None
-        assert component.async_client is None
-
-    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
-    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
-    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
-        sync_client = MagicMock()
-        async_client = MagicMock(close=AsyncMock())
-        mock_sync_cls.return_value = sync_client
-        mock_async_cls.return_value = async_client
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
-        component.warm_up()
-        await component.warm_up_async()
-
-        component.close()
-        assert component.client is None
-        assert component.async_client is async_client
-        async_client.close.assert_not_awaited()
-
-        await component.close_async()
-        assert component.async_client is None
-        sync_client.close.assert_called_once_with()
 
 
 @pytest.mark.integration

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -4,7 +4,7 @@
 
 import json
 import os
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import anthropic
 import pytest
@@ -73,19 +73,19 @@ class TestInit:
         assert len(models) > 0
         assert all(isinstance(m, str) for m in models)
 
-    def test_init_default(self, monkeypatch):
+    def test_init_default(self):
         """
         Test the default initialization of the AnthropicChatGenerator component.
         """
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key")
         component = AnthropicChatGenerator()
-        assert component.client.api_key == "test-api-key"
+        assert component.client is None
+        assert component.async_client is None
         assert component.model == "claude-sonnet-4-5"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.tools is None
 
-    def test_init_with_parameters(self, monkeypatch):
+    def test_init_with_parameters(self):
         """
         Test that the AnthropicChatGenerator component initializes with parameters.
         """
@@ -98,19 +98,12 @@ class TestInit:
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
             tools=[tool],
         )
-        assert component.client.api_key == "test-api-key"
+        assert component.client is None
+        assert component.async_client is None
         assert component.model == "claude-sonnet-4-5"
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
         assert component.tools == [tool]
-
-    def test_init_fail_wo_api_key(self, monkeypatch):
-        """
-        Test that the AnthropicChatGenerator component fails to initialize without an API key.
-        """
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        with pytest.raises(ValueError):
-            AnthropicChatGenerator()
 
     def test_init_fail_with_duplicate_tool_names(self, monkeypatch, tools):
         """
@@ -237,23 +230,6 @@ class TestSerialization:
         assert component.tools == [
             Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
         ]
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        """
-        Test that the AnthropicChatGenerator component fails to deserialize from a dictionary without an API key.
-        """
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        data = {
-            "type": "haystack_integrations.components.generators.anthropic.chat.chat_generator.AnthropicChatGenerator",
-            "init_parameters": {
-                "api_key": {"env_vars": ["ANTHROPIC_API_KEY"], "type": "env_var", "strict": True},
-                "model": "claude-sonnet-4-5",
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
-            },
-        }
-        with pytest.raises(ValueError):
-            AnthropicChatGenerator.from_dict(data)
 
     def test_serde_in_pipeline(self):
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
@@ -725,6 +701,89 @@ class TestPromptCaching:
 
         assert sys_blocks[0]["cache_control"] == {"type": "ephemeral", "example_key": "example_val"}
         assert non_sys[0]["content"][0]["cache_control"]["type"] == "ephemeral"
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_ANTHROPIC_API_KEY", raising=False)
+        component = AnthropicChatGenerator(api_key=Secret.from_env_var("MISSING_ANTHROPIC_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_ANTHROPIC_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
+    def test_sync_lifecycle(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        client = mock_client_cls.return_value
+
+        component.warm_up()
+        assert component.client is client
+        assert component.async_client is None
+
+        component.close()
+        client.close.assert_called_once_with()
+        assert component.client is None
+
+        component.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
+    async def test_async_lifecycle(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await component.warm_up_async()
+        assert component.async_client is client
+        assert component.client is None
+
+        await component.close_async()
+        client.close.assert_awaited_once_with()
+        assert component.async_client is None
+
+        await component.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component.warm_up()
+        component.warm_up()
+        mock_client_cls.assert_called_once_with(api_key="test-api-key")
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        await component.warm_up_async()
+        await component.warm_up_async()
+        mock_client_cls.assert_called_once_with(api_key="test-api-key")
+
+    async def test_close_is_safe_without_warm_up(self):
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component.close()
+        await component.close_async()
+        assert component.client is None
+        assert component.async_client is None
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
+    @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        sync_client = MagicMock()
+        async_client = MagicMock(close=AsyncMock())
+        mock_sync_cls.return_value = sync_client
+        mock_async_cls.return_value = async_client
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component.warm_up()
+        await component.warm_up_async()
+
+        component.close()
+        assert component.client is None
+        assert component.async_client is async_client
+        async_client.close.assert_not_awaited()
+
+        await component.close_async()
+        assert component.async_client is None
+        sync_client.close.assert_called_once_with()
 
 
 @pytest.mark.integration

--- a/integrations/anthropic/tests/test_chat_generator.py
+++ b/integrations/anthropic/tests/test_chat_generator.py
@@ -746,10 +746,10 @@ class TestComponentLifecycle:
 
     @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.Anthropic")
     def test_warm_up_is_idempotent(self, mock_client_cls):
-        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"))
+        component = AnthropicChatGenerator(api_key=Secret.from_token("test-api-key"), timeout=10.0, max_retries=1)
         component.warm_up()
         component.warm_up()
-        mock_client_cls.assert_called_once_with(api_key="test-api-key")
+        mock_client_cls.assert_called_once_with(api_key="test-api-key", timeout=10.0, max_retries=1)
 
     @patch("haystack_integrations.components.generators.anthropic.chat.chat_generator.AsyncAnthropic")
     async def test_warm_up_async_is_idempotent(self, mock_client_cls):

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -256,10 +256,12 @@ class TestComponentLifecycle:
 
     @patch("haystack_integrations.components.generators.anthropic.chat.foundry_chat_generator.AnthropicFoundry")
     def test_warm_up_is_idempotent(self, mock_client_cls):
-        component = AnthropicFoundryChatGenerator(api_key=Secret.from_token("test-key"), resource="my-resource")
+        component = AnthropicFoundryChatGenerator(
+            api_key=Secret.from_token("test-key"), resource="my-resource", timeout=10.0, max_retries=1
+        )
         component.warm_up()
         component.warm_up()
-        mock_client_cls.assert_called_once_with(api_key="test-key", resource="my-resource")
+        mock_client_cls.assert_called_once_with(api_key="test-key", resource="my-resource", timeout=10.0, max_retries=1)
 
     @patch("haystack_integrations.components.generators.anthropic.chat.foundry_chat_generator.AsyncAnthropicFoundry")
     async def test_warm_up_async_is_idempotent(self, mock_client_cls):

--- a/integrations/anthropic/tests/test_foundry_chat_generator.py
+++ b/integrations/anthropic/tests/test_foundry_chat_generator.py
@@ -1,9 +1,11 @@
 import os
+from unittest.mock import AsyncMock, patch
 
 import anthropic
 import pytest
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, ChatRole
+from haystack.utils import Secret
 
 from haystack_integrations.components.generators.anthropic import AnthropicFoundryChatGenerator
 
@@ -62,15 +64,6 @@ class TestUnit:
         monkeypatch.delenv("ANTHROPIC_FOUNDRY_RESOURCE", raising=False)
         with pytest.raises(ValueError, match="Either 'resource' or 'endpoint' must be provided"):
             AnthropicFoundryChatGenerator()
-
-    def test_warm_up(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
-        component = AnthropicFoundryChatGenerator(resource="my-resource")
-        assert component.client is None
-        assert component.async_client is None
-        component.warm_up()
-        assert component.client is not None
-        assert component.async_client is not None
 
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
@@ -186,9 +179,10 @@ class TestUnit:
     def test_run_triggers_warm_up(self, chat_messages, mock_chat_completion, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
         component = AnthropicFoundryChatGenerator(resource="my-resource")
-        assert not component._is_warmed_up
+        assert component.client is None
         response = component.run(chat_messages)
-        assert component._is_warmed_up
+        assert component.client is not None
+        assert component.async_client is None
         assert isinstance(response, dict)
         assert "replies" in response
         assert isinstance(response["replies"], list)
@@ -214,10 +208,65 @@ class TestUnit:
     async def test_run_async_triggers_warm_up(self, mock_anthropic_completion_async, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "test-key")
         component = AnthropicFoundryChatGenerator(resource="my-resource")
-        assert not component._is_warmed_up
+        assert component.async_client is None
         response = await component.run_async([ChatMessage.from_user("hi")])
-        assert component._is_warmed_up
+        assert component.async_client is not None
+        assert component.client is None
         assert "replies" in response
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_ANTHROPIC_FOUNDRY_API_KEY", raising=False)
+        component = AnthropicFoundryChatGenerator(
+            api_key=Secret.from_env_var("MISSING_ANTHROPIC_FOUNDRY_API_KEY"), resource="my-resource"
+        )
+
+        with pytest.raises(ValueError, match="MISSING_ANTHROPIC_FOUNDRY_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.foundry_chat_generator.AnthropicFoundry")
+    def test_sync_lifecycle(self, mock_client_cls):
+        component = AnthropicFoundryChatGenerator(api_key=Secret.from_token("test-key"), resource="my-resource")
+        client = mock_client_cls.return_value
+
+        component.warm_up()
+        assert component.client is client
+        assert component.async_client is None
+        component.close()
+        client.close.assert_called_once_with()
+        assert component.client is None
+        component.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.foundry_chat_generator.AsyncAnthropicFoundry")
+    async def test_async_lifecycle(self, mock_client_cls):
+        component = AnthropicFoundryChatGenerator(api_key=Secret.from_token("test-key"), resource="my-resource")
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await component.warm_up_async()
+        assert component.async_client is client
+        assert component.client is None
+        await component.close_async()
+        client.close.assert_awaited_once_with()
+        assert component.async_client is None
+        await component.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.foundry_chat_generator.AnthropicFoundry")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = AnthropicFoundryChatGenerator(api_key=Secret.from_token("test-key"), resource="my-resource")
+        component.warm_up()
+        component.warm_up()
+        mock_client_cls.assert_called_once_with(api_key="test-key", resource="my-resource")
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.foundry_chat_generator.AsyncAnthropicFoundry")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = AnthropicFoundryChatGenerator(api_key=Secret.from_token("test-key"), resource="my-resource")
+        await component.warm_up_async()
+        await component.warm_up_async()
+        mock_client_cls.assert_called_once_with(api_key="test-key", resource="my-resource")
 
 
 @pytest.mark.integration

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import AsyncMock, patch
 
 import anthropic
 import pytest
@@ -23,6 +24,8 @@ class TestUnit:
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.ignore_tools_thinking_messages
+        assert component.client is None
+        assert component.async_client is None
 
     def test_init_with_parameters(self):
         component = AnthropicVertexChatGenerator(
@@ -151,6 +154,51 @@ class TestUnit:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.generators.anthropic.chat.vertex_chat_generator.AnthropicVertex")
+    def test_sync_lifecycle(self, mock_client_cls):
+        component = AnthropicVertexChatGenerator(region="us-central1", project_id="test-project-id")
+        client = mock_client_cls.return_value
+
+        component.warm_up()
+        assert component.client is client
+        assert component.async_client is None
+        component.close()
+        client.close.assert_called_once_with()
+        assert component.client is None
+        component.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.vertex_chat_generator.AsyncAnthropicVertex")
+    async def test_async_lifecycle(self, mock_client_cls):
+        component = AnthropicVertexChatGenerator(region="us-central1", project_id="test-project-id")
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await component.warm_up_async()
+        assert component.async_client is client
+        assert component.client is None
+        await component.close_async()
+        client.close.assert_awaited_once_with()
+        assert component.async_client is None
+        await component.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.vertex_chat_generator.AnthropicVertex")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = AnthropicVertexChatGenerator(region="us-central1", project_id="test-project-id")
+        component.warm_up()
+        component.warm_up()
+        mock_client_cls.assert_called_once_with(region="us-central1", project_id="test-project-id")
+
+    @patch("haystack_integrations.components.generators.anthropic.chat.vertex_chat_generator.AsyncAnthropicVertex")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = AnthropicVertexChatGenerator(region="us-central1", project_id="test-project-id")
+        await component.warm_up_async()
+        await component.warm_up_async()
+        mock_client_cls.assert_called_once_with(region="us-central1", project_id="test-project-id")
 
 
 @pytest.mark.integration

--- a/integrations/anthropic/tests/test_vertex_chat_generator.py
+++ b/integrations/anthropic/tests/test_vertex_chat_generator.py
@@ -188,10 +188,14 @@ class TestComponentLifecycle:
 
     @patch("haystack_integrations.components.generators.anthropic.chat.vertex_chat_generator.AnthropicVertex")
     def test_warm_up_is_idempotent(self, mock_client_cls):
-        component = AnthropicVertexChatGenerator(region="us-central1", project_id="test-project-id")
+        component = AnthropicVertexChatGenerator(
+            region="us-central1", project_id="test-project-id", timeout=10.0, max_retries=1
+        )
         component.warm_up()
         component.warm_up()
-        mock_client_cls.assert_called_once_with(region="us-central1", project_id="test-project-id")
+        mock_client_cls.assert_called_once_with(
+            region="us-central1", project_id="test-project-id", timeout=10.0, max_retries=1
+        )
 
     @patch("haystack_integrations.components.generators.anthropic.chat.vertex_chat_generator.AsyncAnthropicVertex")
     async def test_warm_up_async_is_idempotent(self, mock_client_cls):


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- implement lifecycle handling, following criteria in https://github.com/deepset-ai/haystack-private/issues/440#issuecomment-5526157817
  - secrets resolved and client created in `warm_up` instead of `__init__`
  - added closing methods
  - separated sync and async lifecycle
  - (as a consequence, simplified Foundry Chat Generator)
- pin `haystack-ai>=3.0.0`

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
