### PR TITLE
ci: temporary run of AmazonBedrockTokenCounter live tests (do not merge)

### DIFF
--- a/integrations/amazon_bedrock/pydoc/config_docusaurus.yml
+++ b/integrations/amazon_bedrock/pydoc/config_docusaurus.yml
@@ -10,6 +10,7 @@ loaders:
       - haystack_integrations.components.generators.amazon_bedrock.chat.chat_generator
       - haystack_integrations.components.rankers.amazon_bedrock.ranker
       - haystack_integrations.components.retrievers.amazon_bedrock.knowledge_base_retriever
+      - haystack_integrations.token_counters.amazon_bedrock.token_counter
       - haystack_integrations.components.downloaders.s3.s3_downloader
       - haystack_integrations.common.s3.utils
       - haystack_integrations.common.s3.errors

--- a/integrations/amazon_bedrock/pyproject.toml
+++ b/integrations/amazon_bedrock/pyproject.toml
@@ -76,6 +76,7 @@ types = """mypy -p haystack_integrations.common.amazon_bedrock \
 -p haystack_integrations.components.generators.amazon_bedrock \
 -p haystack_integrations.components.rankers.amazon_bedrock \
 -p haystack_integrations.components.retrievers.amazon_bedrock \
+-p haystack_integrations.token_counters.amazon_bedrock \
 -p haystack_integrations.components.downloaders.s3 \
 -p haystack_integrations.common.s3 {args}"""
 

--- a/integrations/amazon_bedrock/src/haystack_integrations/token_counters/amazon_bedrock/__init__.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/token_counters/amazon_bedrock/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from .token_counter import AmazonBedrockTokenCounter
+
+__all__ = ["AmazonBedrockTokenCounter"]

--- a/integrations/amazon_bedrock/src/haystack_integrations/token_counters/amazon_bedrock/token_counter.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/token_counters/amazon_bedrock/token_counter.py
@@ -36,7 +36,7 @@ class AmazonBedrockTokenCounter:
     The messages and tools are converted to the Bedrock `Converse` format (the same conversion the
     `AmazonBedrockChatGenerator` uses), so the count matches what an equivalent `Converse` request would consume.
 
-    Because it delegates to a server-side API, `count()` measures a **complete, valid conversation** rather than an
+    Because it delegates to a server-side API, `count()` measures a complete, valid conversation rather than an
     arbitrary set of messages: Bedrock validates the input the same way the `Converse` inference API does (it must
     begin with a user message, and tool results must pair with the tool calls that produced them). This is the right
     fit for sizing a whole request before sending it - its intended use - but it cannot size a stand-alone fragment

--- a/integrations/amazon_bedrock/src/haystack_integrations/token_counters/amazon_bedrock/token_counter.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/token_counters/amazon_bedrock/token_counter.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from haystack import default_from_dict, default_to_dict
+from haystack.dataclasses import ChatMessage
+from haystack.tools import ToolsType, flatten_tools_or_toolsets
+from haystack.utils.auth import Secret
+
+from haystack_integrations.common.amazon_bedrock.errors import (
+    AmazonBedrockConfigurationError,
+    AmazonBedrockInferenceError,
+)
+from haystack_integrations.common.amazon_bedrock.utils import get_aws_session
+
+# Reuse the chat generator's Converse formatting so the count reflects exactly what
+# `AmazonBedrockChatGenerator` would send to Bedrock for the same messages and tools.
+from haystack_integrations.components.generators.amazon_bedrock.chat.utils import (
+    _format_messages,
+    _format_tools,
+)
+
+
+class AmazonBedrockTokenCounter:
+    """
+    Counts tokens with Amazon Bedrock's `CountTokens` API.
+
+    Implements Haystack's `TokenCounter` protocol. Unlike local, tokenizer-based counters, this counter sends the
+    input to Bedrock's `CountTokens` operation, so the returned count reflects the model's exact tokenization,
+    including the formatting Bedrock applies to messages, system prompts, and tool schemas.
+
+    The messages and tools are converted to the Bedrock `Converse` format (the same conversion the
+    `AmazonBedrockChatGenerator` uses), so the count matches what an equivalent `Converse` request would consume.
+
+    Because it delegates to a server-side API, `count()` measures a **complete, valid conversation** rather than an
+    arbitrary set of messages: Bedrock validates the input the same way the `Converse` inference API does (it must
+    begin with a user message, and tool results must pair with the tool calls that produced them). This is the right
+    fit for sizing a whole request before sending it - its intended use - but it cannot size a stand-alone fragment
+    such as a single tool-result message. For fragment-level counting (for example inside a compactor that measures
+    individual messages), use a local counter such as `ApproximateTokenCounter`.
+
+    ## Usage Example:
+    ```python
+    from haystack.dataclasses import ChatMessage
+    from haystack_integrations.token_counters.amazon_bedrock import AmazonBedrockTokenCounter
+
+    counter = AmazonBedrockTokenCounter(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+    messages = [ChatMessage.from_user("Hello, how are you?")]
+    token_count = counter.count(messages)
+    print(f"Token count: {token_count}")
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        aws_access_key_id: Secret | None = Secret.from_env_var(["AWS_ACCESS_KEY_ID"], strict=False),  # noqa: B008
+        aws_secret_access_key: Secret | None = Secret.from_env_var(  # noqa: B008
+            ["AWS_SECRET_ACCESS_KEY"], strict=False
+        ),
+        aws_session_token: Secret | None = Secret.from_env_var(["AWS_SESSION_TOKEN"], strict=False),  # noqa: B008
+        aws_region_name: Secret | str | None = Secret.from_env_var(["AWS_DEFAULT_REGION"], strict=False),  # noqa: B008
+        aws_profile_name: Secret | None = Secret.from_env_var(["AWS_PROFILE"], strict=False),  # noqa: B008
+        boto3_config: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Initialize the counter.
+
+        :param model: The Bedrock model id (or ARN) whose tokenization should be used, for example
+            `"anthropic.claude-3-5-sonnet-20240620-v1:0"`. Token counts are model-specific.
+        :param aws_access_key_id: AWS access key ID.
+        :param aws_secret_access_key: AWS secret access key.
+        :param aws_session_token: AWS session token.
+        :param aws_region_name: AWS region name. Make sure the region you set supports Amazon Bedrock.
+        :param aws_profile_name: AWS profile name.
+        :param boto3_config: Dictionary of configuration options for the underlying Boto3 client.
+        :raises ValueError: If `model` is empty.
+        """
+        if not model:
+            msg = "'model' cannot be None or empty string"
+            raise ValueError(msg)
+
+        self.model = model
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.aws_session_token = aws_session_token
+        self.aws_region_name = aws_region_name
+        self.aws_profile_name = aws_profile_name
+        self.boto3_config = boto3_config
+
+        self.client: Any = None
+
+    def warm_up(self) -> None:
+        """
+        Initialize the Amazon Bedrock client.
+
+        :raises AmazonBedrockConfigurationError: If the AWS environment is not configured correctly.
+        """
+        if self.client is not None:
+            return
+
+        def resolve_secret(secret: Secret | str | None) -> str | None:
+            return secret.resolve_value() if isinstance(secret, Secret) else secret
+
+        config = Config(
+            user_agent_extra="x-client-framework:haystack",
+            **(self.boto3_config if self.boto3_config else {}),
+        )
+
+        try:
+            session = get_aws_session(
+                aws_access_key_id=resolve_secret(self.aws_access_key_id),
+                aws_secret_access_key=resolve_secret(self.aws_secret_access_key),
+                aws_session_token=resolve_secret(self.aws_session_token),
+                aws_region_name=resolve_secret(self.aws_region_name),
+                aws_profile_name=resolve_secret(self.aws_profile_name),
+            )
+            self.client = session.client("bedrock-runtime", config=config)
+        except Exception as exception:
+            msg = (
+                "Could not connect to Amazon Bedrock. Make sure the AWS environment is configured correctly. "
+                "See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration"
+            )
+            raise AmazonBedrockConfigurationError(msg) from exception
+
+    def count(self, messages: list[ChatMessage], tools: ToolsType | None = None) -> int:
+        """
+        Return the number of input tokens Bedrock will use for the given messages and tools.
+
+        `messages` must form a complete, valid conversation: Bedrock validates it the same way the `Converse`
+        inference API does (it must begin with a user message, and tool results must pair with their tool calls).
+        To size an arbitrary fragment such as a single message, use a local counter like `ApproximateTokenCounter`.
+
+        :param messages: The messages to measure.
+        :param tools: Tools whose schemas are sent alongside the messages, and so consume tokens too. Pass them to
+            have them counted; leave as None to measure the messages alone.
+        :returns: The token count, or `0` when there is nothing to measure.
+        :raises AmazonBedrockInferenceError: If the Bedrock `CountTokens` request fails.
+        """
+        if not messages and not tools:
+            return 0
+
+        self.warm_up()
+        client = self.client
+        if client is None:
+            msg = "The Amazon Bedrock client was not initialized."
+            raise RuntimeError(msg)
+
+        system_prompts, bedrock_messages = _format_messages(messages)
+        converse_input: dict[str, Any] = {"messages": bedrock_messages}
+        if system_prompts:
+            converse_input["system"] = system_prompts
+
+        tool_config = _format_tools(flatten_tools_or_toolsets(tools)) if tools else None
+        if tool_config:
+            converse_input["toolConfig"] = tool_config
+
+        try:
+            response = client.count_tokens(modelId=self.model, input={"converse": converse_input})
+        except ClientError as exception:
+            msg = (
+                f"Could not count tokens using the model '{self.model}'. Amazon Bedrock's CountTokens API sizes only a "
+                f"complete, valid conversation and requires a model that supports token counting; see the underlying "
+                f"error for details."
+            )
+            raise AmazonBedrockInferenceError(msg) from exception
+
+        return response["inputTokens"]
+
+    def close(self) -> None:
+        """Close the Amazon Bedrock client and release its resources."""
+        if self.client is not None:
+            self.client.close()
+            self.client = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the counter.
+
+        :returns: A dictionary representation of the counter.
+        """
+        return default_to_dict(
+            self,
+            model=self.model,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
+            aws_region_name=self.aws_region_name,
+            aws_profile_name=self.aws_profile_name,
+            boto3_config=self.boto3_config,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AmazonBedrockTokenCounter":
+        """
+        Deserialize the counter.
+
+        :param data: A dictionary representation of the counter.
+        :returns: The deserialized counter.
+        """
+        return default_from_dict(cls, data)

--- a/integrations/amazon_bedrock/tests/test_token_counter.py
+++ b/integrations/amazon_bedrock/tests/test_token_counter.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from botocore.exceptions import ClientError
-from haystack.dataclasses import ChatMessage
+from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.tools import Tool
 from haystack.utils.auth import Secret
 
@@ -35,18 +35,6 @@ class TestAmazonBedrockTokenCounter:
         # the client is created lazily, on warm_up
         assert counter.client is None
 
-    def test_init_custom_parameters(self):
-        counter = AmazonBedrockTokenCounter(
-            model=MODEL,
-            aws_access_key_id=Secret.from_token("id"),
-            aws_secret_access_key=Secret.from_token("key"),
-            aws_region_name=Secret.from_token("us-west-2"),
-            boto3_config={"read_timeout": 1000},
-        )
-        assert counter.boto3_config == {"read_timeout": 1000}
-        assert counter.aws_region_name.resolve_value() == "us-west-2"
-        assert counter.client is None
-
     def test_empty_model(self):
         with pytest.raises(ValueError, match="cannot be None or empty string"):
             AmazonBedrockTokenCounter(model="")
@@ -68,12 +56,6 @@ class TestAmazonBedrockTokenCounter:
         with patch(_GET_AWS_SESSION, side_effect=Exception("boom")):
             with pytest.raises(AmazonBedrockConfigurationError):
                 counter.warm_up()
-
-    def test_user_agent(self, mock_boto3_session):
-        counter = AmazonBedrockTokenCounter(model=MODEL)
-        counter.warm_up()
-        config = mock_boto3_session.return_value.client.call_args.kwargs["config"]
-        assert config.user_agent_extra == "x-client-framework:haystack"
 
     def test_count(self, mock_boto3_session):
         counter = AmazonBedrockTokenCounter(model=MODEL)
@@ -109,12 +91,6 @@ class TestAmazonBedrockTokenCounter:
         )
         with pytest.raises(AmazonBedrockInferenceError, match="Could not count tokens"):
             counter.count([ChatMessage.from_user("Hello!")])
-
-    def test_count_raises_if_client_missing_after_warm_up(self):
-        counter = AmazonBedrockTokenCounter(model=MODEL)
-        with patch.object(counter, "warm_up"):  # no-op warm_up leaves the client unset
-            with pytest.raises(RuntimeError, match="client was not initialized"):
-                counter.count([ChatMessage.from_user("Hello!")])
 
     def test_close_releases_the_client(self, mock_boto3_session):
         counter = AmazonBedrockTokenCounter(model=MODEL)
@@ -162,12 +138,6 @@ class TestAmazonBedrockTokenCounter:
         assert counter.model == MODEL
         assert counter.boto3_config == {"read_timeout": 1000}
 
-    def test_from_dict_aws_region_name(self):
-        counter = AmazonBedrockTokenCounter.from_dict(
-            {"type": CLASS_TYPE, "init_parameters": {"model": MODEL, "aws_region_name": "us-east-1"}}
-        )
-        assert counter.aws_region_name == "us-east-1"
-
 
 @pytest.mark.integration
 @pytest.mark.skipif(
@@ -175,13 +145,22 @@ class TestAmazonBedrockTokenCounter:
     reason="AWS_REGION must be set (with AWS credentials available) for a live Bedrock call",
 )
 class TestAmazonBedrockTokenCounterInference:
-    def test_count_live(self):
+    def test_count_complex(self):
+        """Count tokens for a conversation with system, user, assistant and tool result messages, plus tools."""
         # Requires a model that supports Bedrock's CountTokens API (e.g. a current Claude model) and ambient AWS
         # credentials (a profile, static keys, or a Bedrock bearer token).
+        tool_call = ToolCall(tool_name="weather", arguments={"city": "Paris"}, id="tooluse_01")
+        messages = [
+            ChatMessage.from_system("You are a helpful weather assistant."),
+            ChatMessage.from_user("What is the weather in Paris?"),
+            ChatMessage.from_assistant("Let me check the weather for you.", tool_calls=[tool_call]),
+            ChatMessage.from_tool(tool_result="Weather in Paris: sunny", origin=tool_call),
+            ChatMessage.from_assistant("The weather in Paris is sunny."),
+        ]
         counter = AmazonBedrockTokenCounter(
             model="anthropic.claude-sonnet-4-20250514-v1:0",
             aws_region_name=Secret.from_token(os.environ["AWS_REGION"]),
         )
-        count = counter.count([ChatMessage.from_user("What is the capital of France?")])
+        count = counter.count(messages, tools=[_weather_tool()])
         assert isinstance(count, int)
-        assert count > 0
+        assert count > 20

--- a/integrations/amazon_bedrock/tests/test_token_counter.py
+++ b/integrations/amazon_bedrock/tests/test_token_counter.py
@@ -1,0 +1,187 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+from haystack.dataclasses import ChatMessage
+from haystack.tools import Tool
+from haystack.utils.auth import Secret
+
+from haystack_integrations.common.amazon_bedrock.errors import (
+    AmazonBedrockConfigurationError,
+    AmazonBedrockInferenceError,
+)
+from haystack_integrations.token_counters.amazon_bedrock import AmazonBedrockTokenCounter
+
+CLASS_TYPE = "haystack_integrations.token_counters.amazon_bedrock.token_counter.AmazonBedrockTokenCounter"
+MODEL = "anthropic.claude-sonnet-4-20250514-v1:0"
+
+_GET_AWS_SESSION = "haystack_integrations.token_counters.amazon_bedrock.token_counter.get_aws_session"
+
+
+def _weather_tool() -> Tool:
+    return Tool(
+        name="weather",
+        description="Get the weather for a city",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        function=lambda city: f"Weather in {city}: sunny",
+    )
+
+
+class TestAmazonBedrockTokenCounter:
+    def test_init(self):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        assert counter.model == MODEL
+        # the client is created lazily, on warm_up
+        assert counter.client is None
+
+    def test_init_custom_parameters(self):
+        counter = AmazonBedrockTokenCounter(
+            model=MODEL,
+            aws_access_key_id=Secret.from_token("id"),
+            aws_secret_access_key=Secret.from_token("key"),
+            aws_region_name=Secret.from_token("us-west-2"),
+            boto3_config={"read_timeout": 1000},
+        )
+        assert counter.boto3_config == {"read_timeout": 1000}
+        assert counter.aws_region_name.resolve_value() == "us-west-2"
+        assert counter.client is None
+
+    def test_empty_model(self):
+        with pytest.raises(ValueError, match="cannot be None or empty string"):
+            AmazonBedrockTokenCounter(model="")
+
+    def test_empty_input_does_not_initialize_the_client(self):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        assert counter.count([]) == 0
+        assert counter.client is None
+
+    def test_warm_up_initializes_the_client_once(self, mock_boto3_session):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        counter.warm_up()
+        counter.warm_up()
+        mock_boto3_session.return_value.client.assert_called_once()
+        assert mock_boto3_session.return_value.client.call_args[0][0] == "bedrock-runtime"
+
+    def test_warm_up_connection_error(self):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        with patch(_GET_AWS_SESSION, side_effect=Exception("boom")):
+            with pytest.raises(AmazonBedrockConfigurationError):
+                counter.warm_up()
+
+    def test_user_agent(self, mock_boto3_session):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        counter.warm_up()
+        config = mock_boto3_session.return_value.client.call_args.kwargs["config"]
+        assert config.user_agent_extra == "x-client-framework:haystack"
+
+    def test_count(self, mock_boto3_session):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        counter.warm_up()
+        counter.client.count_tokens.return_value = {"inputTokens": 42}
+
+        messages = [ChatMessage.from_system("You are a helpful assistant."), ChatMessage.from_user("Hello!")]
+        assert counter.count(messages) == 42
+
+        kwargs = counter.client.count_tokens.call_args.kwargs
+        assert kwargs["modelId"] == MODEL
+        converse = kwargs["input"]["converse"]
+        assert converse["system"] == [{"text": "You are a helpful assistant."}]
+        assert converse["messages"][0]["role"] == "user"
+        assert "toolConfig" not in converse
+
+    def test_count_with_tools(self, mock_boto3_session):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        counter.warm_up()
+        counter.client.count_tokens.return_value = {"inputTokens": 100}
+
+        result = counter.count([ChatMessage.from_user("What is the weather?")], tools=[_weather_tool()])
+        assert result == 100
+
+        converse = counter.client.count_tokens.call_args.kwargs["input"]["converse"]
+        assert converse["toolConfig"]["tools"][0]["toolSpec"]["name"] == "weather"
+
+    def test_count_raises_inference_error(self, mock_boto3_session):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        counter.warm_up()
+        counter.client.count_tokens.side_effect = ClientError(
+            {"Error": {"Code": "ValidationException", "Message": "boom"}}, "CountTokens"
+        )
+        with pytest.raises(AmazonBedrockInferenceError, match="Could not count tokens"):
+            counter.count([ChatMessage.from_user("Hello!")])
+
+    def test_count_raises_if_client_missing_after_warm_up(self):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        with patch.object(counter, "warm_up"):  # no-op warm_up leaves the client unset
+            with pytest.raises(RuntimeError, match="client was not initialized"):
+                counter.count([ChatMessage.from_user("Hello!")])
+
+    def test_close_releases_the_client(self, mock_boto3_session):
+        counter = AmazonBedrockTokenCounter(model=MODEL)
+        counter.warm_up()
+        client = counter.client
+        counter.close()
+        client.close.assert_called_once_with()
+        assert counter.client is None
+        counter.close()  # closing again is a no-op
+
+    def test_to_dict(self):
+        counter = AmazonBedrockTokenCounter(model=MODEL, boto3_config={"read_timeout": 1000})
+        assert counter.to_dict() == {
+            "type": CLASS_TYPE,
+            "init_parameters": {
+                "aws_access_key_id": {"type": "env_var", "env_vars": ["AWS_ACCESS_KEY_ID"], "strict": False},
+                "aws_secret_access_key": {"type": "env_var", "env_vars": ["AWS_SECRET_ACCESS_KEY"], "strict": False},
+                "aws_session_token": {"type": "env_var", "env_vars": ["AWS_SESSION_TOKEN"], "strict": False},
+                "aws_region_name": {"type": "env_var", "env_vars": ["AWS_DEFAULT_REGION"], "strict": False},
+                "aws_profile_name": {"type": "env_var", "env_vars": ["AWS_PROFILE"], "strict": False},
+                "model": MODEL,
+                "boto3_config": {"read_timeout": 1000},
+            },
+        }
+
+    def test_from_dict(self):
+        counter = AmazonBedrockTokenCounter.from_dict(
+            {
+                "type": CLASS_TYPE,
+                "init_parameters": {
+                    "aws_access_key_id": {"type": "env_var", "env_vars": ["AWS_ACCESS_KEY_ID"], "strict": False},
+                    "aws_secret_access_key": {
+                        "type": "env_var",
+                        "env_vars": ["AWS_SECRET_ACCESS_KEY"],
+                        "strict": False,
+                    },
+                    "aws_session_token": {"type": "env_var", "env_vars": ["AWS_SESSION_TOKEN"], "strict": False},
+                    "aws_region_name": {"type": "env_var", "env_vars": ["AWS_DEFAULT_REGION"], "strict": False},
+                    "aws_profile_name": {"type": "env_var", "env_vars": ["AWS_PROFILE"], "strict": False},
+                    "model": MODEL,
+                    "boto3_config": {"read_timeout": 1000},
+                },
+            }
+        )
+        assert counter.model == MODEL
+        assert counter.boto3_config == {"read_timeout": 1000}
+
+    def test_from_dict_aws_region_name(self):
+        counter = AmazonBedrockTokenCounter.from_dict(
+            {"type": CLASS_TYPE, "init_parameters": {"model": MODEL, "aws_region_name": "us-east-1"}}
+        )
+        assert counter.aws_region_name == "us-east-1"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("AWS_REGION"),
+    reason="AWS_REGION must be set (with AWS credentials available) for a live Bedrock call",
+)
+class TestAmazonBedrockTokenCounterInference:
+    def test_count_live(self):
+        # Requires a model that supports Bedrock's CountTokens API (e.g. a current Claude model) and ambient AWS
+        # credentials (a profile, static keys, or a Bedrock bearer token).
+        counter = AmazonBedrockTokenCounter(
+            model="anthropic.claude-sonnet-4-20250514-v1:0",
+            aws_region_name=Secret.from_token(os.environ["AWS_REGION"]),
+        )
+        count = counter.count([ChatMessage.from_user("What is the capital of France?")])
+        assert isinstance(count, int)
+        assert count > 0


### PR DESCRIPTION
Temporary same-repo copy of #3865 so the Bedrock integration tests run with the CI AWS role, which fork PRs cannot access. Will be closed and the branch deleted once the run finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)