### PR TITLE
feat: per-request credentials for MCP servers (OAuth token providers)

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/__init__.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/__init__.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .mcp_client_credentials import ClientCredentialsTokenProvider, MCPTokenRequestError
+from .mcp_token_provider import MCPTokenProvider, TokenProviderAuth
 from .mcp_tool import (
     MCPClient,
     MCPConnectionError,
@@ -20,11 +22,14 @@ from .mcp_tool import (
 from .mcp_toolset import MCPToolset
 
 __all__ = [
+    "ClientCredentialsTokenProvider",
     "MCPClient",
     "MCPConnectionError",
     "MCPError",
     "MCPInvocationError",
     "MCPServerInfo",
+    "MCPTokenProvider",
+    "MCPTokenRequestError",
     "MCPTool",
     "MCPToolNotFoundError",
     "MCPToolset",
@@ -34,4 +39,5 @@ __all__ = [
     "StdioServerInfo",
     "StreamableHttpClient",
     "StreamableHttpServerInfo",
+    "TokenProviderAuth",
 ]

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_client_credentials.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_client_credentials.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+"""OAuth2 client-credentials tokens for MCP servers."""
+
+import base64
+import threading
+import time
+from typing import Any, Literal
+
+import httpx
+from haystack import logging
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+from haystack_integrations.tools.mcp.mcp_token_provider import MCPTokenProvider
+
+logger = logging.getLogger(__name__)
+
+ClientAuthMethod = Literal["client_secret_basic", "client_secret_post"]
+
+DEFAULT_EXPIRY_BUFFER_SECONDS = 30
+DEFAULT_TIMEOUT_SECONDS = 30
+HTTP_OK = 200
+
+# Long enough that a token with no advertised lifetime is not refetched constantly, short enough
+# that a silently rotated one is picked up without waiting for a rejection.
+NO_EXPIRY_LIFETIME_SECONDS = 3600
+
+
+class MCPTokenRequestError(Exception):
+    """Raised when an access token could not be obtained."""
+
+
+class ClientCredentialsTokenProvider(MCPTokenProvider):
+    """
+    Obtains access tokens from an OAuth2 token endpoint using the client-credentials grant.
+
+    This is the machine-to-machine case: the pipeline itself is the client, so there is no user to
+    send through a consent screen. Tokens are fetched on demand, cached until shortly before they
+    expire, and re-fetched when the server rejects one.
+
+    ```python
+    from haystack.utils import Secret
+    from haystack_integrations.tools.mcp import ClientCredentialsTokenProvider, StreamableHttpServerInfo
+
+    server_info = StreamableHttpServerInfo(
+        url="https://mcp.example.com/mcp",
+        token_provider=ClientCredentialsTokenProvider(
+            token_url="https://auth.example.com/oauth/token",
+            client_id="my-client",
+            client_secret=Secret.from_env_var("MCP_CLIENT_SECRET"),
+            scope="mcp:read",
+        ),
+    )
+    ```
+
+    Unlike a ``token`` set from a ``Secret``, which is read once when the client is built, this is
+    consulted per request — so a pipeline that runs longer than a token's lifetime keeps working.
+
+    :param token_url: The OAuth2 token endpoint
+    :param client_id: Client identifier issued by the authorization server
+    :param client_secret: Client secret, as a ``Secret`` so it is never serialized in the clear
+    :param scope: Space-separated scopes to request, when the server needs them
+    :param client_auth_method: How to present the client credentials. ``client_secret_basic`` sends
+        an HTTP Basic header, which RFC 6749 requires every authorization server to accept;
+        ``client_secret_post`` puts them in the form body, which some servers require instead.
+    :param expiry_buffer_seconds: Refresh this many seconds before a token actually expires, so a
+        token does not lapse in flight
+    :param timeout_seconds: Timeout for the token request
+    """
+
+    def __init__(
+        self,
+        *,
+        token_url: str,
+        client_id: str,
+        client_secret: Secret,
+        scope: str | None = None,
+        client_auth_method: ClientAuthMethod = "client_secret_basic",
+        expiry_buffer_seconds: int = DEFAULT_EXPIRY_BUFFER_SECONDS,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.token_url = token_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scope = scope
+        self.client_auth_method: ClientAuthMethod = client_auth_method
+        self.expiry_buffer_seconds = expiry_buffer_seconds
+        self.timeout_seconds = timeout_seconds
+
+        # A tool call can be made from more than one thread, and every HTTP request asks for a
+        # token, so the cache is guarded rather than merely assigned.
+        self._lock = threading.Lock()
+        self._access_token: str | None = None
+        self._expires_at: float = 0.0
+
+    def token(self) -> str:
+        """
+        Returns a cached token, fetching a new one when none is held or it is about to expire.
+
+        :returns: A bearer token
+        :raises MCPTokenRequestError: If the token endpoint cannot be reached or refuses
+        """
+        with self._lock:
+            if self._access_token is not None and time.monotonic() < self._expires_at:
+                return self._access_token
+
+            token, expires_in = self._fetch()
+            self._access_token = token
+            self._expires_at = time.monotonic() + max(expires_in - self.expiry_buffer_seconds, 0)
+            return token
+
+    def invalidate(self) -> None:
+        """
+        Drops the cached token, so the next call fetches a fresh one.
+
+        Called when a server rejected the token — which can happen well before it was due to
+        expire, for instance after it was revoked.
+        """
+        with self._lock:
+            self._access_token = None
+            self._expires_at = 0.0
+
+    def _fetch(self) -> tuple[str, int]:
+        """
+        Performs the client-credentials request.
+
+        :returns: The access token and its lifetime in seconds
+        :raises MCPTokenRequestError: If the request fails or the response carries no token
+        """
+        data: dict[str, str] = {"grant_type": "client_credentials"}
+        if self.scope:
+            data["scope"] = self.scope
+
+        headers = {"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"}
+        secret = self.client_secret.resolve_value() or ""
+
+        if self.client_auth_method == "client_secret_basic":
+            encoded = base64.b64encode(f"{self.client_id}:{secret}".encode()).decode()
+            headers["Authorization"] = f"Basic {encoded}"
+        else:
+            data["client_id"] = self.client_id
+            data["client_secret"] = secret
+
+        try:
+            response = httpx.post(self.token_url, data=data, headers=headers, timeout=self.timeout_seconds)
+        except httpx.HTTPError as error:
+            message = f"Could not reach the token endpoint {self.token_url}: {error}"
+            raise MCPTokenRequestError(message) from error
+
+        if response.status_code != HTTP_OK:
+            message = f"Token endpoint {self.token_url} refused the request with status {response.status_code}."
+            raise MCPTokenRequestError(message)
+
+        try:
+            document = response.json()
+        except ValueError as error:
+            message = f"Token endpoint {self.token_url} did not return JSON."
+            raise MCPTokenRequestError(message) from error
+
+        access_token = document.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            message = f"Token endpoint {self.token_url} returned no access token."
+            raise MCPTokenRequestError(message)
+
+        # `expires_in` is optional. Treating an absent lifetime as zero would refetch on every
+        # request; instead the token is held until a server rejects it.
+        try:
+            lifetime = int(float(document["expires_in"]))
+        except (KeyError, TypeError, ValueError):
+            logger.debug("Token endpoint returned no usable expires_in; holding the token for an hour")
+            lifetime = NO_EXPIRY_LIFETIME_SECONDS
+
+        return access_token, max(lifetime, 0)
+
+    def _init_parameters(self) -> dict[str, Any]:
+        """The keyword arguments needed to rebuild this provider, with the secret by reference."""
+        return {
+            "token_url": self.token_url,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret.to_dict(),
+            "scope": self.scope,
+            "client_auth_method": self.client_auth_method,
+            "expiry_buffer_seconds": self.expiry_buffer_seconds,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ClientCredentialsTokenProvider":
+        """
+        Rebuilds the provider, resolving the client secret back into a ``Secret``.
+
+        :param data: A descriptor produced by ``to_dict``
+        :returns: The reconstructed provider
+        """
+        init_parameters = dict(data.get("init_parameters") or {})
+        deserialize_secrets_inplace(init_parameters, keys=["client_secret"])
+        return cls(**init_parameters)

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_token_provider.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_token_provider.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Per-request credentials for MCP servers.
+
+A ``Secret`` is resolved once, when the client is built. That is fine for an API key but wrong for
+an OAuth access token, which expires: a long-running pipeline holds a credential that was valid at
+start-up and has no way to obtain a new one, so recovery means redeploying.
+
+A token provider is asked for the credential on *every* HTTP request the transport makes instead,
+and is told when a token was rejected so the next call can produce a fresh one. It is serialized
+with the pipeline, so the descriptor -- not the secret -- is what gets stored.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Generator
+from typing import Any
+
+from haystack.core.serialization import generate_qualified_class_name
+
+from haystack_integrations.tools.mcp.compatibility_layer import http_lib
+
+UNAUTHORIZED = 401
+
+
+class MCPTokenProvider(ABC):
+    """
+    Supplies a bearer token for an MCP server, freshly, on demand.
+
+    Implementations are expected to cache: ``token`` is called once per HTTP request, so a provider
+    that fetched remotely every time would add a round trip to every tool call.
+    """
+
+    @abstractmethod
+    def token(self) -> str:
+        """Returns a token believed to be currently valid."""
+
+    @abstractmethod
+    def invalidate(self) -> None:
+        """Marks the last returned token as rejected, so the next ``token`` call obtains another."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the provider as a descriptor.
+
+        :returns: The provider's qualified type and its init parameters
+        """
+        return {"type": generate_qualified_class_name(type(self)), "init_parameters": self._init_parameters()}
+
+    def _init_parameters(self) -> dict[str, Any]:
+        """The keyword arguments needed to rebuild this provider. Must not contain secrets."""
+        return {}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MCPTokenProvider":
+        """
+        Rebuilds a provider from its descriptor.
+
+        :param data: A descriptor produced by ``to_dict``
+        :returns: The reconstructed provider
+        """
+        return cls(**(data.get("init_parameters") or {}))
+
+
+class TokenProviderAuth(http_lib.Auth):  # type: ignore[misc,name-defined]
+    """
+    Applies a token provider to every request, and retries once when it is rejected.
+
+    Typed against ``Any`` rather than ``httpx.Request``: the SDK uses ``httpx`` on v1 and ``httpx2``
+    on v2, and the compatibility layer picks one at import time.
+
+    ``httpx.Auth`` flows may inspect the response and yield a second request, which is what makes
+    the refresh-and-retry happen inside the request that failed. The MCP session stays up: no
+    reconnect, no lost transport, and nothing for the caller to handle.
+    """
+
+    # Tells httpx to buffer the response body so the flow can look at the status code.
+    requires_response_body = False
+
+    def __init__(self, provider: MCPTokenProvider) -> None:
+        self._provider = provider
+
+    def auth_flow(self, request: Any) -> Generator[Any, Any, None]:
+        """Attaches a bearer token, and on a 401 obtains a new one and sends the request again."""
+        request.headers["Authorization"] = f"Bearer {self._provider.token()}"
+        response = yield request
+
+        if response.status_code != UNAUTHORIZED:
+            return
+
+        self._provider.invalidate()
+        request.headers["Authorization"] = f"Bearer {self._provider.token()}"
+        yield request

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -26,6 +26,7 @@ from haystack.utils import Secret, deserialize_secrets_inplace
 from haystack.utils.auth import SecretType
 from haystack.utils.url_validation import is_valid_http_url
 
+from haystack_integrations.tools.mcp.mcp_token_provider import MCPTokenProvider, TokenProviderAuth
 from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
@@ -272,6 +273,17 @@ class MCPClient(ABC):
         """
         pass
 
+    def _auth(self) -> TokenProviderAuth | None:
+        """
+        The per-request credential, when this client was given a token provider.
+
+        An ``httpx.Auth`` rather than a header: the token is then read at request time, and a
+        rejected one is refreshed and retried inside the request that failed, so the MCP session
+        survives a token expiring mid-run.
+        """
+        provider = getattr(self, "token_provider", None)
+        return TokenProviderAuth(provider) if provider else None
+
     async def call_tool(self, tool_name: str, tool_args: dict[str, Any]) -> str:
         """
         Call a tool on the connected MCP server.
@@ -489,6 +501,8 @@ class SSEClient(MCPClient):
         )
         # Resolve Secret values in headers dictionary
         self.headers: dict[str, str] | None = _resolve_headers(server_info.headers)
+        # Deliberately not resolved here: a provider is consulted per request, which is its point.
+        self.token_provider: MCPTokenProvider | None = server_info.token_provider
         self.timeout: int = server_info.timeout
 
     async def connect(self) -> list[types.Tool]:
@@ -508,7 +522,7 @@ class SSEClient(MCPClient):
             headers = {"Authorization": f"Bearer {self.token}"}
 
         sse_transport = await self.exit_stack.enter_async_context(
-            sse_client(self.url, headers=headers, timeout=self.timeout)
+            sse_client(self.url, headers=headers, timeout=self.timeout, auth=self._auth())
         )
         return await self._initialize_session_with_transport(sse_transport, f"HTTP server at {self.url}")
 
@@ -540,6 +554,8 @@ class StreamableHttpClient(MCPClient):
         )
         # Resolve Secret values in headers dictionary
         self.headers: dict[str, str] | None = _resolve_headers(server_info.headers)
+        # Deliberately not resolved here: a provider is consulted per request, which is its point.
+        self.token_provider: MCPTokenProvider | None = server_info.token_provider
         self.timeout: int = server_info.timeout
 
     async def connect(self) -> list[types.Tool]:
@@ -558,7 +574,7 @@ class StreamableHttpClient(MCPClient):
         elif self.token:
             headers = {"Authorization": f"Bearer {self.token}"}
 
-        http_client = create_mcp_http_client(headers=headers, timeout=self.timeout)  # type: ignore[arg-type]
+        http_client = create_mcp_http_client(headers=headers, timeout=self.timeout, auth=self._auth())  # type: ignore[arg-type]
         streamablehttp_transport = await self.exit_stack.enter_async_context(
             streamable_http_client(self.url, http_client=http_client)
         )
@@ -619,6 +635,13 @@ class MCPServerInfo(ABC):
 
         secret_types = {e.value for e in SecretType}
         field_names = {f.name for f in fields(cls)}
+
+        # A token provider is a class descriptor, not a Secret, so the generic secret walk below
+        # would leave it a plain dict and the client would try to call `.token()` on it.
+        provider = data_copy.get("token_provider")
+        if isinstance(provider, dict) and provider.get("type"):
+            provider_class = import_class_by_name(provider["type"])
+            data_copy["token_provider"] = provider_class.from_dict(provider)
 
         # Iterate over a static list of items to avoid mutation issues
         for name, value in list(data_copy.items()):
@@ -685,6 +708,7 @@ class SSEServerInfo(MCPServerInfo):
     url: str | None = None
     base_url: str | None = None  # deprecated
     token: str | Secret | None = None
+    token_provider: MCPTokenProvider | None = None
     headers: dict[str, str | Secret] | None = None
     timeout: int = 30
     max_retries: int = 3
@@ -771,6 +795,7 @@ class StreamableHttpServerInfo(MCPServerInfo):
 
     url: str
     token: str | Secret | None = None
+    token_provider: MCPTokenProvider | None = None
     headers: dict[str, str | Secret] | None = None
     timeout: int = 30
     max_retries: int = 3

--- a/integrations/mcp/tests/test_mcp_server_info.py
+++ b/integrations/mcp/tests/test_mcp_server_info.py
@@ -146,6 +146,7 @@ class TestMCPServerInfo:
             "type": "haystack_integrations.tools.mcp.mcp_tool.StreamableHttpServerInfo",
             "url": "http://example.com/mcp",
             "token": {"type": "env_var", "env_vars": ["TEST_TOKEN"], "strict": True},
+            "token_provider": None,
             "headers": None,
             "timeout": 45,
             "max_retries": 3,

--- a/integrations/mcp/tests/test_mcp_token_provider.py
+++ b/integrations/mcp/tests/test_mcp_token_provider.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Per-request credentials for MCP servers.
+
+The property that matters, and the one a ``Secret`` cannot provide: the credential is read on every
+HTTP request rather than once when the client is built. A pipeline that outlives a token's lifetime
+therefore keeps working instead of failing until it is redeployed.
+"""
+
+import pytest
+from haystack.utils import Secret
+
+from haystack_integrations.tools.mcp import (
+    ClientCredentialsTokenProvider,
+    MCPTokenProvider,
+    MCPTool,
+    StreamableHttpServerInfo,
+    TokenProviderAuth,
+)
+from haystack_integrations.tools.mcp.compatibility_layer import http_lib
+
+TOKEN_URL = "https://auth.example.com/oauth/token"
+
+
+class CountingProvider(MCPTokenProvider):
+    """Hands out a new token each time it is asked, and counts how often that happens."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.invalidations = 0
+
+    def token(self) -> str:
+        self.calls += 1
+        return f"token-{self.calls}"
+
+    def invalidate(self) -> None:
+        self.invalidations += 1
+
+
+class TestTokenProviderAuth:
+    """The auth flow attaches a token per request and recovers from a rejected one in place."""
+
+    @staticmethod
+    def _client(provider: MCPTokenProvider, handler) -> "http_lib.Client":
+        transport = http_lib.MockTransport(handler)
+        return http_lib.Client(transport=transport, auth=TokenProviderAuth(provider))
+
+    def test_attaches_a_bearer_token(self) -> None:
+        provider = CountingProvider()
+        seen = []
+
+        def handler(request):
+            seen.append(request.headers.get("Authorization"))
+            return http_lib.Response(200)
+
+        self._client(provider, handler).get("https://mcp.example.com/mcp")
+
+        assert seen == ["Bearer token-1"]
+
+    def test_asks_again_for_every_request(self) -> None:
+        """A Secret is resolved once; this is the difference that keeps a long run alive."""
+        provider = CountingProvider()
+        client = self._client(provider, lambda _request: http_lib.Response(200))
+
+        client.get("https://mcp.example.com/mcp")
+        client.get("https://mcp.example.com/mcp")
+        client.get("https://mcp.example.com/mcp")
+
+        assert provider.calls == 3
+
+    def test_refreshes_and_retries_within_the_rejected_request(self) -> None:
+        """A 401 is recovered inside the failing request, so the MCP session is never torn down."""
+        provider = CountingProvider()
+        seen = []
+
+        def handler(request):
+            seen.append(request.headers.get("Authorization"))
+            return http_lib.Response(401) if len(seen) == 1 else http_lib.Response(200)
+
+        response = self._client(provider, handler).get("https://mcp.example.com/mcp")
+
+        assert response.status_code == 200
+        assert seen == ["Bearer token-1", "Bearer token-2"]
+        assert provider.invalidations == 1
+
+    def test_gives_up_after_one_retry(self) -> None:
+        """A server that rejects every token is a configuration problem, not something to loop on."""
+        provider = CountingProvider()
+        attempts = []
+
+        def handler(request):
+            attempts.append(request.headers.get("Authorization"))
+            return http_lib.Response(401)
+
+        response = self._client(provider, handler).get("https://mcp.example.com/mcp")
+
+        assert response.status_code == 401
+        assert len(attempts) == 2
+
+
+class TestClientCredentialsTokenProvider:
+    """The OAuth2 machine-to-machine grant, which is what most self-hosted MCP servers expect."""
+
+    @staticmethod
+    def _provider(**kwargs) -> ClientCredentialsTokenProvider:
+        defaults = {
+            "token_url": TOKEN_URL,
+            "client_id": "my-client",
+            "client_secret": Secret.from_token("shh"),
+        }
+        return ClientCredentialsTokenProvider(**{**defaults, **kwargs})
+
+    def test_caches_until_shortly_before_expiry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Every HTTP request asks for a token, so fetching each time would add a round trip."""
+        calls = []
+
+        def fake_post(url, **_kwargs):
+            calls.append(url)
+            return http_lib.Response(200, json={"access_token": "at-1", "expires_in": 3600})
+
+        monkeypatch.setattr("haystack_integrations.tools.mcp.mcp_client_credentials.httpx.post", fake_post)
+        provider = self._provider()
+
+        assert [provider.token() for _ in range(3)] == ["at-1", "at-1", "at-1"]
+        assert len(calls) == 1
+
+    def test_fetches_again_after_invalidation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A token can be rejected long before it was due to expire — revoked, for instance."""
+        issued = iter(["at-1", "at-2"])
+        monkeypatch.setattr(
+            "haystack_integrations.tools.mcp.mcp_client_credentials.httpx.post",
+            lambda _url, **_kwargs: http_lib.Response(200, json={"access_token": next(issued), "expires_in": 3600}),
+        )
+        provider = self._provider()
+
+        first = provider.token()
+        provider.invalidate()
+        second = provider.token()
+
+        assert (first, second) == ("at-1", "at-2")
+
+    def test_sends_the_client_secret_as_basic_auth_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RFC 6749 requires every authorization server to accept Basic; not all accept the body."""
+        captured = {}
+
+        def fake_post(_url, **kwargs):
+            captured.update(kwargs)
+            return http_lib.Response(200, json={"access_token": "at", "expires_in": 60})
+
+        monkeypatch.setattr("haystack_integrations.tools.mcp.mcp_client_credentials.httpx.post", fake_post)
+        self._provider().token()
+
+        assert captured["headers"]["Authorization"].startswith("Basic ")
+        assert "client_secret" not in captured["data"]
+
+    def test_can_send_the_client_secret_in_the_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = {}
+
+        def fake_post(_url, **kwargs):
+            captured.update(kwargs)
+            return http_lib.Response(200, json={"access_token": "at", "expires_in": 60})
+
+        monkeypatch.setattr("haystack_integrations.tools.mcp.mcp_client_credentials.httpx.post", fake_post)
+        self._provider(client_auth_method="client_secret_post").token()
+
+        assert captured["data"]["client_secret"] == "shh"
+        assert "Authorization" not in captured["headers"]
+
+    def test_serializes_the_secret_by_reference(self) -> None:
+        provider = self._provider(client_secret=Secret.from_env_var("MCP_CLIENT_SECRET"), scope="mcp:read")
+
+        descriptor = provider.to_dict()
+
+        assert descriptor["init_parameters"]["client_secret"] == {
+            "type": "env_var",
+            "env_vars": ["MCP_CLIENT_SECRET"],
+            "strict": True,
+        }
+
+    def test_survives_a_serialization_round_trip(self) -> None:
+        server_info = StreamableHttpServerInfo(
+            url="https://mcp.example.com/mcp",
+            token_provider=self._provider(client_secret=Secret.from_env_var("MCP_CLIENT_SECRET")),
+        )
+
+        restored = StreamableHttpServerInfo.from_dict(server_info.to_dict())
+
+        assert isinstance(restored.token_provider, ClientCredentialsTokenProvider)
+        assert restored.token_provider.token_url == TOKEN_URL
+
+
+@pytest.mark.integration
+class TestAgainstARealServer:
+    """End-to-end over real HTTP against a real MCP server.
+
+    This is the check worth having before a release: it proves the provider is consulted by the
+    actual transport on every request, not merely that the plumbing type-checks.
+    """
+
+    def test_the_provider_is_consulted_for_each_tool_call(self, mcp_calculator_server) -> None:
+        port = mcp_calculator_server("streamable-http")
+        provider = CountingProvider()
+
+        tool = MCPTool(
+            name="add",
+            server_info=StreamableHttpServerInfo(url=f"http://127.0.0.1:{port}/mcp", token_provider=provider),
+        )
+
+        assert tool.invoke(a=2, b=3)
+        calls_after_first = provider.calls
+        assert tool.invoke(a=4, b=5)
+
+        # The point of the exercise: a Secret would have been read once, before the first call.
+        assert provider.calls > calls_after_first


### PR DESCRIPTION
### Related Issues

None filed — happy to open one. Raised while building OAuth support for MCP tools in deepset Cloud, but the gap is not platform-specific.

### Proposed Changes

A `Secret` is resolved **once**, when the MCP client is built. That is right for an API key and wrong for an OAuth access token, which expires: a long-running pipeline holds a credential that was valid at start-up and no way to obtain another, so recovery means redeploying.

This adds a `token_provider` to `SSEServerInfo` and `StreamableHttpServerInfo`, consulted on **every HTTP request the transport makes**.

- **`MCPTokenProvider`** — `token()` / `invalidate()`, serialized as a class descriptor so a pipeline stores the descriptor rather than a credential.
- **`TokenProviderAuth`** — an `httpx.Auth`. Because auth flows may inspect the response and yield a second request, a rejected token is refreshed and retried *inside the request that failed*: the MCP session stays up, with no reconnect and nothing for the caller to handle.
- **`ClientCredentialsTokenProvider`** — the OAuth2 machine-to-machine grant, which is what most self-hosted MCP servers expect. Caches until shortly before expiry, re-fetches when a server rejects a token, and supports both `client_secret_basic` (the RFC 6749 baseline) and `client_secret_post`.

Existing behaviour is untouched: `token` and `headers` work exactly as before, and a server info without a provider produces no `auth`.

#### Why ship a concrete provider rather than only the hook

An abstraction with just one private implementation behind it is validated by a single case. The client-credentials provider holds a `client_secret`, which forced `to_dict` to serialize it **by reference**:

```python
{'type': 'env_var', 'env_vars': ['MCP_CLIENT_SECRET'], 'strict': True}
```

Our own provider holds no secret, so that requirement would never have surfaced.

#### Compatibility with both SDK generations

Built on the layer from #3878. `TokenProviderAuth` derives from `http_lib.Auth`, so it is `httpx.Auth` on SDK v1 and `httpx2.Auth` on v2 — confirmed at runtime. `create_mcp_http_client(...)` and `sse_client(...)` accept `auth` in both, so **no pin change is needed** and the deliberate removal of the `<2` pin stands.

### How did you test it?

`uv run --with "mcp==<version>" ... pytest tests/` on both generations:

| | |
|---|---|
| mcp 1.28.1 | 124 passed, 7 skipped |
| mcp 2.1.1 | 124 passed, 7 skipped |

`ruff check` clean.

11 new tests cover the auth flow (token attached per request, asked again for every request, refresh-and-retry on 401, gives up after one retry), the provider's caching and invalidation, both client-auth methods, and serialization round-trips.

One is an **end-to-end test against a real FastMCP server over HTTP**, asserting the provider is consulted again for a second tool call — the property a `Secret` cannot have. It earned its place immediately: it caught an abstract-method mix-up that `ruff` and the unit tests both passed, where a helper inserted above `connect` had captured its `@abstractmethod` decorator.

### Note for reviewers

`SSEServerInfo.to_dict` and `StreamableHttpServerInfo.to_dict` now emit a `token_provider` key, so one test asserting an exact dict was updated. Deserializing previously stored pipelines is unaffected — the field defaults to `None`.

Opened as a draft: we would like to exercise this from the platform side before it is released, so that any shape problem is found now rather than after a version is cut.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
