### PR TITLE
refactor!: Cohere - create clients in warm up methods

### DIFF
--- a/integrations/cohere/pyproject.toml
+++ b/integrations/cohere/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "cohere>=5.17.0", "pydantic>=2.12.0"]
+dependencies = ["haystack-ai>=3.0.0", "cohere>=5.17.0", "pydantic>=2.12.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cohere#readme"

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
@@ -95,18 +95,28 @@ class CohereDocumentEmbedder:
         self.embedding_separator = embedding_separator
         self.embedding_type = embedding_type or EmbeddingTypes.FLOAT
 
-        self._client = ClientV2(
-            api_key=self.api_key.resolve_value(),
-            base_url=self.api_base_url,
-            timeout=self.timeout,
-            client_name="haystack",
-        )
-        self._async_client = AsyncClientV2(
-            api_key=self.api_key.resolve_value(),
-            base_url=self.api_base_url,
-            timeout=self.timeout,
-            client_name="haystack",
-        )
+        self._client: ClientV2 | None = None
+        self._async_client: AsyncClientV2 | None = None
+
+    def warm_up(self) -> None:
+        """Create the synchronous Cohere client."""
+        if self._client is None:
+            self._client = ClientV2(
+                api_key=self.api_key.resolve_value(),
+                base_url=self.api_base_url,
+                timeout=self.timeout,
+                client_name="haystack",
+            )
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Cohere client."""
+        if self._async_client is None:
+            self._async_client = AsyncClientV2(
+                api_key=self.api_key.resolve_value(),
+                base_url=self.api_base_url,
+                timeout=self.timeout,
+                client_name="haystack",
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -191,6 +201,8 @@ class CohereDocumentEmbedder:
         if not documents:
             return {"documents": [], "meta": {}}
 
+        self.warm_up()
+        assert self._client is not None
         texts_to_embed = self._prepare_texts_to_embed(documents)
 
         all_embeddings, metadata = get_response(
@@ -227,6 +239,8 @@ class CohereDocumentEmbedder:
         if not documents:
             return {"documents": [], "meta": {}}
 
+        await self.warm_up_async()
+        assert self._async_client is not None
         texts_to_embed = self._prepare_texts_to_embed(documents)
 
         all_embeddings, metadata = await get_async_response(

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_image_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_image_embedder.py
@@ -128,18 +128,28 @@ class CohereDocumentImageEmbedder:
         self._api_base_url = api_base_url
         self._timeout = timeout
 
-        self._client = ClientV2(
-            api_key=self._api_key.resolve_value(),
-            base_url=self._api_base_url,
-            timeout=self._timeout,
-            client_name="haystack",
-        )
-        self._async_client = AsyncClientV2(
-            api_key=self._api_key.resolve_value(),
-            base_url=self._api_base_url,
-            timeout=self._timeout,
-            client_name="haystack",
-        )
+        self._client: ClientV2 | None = None
+        self._async_client: AsyncClientV2 | None = None
+
+    def warm_up(self) -> None:
+        """Create the synchronous Cohere client."""
+        if self._client is None:
+            self._client = ClientV2(
+                api_key=self._api_key.resolve_value(),
+                base_url=self._api_base_url,
+                timeout=self._timeout,
+                client_name="haystack",
+            )
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Cohere client."""
+        if self._async_client is None:
+            self._async_client = AsyncClientV2(
+                api_key=self._api_key.resolve_value(),
+                base_url=self._api_base_url,
+                timeout=self._timeout,
+                client_name="haystack",
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -264,6 +274,8 @@ class CohereDocumentImageEmbedder:
             - `documents`: Documents with embeddings.
         """
 
+        self.warm_up()
+        assert self._client is not None
         images_to_embed = self._extract_images_to_embed(documents)
 
         embeddings = []
@@ -312,6 +324,8 @@ class CohereDocumentImageEmbedder:
             - `documents`: Documents with embeddings.
         """
 
+        await self.warm_up_async()
+        assert self._async_client is not None
         images_to_embed = self._extract_images_to_embed(documents)
 
         embeddings = []

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/text_embedder.py
@@ -78,19 +78,28 @@ class CohereTextEmbedder:
         self.timeout = timeout
         self.embedding_type = embedding_type or EmbeddingTypes.FLOAT
 
-        self._client = ClientV2(
-            api_key=self.api_key.resolve_value(),
-            base_url=self.api_base_url,
-            timeout=self.timeout,
-            client_name="haystack",
-        )
+        self._client: ClientV2 | None = None
+        self._async_client: AsyncClientV2 | None = None
 
-        self._async_client = AsyncClientV2(
-            api_key=self.api_key.resolve_value(),
-            base_url=self.api_base_url,
-            timeout=self.timeout,
-            client_name="haystack",
-        )
+    def warm_up(self) -> None:
+        """Create the synchronous Cohere client."""
+        if self._client is None:
+            self._client = ClientV2(
+                api_key=self.api_key.resolve_value(),
+                base_url=self.api_base_url,
+                timeout=self.timeout,
+                client_name="haystack",
+            )
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Cohere client."""
+        if self._async_client is None:
+            self._async_client = AsyncClientV2(
+                api_key=self.api_key.resolve_value(),
+                base_url=self.api_base_url,
+                timeout=self.timeout,
+                client_name="haystack",
+            )
 
     def _validate_input(self, text: str) -> None:
         if not isinstance(text, str):
@@ -155,6 +164,8 @@ class CohereTextEmbedder:
             If the input is not a string.
         """
         self._validate_input(text=text)
+        self.warm_up()
+        assert self._client is not None
 
         embedding, metadata = get_response(
             cohere_client=self._client,
@@ -187,6 +198,8 @@ class CohereTextEmbedder:
             If the input is not a string.
         """
         self._validate_input(text=text)
+        await self.warm_up_async()
+        assert self._async_client is not None
 
         embedding, metadata = await get_async_response(
             cohere_async_client=self._async_client,

--- a/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
+++ b/integrations/cohere/src/haystack_integrations/components/generators/cohere/chat/chat_generator.py
@@ -579,22 +579,35 @@ class CohereChatGenerator:
         self.timeout = timeout
         self.max_retries = max_retries
 
+        self.client: ClientV2 | None = None
+        self.async_client: AsyncClientV2 | None = None
+
+    def _client_kwargs(self, *, async_client: bool) -> dict[str, Any]:
+        """Build the keyword arguments used to create a Cohere client."""
         client_kwargs: dict[str, Any] = {
             "api_key": self.api_key.resolve_value(),
             "base_url": self.api_base_url,
             "client_name": "haystack",
         }
-        if timeout is not None:
-            client_kwargs["timeout"] = timeout
+        if self.timeout is not None:
+            client_kwargs["timeout"] = self.timeout
 
-        sync_kwargs = {**client_kwargs}
-        async_kwargs = {**client_kwargs}
-        if max_retries is not None:
-            sync_kwargs["httpx_client"] = HTTPXClient(transport=HTTPTransport(retries=max_retries))
-            async_kwargs["httpx_client"] = AsyncHTTPXClient(transport=AsyncHTTPTransport(retries=max_retries))
+        if self.max_retries is not None:
+            if async_client:
+                client_kwargs["httpx_client"] = AsyncHTTPXClient(transport=AsyncHTTPTransport(retries=self.max_retries))
+            else:
+                client_kwargs["httpx_client"] = HTTPXClient(transport=HTTPTransport(retries=self.max_retries))
+        return client_kwargs
 
-        self.client = ClientV2(**sync_kwargs)
-        self.async_client = AsyncClientV2(**async_kwargs)
+    def warm_up(self) -> None:
+        """Create the synchronous Cohere client."""
+        if self.client is None:
+            self.client = ClientV2(**self._client_kwargs(async_client=False))
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Cohere client."""
+        if self.async_client is None:
+            self.async_client = AsyncClientV2(**self._client_kwargs(async_client=True))
 
     def _get_telemetry_data(self) -> dict[str, Any]:
         """
@@ -665,6 +678,8 @@ class CohereChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: a list of `ChatMessage` instances representing the generated responses.
         """
+        self.warm_up()
+        assert self.client is not None
         messages = _normalize_messages(messages)
 
         # update generation kwargs by merging with the generation kwargs passed to the run method
@@ -732,6 +747,8 @@ class CohereChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: a list of `ChatMessage` instances representing the generated responses.
         """
+        await self.warm_up_async()
+        assert self.async_client is not None
         messages = _normalize_messages(messages)
 
         # update generation kwargs by merging with the generation kwargs passed to the run method

--- a/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
+++ b/integrations/cohere/src/haystack_integrations/components/rankers/cohere/ranker.py
@@ -69,12 +69,22 @@ class CohereRanker:
         self.meta_data_separator = meta_data_separator
         self.max_tokens_per_doc = max_tokens_per_doc
 
-        self._cohere_client = ClientV2(
-            api_key=self.api_key.resolve_value(), base_url=self.api_base_url, client_name="haystack"
-        )
-        self._cohere_async_client = AsyncClientV2(
-            api_key=self.api_key.resolve_value(), base_url=self.api_base_url, client_name="haystack"
-        )
+        self._cohere_client: ClientV2 | None = None
+        self._cohere_async_client: AsyncClientV2 | None = None
+
+    def warm_up(self) -> None:
+        """Create the synchronous Cohere client."""
+        if self._cohere_client is None:
+            self._cohere_client = ClientV2(
+                api_key=self.api_key.resolve_value(), base_url=self.api_base_url, client_name="haystack"
+            )
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Cohere client."""
+        if self._cohere_async_client is None:
+            self._cohere_async_client = AsyncClientV2(
+                api_key=self.api_key.resolve_value(), base_url=self.api_base_url, client_name="haystack"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -172,6 +182,8 @@ class CohereRanker:
 
         :raises ValueError: If `top_k` is not > 0.
         """
+        self.warm_up()
+        assert self._cohere_client is not None
         cohere_input_docs, top_k = self._prepare_cohere_input_docs(documents, top_k)
 
         response = self._cohere_client.rerank(
@@ -205,6 +217,8 @@ class CohereRanker:
 
         :raises ValueError: If `top_k` is not > 0.
         """
+        await self.warm_up_async()
+        assert self._cohere_async_client is not None
         cohere_input_docs, top_k = self._prepare_cohere_input_docs(documents, top_k)
 
         response = await self._cohere_async_client.rerank(

--- a/integrations/cohere/tests/test_chat_generator.py
+++ b/integrations/cohere/tests/test_chat_generator.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from cohere.core import ApiError
@@ -151,7 +151,7 @@ class TestFormatMessage:
         assert formatted_message["content"][2]["type"] == "image_url"
 
 
-class TestCohereChatGenerator:
+class TestInitializationAndSerialization:
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = CohereChatGenerator.SUPPORTED_MODELS
@@ -170,12 +170,8 @@ class TestCohereChatGenerator:
         assert not component.generation_kwargs
         assert component.timeout is None
         assert component.max_retries is None
-
-    def test_init_fail_wo_api_key(self, monkeypatch):
-        monkeypatch.delenv("COHERE_API_KEY", raising=False)
-        monkeypatch.delenv("CO_API_KEY", raising=False)
-        with pytest.raises(ValueError):
-            CohereChatGenerator()
+        assert component.client is None
+        assert component.async_client is None
 
     def test_init_with_parameters(self):
         component = CohereChatGenerator(
@@ -290,31 +286,6 @@ class TestCohereChatGenerator:
         }
         assert component.timeout is None
         assert component.max_retries is None
-
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("COHERE_API_KEY", raising=False)
-        monkeypatch.delenv("CO_API_KEY", raising=False)
-        data = {
-            "type": "haystack_integrations.components.generators.cohere.chat.chat_generator.CohereChatGenerator",
-            "init_parameters": {
-                "model": "command-a-03-2025",
-                "api_base_url": "test-base-url",
-                "api_key": {
-                    "env_vars": ["COHERE_API_KEY", "CO_API_KEY"],
-                    "strict": True,
-                    "type": "env_var",
-                },
-                "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
-                "generation_kwargs": {
-                    "max_tokens": 10,
-                    "some_test_param": "test-params",
-                },
-                "timeout": None,
-                "max_retries": None,
-            },
-        }
-        with pytest.raises(ValueError):
-            CohereChatGenerator.from_dict(data)
 
     def test_serde_in_pipeline(self, monkeypatch):
         """
@@ -450,7 +421,55 @@ class TestCohereChatGenerator:
         assert restored.tools[0].name == "tool1"
         assert len(list(restored.tools[1])) == 1
 
-    def test_run_image(self):
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_COHERE_API_KEY", raising=False)
+        component = CohereChatGenerator(api_key=Secret.from_env_var("MISSING_COHERE_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_COHERE_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.ClientV2")
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.HTTPXClient")
+    def test_warm_up_is_idempotent(self, mock_httpx_cls, mock_client_cls):
+        component = CohereChatGenerator(api_key=Secret.from_token("test-api-key"), max_retries=2)
+
+        component.warm_up()
+        component.warm_up()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://api.cohere.com",
+            client_name="haystack",
+            httpx_client=mock_httpx_cls.return_value,
+        )
+        mock_httpx_cls.assert_called_once()
+        assert component.client is mock_client_cls.return_value
+        assert component.async_client is None
+
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.AsyncClientV2")
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.AsyncHTTPXClient")
+    async def test_warm_up_async_is_idempotent(self, mock_httpx_cls, mock_client_cls):
+        component = CohereChatGenerator(api_key=Secret.from_token("test-api-key"), max_retries=2)
+
+        await component.warm_up_async()
+        await component.warm_up_async()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://api.cohere.com",
+            client_name="haystack",
+            httpx_client=mock_httpx_cls.return_value,
+        )
+        mock_httpx_cls.assert_called_once()
+        assert component.async_client is mock_client_cls.return_value
+        assert component.client is None
+
+
+class TestRun:
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.ClientV2")
+    def test_run_image(self, mock_client_cls):
         """Test multimodal message processing with mocked client."""
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
@@ -469,7 +488,8 @@ class TestCohereChatGenerator:
         mock_response.finish_reason = "COMPLETE"
         mock_response.usage = None
 
-        generator.client.chat = MagicMock(return_value=mock_response)
+        client = mock_client_cls.return_value
+        client.chat.return_value = mock_response
 
         result = generator.run(messages=messages)
 
@@ -479,8 +499,8 @@ class TestCohereChatGenerator:
         assert result["replies"][0].text == "This is a test image response"
 
         # Verify the client was called with the correct format
-        generator.client.chat.assert_called_once()
-        call_args = generator.client.chat.call_args
+        client.chat.assert_called_once()
+        call_args = client.chat.call_args
         formatted_messages = call_args[1]["messages"]
 
         assert len(formatted_messages) == 1
@@ -493,7 +513,8 @@ class TestCohereChatGenerator:
         assert multimodal_msg["content"][0]["type"] == "text"
         assert multimodal_msg["content"][1]["type"] == "image_url"
 
-    def test_run_with_string_input(self):
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.ClientV2")
+    def test_run_with_string_input(self, mock_client_cls):
         """Test that a string input is converted to a user ChatMessage before sending to the API."""
         generator = CohereChatGenerator(api_key=Secret.from_token("test-api-key"))
 
@@ -505,12 +526,13 @@ class TestCohereChatGenerator:
         mock_response.finish_reason = "COMPLETE"
         mock_response.usage = None
 
-        generator.client.chat = MagicMock(return_value=mock_response)
+        client = mock_client_cls.return_value
+        client.chat.return_value = mock_response
 
         result = generator.run("What's the capital of France?")
 
-        generator.client.chat.assert_called_once()
-        call_args = generator.client.chat.call_args
+        client.chat.assert_called_once()
+        call_args = client.chat.call_args
         sent_messages = call_args[1]["messages"]
 
         assert len(sent_messages) == 1
@@ -520,7 +542,8 @@ class TestCohereChatGenerator:
         assert isinstance(result["replies"][0], ChatMessage)
 
     @pytest.mark.asyncio
-    async def test_run_async_with_string_input(self):
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.AsyncClientV2")
+    async def test_run_async_with_string_input(self, mock_client_cls):
         """Test that a string input is converted to a user ChatMessage before sending to the async API."""
         generator = CohereChatGenerator(api_key=Secret.from_token("test-api-key"))
 
@@ -532,12 +555,13 @@ class TestCohereChatGenerator:
         mock_response.finish_reason = "COMPLETE"
         mock_response.usage = None
 
-        generator.async_client.chat = AsyncMock(return_value=mock_response)
+        client = mock_client_cls.return_value
+        client.chat = AsyncMock(return_value=mock_response)
 
         result = await generator.run_async("What's the capital of France?")
 
-        generator.async_client.chat.assert_called_once()
-        call_args = generator.async_client.chat.call_args
+        client.chat.assert_called_once()
+        call_args = client.chat.call_args
         sent_messages = call_args[1]["messages"]
 
         assert len(sent_messages) == 1
@@ -546,7 +570,8 @@ class TestCohereChatGenerator:
         assert len(result["replies"]) == 1
         assert isinstance(result["replies"][0], ChatMessage)
 
-    def test_run_with_generation_kwargs(self):
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.ClientV2")
+    def test_run_with_generation_kwargs(self, mock_client_cls):
         generator = CohereChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             generation_kwargs={"max_tokens": 100, "temperature": 0.5},
@@ -560,16 +585,18 @@ class TestCohereChatGenerator:
         mock_response.finish_reason = "COMPLETE"
         mock_response.usage = None
 
-        generator.client.chat = MagicMock(return_value=mock_response)
+        client = mock_client_cls.return_value
+        client.chat.return_value = mock_response
 
         generator.run([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
 
-        _, kwargs = generator.client.chat.call_args
+        _, kwargs = client.chat.call_args
         assert kwargs["max_tokens"] == 100
         assert kwargs["temperature"] == 0.9
 
     @pytest.mark.asyncio
-    async def test_run_async_with_generation_kwargs(self):
+    @patch("haystack_integrations.components.generators.cohere.chat.chat_generator.AsyncClientV2")
+    async def test_run_async_with_generation_kwargs(self, mock_client_cls):
         generator = CohereChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             generation_kwargs={"max_tokens": 100, "temperature": 0.5},
@@ -583,11 +610,12 @@ class TestCohereChatGenerator:
         mock_response.finish_reason = "COMPLETE"
         mock_response.usage = None
 
-        generator.async_client.chat = AsyncMock(return_value=mock_response)
+        client = mock_client_cls.return_value
+        client.chat = AsyncMock(return_value=mock_response)
 
         await generator.run_async([ChatMessage.from_user("Hello")], generation_kwargs={"temperature": 0.9})
 
-        _, kwargs = generator.async_client.chat.call_args
+        _, kwargs = client.chat.call_args
         assert kwargs["max_tokens"] == 100
         assert kwargs["temperature"] == 0.9
 

--- a/integrations/cohere/tests/test_document_embedder.py
+++ b/integrations/cohere/tests/test_document_embedder.py
@@ -14,7 +14,7 @@ from haystack_integrations.components.embedders.cohere.embedding_types import Em
 COHERE_API_URL = "https://api.cohere.com"
 
 
-class TestCohereDocumentEmbedder:
+class TestInitializationAndSerialization:
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = CohereDocumentEmbedder.SUPPORTED_MODELS
@@ -36,6 +36,8 @@ class TestCohereDocumentEmbedder:
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
         assert embedder.embedding_type == EmbeddingTypes.FLOAT
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init_with_parameters(self):
         embedder = CohereDocumentEmbedder(
@@ -149,6 +151,49 @@ class TestCohereDocumentEmbedder:
         assert embedder.embedding_type == EmbeddingTypes.FLOAT
         assert not hasattr(embedder, "use_async_client")
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_COHERE_API_KEY", raising=False)
+        component = CohereDocumentEmbedder(api_key=Secret.from_env_var("MISSING_COHERE_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_COHERE_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.embedders.cohere.document_embedder.ClientV2")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = CohereDocumentEmbedder(api_key=Secret.from_token("test-api-key"))
+
+        component.warm_up()
+        component.warm_up()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url=COHERE_API_URL,
+            timeout=120.0,
+            client_name="haystack",
+        )
+        assert component._client is mock_client_cls.return_value
+        assert component._async_client is None
+
+    @patch("haystack_integrations.components.embedders.cohere.document_embedder.AsyncClientV2")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = CohereDocumentEmbedder(api_key=Secret.from_token("test-api-key"))
+
+        await component.warm_up_async()
+        await component.warm_up_async()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url=COHERE_API_URL,
+            timeout=120.0,
+            client_name="haystack",
+        )
+        assert component._async_client is mock_client_cls.return_value
+        assert component._client is None
+
+
+class TestRun:
     def test_run_wrong_input_format(self):
         embedder = CohereDocumentEmbedder(api_key=Secret.from_token("test-api-key"))
 

--- a/integrations/cohere/tests/test_document_image_embedder.py
+++ b/integrations/cohere/tests/test_document_image_embedder.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from cohere.types import EmbedByTypeResponse, EmbedByTypeResponseEmbeddings
 from haystack import Document
+from haystack.utils import Secret
 
 from haystack_integrations.components.embedders.cohere.document_image_embedder import (
     CohereDocumentImageEmbedder,
@@ -19,7 +20,7 @@ from haystack_integrations.components.embedders.cohere.embedding_types import Em
 IMPORT_PATH = "haystack_integrations.components.embedders.cohere.document_image_embedder"
 
 
-class TestCohereDocumentImageEmbedder:
+class TestInitializationAndSerialization:
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = CohereDocumentImageEmbedder.SUPPORTED_MODELS
@@ -42,8 +43,8 @@ class TestCohereDocumentImageEmbedder:
         assert embedder._api_base_url == "https://api.cohere.com"
         assert embedder._timeout == 120
         assert embedder._api_key.resolve_value() == "test-api-key"
-        assert embedder._client is not None
-        assert embedder._async_client is not None
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init_with_parameters(self, monkeypatch):
         monkeypatch.setenv("COHERE_API_KEY", "test-api-key")
@@ -68,8 +69,8 @@ class TestCohereDocumentImageEmbedder:
         assert embedder._api_base_url == "https://api.cohere.com/v1"
         assert embedder._timeout == 300
         assert embedder._api_key.resolve_value() == "test-api-key"
-        assert embedder._client is not None
-        assert embedder._async_client is not None
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_to_dict(self, monkeypatch):
         monkeypatch.setenv("COHERE_API_KEY", "test-api-key")
@@ -125,9 +126,52 @@ class TestCohereDocumentImageEmbedder:
         assert component._api_base_url == "https://api.cohere.com/v1"
         assert component._timeout == 300
         assert component._api_key.resolve_value() == "test-api-key"
-        assert component._client is not None
-        assert component._async_client is not None
+        assert component._client is None
+        assert component._async_client is None
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_COHERE_API_KEY", raising=False)
+        component = CohereDocumentImageEmbedder(api_key=Secret.from_env_var("MISSING_COHERE_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_COHERE_API_KEY"):
+            component.warm_up()
+
+    @patch(f"{IMPORT_PATH}.ClientV2")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = CohereDocumentImageEmbedder(api_key=Secret.from_token("test-api-key"))
+
+        component.warm_up()
+        component.warm_up()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://api.cohere.com",
+            timeout=120.0,
+            client_name="haystack",
+        )
+        assert component._client is mock_client_cls.return_value
+        assert component._async_client is None
+
+    @patch(f"{IMPORT_PATH}.AsyncClientV2")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = CohereDocumentImageEmbedder(api_key=Secret.from_token("test-api-key"))
+
+        await component.warm_up_async()
+        await component.warm_up_async()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://api.cohere.com",
+            timeout=120.0,
+            client_name="haystack",
+        )
+        assert component._async_client is mock_client_cls.return_value
+        assert component._client is None
+
+
+class TestRun:
     def test_extract_images_to_embed_wrong_input_format(self, monkeypatch):
         monkeypatch.setenv("COHERE_API_KEY", "test-api-key")
         embedder = CohereDocumentImageEmbedder(model="model")

--- a/integrations/cohere/tests/test_ranker.py
+++ b/integrations/cohere/tests/test_ranker.py
@@ -53,7 +53,7 @@ def mock_async_ranker_response():
         yield mock_ranker_response
 
 
-class TestCohereRanker:
+class TestInitializationAndSerialization:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
         component = CohereRanker()
@@ -64,12 +64,8 @@ class TestCohereRanker:
         assert component.meta_fields_to_embed == []
         assert component.meta_data_separator == "\n"
         assert component.max_tokens_per_doc == 4096
-
-    def test_init_fail_wo_api_key(self, monkeypatch):
-        monkeypatch.delenv("CO_API_KEY", raising=False)
-        monkeypatch.delenv("COHERE_API_KEY", raising=False)
-        with pytest.raises(ValueError, match=r"None of the following authentication environment variables are set: *"):
-            CohereRanker()
+        assert component._cohere_client is None
+        assert component._cohere_async_client is None
 
     def test_init_with_parameters(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
@@ -155,21 +151,39 @@ class TestCohereRanker:
         assert component.meta_data_separator == ","
         assert component.max_tokens_per_doc == 100
 
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("CO_API_KEY", raising=False)
-        monkeypatch.delenv("COHERE_API_KEY", raising=False)
-        data = {
-            "type": "haystack_integrations.components.rankers.cohere.ranker.CohereRanker",
-            "init_parameters": {
-                "model": "rerank-multilingual-v3.0",
-                "api_key": {"env_vars": ["COHERE_API_KEY", "CO_API_KEY"], "strict": True, "type": "env_var"},
-                "top_k": 2,
-                "max_tokens_per_doc": 100,
-            },
-        }
-        with pytest.raises(ValueError, match=r"None of the following authentication environment variables are set: *"):
-            CohereRanker.from_dict(data)
 
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_COHERE_API_KEY", raising=False)
+        component = CohereRanker(api_key=Secret.from_env_var("MISSING_COHERE_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_COHERE_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.rankers.cohere.ranker.ClientV2")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = CohereRanker(api_key=Secret.from_token("test-api-key"))
+
+        component.warm_up()
+        component.warm_up()
+
+        mock_client_cls.assert_called_once_with(api_key="test-api-key", base_url=COHERE_API_URL, client_name="haystack")
+        assert component._cohere_client is mock_client_cls.return_value
+        assert component._cohere_async_client is None
+
+    @patch("haystack_integrations.components.rankers.cohere.ranker.AsyncClientV2")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = CohereRanker(api_key=Secret.from_token("test-api-key"))
+
+        await component.warm_up_async()
+        await component.warm_up_async()
+
+        mock_client_cls.assert_called_once_with(api_key="test-api-key", base_url=COHERE_API_URL, client_name="haystack")
+        assert component._cohere_async_client is mock_client_cls.return_value
+        assert component._cohere_client is None
+
+
+class TestRun:
     def test_prepare_cohere_input_docs_default_separator(self, monkeypatch):
         monkeypatch.setenv("CO_API_KEY", "test-api-key")
         component = CohereRanker(meta_fields_to_embed=["meta_field_1", "meta_field_2"])

--- a/integrations/cohere/tests/test_text_embedder.py
+++ b/integrations/cohere/tests/test_text_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+from unittest.mock import patch
 
 import pytest
 from haystack.utils import Secret
@@ -12,7 +13,7 @@ from haystack_integrations.components.embedders.cohere.embedding_types import Em
 COHERE_API_URL = "https://api.cohere.com"
 
 
-class TestCohereTextEmbedder:
+class TestInitializationAndSerialization:
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = CohereTextEmbedder.SUPPORTED_MODELS
@@ -33,6 +34,8 @@ class TestCohereTextEmbedder:
         assert embedder.api_base_url == COHERE_API_URL
         assert embedder.truncate == "END"
         assert embedder.timeout == 120
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init_with_parameters(self):
         """
@@ -128,6 +131,49 @@ class TestCohereTextEmbedder:
         assert embedder.embedding_type == EmbeddingTypes.FLOAT
         assert not hasattr(embedder, "use_async_client")
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_COHERE_API_KEY", raising=False)
+        component = CohereTextEmbedder(api_key=Secret.from_env_var("MISSING_COHERE_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_COHERE_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.embedders.cohere.text_embedder.ClientV2")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = CohereTextEmbedder(api_key=Secret.from_token("test-api-key"))
+
+        component.warm_up()
+        component.warm_up()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url=COHERE_API_URL,
+            timeout=120.0,
+            client_name="haystack",
+        )
+        assert component._client is mock_client_cls.return_value
+        assert component._async_client is None
+
+    @patch("haystack_integrations.components.embedders.cohere.text_embedder.AsyncClientV2")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = CohereTextEmbedder(api_key=Secret.from_token("test-api-key"))
+
+        await component.warm_up_async()
+        await component.warm_up_async()
+
+        mock_client_cls.assert_called_once_with(
+            api_key="test-api-key",
+            base_url=COHERE_API_URL,
+            timeout=120.0,
+            client_name="haystack",
+        )
+        assert component._async_client is mock_client_cls.return_value
+        assert component._client is None
+
+
+class TestRun:
     def test_run_wrong_input_format(self):
         """
         Test for checking incorrect input when creating embedding.


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- create clients in idempotent `warm_up`/`warm_up_async` methods instead of `__init__`
- no closing methods, as Cohere SDK does not expose them
- pin `haystack-ai>=3.0.0`

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
