### PR TITLE
refactor: standardize Chonkie warm up

### DIFF
--- a/integrations/chonkie/pyproject.toml
+++ b/integrations/chonkie/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai", "chonkie[all]>=1.6.4"]
+dependencies = ["haystack-ai>=3.0.0", "chonkie[all]>=1.6.4"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chonkie#readme"

--- a/integrations/chonkie/pyproject.toml
+++ b/integrations/chonkie/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=3.0.0", "chonkie[all]>=1.6.4"]
+dependencies = ["haystack-ai", "chonkie[all]>=1.6.4"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chonkie#readme"

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/recursive_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/recursive_splitter.py
@@ -65,10 +65,17 @@ class ChonkieRecursiveDocumentSplitter:
         else:
             self.rules = rules
 
+        self._chunker: chonkie.RecursiveChunker | None = None
+
+    def warm_up(self) -> None:
+        """Initialize the Chonkie recursive chunker."""
+        if self._chunker is not None:
+            return
+
         kwargs: dict[str, Any] = {
-            "tokenizer": tokenizer,
-            "chunk_size": chunk_size,
-            "min_characters_per_chunk": min_characters_per_chunk,
+            "tokenizer": self.tokenizer,
+            "chunk_size": self.chunk_size,
+            "min_characters_per_chunk": self.min_characters_per_chunk,
         }
         if self.rules is not None:
             kwargs["rules"] = self.rules
@@ -83,6 +90,12 @@ class ChonkieRecursiveDocumentSplitter:
         :param documents: The list of documents to split.
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
+        self.warm_up()
+        chunker = self._chunker
+        if chunker is None:
+            msg = "The Chonkie recursive chunker was not initialized."
+            raise RuntimeError(msg)
+
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieRecursiveDocumentSplitter expects a list of Document objects."
             raise TypeError(msg)
@@ -100,7 +113,7 @@ class ChonkieRecursiveDocumentSplitter:
                 )
                 continue
 
-            chunks = self._chunker.chunk(doc.content)
+            chunks = chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/recursive_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/recursive_splitter.py
@@ -91,10 +91,7 @@ class ChonkieRecursiveDocumentSplitter:
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
         self.warm_up()
-        chunker = self._chunker
-        if chunker is None:
-            msg = "The Chonkie recursive chunker was not initialized."
-            raise RuntimeError(msg)
+        assert self._chunker is not None  # noqa: S101
 
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieRecursiveDocumentSplitter expects a list of Document objects."
@@ -113,7 +110,7 @@ class ChonkieRecursiveDocumentSplitter:
                 )
                 continue
 
-            chunks = chunker.chunk(doc.content)
+            chunks = self._chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/semantic_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/semantic_splitter.py
@@ -116,10 +116,7 @@ class ChonkieSemanticDocumentSplitter:
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
         self.warm_up()
-        chunker = self._chunker
-        if chunker is None:
-            msg = "The Chonkie semantic chunker was not initialized."
-            raise RuntimeError(msg)
+        assert self._chunker is not None  # noqa: S101
 
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieSemanticDocumentSplitter expects a list of Document objects."
@@ -138,7 +135,7 @@ class ChonkieSemanticDocumentSplitter:
                 )
                 continue
 
-            chunks = chunker.chunk(doc.content)
+            chunks = self._chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/semantic_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/semantic_splitter.py
@@ -115,13 +115,15 @@ class ChonkieSemanticDocumentSplitter:
         :param documents: The list of documents to split.
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
+        self.warm_up()
+        chunker = self._chunker
+        if chunker is None:
+            msg = "The Chonkie semantic chunker was not initialized."
+            raise RuntimeError(msg)
+
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieSemanticDocumentSplitter expects a list of Document objects."
             raise TypeError(msg)
-
-        if self._chunker is None:
-            self.warm_up()
-            assert self._chunker is not None  # noqa: S101
 
         chunked_documents = []
         for doc in documents:
@@ -136,7 +138,7 @@ class ChonkieSemanticDocumentSplitter:
                 )
                 continue
 
-            chunks = self._chunker.chunk(doc.content)
+            chunks = chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/semantic_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/semantic_splitter.py
@@ -115,12 +115,12 @@ class ChonkieSemanticDocumentSplitter:
         :param documents: The list of documents to split.
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
-        self.warm_up()
-        assert self._chunker is not None  # noqa: S101
-
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieSemanticDocumentSplitter expects a list of Document objects."
             raise TypeError(msg)
+
+        self.warm_up()
+        assert self._chunker is not None  # noqa: S101
 
         chunked_documents = []
         for doc in documents:

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/sentence_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/sentence_splitter.py
@@ -99,10 +99,7 @@ class ChonkieSentenceDocumentSplitter:
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
         self.warm_up()
-        chunker = self._chunker
-        if chunker is None:
-            msg = "The Chonkie sentence chunker was not initialized."
-            raise RuntimeError(msg)
+        assert self._chunker is not None  # noqa: S101
 
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieSentenceDocumentSplitter expects a list of Document objects."
@@ -121,7 +118,7 @@ class ChonkieSentenceDocumentSplitter:
                 )
                 continue
 
-            chunks = chunker.chunk(doc.content)
+            chunks = self._chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/sentence_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/sentence_splitter.py
@@ -69,17 +69,24 @@ class ChonkieSentenceDocumentSplitter:
         self.skip_empty_documents = skip_empty_documents
         self.page_break_character = page_break_character
 
+        self._chunker: chonkie.SentenceChunker | None = None
+
+    def warm_up(self) -> None:
+        """Initialize the Chonkie sentence chunker."""
+        if self._chunker is not None:
+            return
+
         kwargs: dict[str, Any] = {
-            "tokenizer": tokenizer,
-            "chunk_size": chunk_size,
-            "chunk_overlap": chunk_overlap,
-            "min_sentences_per_chunk": min_sentences_per_chunk,
-            "min_characters_per_sentence": min_characters_per_sentence,
-            "approximate": approximate,
-            "include_delim": include_delim,
+            "tokenizer": self.tokenizer,
+            "chunk_size": self.chunk_size,
+            "chunk_overlap": self.chunk_overlap,
+            "min_sentences_per_chunk": self.min_sentences_per_chunk,
+            "min_characters_per_sentence": self.min_characters_per_sentence,
+            "approximate": self.approximate,
+            "include_delim": self.include_delim,
         }
-        if delim is not None:
-            kwargs["delim"] = delim
+        if self.delim is not None:
+            kwargs["delim"] = self.delim
 
         self._chunker = chonkie.SentenceChunker(**kwargs)
 
@@ -91,6 +98,12 @@ class ChonkieSentenceDocumentSplitter:
         :param documents: The list of documents to split.
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
+        self.warm_up()
+        chunker = self._chunker
+        if chunker is None:
+            msg = "The Chonkie sentence chunker was not initialized."
+            raise RuntimeError(msg)
+
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieSentenceDocumentSplitter expects a list of Document objects."
             raise TypeError(msg)
@@ -108,7 +121,7 @@ class ChonkieSentenceDocumentSplitter:
                 )
                 continue
 
-            chunks = self._chunker.chunk(doc.content)
+            chunks = chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/token_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/token_splitter.py
@@ -54,11 +54,16 @@ class ChonkieTokenDocumentSplitter:
         self.skip_empty_documents = skip_empty_documents
         self.page_break_character = page_break_character
 
-        self._chunker = chonkie.TokenChunker(
-            tokenizer=tokenizer,
-            chunk_size=chunk_size,
-            chunk_overlap=chunk_overlap,
-        )
+        self._chunker: chonkie.TokenChunker | None = None
+
+    def warm_up(self) -> None:
+        """Initialize the Chonkie token chunker."""
+        if self._chunker is None:
+            self._chunker = chonkie.TokenChunker(
+                tokenizer=self.tokenizer,
+                chunk_size=self.chunk_size,
+                chunk_overlap=self.chunk_overlap,
+            )
 
     @component.output_types(documents=list[Document])
     def run(self, documents: list[Document]) -> dict[str, list[Document]]:
@@ -68,6 +73,12 @@ class ChonkieTokenDocumentSplitter:
         :param documents: The list of documents to split.
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
+        self.warm_up()
+        chunker = self._chunker
+        if chunker is None:
+            msg = "The Chonkie token chunker was not initialized."
+            raise RuntimeError(msg)
+
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieTokenDocumentSplitter expects a list of Document objects."
             raise TypeError(msg)
@@ -85,7 +96,7 @@ class ChonkieTokenDocumentSplitter:
                 )
                 continue
 
-            chunks = self._chunker.chunk(doc.content)
+            chunks = chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/token_splitter.py
+++ b/integrations/chonkie/src/haystack_integrations/components/preprocessors/chonkie/token_splitter.py
@@ -74,10 +74,7 @@ class ChonkieTokenDocumentSplitter:
         :returns: A dictionary with the "documents" key containing the list of chunks.
         """
         self.warm_up()
-        chunker = self._chunker
-        if chunker is None:
-            msg = "The Chonkie token chunker was not initialized."
-            raise RuntimeError(msg)
+        assert self._chunker is not None  # noqa: S101
 
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = "ChonkieTokenDocumentSplitter expects a list of Document objects."
@@ -96,7 +93,7 @@ class ChonkieTokenDocumentSplitter:
                 )
                 continue
 
-            chunks = chunker.chunk(doc.content)
+            chunks = self._chunker.chunk(doc.content)
             base_page = doc.meta.get("page_number", 1) if doc.meta else 1
             for split_id, chunk in enumerate(chunks):
                 current_page = base_page + doc.content[: chunk.start_index].count(self.page_break_character)

--- a/integrations/chonkie/tests/test_recursive_splitter.py
+++ b/integrations/chonkie/tests/test_recursive_splitter.py
@@ -10,7 +10,7 @@ from haystack import Document
 from haystack_integrations.components.preprocessors.chonkie import ChonkieRecursiveDocumentSplitter
 
 
-class TestInitializationAndSerialization:
+class TestChonkieRecursiveDocumentSplitter:
     def test_init_default(self):
         chunker = ChonkieRecursiveDocumentSplitter()
         assert chunker.chunk_size == 2048
@@ -103,8 +103,6 @@ class TestInitializationAndSerialization:
         assert chunker.rules.levels[0].delimiters == ["\n\n"]
         assert chunker._chunker is None
 
-
-class TestComponentLifecycle:
     @patch("haystack_integrations.components.preprocessors.chonkie.recursive_splitter.chonkie.RecursiveChunker")
     def test_warm_up_is_idempotent(self, mock_chunker):
         splitter = ChonkieRecursiveDocumentSplitter()
@@ -113,8 +111,6 @@ class TestComponentLifecycle:
         splitter.warm_up()
         mock_chunker.assert_called_once_with(tokenizer="character", chunk_size=2048, min_characters_per_chunk=24)
 
-
-class TestChonkieRecursiveDocumentSplitterRun:
     def test_run(self):
         chunker = ChonkieRecursiveDocumentSplitter(chunk_size=10, min_characters_per_chunk=2)
         doc = Document(content="Hello world! This is a test string for chunking.")

--- a/integrations/chonkie/tests/test_recursive_splitter.py
+++ b/integrations/chonkie/tests/test_recursive_splitter.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from unittest.mock import patch
+
 import pytest
 from chonkie.types.recursive import RecursiveLevel, RecursiveRules
 from haystack import Document
@@ -8,12 +10,13 @@ from haystack import Document
 from haystack_integrations.components.preprocessors.chonkie import ChonkieRecursiveDocumentSplitter
 
 
-class TestChonkieRecursiveDocumentSplitter:
+class TestInitializationAndSerialization:
     def test_init_default(self):
         chunker = ChonkieRecursiveDocumentSplitter()
         assert chunker.chunk_size == 2048
         assert chunker.tokenizer == "character"
         assert chunker.min_characters_per_chunk == 24
+        assert chunker._chunker is None
 
     def test_to_dict(self):
         chunker = ChonkieRecursiveDocumentSplitter(chunk_size=1024, tokenizer="word", min_characters_per_chunk=10)
@@ -98,7 +101,20 @@ class TestChonkieRecursiveDocumentSplitter:
         assert chunker.min_characters_per_chunk == 10
         assert isinstance(chunker.rules, RecursiveRules)
         assert chunker.rules.levels[0].delimiters == ["\n\n"]
+        assert chunker._chunker is None
 
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.preprocessors.chonkie.recursive_splitter.chonkie.RecursiveChunker")
+    def test_warm_up_is_idempotent(self, mock_chunker):
+        splitter = ChonkieRecursiveDocumentSplitter()
+        splitter.warm_up()
+        assert splitter._chunker is mock_chunker.return_value
+        splitter.warm_up()
+        mock_chunker.assert_called_once_with(tokenizer="character", chunk_size=2048, min_characters_per_chunk=24)
+
+
+class TestChonkieRecursiveDocumentSplitterRun:
     def test_run(self):
         chunker = ChonkieRecursiveDocumentSplitter(chunk_size=10, min_characters_per_chunk=2)
         doc = Document(content="Hello world! This is a test string for chunking.")

--- a/integrations/chonkie/tests/test_recursive_splitter.py
+++ b/integrations/chonkie/tests/test_recursive_splitter.py
@@ -105,11 +105,14 @@ class TestChonkieRecursiveDocumentSplitter:
 
     @patch("haystack_integrations.components.preprocessors.chonkie.recursive_splitter.chonkie.RecursiveChunker")
     def test_warm_up_is_idempotent(self, mock_chunker):
-        splitter = ChonkieRecursiveDocumentSplitter()
+        rules = RecursiveRules(levels=[RecursiveLevel(delimiters=["\n\n"], include_delim="prev")])
+        splitter = ChonkieRecursiveDocumentSplitter(rules=rules)
         splitter.warm_up()
         assert splitter._chunker is mock_chunker.return_value
         splitter.warm_up()
-        mock_chunker.assert_called_once_with(tokenizer="character", chunk_size=2048, min_characters_per_chunk=24)
+        mock_chunker.assert_called_once_with(
+            tokenizer="character", chunk_size=2048, min_characters_per_chunk=24, rules=rules
+        )
 
     def test_run(self):
         chunker = ChonkieRecursiveDocumentSplitter(chunk_size=10, min_characters_per_chunk=2)

--- a/integrations/chonkie/tests/test_semantic_splitter.py
+++ b/integrations/chonkie/tests/test_semantic_splitter.py
@@ -10,7 +10,7 @@ from haystack import Document
 from haystack_integrations.components.preprocessors.chonkie import ChonkieSemanticDocumentSplitter
 
 
-class TestInitializationAndSerialization:
+class TestChonkieSemanticDocumentSplitter:
     def test_init_default(self):
         chunker = ChonkieSemanticDocumentSplitter()
         assert chunker.embedding_model == "minishlab/potion-base-32M"
@@ -84,8 +84,6 @@ class TestInitializationAndSerialization:
         assert chunker.filter_tolerance == 0.1
         assert chunker._chunker is None
 
-
-class TestComponentLifecycle:
     @patch("haystack_integrations.components.preprocessors.chonkie.semantic_splitter.chonkie.SemanticChunker")
     def test_warm_up_is_idempotent(self, mock_chunker):
         splitter = ChonkieSemanticDocumentSplitter()
@@ -94,8 +92,6 @@ class TestComponentLifecycle:
         splitter.warm_up()
         mock_chunker.assert_called_once()
 
-
-class TestChonkieSemanticDocumentSplitterRun:
     @patch("haystack_integrations.components.preprocessors.chonkie.semantic_splitter.chonkie.SemanticChunker")
     def test_run(self, mock_chunker):
         # Setup mock return chunks

--- a/integrations/chonkie/tests/test_semantic_splitter.py
+++ b/integrations/chonkie/tests/test_semantic_splitter.py
@@ -10,7 +10,7 @@ from haystack import Document
 from haystack_integrations.components.preprocessors.chonkie import ChonkieSemanticDocumentSplitter
 
 
-class TestChonkieSemanticDocumentSplitter:
+class TestInitializationAndSerialization:
     def test_init_default(self):
         chunker = ChonkieSemanticDocumentSplitter()
         assert chunker.embedding_model == "minishlab/potion-base-32M"
@@ -82,19 +82,20 @@ class TestChonkieSemanticDocumentSplitter:
         assert chunker.filter_window == 3
         assert chunker.filter_polyorder == 2
         assert chunker.filter_tolerance == 0.1
-
-    @patch("haystack_integrations.components.preprocessors.chonkie.semantic_splitter.chonkie.SemanticChunker")
-    def test_warm_up(self, mock_chunker):
-        chunker = ChonkieSemanticDocumentSplitter()
         assert chunker._chunker is None
-        chunker.warm_up()
-        assert chunker._chunker is not None
+
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.preprocessors.chonkie.semantic_splitter.chonkie.SemanticChunker")
+    def test_warm_up_is_idempotent(self, mock_chunker):
+        splitter = ChonkieSemanticDocumentSplitter()
+        splitter.warm_up()
+        assert splitter._chunker is mock_chunker.return_value
+        splitter.warm_up()
         mock_chunker.assert_called_once()
 
-        # Calling warm_up again should not re-initialize
-        chunker.warm_up()
-        mock_chunker.assert_called_once()
 
+class TestChonkieSemanticDocumentSplitterRun:
     @patch("haystack_integrations.components.preprocessors.chonkie.semantic_splitter.chonkie.SemanticChunker")
     def test_run(self, mock_chunker):
         # Setup mock return chunks

--- a/integrations/chonkie/tests/test_sentence_splitter.py
+++ b/integrations/chonkie/tests/test_sentence_splitter.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
@@ -8,7 +10,7 @@ from haystack import Document
 from haystack_integrations.components.preprocessors.chonkie import ChonkieSentenceDocumentSplitter
 
 
-class TestChonkieSentenceDocumentSplitter:
+class TestInitializationAndSerialization:
     def test_init_default(self):
         chunker = ChonkieSentenceDocumentSplitter()
         assert chunker.chunk_size == 2048
@@ -19,6 +21,7 @@ class TestChonkieSentenceDocumentSplitter:
         assert chunker.approximate is False
         assert chunker.delim is None
         assert chunker.include_delim == "prev"
+        assert chunker._chunker is None
 
     def test_to_dict(self):
         chunker = ChonkieSentenceDocumentSplitter(
@@ -71,7 +74,28 @@ class TestChonkieSentenceDocumentSplitter:
         assert chunker.approximate is True
         assert chunker.delim == [". ", "? "]
         assert chunker.include_delim == "next"
+        assert chunker._chunker is None
 
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.preprocessors.chonkie.sentence_splitter.chonkie.SentenceChunker")
+    def test_warm_up_is_idempotent(self, mock_chunker):
+        splitter = ChonkieSentenceDocumentSplitter()
+        splitter.warm_up()
+        assert splitter._chunker is mock_chunker.return_value
+        splitter.warm_up()
+        mock_chunker.assert_called_once_with(
+            tokenizer="character",
+            chunk_size=2048,
+            chunk_overlap=0,
+            min_sentences_per_chunk=1,
+            min_characters_per_sentence=12,
+            approximate=False,
+            include_delim="prev",
+        )
+
+
+class TestChonkieSentenceDocumentSplitterRun:
     def test_run(self):
         chunker = ChonkieSentenceDocumentSplitter(chunk_size=15, chunk_overlap=2)
         doc = Document(content="Hello world! This is a test string for chunking. Here is a new sentence.")

--- a/integrations/chonkie/tests/test_sentence_splitter.py
+++ b/integrations/chonkie/tests/test_sentence_splitter.py
@@ -77,7 +77,8 @@ class TestChonkieSentenceDocumentSplitter:
 
     @patch("haystack_integrations.components.preprocessors.chonkie.sentence_splitter.chonkie.SentenceChunker")
     def test_warm_up_is_idempotent(self, mock_chunker):
-        splitter = ChonkieSentenceDocumentSplitter()
+        delim = [". ", "? "]
+        splitter = ChonkieSentenceDocumentSplitter(delim=delim)
         splitter.warm_up()
         assert splitter._chunker is mock_chunker.return_value
         splitter.warm_up()
@@ -89,6 +90,7 @@ class TestChonkieSentenceDocumentSplitter:
             min_characters_per_sentence=12,
             approximate=False,
             include_delim="prev",
+            delim=delim,
         )
 
     def test_run(self):

--- a/integrations/chonkie/tests/test_sentence_splitter.py
+++ b/integrations/chonkie/tests/test_sentence_splitter.py
@@ -1,16 +1,15 @@
-from unittest.mock import patch
-
-import pytest
-
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from unittest.mock import patch
+
+import pytest
 from haystack import Document
 
 from haystack_integrations.components.preprocessors.chonkie import ChonkieSentenceDocumentSplitter
 
 
-class TestInitializationAndSerialization:
+class TestChonkieSentenceDocumentSplitter:
     def test_init_default(self):
         chunker = ChonkieSentenceDocumentSplitter()
         assert chunker.chunk_size == 2048
@@ -76,8 +75,6 @@ class TestInitializationAndSerialization:
         assert chunker.include_delim == "next"
         assert chunker._chunker is None
 
-
-class TestComponentLifecycle:
     @patch("haystack_integrations.components.preprocessors.chonkie.sentence_splitter.chonkie.SentenceChunker")
     def test_warm_up_is_idempotent(self, mock_chunker):
         splitter = ChonkieSentenceDocumentSplitter()
@@ -94,8 +91,6 @@ class TestComponentLifecycle:
             include_delim="prev",
         )
 
-
-class TestChonkieSentenceDocumentSplitterRun:
     def test_run(self):
         chunker = ChonkieSentenceDocumentSplitter(chunk_size=15, chunk_overlap=2)
         doc = Document(content="Hello world! This is a test string for chunking. Here is a new sentence.")

--- a/integrations/chonkie/tests/test_token_splitter.py
+++ b/integrations/chonkie/tests/test_token_splitter.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
@@ -8,12 +10,13 @@ from haystack import Document
 from haystack_integrations.components.preprocessors.chonkie import ChonkieTokenDocumentSplitter
 
 
-class TestChonkieTokenDocumentSplitter:
+class TestInitializationAndSerialization:
     def test_init_default(self):
         chunker = ChonkieTokenDocumentSplitter()
         assert chunker.chunk_size == 2048
         assert chunker.tokenizer == "character"
         assert chunker.chunk_overlap == 0
+        assert chunker._chunker is None
 
     def test_to_dict(self):
         chunker = ChonkieTokenDocumentSplitter(chunk_size=1024, tokenizer="word", chunk_overlap=50)
@@ -42,7 +45,20 @@ class TestChonkieTokenDocumentSplitter:
         assert chunker.chunk_size == 1024
         assert chunker.tokenizer == "word"
         assert chunker.chunk_overlap == 50
+        assert chunker._chunker is None
 
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.preprocessors.chonkie.token_splitter.chonkie.TokenChunker")
+    def test_warm_up_is_idempotent(self, mock_chunker):
+        splitter = ChonkieTokenDocumentSplitter()
+        splitter.warm_up()
+        assert splitter._chunker is mock_chunker.return_value
+        splitter.warm_up()
+        mock_chunker.assert_called_once_with(tokenizer="character", chunk_size=2048, chunk_overlap=0)
+
+
+class TestChonkieTokenDocumentSplitterRun:
     def test_run(self):
         chunker = ChonkieTokenDocumentSplitter(chunk_size=10, chunk_overlap=2)
         doc = Document(content="Hello world! This is a test string for chunking.")

--- a/integrations/chonkie/tests/test_token_splitter.py
+++ b/integrations/chonkie/tests/test_token_splitter.py
@@ -1,16 +1,15 @@
-from unittest.mock import patch
-
-import pytest
-
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from unittest.mock import patch
+
+import pytest
 from haystack import Document
 
 from haystack_integrations.components.preprocessors.chonkie import ChonkieTokenDocumentSplitter
 
 
-class TestInitializationAndSerialization:
+class TestChonkieTokenDocumentSplitter:
     def test_init_default(self):
         chunker = ChonkieTokenDocumentSplitter()
         assert chunker.chunk_size == 2048
@@ -47,8 +46,6 @@ class TestInitializationAndSerialization:
         assert chunker.chunk_overlap == 50
         assert chunker._chunker is None
 
-
-class TestComponentLifecycle:
     @patch("haystack_integrations.components.preprocessors.chonkie.token_splitter.chonkie.TokenChunker")
     def test_warm_up_is_idempotent(self, mock_chunker):
         splitter = ChonkieTokenDocumentSplitter()
@@ -57,8 +54,6 @@ class TestComponentLifecycle:
         splitter.warm_up()
         mock_chunker.assert_called_once_with(tokenizer="character", chunk_size=2048, chunk_overlap=0)
 
-
-class TestChonkieTokenDocumentSplitterRun:
     def test_run(self):
         chunker = ChonkieTokenDocumentSplitter(chunk_size=10, chunk_overlap=2)
         doc = Document(content="Hello world! This is a test string for chunking.")


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- add idempotent `warm_up` method to components that lacked it and built the chunker in `__init__`
- no `close` since Chonkie does not expose cleanup

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
