### PR TITLE
feat!: HF API - add lifecycle handling

### DIFF
--- a/integrations/huggingface_api/pyproject.toml
+++ b/integrations/huggingface_api/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "httpx>=0.27.0", "huggingface_hub[inference]>=0.35.0"]
+dependencies = ["haystack-ai>=3.0.0", "httpx>=0.27.0", "huggingface_hub[inference]>=0.35.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/huggingface_api#readme"

--- a/integrations/huggingface_api/pyproject.toml
+++ b/integrations/huggingface_api/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=3.0.0", "httpx>=0.27.0", "huggingface_hub[inference]>=0.35.0"]
+dependencies = ["haystack-ai>=3.0.0", "httpx>=0.27.0", "huggingface_hub[inference]>=1.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/huggingface_api#readme"

--- a/integrations/huggingface_api/src/haystack_integrations/common/huggingface_api/utils.py
+++ b/integrations/huggingface_api/src/haystack_integrations/common/huggingface_api/utils.py
@@ -7,6 +7,7 @@ from enum import Enum
 from haystack.utils import Secret
 from huggingface_hub import HfApi
 from huggingface_hub.errors import RepositoryNotFoundError
+from huggingface_hub.utils import build_hf_headers, get_async_session, hf_raise_for_status
 
 
 class HFGenerationAPIType(Enum):
@@ -98,11 +99,32 @@ def _check_valid_model(model_id: str, model_type: HFModelType, token: Secret | N
         msg = f"Model {model_id} not found on HuggingFace Hub. Please provide a valid HuggingFace model_id."
         raise ValueError(msg) from e
 
+    _validate_model_type(model_id, model_type, model_info.pipeline_tag)
+
+
+async def _check_valid_model_async(model_id: str, model_type: HFModelType, token: Secret | None) -> None:
+    """Check asynchronously if the provided model ID corresponds to a valid model on Hugging Face Hub."""
+    api = HfApi()
+    try:
+        async with get_async_session() as client:
+            response = await client.get(
+                f"{api.endpoint}/api/models/{model_id}",
+                headers=build_hf_headers(token=token.resolve_value() if token else None),
+            )
+            hf_raise_for_status(response)
+    except RepositoryNotFoundError as e:
+        msg = f"Model {model_id} not found on HuggingFace Hub. Please provide a valid HuggingFace model_id."
+        raise ValueError(msg) from e
+
+    _validate_model_type(model_id, model_type, response.json().get("pipeline_tag"))
+
+
+def _validate_model_type(model_id: str, model_type: HFModelType, pipeline_tag: str | None) -> None:
     if model_type == HFModelType.EMBEDDING:
-        allowed_model = model_info.pipeline_tag in ["sentence-similarity", "feature-extraction"]
+        allowed_model = pipeline_tag in ["sentence-similarity", "feature-extraction"]
         error_msg = f"Model {model_id} is not a embedding model. Please provide a embedding model."
     elif model_type == HFModelType.GENERATION:
-        allowed_model = model_info.pipeline_tag in ["text-generation", "text2text-generation", "image-text-to-text"]
+        allowed_model = pipeline_tag in ["text-generation", "text2text-generation", "image-text-to-text"]
         error_msg = f"Model {model_id} is not a text generation model. Please provide a text generation model."
     else:
         allowed_model = False

--- a/integrations/huggingface_api/src/haystack_integrations/common/huggingface_api/utils.py
+++ b/integrations/huggingface_api/src/haystack_integrations/common/huggingface_api/utils.py
@@ -83,14 +83,15 @@ class HFModelType(Enum):
 
 def _check_valid_model(model_id: str, model_type: HFModelType, token: Secret | None) -> None:
     """
-    Check if the provided model ID corresponds to a valid model on HuggingFace Hub.
+    Check if the provided model ID corresponds to a valid model on Hugging Face Hub.
 
-    Also check if the model is an embedding or generation model.
+    Also check if the model supports the requested embedding or generation task.
 
-    :param model_id: A string representing the HuggingFace model ID.
-    :param model_type: the model type, HFModelType.EMBEDDING or HFModelType.GENERATION
-    :param token: The optional authentication token.
-    :raises ValueError: If the model is not found or is not a embedding model.
+    :param model_id: A string representing the Hugging Face model ID.
+    :param model_type: The model type, `HFModelType.EMBEDDING` or `HFModelType.GENERATION`.
+    :param token: The optional authentication secret.
+    :raises ValueError: If the secret cannot be resolved, the model is not found, or it does not match the
+        requested type.
     """
     api = HfApi()
     try:
@@ -103,7 +104,17 @@ def _check_valid_model(model_id: str, model_type: HFModelType, token: Secret | N
 
 
 async def _check_valid_model_async(model_id: str, model_type: HFModelType, token: Secret | None) -> None:
-    """Check asynchronously if the provided model ID corresponds to a valid model on Hugging Face Hub."""
+    """
+    Asynchronously check if the provided model ID corresponds to a valid model on Hugging Face Hub.
+
+    Also check if the model supports the requested embedding or generation task.
+
+    :param model_id: A string representing the Hugging Face model ID.
+    :param model_type: The model type, `HFModelType.EMBEDDING` or `HFModelType.GENERATION`.
+    :param token: The optional authentication secret.
+    :raises ValueError: If the secret cannot be resolved, the model is not found, or it does not match the
+        requested type.
+    """
     api = HfApi()
     try:
         async with get_async_session() as client:

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from asyncio import Semaphore, gather, to_thread
+from asyncio import Semaphore, gather
 from dataclasses import replace
 from itertools import chain
 from typing import Any
@@ -18,6 +18,7 @@ from haystack_integrations.common.huggingface_api.utils import (
     HFEmbeddingAPIType,
     HFModelType,
     _check_valid_model,
+    _check_valid_model_async,
 )
 
 logger = logging.getLogger(__name__)
@@ -199,6 +200,10 @@ class HuggingFaceAPIDocumentEmbedder:
         if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
             _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
 
+    async def _validate_model_async(self) -> None:
+        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+            await _check_valid_model_async(self._model_or_url, HFModelType.EMBEDDING, self.token)
+
     def _client_kwargs(self) -> dict[str, Any]:
         """Build the keyword arguments used to create Hugging Face clients."""
         return {"model": self._model_or_url, "token": self.token.resolve_value() if self.token else None}
@@ -212,8 +217,7 @@ class HuggingFaceAPIDocumentEmbedder:
     async def warm_up_async(self) -> None:
         """Create the asynchronous Hugging Face client."""
         if self._async_client is None:
-            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
-                await to_thread(self._validate_model)
+            await self._validate_model_async()
             self._async_client = AsyncInferenceClient(**self._client_kwargs())
 
     def close(self) -> None:
@@ -311,7 +315,12 @@ class HuggingFaceAPIDocumentEmbedder:
         ):
             batch = texts_to_embed[i : i + batch_size]
 
-            np_embeddings = self._client.feature_extraction(text=batch, truncate=truncate, normalize=normalize)
+            # huggingface_hub 1.0 types this parameter as str even though the API accepts batched inputs.
+            np_embeddings = self._client.feature_extraction(
+                text=batch,  # type: ignore[arg-type]
+                truncate=truncate,
+                normalize=normalize,
+            )
 
             if np_embeddings.ndim != _EXPECTED_EMBEDDING_NDIM or np_embeddings.shape[0] != len(batch):
                 msg = f"Expected embedding shape ({batch_size}, embedding_dim), got {np_embeddings.shape}"
@@ -334,8 +343,11 @@ class HuggingFaceAPIDocumentEmbedder:
 
         async def _runner(batch: list[str]) -> list[list[float]]:
             async with sem:
+                # huggingface_hub 1.0 types this parameter as str even though the API accepts batched inputs.
                 np_embeddings = await async_client.feature_extraction(
-                    text=batch, truncate=truncate, normalize=normalize
+                    text=batch,  # type: ignore[arg-type]
+                    truncate=truncate,
+                    normalize=normalize,
                 )
 
                 if np_embeddings.ndim != _EXPECTED_EMBEDDING_NDIM or np_embeddings.shape[0] != len(batch):

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from asyncio import Semaphore, gather
+from asyncio import Semaphore, gather, to_thread
 from dataclasses import replace
 from itertools import chain
 from typing import Any
@@ -161,7 +161,6 @@ class HuggingFaceAPIDocumentEmbedder:
             if model is None:
                 msg = "To use the Serverless Inference API, you need to specify the `model` parameter in `api_params`."
                 raise ValueError(msg)
-            _check_valid_model(model, HFModelType.EMBEDDING, token)
             model_or_url = model
         elif api_type in [HFEmbeddingAPIType.INFERENCE_ENDPOINTS, HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE]:
             url = api_params.get("url")
@@ -179,8 +178,6 @@ class HuggingFaceAPIDocumentEmbedder:
             msg = f"Unknown api_type {api_type}"
             raise ValueError(msg)
 
-        client_args: dict[str, Any] = {"model": model_or_url, "token": token.resolve_value() if token else None}
-
         self.api_type = api_type
         self.api_params = api_params
         self.token = token
@@ -193,8 +190,43 @@ class HuggingFaceAPIDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
         self.concurrency_limit = concurrency_limit
-        self._client = InferenceClient(**client_args)
-        self._async_client = AsyncInferenceClient(**client_args)
+        self._model_or_url = model_or_url
+        self._client: InferenceClient | None = None
+        self._async_client: AsyncInferenceClient | None = None
+
+    def _validate_model(self) -> None:
+        """Validate the configured serverless model."""
+        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+            _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments used to create Hugging Face clients."""
+        return {"model": self._model_or_url, "token": self.token.resolve_value() if self.token else None}
+
+    def warm_up(self) -> None:
+        """Create the synchronous Hugging Face client."""
+        if self._client is None:
+            self._validate_model()
+            self._client = InferenceClient(**self._client_kwargs())
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Hugging Face client."""
+        if self._async_client is None:
+            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+                await to_thread(self._validate_model)
+            self._async_client = AsyncInferenceClient(**self._client_kwargs())
+
+    def close(self) -> None:
+        """Close the synchronous Hugging Face client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous Hugging Face client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -270,6 +302,7 @@ class HuggingFaceAPIDocumentEmbedder:
         """
         Embed a list of texts in batches.
         """
+        assert self._client is not None  # noqa: S101
         truncate, normalize = self._adjust_api_parameters(self.truncate, self.normalize, self.api_type)
 
         all_embeddings: list = []
@@ -292,6 +325,8 @@ class HuggingFaceAPIDocumentEmbedder:
         """
         Embed a list of texts in batches asynchronously.
         """
+        assert self._async_client is not None  # noqa: S101
+        async_client = self._async_client
         truncate, normalize = self._adjust_api_parameters(self.truncate, self.normalize, self.api_type)
         sem = Semaphore(max(1, self.concurrency_limit))
         num_batches = (len(texts_to_embed) + batch_size - 1) // batch_size
@@ -299,7 +334,7 @@ class HuggingFaceAPIDocumentEmbedder:
 
         async def _runner(batch: list[str]) -> list[list[float]]:
             async with sem:
-                np_embeddings = await self._async_client.feature_extraction(
+                np_embeddings = await async_client.feature_extraction(
                     text=batch, truncate=truncate, normalize=normalize
                 )
 
@@ -342,6 +377,9 @@ class HuggingFaceAPIDocumentEmbedder:
             A dictionary with the following keys:
             - `documents`: A list of documents with embeddings.
         """
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
+
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = (
                 "HuggingFaceAPIDocumentEmbedder expects a list of Documents as input."
@@ -375,6 +413,9 @@ class HuggingFaceAPIDocumentEmbedder:
             A dictionary with the following keys:
             - `documents`: A list of documents with embeddings.
         """
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
+
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = (
                 "HuggingFaceAPIDocumentEmbedder expects a list of Documents as input."

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
@@ -315,7 +315,7 @@ class HuggingFaceAPIDocumentEmbedder:
         ):
             batch = texts_to_embed[i : i + batch_size]
 
-            # huggingface_hub 1.0 types this parameter as str even though the API accepts batched inputs.
+            # a batch is accepted but text is typed as str
             np_embeddings = self._client.feature_extraction(
                 text=batch,  # type: ignore[arg-type]
                 truncate=truncate,
@@ -343,7 +343,7 @@ class HuggingFaceAPIDocumentEmbedder:
 
         async def _runner(batch: list[str]) -> list[list[float]]:
             async with sem:
-                # huggingface_hub 1.0 types this parameter as str even though the API accepts batched inputs.
+                # a batch is accepted but text is typed as str
                 np_embeddings = await async_client.feature_extraction(
                     text=batch,  # type: ignore[arg-type]
                     truncate=truncate,

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/document_embedder.py
@@ -195,15 +195,6 @@ class HuggingFaceAPIDocumentEmbedder:
         self._client: InferenceClient | None = None
         self._async_client: AsyncInferenceClient | None = None
 
-    def _validate_model(self) -> None:
-        """Validate the configured serverless model."""
-        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
-            _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
-
-    async def _validate_model_async(self) -> None:
-        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
-            await _check_valid_model_async(self._model_or_url, HFModelType.EMBEDDING, self.token)
-
     def _client_kwargs(self) -> dict[str, Any]:
         """Build the keyword arguments used to create Hugging Face clients."""
         return {"model": self._model_or_url, "token": self.token.resolve_value() if self.token else None}
@@ -211,13 +202,15 @@ class HuggingFaceAPIDocumentEmbedder:
     def warm_up(self) -> None:
         """Create the synchronous Hugging Face client."""
         if self._client is None:
-            self._validate_model()
+            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+                _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
             self._client = InferenceClient(**self._client_kwargs())
 
     async def warm_up_async(self) -> None:
         """Create the asynchronous Hugging Face client."""
         if self._async_client is None:
-            await self._validate_model_async()
+            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+                await _check_valid_model_async(self._model_or_url, HFModelType.EMBEDDING, self.token)
             self._async_client = AsyncInferenceClient(**self._client_kwargs())
 
     def close(self) -> None:

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from asyncio import to_thread
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -14,6 +13,7 @@ from haystack_integrations.common.huggingface_api.utils import (
     HFEmbeddingAPIType,
     HFModelType,
     _check_valid_model,
+    _check_valid_model_async,
 )
 
 logger = logging.getLogger(__name__)
@@ -159,6 +159,10 @@ class HuggingFaceAPITextEmbedder:
         if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
             _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
 
+    async def _validate_model_async(self) -> None:
+        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+            await _check_valid_model_async(self._model_or_url, HFModelType.EMBEDDING, self.token)
+
     def _client_kwargs(self) -> dict[str, Any]:
         """Build the keyword arguments used to create Hugging Face clients."""
         return {"model": self._model_or_url, "token": self.token.resolve_value() if self.token else None}
@@ -172,8 +176,7 @@ class HuggingFaceAPITextEmbedder:
     async def warm_up_async(self) -> None:
         """Create the asynchronous Hugging Face client."""
         if self._async_client is None:
-            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
-                await to_thread(self._validate_model)
+            await self._validate_model_async()
             self._async_client = AsyncInferenceClient(**self._client_kwargs())
 
     def close(self) -> None:

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from asyncio import to_thread
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -125,7 +126,6 @@ class HuggingFaceAPITextEmbedder:
             if model is None:
                 msg = "To use the Serverless Inference API, you need to specify the `model` parameter in `api_params`."
                 raise ValueError(msg)
-            _check_valid_model(model, HFModelType.EMBEDDING, token)
             model_or_url = model
         elif api_type in [HFEmbeddingAPIType.INFERENCE_ENDPOINTS, HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE]:
             url = api_params.get("url")
@@ -150,8 +150,43 @@ class HuggingFaceAPITextEmbedder:
         self.suffix = suffix
         self.truncate = truncate
         self.normalize = normalize
-        self._client = InferenceClient(model_or_url, token=token.resolve_value() if token else None)
-        self._async_client = AsyncInferenceClient(model_or_url, token=token.resolve_value() if token else None)
+        self._model_or_url = model_or_url
+        self._client: InferenceClient | None = None
+        self._async_client: AsyncInferenceClient | None = None
+
+    def _validate_model(self) -> None:
+        """Validate the configured serverless model."""
+        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+            _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments used to create Hugging Face clients."""
+        return {"model": self._model_or_url, "token": self.token.resolve_value() if self.token else None}
+
+    def warm_up(self) -> None:
+        """Create the synchronous Hugging Face client."""
+        if self._client is None:
+            self._validate_model()
+            self._client = InferenceClient(**self._client_kwargs())
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Hugging Face client."""
+        if self._async_client is None:
+            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+                await to_thread(self._validate_model)
+            self._async_client = AsyncInferenceClient(**self._client_kwargs())
+
+    def close(self) -> None:
+        """Close the synchronous Hugging Face client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous Hugging Face client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def _prepare_input(self, text: str) -> tuple[str, bool | None, bool | None]:
         if not isinstance(text, str):
@@ -224,6 +259,9 @@ class HuggingFaceAPITextEmbedder:
             A dictionary with the following keys:
             - `embedding`: The embedding of the input text.
         """
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
+
         text_to_embed, truncate_val, normalize_val = self._prepare_input(text)
 
         np_embedding = self._client.feature_extraction(
@@ -256,6 +294,9 @@ class HuggingFaceAPITextEmbedder:
             A dictionary with the following keys:
             - `embedding`: The embedding of the input text.
         """
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
+
         text_to_embed, truncate_val, normalize_val = self._prepare_input(text)
 
         np_embedding = await self._async_client.feature_extraction(

--- a/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/embedders/huggingface_api/text_embedder.py
@@ -154,15 +154,6 @@ class HuggingFaceAPITextEmbedder:
         self._client: InferenceClient | None = None
         self._async_client: AsyncInferenceClient | None = None
 
-    def _validate_model(self) -> None:
-        """Validate the configured serverless model."""
-        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
-            _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
-
-    async def _validate_model_async(self) -> None:
-        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
-            await _check_valid_model_async(self._model_or_url, HFModelType.EMBEDDING, self.token)
-
     def _client_kwargs(self) -> dict[str, Any]:
         """Build the keyword arguments used to create Hugging Face clients."""
         return {"model": self._model_or_url, "token": self.token.resolve_value() if self.token else None}
@@ -170,13 +161,15 @@ class HuggingFaceAPITextEmbedder:
     def warm_up(self) -> None:
         """Create the synchronous Hugging Face client."""
         if self._client is None:
-            self._validate_model()
+            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+                _check_valid_model(self._model_or_url, HFModelType.EMBEDDING, self.token)
             self._client = InferenceClient(**self._client_kwargs())
 
     async def warm_up_async(self) -> None:
         """Create the asynchronous Hugging Face client."""
         if self._async_client is None:
-            await self._validate_model_async()
+            if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+                await _check_valid_model_async(self._model_or_url, HFModelType.EMBEDDING, self.token)
             self._async_client = AsyncInferenceClient(**self._client_kwargs())
 
     def close(self) -> None:

--- a/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
@@ -4,7 +4,6 @@
 
 import inspect
 import json
-from asyncio import to_thread
 from collections.abc import AsyncIterable, Iterable
 from datetime import datetime, timezone
 from typing import Any, Union
@@ -50,6 +49,7 @@ from haystack_integrations.common.huggingface_api.utils import (
     HFGenerationAPIType,
     HFModelType,
     _check_valid_model,
+    _check_valid_model_async,
 )
 
 logger = logging.getLogger(__name__)
@@ -449,6 +449,10 @@ class HuggingFaceAPIChatGenerator:
         if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
             _check_valid_model(self._model_or_url, HFModelType.GENERATION, self.token)
 
+    async def _validate_model_async(self) -> None:
+        if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
+            await _check_valid_model_async(self._model_or_url, HFModelType.GENERATION, self.token)
+
     def _client_kwargs(self) -> dict[str, Any]:
         """Build the keyword arguments used to create Hugging Face clients."""
         return {
@@ -477,8 +481,7 @@ class HuggingFaceAPIChatGenerator:
         """Create the asynchronous Hugging Face client and warm up the configured tools."""
         self._warm_up_tools()
         if self._async_client is None:
-            if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
-                await to_thread(self._validate_model)
+            await self._validate_model_async()
             self._async_client = AsyncInferenceClient(**self._client_kwargs())
 
     def close(self) -> None:

--- a/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
@@ -4,6 +4,7 @@
 
 import inspect
 import json
+from asyncio import to_thread
 from collections.abc import AsyncIterable, Iterable
 from datetime import datetime, timezone
 from typing import Any, Union
@@ -404,7 +405,6 @@ class HuggingFaceAPIChatGenerator:
             if model is None:
                 msg = "To use the Serverless Inference API, you need to specify the `model` parameter in `api_params`."
                 raise ValueError(msg)
-            _check_valid_model(model, HFModelType.GENERATION, token)
             model_or_url = model
         elif api_type in [HFGenerationAPIType.INFERENCE_ENDPOINTS, HFGenerationAPIType.TEXT_GENERATION_INFERENCE]:
             url = api_params.get("url")
@@ -438,27 +438,60 @@ class HuggingFaceAPIChatGenerator:
         self.token = token
         self.generation_kwargs = generation_kwargs
         self.streaming_callback = streaming_callback
-
-        resolved_api_params: dict[str, Any] = {k: v for k, v in api_params.items() if k not in ("model", "url")}
-        self._client = InferenceClient(
-            model_or_url, token=token.resolve_value() if token else None, **resolved_api_params
-        )
-        self._async_client = AsyncInferenceClient(
-            model_or_url, token=token.resolve_value() if token else None, **resolved_api_params
-        )
         self.tools = tools
-        self._is_warmed_up = False
+        self._model_or_url = model_or_url
+        self._client: InferenceClient | None = None
+        self._async_client: AsyncInferenceClient | None = None
+        self._tools_warmed_up = False
+
+    def _validate_model(self) -> None:
+        """Validate the configured serverless model."""
+        if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
+            _check_valid_model(self._model_or_url, HFModelType.GENERATION, self.token)
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments used to create Hugging Face clients."""
+        return {
+            "model": self._model_or_url,
+            "token": self.token.resolve_value() if self.token else None,
+            **{k: v for k, v in self.api_params.items() if k not in ("model", "url")},
+        }
+
+    def _warm_up_tools(self) -> None:
+        if not self._tools_warmed_up:
+            warm_up_tools(self.tools)
+            self._tools_warmed_up = True
 
     def warm_up(self) -> None:
         """
         Warm up the Hugging Face API chat generator.
 
-        This will warm up the tools registered in the chat generator.
-        This method is idempotent and will only warm up the tools once.
+        This creates the synchronous client and warms up the configured tools.
         """
-        if not self._is_warmed_up:
-            warm_up_tools(self.tools)
-            self._is_warmed_up = True
+        self._warm_up_tools()
+        if self._client is None:
+            self._validate_model()
+            self._client = InferenceClient(**self._client_kwargs())
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Hugging Face client and warm up the configured tools."""
+        self._warm_up_tools()
+        if self._async_client is None:
+            if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
+                await to_thread(self._validate_model)
+            self._async_client = AsyncInferenceClient(**self._client_kwargs())
+
+    def close(self) -> None:
+        """Close the synchronous Hugging Face client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous Hugging Face client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -520,8 +553,8 @@ class HuggingFaceAPIChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: A list containing the generated responses as ChatMessage objects.
         """
-        if not self._is_warmed_up:
-            self.warm_up()
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
 
         messages = _normalize_messages(messages)
 
@@ -582,8 +615,8 @@ class HuggingFaceAPIChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: A list containing the generated responses as ChatMessage objects.
         """
-        if not self._is_warmed_up:
-            self.warm_up()
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
 
         messages = _normalize_messages(messages)
 
@@ -615,6 +648,7 @@ class HuggingFaceAPIChatGenerator:
         generation_kwargs: dict[str, Any],
         streaming_callback: SyncStreamingCallbackT,
     ) -> dict[str, list[ChatMessage]]:
+        assert self._client is not None  # noqa: S101
         api_output: Iterable[ChatCompletionStreamOutput] = self._client.chat_completion(
             messages,
             stream=True,
@@ -643,6 +677,7 @@ class HuggingFaceAPIChatGenerator:
         generation_kwargs: dict[str, Any],
         tools: list["ChatCompletionInputTool"] | None = None,
     ) -> dict[str, list[ChatMessage]]:
+        assert self._client is not None  # noqa: S101
         api_chat_output: ChatCompletionOutput = self._client.chat_completion(
             messages=messages, tools=tools, **generation_kwargs
         )
@@ -686,6 +721,7 @@ class HuggingFaceAPIChatGenerator:
         generation_kwargs: dict[str, Any],
         streaming_callback: StreamingCallbackT,
     ) -> dict[str, list[ChatMessage]]:
+        assert self._async_client is not None  # noqa: S101
         api_output: AsyncIterable[ChatCompletionStreamOutput] = await self._async_client.chat_completion(
             messages,
             stream=True,
@@ -717,6 +753,7 @@ class HuggingFaceAPIChatGenerator:
         generation_kwargs: dict[str, Any],
         tools: list["ChatCompletionInputTool"] | None = None,
     ) -> dict[str, list[ChatMessage]]:
+        assert self._async_client is not None  # noqa: S101
         api_chat_output: ChatCompletionOutput = await self._async_client.chat_completion(
             messages=messages, tools=tools, **generation_kwargs
         )

--- a/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
+++ b/integrations/huggingface_api/src/haystack_integrations/components/generators/huggingface_api/chat/chat_generator.py
@@ -444,15 +444,6 @@ class HuggingFaceAPIChatGenerator:
         self._async_client: AsyncInferenceClient | None = None
         self._tools_warmed_up = False
 
-    def _validate_model(self) -> None:
-        """Validate the configured serverless model."""
-        if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
-            _check_valid_model(self._model_or_url, HFModelType.GENERATION, self.token)
-
-    async def _validate_model_async(self) -> None:
-        if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
-            await _check_valid_model_async(self._model_or_url, HFModelType.GENERATION, self.token)
-
     def _client_kwargs(self) -> dict[str, Any]:
         """Build the keyword arguments used to create Hugging Face clients."""
         return {
@@ -474,14 +465,16 @@ class HuggingFaceAPIChatGenerator:
         """
         self._warm_up_tools()
         if self._client is None:
-            self._validate_model()
+            if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
+                _check_valid_model(self._model_or_url, HFModelType.GENERATION, self.token)
             self._client = InferenceClient(**self._client_kwargs())
 
     async def warm_up_async(self) -> None:
         """Create the asynchronous Hugging Face client and warm up the configured tools."""
         self._warm_up_tools()
         if self._async_client is None:
-            await self._validate_model_async()
+            if self.api_type == HFGenerationAPIType.SERVERLESS_INFERENCE_API:
+                await _check_valid_model_async(self._model_or_url, HFModelType.GENERATION, self.token)
             self._async_client = AsyncInferenceClient(**self._client_kwargs())
 
     def close(self) -> None:

--- a/integrations/huggingface_api/tests/test_chat_generator.py
+++ b/integrations/huggingface_api/tests/test_chat_generator.py
@@ -129,12 +129,12 @@ def streaming_callback_handler(x):
     return x
 
 
-class TestHuggingFaceAPIChatGenerator:
+class TestInitializationAndSerialization:
     def test_init_invalid_api_type(self):
         with pytest.raises(ValueError):
             HuggingFaceAPIChatGenerator(api_type="invalid_api_type", api_params={})
 
-    def test_init_serverless(self, mock_check_valid_model):
+    def test_init_serverless(self):
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"temperature": 0.6}
         stop_words = ["stop"]
@@ -155,11 +155,10 @@ class TestHuggingFaceAPIChatGenerator:
         assert generator.streaming_callback == streaming_callback
         assert generator.tools is None
 
-        # check that client and async_client are initialized
-        assert generator._client.model == model
-        assert generator._async_client.model == model
+        assert generator._client is None
+        assert generator._async_client is None
 
-    def test_init_serverless_with_tools(self, mock_check_valid_model, tools):
+    def test_init_serverless_with_tools(self, tools):
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"temperature": 0.6}
         stop_words = ["stop"]
@@ -181,15 +180,8 @@ class TestHuggingFaceAPIChatGenerator:
         assert generator.streaming_callback == streaming_callback
         assert generator.tools == tools
 
-        assert generator._client.model == model
-        assert generator._async_client.model == model
-
-    def test_init_serverless_invalid_model(self, mock_check_valid_model):
-        mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id", response=MagicMock())
-        with pytest.raises(RepositoryNotFoundError):
-            HuggingFaceAPIChatGenerator(
-                api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "invalid_model_id"}
-            )
+        assert generator._client is None
+        assert generator._async_client is None
 
     def test_init_serverless_no_model(self):
         with pytest.raises(ValueError):
@@ -218,8 +210,8 @@ class TestHuggingFaceAPIChatGenerator:
         assert generator.streaming_callback == streaming_callback
         assert generator.tools is None
 
-        assert generator._client.model == url
-        assert generator._async_client.model == url
+        assert generator._client is None
+        assert generator._async_client is None
 
     def test_init_tgi_invalid_url(self):
         with pytest.raises(ValueError):
@@ -233,7 +225,7 @@ class TestHuggingFaceAPIChatGenerator:
                 api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE, api_params={"param": "irrelevant"}
             )
 
-    def test_init_fail_with_duplicate_tool_names(self, mock_check_valid_model, tools):
+    def test_init_fail_with_duplicate_tool_names(self, tools):
         duplicate_tools = [tools[0], tools[0]]
         with pytest.raises(ValueError):
             HuggingFaceAPIChatGenerator(
@@ -242,7 +234,7 @@ class TestHuggingFaceAPIChatGenerator:
                 tools=duplicate_tools,
             )
 
-    def test_init_fail_with_tools_and_streaming(self, mock_check_valid_model, tools):
+    def test_init_fail_with_tools_and_streaming(self, tools):
         with pytest.raises(ValueError):
             HuggingFaceAPIChatGenerator(
                 api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
@@ -251,7 +243,7 @@ class TestHuggingFaceAPIChatGenerator:
                 streaming_callback=streaming_callback_handler,
             )
 
-    def test_to_dict(self, mock_check_valid_model):
+    def test_to_dict(self):
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
 
         generator = HuggingFaceAPIChatGenerator(
@@ -275,7 +267,7 @@ class TestHuggingFaceAPIChatGenerator:
         loaded = HuggingFaceAPIChatGenerator.from_dict(result)
         assert loaded.tools == [tool]
 
-    def test_from_dict(self, mock_check_valid_model):
+    def test_from_dict(self):
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
 
         generator = HuggingFaceAPIChatGenerator(
@@ -297,7 +289,7 @@ class TestHuggingFaceAPIChatGenerator:
         assert generator_2.streaming_callback is None
         assert generator_2.tools == [tool]
 
-    def test_serde_in_pipeline(self, mock_check_valid_model):
+    def test_serde_in_pipeline(self):
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
 
         generator = HuggingFaceAPIChatGenerator(
@@ -343,6 +335,130 @@ class TestHuggingFaceAPIChatGenerator:
         new_pipeline = Pipeline.loads(pipeline_yaml)
         assert new_pipeline == pipeline
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_env_var("MISSING_HF_TOKEN"),
+        )
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            generator.warm_up()
+
+    def test_invalid_model_is_checked_at_warm_up(self, mock_check_valid_model):
+        mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id", response=MagicMock())
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "invalid_model_id"}
+        )
+        with pytest.raises(RepositoryNotFoundError):
+            generator.warm_up()
+
+    @patch("haystack_integrations.components.generators.huggingface_api.chat.chat_generator.InferenceClient")
+    def test_sync_lifecycle(self, mock_client_cls):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_token("test-token"),
+        )
+        client = mock_client_cls.return_value
+
+        generator.warm_up()
+        assert generator._client is client
+        assert generator._async_client is None
+
+        generator.close()
+        client.close.assert_called_once_with()
+        assert generator._client is None
+
+        generator.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.generators.huggingface_api.chat.chat_generator.AsyncInferenceClient")
+    async def test_async_lifecycle(self, mock_client_cls):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_token("test-token"),
+        )
+        client = MagicMock(close=AsyncMock())
+        mock_client_cls.return_value = client
+
+        await generator.warm_up_async()
+        assert generator._async_client is client
+        assert generator._client is None
+
+        await generator.close_async()
+        client.close.assert_awaited_once_with()
+        assert generator._async_client is None
+
+        await generator.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.huggingface_api.chat.chat_generator.InferenceClient")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        generator.warm_up()
+        generator.warm_up()
+        mock_client_cls.assert_called_once_with(model="https://example.com", token=None)
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.generators.huggingface_api.chat.chat_generator.AsyncInferenceClient")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        await generator.warm_up_async()
+        await generator.warm_up_async()
+        mock_client_cls.assert_called_once_with(model="https://example.com", token=None)
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        generator.close()
+        await generator.close_async()
+        assert generator._client is None
+        assert generator._async_client is None
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.generators.huggingface_api.chat.chat_generator.AsyncInferenceClient")
+    @patch("haystack_integrations.components.generators.huggingface_api.chat.chat_generator.InferenceClient")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        sync_client = mock_sync_cls.return_value
+        async_client = MagicMock(close=AsyncMock())
+        mock_async_cls.return_value = async_client
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.TEXT_GENERATION_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        generator.warm_up()
+        await generator.warm_up_async()
+
+        generator.close()
+        assert generator._client is None
+        assert generator._async_client is async_client
+        async_client.close.assert_not_awaited()
+
+        await generator.close_async()
+        assert generator._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_run(self, mock_check_valid_model, mock_chat_completion, chat_messages):
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
@@ -755,145 +871,8 @@ class TestHuggingFaceAPIChatGenerator:
         expected_stream_chunk.meta.pop("received_at", None)
         assert converted_stream_chunk == expected_stream_chunk
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    def test_live_run_serverless(self):
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
 
-        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
-        # templating for us.
-        messages = [
-            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
-        ]
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) > 0
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert response["replies"][0].text is not None
-        meta = response["replies"][0].meta
-        assert "usage" in meta
-        assert "prompt_tokens" in meta["usage"]
-        assert meta["usage"]["prompt_tokens"] > 0
-        assert "completion_tokens" in meta["usage"]
-        assert meta["usage"]["completion_tokens"] > 0
-        assert meta["model"] == "Qwen/Qwen3.5-9B"
-        assert meta["finish_reason"] is not None
-
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    def test_live_run_serverless_streaming(self):
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-            streaming_callback=streaming_callback_handler,
-        )
-
-        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
-        # templating for us.
-        messages = [
-            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
-        ]
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) > 0
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert response["replies"][0].text is not None
-
-        response_meta = response["replies"][0].meta
-        assert "completion_start_time" in response_meta
-        assert datetime.fromisoformat(response_meta["completion_start_time"]) <= datetime.now(timezone.utc)
-        assert "usage" in response_meta
-        assert "prompt_tokens" in response_meta["usage"]
-        assert response_meta["usage"]["prompt_tokens"] >= 0
-        assert "completion_tokens" in response_meta["usage"]
-        assert response_meta["usage"]["completion_tokens"] >= 0
-        assert response_meta["model"] == "Qwen/Qwen3.5-9B"
-        assert response_meta["finish_reason"] is not None
-
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    def test_live_run_with_tools(self, tools):
-        """
-        We test the round trip: generate tool call, pass tool message, generate response.
-
-        The model used here is not gated and kept in a warm state.
-        """
-
-        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"temperature": 0.5, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
-
-        results = generator.run(chat_messages, tools=tools)
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.tool_name == "weather"
-        assert "city" in tool_call.arguments
-        assert "Paris" in tool_call.arguments["city"]
-        assert message.meta["finish_reason"] == "tool_calls"
-
-        new_messages = [*chat_messages, message, ChatMessage.from_tool(tool_result="22° C", origin=tool_call)]
-
-        # the model tends to make tool calls if provided with tools, so we don't pass them here
-        results = generator.run(new_messages, generation_kwargs={"max_tokens": 50})
-
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower() and "22" in final_message.text
-
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    def test_live_run_multimodal(self, test_files_path):
-        image_path = test_files_path / "apple.jpg"
-        # Resize the image to keep this test fast
-        image_content = ImageContent.from_file_path(file_path=image_path, size=(100, 100))
-        messages = [ChatMessage.from_user(content_parts=["What does this image show? Max 5 words", image_content])]
-
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
-
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) > 0
-        message = response["replies"][0]
-        assert message.text
-        assert len(message.text) > 0
-        assert any(word in message.text.lower() for word in ["apple", "fruit", "red"])
-
+class TestAsyncRun:
     @pytest.mark.asyncio
     async def test_run_async(self, mock_check_valid_model, mock_chat_completion_async, chat_messages):
         generator = HuggingFaceAPIChatGenerator(
@@ -1079,96 +1058,9 @@ class TestHuggingFaceAPIChatGenerator:
             "usage": {"completion_tokens": 30, "prompt_tokens": 426},
         }
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    @pytest.mark.asyncio
-    async def test_live_run_async_serverless(self):
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
 
-        messages = [
-            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
-        ]
-        try:
-            response = await generator.run_async(messages=messages)
-
-            assert "replies" in response
-            assert isinstance(response["replies"], list)
-            assert len(response["replies"]) > 0
-            assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-            assert response["replies"][0].text is not None
-
-            meta = response["replies"][0].meta
-            assert "usage" in meta
-            assert "prompt_tokens" in meta["usage"]
-            assert meta["usage"]["prompt_tokens"] > 0
-            assert "completion_tokens" in meta["usage"]
-            assert meta["usage"]["completion_tokens"] > 0
-            assert meta["model"] == "Qwen/Qwen3.5-9B"
-            assert meta["finish_reason"] is not None
-        finally:
-            await generator._async_client.close()
-
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    @pytest.mark.flaky(reruns=2, reruns_delay=10)
-    def test_live_run_multi_turn_with_reasoning_model(self):
-        """
-        Test multi-turn conversation with a reasoning model.
-
-        This test verifies that:
-        1. Reasoning content is captured from the model's response
-        2. When the assistant message (with reasoning) is sent back in a multi-turn conversation,
-           the API call succeeds (reasoning is dropped during conversion since HF API doesn't support it)
-        """
-        # Note: Using a model that supports reasoning AND a provider that actually follows the spec defined in
-        # huggingface-hub. Reasoning content especially seems to be non-standard across providers and is either left
-        # in the main response or put in a new field that is not part of the official API.
-        # One combo that does respect the spec is together + openai/gpt-oss-20b.
-        # together + openai/gpt-oss-20b actually uses the expected reasoning field in the response
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            # We use together + openai/gpt-oss-20b since it actually returns reasoning content in the expected field
-            api_params={"model": "openai/gpt-oss-20b", "provider": "together"},
-            generation_kwargs={"max_tokens": 300},
-        )
-
-        # First turn: ask a question
-        messages = [ChatMessage.from_user("What is 2 + 2? Answer briefly.")]
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert len(response["replies"]) > 0
-        first_reply = response["replies"][0]
-        assert first_reply.text is not None
-        assert first_reply.reasoning is not None
-
-        # Second turn: send a follow-up including the assistant's previous response
-        # This tests that convert_message_to_hf_format properly handles messages
-        # that may contain ReasoningContent (it should skip it)
-        follow_up_messages = [
-            ChatMessage.from_user("What is 2 + 2? Answer briefly."),
-            first_reply,  # Include the assistant's response with reasoning
-            ChatMessage.from_user("Now what is 3 + 3? Answer briefly."),
-        ]
-        follow_up_response = generator.run(messages=follow_up_messages)
-
-        # Verify the second turn succeeds
-        assert "replies" in follow_up_response
-        assert len(follow_up_response["replies"]) > 0
-        assert follow_up_response["replies"][0].text is not None
-        assert follow_up_response["replies"][0].reasoning is not None
-
-    def test_hugging_face_api_generator_with_toolset_initialization(self, mock_check_valid_model, tools):
+class TestToolsAndReasoning:
+    def test_hugging_face_api_generator_with_toolset_initialization(self, tools):
         """Test that the HuggingFaceAPIChatGenerator can be initialized with a Toolset."""
         toolset = Toolset(tools)
         generator = HuggingFaceAPIChatGenerator(
@@ -1176,7 +1068,7 @@ class TestHuggingFaceAPIChatGenerator:
         )
         assert generator.tools == toolset
 
-    def test_from_dict_with_toolset(self, mock_check_valid_model, tools):
+    def test_from_dict_with_toolset(self, tools):
         """Test that the HuggingFaceAPIChatGenerator can be deserialized from a dictionary with a Toolset."""
         toolset = Toolset(tools)
         component = HuggingFaceAPIChatGenerator(
@@ -1190,7 +1082,7 @@ class TestHuggingFaceAPIChatGenerator:
         assert len(deserialized_component.tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
 
-    def test_to_dict_with_toolset(self, mock_check_valid_model, tools):
+    def test_to_dict_with_toolset(self, tools):
         """Test that the HuggingFaceAPIChatGenerator can be serialized to a dictionary with a Toolset."""
         toolset = Toolset(tools[:1])
         generator = HuggingFaceAPIChatGenerator(
@@ -1251,21 +1143,21 @@ class TestHuggingFaceAPIChatGenerator:
 
         # Verify initial state - warm_up not called yet
         assert MockTool.warm_up_call_count == 0
-        assert not component._is_warmed_up
+        assert not component._tools_warmed_up
 
         # Call warm_up() on the generator
         component.warm_up()
 
         # Assert that the tool's warm_up() was called
         assert MockTool.warm_up_call_count == 1
-        assert component._is_warmed_up
+        assert component._tools_warmed_up
 
         # Call warm_up() again and verify it's idempotent (only warms up once)
         component.warm_up()
 
         # The tool's warm_up should still only have been called once
         assert MockTool.warm_up_call_count == 1
-        assert component._is_warmed_up
+        assert component._tools_warmed_up
 
     def test_warm_up_with_no_tools(self, mock_check_valid_model):
         """Test that warm_up() works when no tools are provided."""
@@ -1274,18 +1166,18 @@ class TestHuggingFaceAPIChatGenerator:
         )
 
         # Verify initial state
-        assert not component._is_warmed_up
+        assert not component._tools_warmed_up
         assert component.tools is None
 
         # Call warm_up() - should not raise an error
         component.warm_up()
 
         # Verify the component is warmed up
-        assert component._is_warmed_up
+        assert component._tools_warmed_up
 
         # Call warm_up() again - should be idempotent
         component.warm_up()
-        assert component._is_warmed_up
+        assert component._tools_warmed_up
 
     def test_warm_up_with_multiple_tools(self, mock_check_valid_model):
         """Test that warm_up() works with multiple tools."""
@@ -1320,7 +1212,7 @@ class TestHuggingFaceAPIChatGenerator:
         # Assert that both tools' warm_up() were called
         assert "tool1" in warm_up_calls
         assert "tool2" in warm_up_calls
-        assert component._is_warmed_up
+        assert component._tools_warmed_up
 
         # Track count
         call_count = len(warm_up_calls)
@@ -1711,3 +1603,214 @@ class TestHuggingFaceAPIChatGenerator:
         params = hf_tools[0].function.parameters or hf_tools[0].function.arguments
         assert "$defs" not in params
         assert params["properties"]["user"]["type"] == "object"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestSyncIntegration:
+    def test_live_run_serverless(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
+        # templating for us.
+        messages = [
+            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
+        ]
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert response["replies"][0].text is not None
+        meta = response["replies"][0].meta
+        assert "usage" in meta
+        assert "prompt_tokens" in meta["usage"]
+        assert meta["usage"]["prompt_tokens"] > 0
+        assert "completion_tokens" in meta["usage"]
+        assert meta["usage"]["completion_tokens"] > 0
+        assert meta["model"] == "Qwen/Qwen3.5-9B"
+        assert meta["finish_reason"] is not None
+
+    def test_live_run_serverless_streaming(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+            streaming_callback=streaming_callback_handler,
+        )
+
+        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
+        # templating for us.
+        messages = [
+            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
+        ]
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert response["replies"][0].text is not None
+
+        response_meta = response["replies"][0].meta
+        assert "completion_start_time" in response_meta
+        assert datetime.fromisoformat(response_meta["completion_start_time"]) <= datetime.now(timezone.utc)
+        assert "usage" in response_meta
+        assert "prompt_tokens" in response_meta["usage"]
+        assert response_meta["usage"]["prompt_tokens"] >= 0
+        assert "completion_tokens" in response_meta["usage"]
+        assert response_meta["usage"]["completion_tokens"] >= 0
+        assert response_meta["model"] == "Qwen/Qwen3.5-9B"
+        assert response_meta["finish_reason"] is not None
+
+    def test_live_run_with_tools(self, tools):
+        """
+        We test the round trip: generate tool call, pass tool message, generate response.
+
+        The model used here is not gated and kept in a warm state.
+        """
+
+        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"temperature": 0.5, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        results = generator.run(chat_messages, tools=tools)
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert "city" in tool_call.arguments
+        assert "Paris" in tool_call.arguments["city"]
+        assert message.meta["finish_reason"] == "tool_calls"
+
+        new_messages = [*chat_messages, message, ChatMessage.from_tool(tool_result="22° C", origin=tool_call)]
+
+        # the model tends to make tool calls if provided with tools, so we don't pass them here
+        results = generator.run(new_messages, generation_kwargs={"max_tokens": 50})
+
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower() and "22" in final_message.text
+
+    def test_live_run_multimodal(self, test_files_path):
+        image_path = test_files_path / "apple.jpg"
+        # Resize the image to keep this test fast
+        image_content = ImageContent.from_file_path(file_path=image_path, size=(100, 100))
+        messages = [ChatMessage.from_user(content_parts=["What does this image show? Max 5 words", image_content])]
+
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        message = response["replies"][0]
+        assert message.text
+        assert len(message.text) > 0
+        assert any(word in message.text.lower() for word in ["apple", "fruit", "red"])
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestAsyncIntegration:
+    @pytest.mark.asyncio
+    async def test_live_run_async_serverless(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        messages = [
+            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
+        ]
+        try:
+            response = await generator.run_async(messages=messages)
+
+            assert "replies" in response
+            assert isinstance(response["replies"], list)
+            assert len(response["replies"]) > 0
+            assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+            assert response["replies"][0].text is not None
+
+            meta = response["replies"][0].meta
+            assert "usage" in meta
+            assert "prompt_tokens" in meta["usage"]
+            assert meta["usage"]["prompt_tokens"] > 0
+            assert "completion_tokens" in meta["usage"]
+            assert meta["usage"]["completion_tokens"] > 0
+            assert meta["model"] == "Qwen/Qwen3.5-9B"
+            assert meta["finish_reason"] is not None
+        finally:
+            await generator.close_async()
+
+    def test_live_run_multi_turn_with_reasoning_model(self):
+        """
+        Test multi-turn conversation with a reasoning model.
+
+        This test verifies that:
+        1. Reasoning content is captured from the model's response
+        2. When the assistant message (with reasoning) is sent back in a multi-turn conversation,
+           the API call succeeds (reasoning is dropped during conversion since HF API doesn't support it)
+        """
+        # Note: Using a model that supports reasoning AND a provider that actually follows the spec defined in
+        # huggingface-hub. Reasoning content especially seems to be non-standard across providers and is either left
+        # in the main response or put in a new field that is not part of the official API.
+        # One combo that does respect the spec is together + openai/gpt-oss-20b.
+        # together + openai/gpt-oss-20b actually uses the expected reasoning field in the response
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            # We use together + openai/gpt-oss-20b since it actually returns reasoning content in the expected field
+            api_params={"model": "openai/gpt-oss-20b", "provider": "together"},
+            generation_kwargs={"max_tokens": 300},
+        )
+
+        # First turn: ask a question
+        messages = [ChatMessage.from_user("What is 2 + 2? Answer briefly.")]
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert len(response["replies"]) > 0
+        first_reply = response["replies"][0]
+        assert first_reply.text is not None
+        assert first_reply.reasoning is not None
+
+        # Second turn: send a follow-up including the assistant's previous response
+        # This tests that convert_message_to_hf_format properly handles messages
+        # that may contain ReasoningContent (it should skip it)
+        follow_up_messages = [
+            ChatMessage.from_user("What is 2 + 2? Answer briefly."),
+            first_reply,  # Include the assistant's response with reasoning
+            ChatMessage.from_user("Now what is 3 + 3? Answer briefly."),
+        ]
+        follow_up_response = generator.run(messages=follow_up_messages)
+
+        # Verify the second turn succeeds
+        assert "replies" in follow_up_response
+        assert len(follow_up_response["replies"]) > 0
+        assert follow_up_response["replies"][0].text is not None
+        assert follow_up_response["replies"][0].reasoning is not None

--- a/integrations/huggingface_api/tests/test_chat_generator.py
+++ b/integrations/huggingface_api/tests/test_chat_generator.py
@@ -68,10 +68,16 @@ def tools():
 
 @pytest.fixture
 def mock_check_valid_model():
-    with patch(
-        "haystack_integrations.components.generators.huggingface_api.chat.chat_generator._check_valid_model",
-        MagicMock(return_value=None),
-    ) as mock:
+    with (
+        patch(
+            "haystack_integrations.components.generators.huggingface_api.chat.chat_generator._check_valid_model",
+            MagicMock(return_value=None),
+        ) as mock,
+        patch(
+            "haystack_integrations.components.generators.huggingface_api.chat.chat_generator._check_valid_model_async",
+            AsyncMock(return_value=None),
+        ),
+    ):
         yield mock
 
 
@@ -872,7 +878,133 @@ class TestRun:
         assert converted_stream_chunk == expected_stream_chunk
 
 
-class TestAsyncRun:
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestSyncIntegration:
+    def test_live_run_serverless(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
+        # templating for us.
+        messages = [
+            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
+        ]
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert response["replies"][0].text is not None
+        meta = response["replies"][0].meta
+        assert "usage" in meta
+        assert "prompt_tokens" in meta["usage"]
+        assert meta["usage"]["prompt_tokens"] > 0
+        assert "completion_tokens" in meta["usage"]
+        assert meta["usage"]["completion_tokens"] > 0
+        assert meta["model"] == "Qwen/Qwen3.5-9B"
+        assert meta["finish_reason"] is not None
+
+    def test_live_run_serverless_streaming(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+            streaming_callback=streaming_callback_handler,
+        )
+
+        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
+        # templating for us.
+        messages = [
+            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
+        ]
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert response["replies"][0].text is not None
+
+        response_meta = response["replies"][0].meta
+        assert "completion_start_time" in response_meta
+        assert datetime.fromisoformat(response_meta["completion_start_time"]) <= datetime.now(timezone.utc)
+        assert "usage" in response_meta
+        assert "prompt_tokens" in response_meta["usage"]
+        assert response_meta["usage"]["prompt_tokens"] >= 0
+        assert "completion_tokens" in response_meta["usage"]
+        assert response_meta["usage"]["completion_tokens"] >= 0
+        assert response_meta["model"] == "Qwen/Qwen3.5-9B"
+        assert response_meta["finish_reason"] is not None
+
+    def test_live_run_with_tools(self, tools):
+        """
+        We test the round trip: generate tool call, pass tool message, generate response.
+
+        The model used here is not gated and kept in a warm state.
+        """
+
+        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"temperature": 0.5, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        results = generator.run(chat_messages, tools=tools)
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert "city" in tool_call.arguments
+        assert "Paris" in tool_call.arguments["city"]
+        assert message.meta["finish_reason"] == "tool_calls"
+
+        new_messages = [*chat_messages, message, ChatMessage.from_tool(tool_result="22° C", origin=tool_call)]
+
+        # the model tends to make tool calls if provided with tools, so we don't pass them here
+        results = generator.run(new_messages, generation_kwargs={"max_tokens": 50})
+
+        assert len(results["replies"]) == 1
+        final_message = results["replies"][0]
+        assert not final_message.tool_calls
+        assert len(final_message.text) > 0
+        assert "paris" in final_message.text.lower() and "22" in final_message.text
+
+    def test_live_run_multimodal(self, test_files_path):
+        image_path = test_files_path / "apple.jpg"
+        # Resize the image to keep this test fast
+        image_content = ImageContent.from_file_path(file_path=image_path, size=(100, 100))
+        messages = [ChatMessage.from_user(content_parts=["What does this image show? Max 5 words", image_content])]
+
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        message = response["replies"][0]
+        assert message.text
+        assert len(message.text) > 0
+        assert any(word in message.text.lower() for word in ["apple", "fruit", "red"])
+
+
+class TestRunAsync:
     @pytest.mark.asyncio
     async def test_run_async(self, mock_check_valid_model, mock_chat_completion_async, chat_messages):
         generator = HuggingFaceAPIChatGenerator(
@@ -1059,7 +1191,99 @@ class TestAsyncRun:
         }
 
 
-class TestToolsAndReasoning:
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestAsyncIntegration:
+    @pytest.mark.asyncio
+    async def test_live_run_async_serverless(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
+            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+        messages = [
+            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
+        ]
+        try:
+            response = await generator.run_async(messages=messages)
+
+            assert "replies" in response
+            assert isinstance(response["replies"], list)
+            assert len(response["replies"]) > 0
+            assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+            assert response["replies"][0].text is not None
+
+            meta = response["replies"][0].meta
+            assert "usage" in meta
+            assert "prompt_tokens" in meta["usage"]
+            assert meta["usage"]["prompt_tokens"] > 0
+            assert "completion_tokens" in meta["usage"]
+            assert meta["usage"]["completion_tokens"] > 0
+            assert meta["model"] == "Qwen/Qwen3.5-9B"
+            assert meta["finish_reason"] is not None
+        finally:
+            await generator.close_async()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestReasoningIntegration:
+    def test_live_run_multi_turn_with_reasoning_model(self):
+        """
+        Test multi-turn conversation with a reasoning model.
+
+        This test verifies that:
+        1. Reasoning content is captured from the model's response
+        2. When the assistant message (with reasoning) is sent back in a multi-turn conversation,
+           the API call succeeds (reasoning is dropped during conversion since HF API doesn't support it)
+        """
+        # Note: Using a model that supports reasoning AND a provider that actually follows the spec defined in
+        # huggingface-hub. Reasoning content especially seems to be non-standard across providers and is either left
+        # in the main response or put in a new field that is not part of the official API.
+        # One combo that does respect the spec is together + openai/gpt-oss-20b.
+        # together + openai/gpt-oss-20b actually uses the expected reasoning field in the response
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            # We use together + openai/gpt-oss-20b since it actually returns reasoning content in the expected field
+            api_params={"model": "openai/gpt-oss-20b", "provider": "together"},
+            generation_kwargs={"max_tokens": 300},
+        )
+
+        # First turn: ask a question
+        messages = [ChatMessage.from_user("What is 2 + 2? Answer briefly.")]
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert len(response["replies"]) > 0
+        first_reply = response["replies"][0]
+        assert first_reply.text is not None
+        assert first_reply.reasoning is not None
+
+        # Second turn: send a follow-up including the assistant's previous response
+        # This tests that convert_message_to_hf_format properly handles messages
+        # that may contain ReasoningContent (it should skip it)
+        follow_up_messages = [
+            ChatMessage.from_user("What is 2 + 2? Answer briefly."),
+            first_reply,  # Include the assistant's response with reasoning
+            ChatMessage.from_user("Now what is 3 + 3? Answer briefly."),
+        ]
+        follow_up_response = generator.run(messages=follow_up_messages)
+
+        # Verify the second turn succeeds
+        assert "replies" in follow_up_response
+        assert len(follow_up_response["replies"]) > 0
+        assert follow_up_response["replies"][0].text is not None
+        assert follow_up_response["replies"][0].reasoning is not None
+
+
+class TestTools:
     def test_hugging_face_api_generator_with_toolset_initialization(self, tools):
         """Test that the HuggingFaceAPIChatGenerator can be initialized with a Toolset."""
         toolset = Toolset(tools)
@@ -1221,6 +1445,8 @@ class TestToolsAndReasoning:
         component.warm_up()
         assert len(warm_up_calls) == call_count
 
+
+class TestReasoning:
     def test_run_with_reasoning_non_streaming(self, mock_check_valid_model, chat_messages):
         """Test that reasoning content is correctly extracted from non-streaming responses."""
         with patch("huggingface_hub.InferenceClient.chat_completion", autospec=True) as mock_chat_completion:
@@ -1541,6 +1767,8 @@ class TestToolsAndReasoning:
         assert streaming_chunk.content == "Hello"
         assert streaming_chunk.reasoning is None
 
+
+class TestToolSchema:
     def test_resolve_schema_refs_no_defs(self):
         """Schema without $defs is returned as-is."""
         schema = {"type": "object", "properties": {"name": {"type": "string"}}}
@@ -1603,214 +1831,3 @@ class TestToolsAndReasoning:
         params = hf_tools[0].function.parameters or hf_tools[0].function.arguments
         assert "$defs" not in params
         assert params["properties"]["user"]["type"] == "object"
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("HF_TOKEN", None),
-    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-)
-class TestSyncIntegration:
-    def test_live_run_serverless(self):
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
-
-        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
-        # templating for us.
-        messages = [
-            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
-        ]
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) > 0
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert response["replies"][0].text is not None
-        meta = response["replies"][0].meta
-        assert "usage" in meta
-        assert "prompt_tokens" in meta["usage"]
-        assert meta["usage"]["prompt_tokens"] > 0
-        assert "completion_tokens" in meta["usage"]
-        assert meta["usage"]["completion_tokens"] > 0
-        assert meta["model"] == "Qwen/Qwen3.5-9B"
-        assert meta["finish_reason"] is not None
-
-    def test_live_run_serverless_streaming(self):
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-            streaming_callback=streaming_callback_handler,
-        )
-
-        # No need for instruction tokens here since we use the chat_completion endpoint which handles the chat
-        # templating for us.
-        messages = [
-            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
-        ]
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) > 0
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert response["replies"][0].text is not None
-
-        response_meta = response["replies"][0].meta
-        assert "completion_start_time" in response_meta
-        assert datetime.fromisoformat(response_meta["completion_start_time"]) <= datetime.now(timezone.utc)
-        assert "usage" in response_meta
-        assert "prompt_tokens" in response_meta["usage"]
-        assert response_meta["usage"]["prompt_tokens"] >= 0
-        assert "completion_tokens" in response_meta["usage"]
-        assert response_meta["usage"]["completion_tokens"] >= 0
-        assert response_meta["model"] == "Qwen/Qwen3.5-9B"
-        assert response_meta["finish_reason"] is not None
-
-    def test_live_run_with_tools(self, tools):
-        """
-        We test the round trip: generate tool call, pass tool message, generate response.
-
-        The model used here is not gated and kept in a warm state.
-        """
-
-        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"temperature": 0.5, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
-
-        results = generator.run(chat_messages, tools=tools)
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.tool_name == "weather"
-        assert "city" in tool_call.arguments
-        assert "Paris" in tool_call.arguments["city"]
-        assert message.meta["finish_reason"] == "tool_calls"
-
-        new_messages = [*chat_messages, message, ChatMessage.from_tool(tool_result="22° C", origin=tool_call)]
-
-        # the model tends to make tool calls if provided with tools, so we don't pass them here
-        results = generator.run(new_messages, generation_kwargs={"max_tokens": 50})
-
-        assert len(results["replies"]) == 1
-        final_message = results["replies"][0]
-        assert not final_message.tool_calls
-        assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower() and "22" in final_message.text
-
-    def test_live_run_multimodal(self, test_files_path):
-        image_path = test_files_path / "apple.jpg"
-        # Resize the image to keep this test fast
-        image_content = ImageContent.from_file_path(file_path=image_path, size=(100, 100))
-        messages = [ChatMessage.from_user(content_parts=["What does this image show? Max 5 words", image_content])]
-
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
-
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) > 0
-        message = response["replies"][0]
-        assert message.text
-        assert len(message.text) > 0
-        assert any(word in message.text.lower() for word in ["apple", "fruit", "red"])
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("HF_TOKEN", None),
-    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-)
-class TestAsyncIntegration:
-    @pytest.mark.asyncio
-    async def test_live_run_async_serverless(self):
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3.5-9B", "provider": "together"},
-            generation_kwargs={"max_tokens": 20, "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
-
-        messages = [
-            ChatMessage.from_user("What is the capital of France? Be concise only provide the capital, nothing else.")
-        ]
-        try:
-            response = await generator.run_async(messages=messages)
-
-            assert "replies" in response
-            assert isinstance(response["replies"], list)
-            assert len(response["replies"]) > 0
-            assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-            assert response["replies"][0].text is not None
-
-            meta = response["replies"][0].meta
-            assert "usage" in meta
-            assert "prompt_tokens" in meta["usage"]
-            assert meta["usage"]["prompt_tokens"] > 0
-            assert "completion_tokens" in meta["usage"]
-            assert meta["usage"]["completion_tokens"] > 0
-            assert meta["model"] == "Qwen/Qwen3.5-9B"
-            assert meta["finish_reason"] is not None
-        finally:
-            await generator.close_async()
-
-    def test_live_run_multi_turn_with_reasoning_model(self):
-        """
-        Test multi-turn conversation with a reasoning model.
-
-        This test verifies that:
-        1. Reasoning content is captured from the model's response
-        2. When the assistant message (with reasoning) is sent back in a multi-turn conversation,
-           the API call succeeds (reasoning is dropped during conversion since HF API doesn't support it)
-        """
-        # Note: Using a model that supports reasoning AND a provider that actually follows the spec defined in
-        # huggingface-hub. Reasoning content especially seems to be non-standard across providers and is either left
-        # in the main response or put in a new field that is not part of the official API.
-        # One combo that does respect the spec is together + openai/gpt-oss-20b.
-        # together + openai/gpt-oss-20b actually uses the expected reasoning field in the response
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            # We use together + openai/gpt-oss-20b since it actually returns reasoning content in the expected field
-            api_params={"model": "openai/gpt-oss-20b", "provider": "together"},
-            generation_kwargs={"max_tokens": 300},
-        )
-
-        # First turn: ask a question
-        messages = [ChatMessage.from_user("What is 2 + 2? Answer briefly.")]
-        response = generator.run(messages=messages)
-
-        assert "replies" in response
-        assert len(response["replies"]) > 0
-        first_reply = response["replies"][0]
-        assert first_reply.text is not None
-        assert first_reply.reasoning is not None
-
-        # Second turn: send a follow-up including the assistant's previous response
-        # This tests that convert_message_to_hf_format properly handles messages
-        # that may contain ReasoningContent (it should skip it)
-        follow_up_messages = [
-            ChatMessage.from_user("What is 2 + 2? Answer briefly."),
-            first_reply,  # Include the assistant's response with reasoning
-            ChatMessage.from_user("Now what is 3 + 3? Answer briefly."),
-        ]
-        follow_up_response = generator.run(messages=follow_up_messages)
-
-        # Verify the second turn succeeds
-        assert "replies" in follow_up_response
-        assert len(follow_up_response["replies"]) > 0
-        assert follow_up_response["replies"][0].text is not None
-        assert follow_up_response["replies"][0].reasoning is not None

--- a/integrations/huggingface_api/tests/test_document_embedder.py
+++ b/integrations/huggingface_api/tests/test_document_embedder.py
@@ -18,10 +18,16 @@ from haystack_integrations.components.embedders.huggingface_api import HuggingFa
 
 @pytest.fixture
 def mock_check_valid_model():
-    with patch(
-        "haystack_integrations.components.embedders.huggingface_api.document_embedder._check_valid_model",
-        MagicMock(return_value=None),
-    ) as mock:
+    with (
+        patch(
+            "haystack_integrations.components.embedders.huggingface_api.document_embedder._check_valid_model",
+            MagicMock(return_value=None),
+        ) as mock,
+        patch(
+            "haystack_integrations.components.embedders.huggingface_api.document_embedder._check_valid_model_async",
+            AsyncMock(return_value=None),
+        ),
+    ):
         yield mock
 
 
@@ -499,6 +505,68 @@ class TestRun:
         assert truncate is True
         assert normalize is False
 
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestIntegration:
+    def test_live_run_serverless(self):
+        docs = [
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
+        ]
+
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
+            meta_fields_to_embed=["topic"],
+            embedding_separator=" | ",
+        )
+        embedder.warm_up()
+        assert embedder._client is not None
+        embedder._client.timeout = 10  # we want to fail fast if the server is not responding
+        result = embedder.run(documents=docs)
+        documents_with_embeddings = result["documents"]
+
+        assert isinstance(documents_with_embeddings, list)
+        assert len(documents_with_embeddings) == len(docs)
+        for doc in documents_with_embeddings:
+            assert isinstance(doc, Document)
+            assert isinstance(doc.embedding, list)
+            assert len(doc.embedding) == 384
+            assert all(isinstance(x, float) for x in doc.embedding)
+
+    @pytest.mark.asyncio
+    async def test_live_run_serverless_async(self) -> None:
+        docs = [
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
+        ]
+
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
+            meta_fields_to_embed=["topic"],
+            embedding_separator=" | ",
+        )
+        await embedder.warm_up_async()
+        assert embedder._async_client is not None
+        embedder._async_client.timeout = 10  # we want to fail fast if the server is not responding
+        result = await embedder.run_async(documents=docs)
+        documents_with_embeddings = result["documents"]
+
+        assert isinstance(documents_with_embeddings, list)
+        assert len(documents_with_embeddings) == len(docs)
+        for doc in documents_with_embeddings:
+            assert isinstance(doc, Document)
+            assert isinstance(doc.embedding, list)
+            assert len(doc.embedding) == 384
+            assert all(isinstance(x, float) for x in doc.embedding)
+
+
+class TestRunAsync:
     @pytest.mark.asyncio
     async def test_embed_batch_async(self, mock_check_valid_model, caplog):
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
@@ -654,66 +722,6 @@ class TestRun:
 
             assert mock_embedding_patch.call_count == 2
 
-        documents_with_embeddings = result["documents"]
-
-        assert isinstance(documents_with_embeddings, list)
-        assert len(documents_with_embeddings) == len(docs)
-        for doc in documents_with_embeddings:
-            assert isinstance(doc, Document)
-            assert isinstance(doc.embedding, list)
-            assert len(doc.embedding) == 384
-            assert all(isinstance(x, float) for x in doc.embedding)
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(
-    not os.environ.get("HF_TOKEN", None),
-    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-)
-class TestIntegration:
-    def test_live_run_serverless(self):
-        docs = [
-            Document(content="I love cheese", meta={"topic": "Cuisine"}),
-            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
-        ]
-
-        embedder = HuggingFaceAPIDocumentEmbedder(
-            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
-            meta_fields_to_embed=["topic"],
-            embedding_separator=" | ",
-        )
-        embedder.warm_up()
-        assert embedder._client is not None
-        embedder._client.timeout = 10  # we want to fail fast if the server is not responding
-        result = embedder.run(documents=docs)
-        documents_with_embeddings = result["documents"]
-
-        assert isinstance(documents_with_embeddings, list)
-        assert len(documents_with_embeddings) == len(docs)
-        for doc in documents_with_embeddings:
-            assert isinstance(doc, Document)
-            assert isinstance(doc.embedding, list)
-            assert len(doc.embedding) == 384
-            assert all(isinstance(x, float) for x in doc.embedding)
-
-    @pytest.mark.asyncio
-    async def test_live_run_serverless_async(self) -> None:
-        docs = [
-            Document(content="I love cheese", meta={"topic": "Cuisine"}),
-            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
-        ]
-
-        embedder = HuggingFaceAPIDocumentEmbedder(
-            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
-            meta_fields_to_embed=["topic"],
-            embedding_separator=" | ",
-        )
-        await embedder.warm_up_async()
-        assert embedder._async_client is not None
-        embedder._async_client.timeout = 10  # we want to fail fast if the server is not responding
-        result = await embedder.run_async(documents=docs)
         documents_with_embeddings = result["documents"]
 
         assert isinstance(documents_with_embeddings, list)

--- a/integrations/huggingface_api/tests/test_document_embedder.py
+++ b/integrations/huggingface_api/tests/test_document_embedder.py
@@ -4,8 +4,7 @@
 
 import os
 import random
-import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from haystack.dataclasses import Document
@@ -30,12 +29,12 @@ def mock_embedding_generation(text, **kwargs):
     return array([[random.random() for _ in range(384)] for _ in range(len(text))])
 
 
-class TestHuggingFaceAPIDocumentEmbedder:
+class TestInitializationAndSerialization:
     def test_init_invalid_api_type(self):
         with pytest.raises(ValueError):
             HuggingFaceAPIDocumentEmbedder(api_type="invalid_api_type", api_params={})
 
-    def test_init_serverless(self, mock_check_valid_model):
+    def test_init_serverless(self):
         model = "BAAI/bge-small-en-v1.5"
         embedder = HuggingFaceAPIDocumentEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": model}
@@ -51,13 +50,8 @@ class TestHuggingFaceAPIDocumentEmbedder:
         assert embedder.progress_bar
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
-
-    def test_init_serverless_invalid_model(self, mock_check_valid_model):
-        mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id", response=MagicMock())
-        with pytest.raises(RepositoryNotFoundError):
-            HuggingFaceAPIDocumentEmbedder(
-                api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "invalid_model_id"}
-            )
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init_serverless_no_model(self):
         with pytest.raises(ValueError):
@@ -82,6 +76,8 @@ class TestHuggingFaceAPIDocumentEmbedder:
         assert embedder.progress_bar
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init_tei_invalid_url(self):
         with pytest.raises(ValueError):
@@ -95,7 +91,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
                 api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE, api_params={"param": "irrelevant"}
             )
 
-    def test_to_dict(self, mock_check_valid_model):
+    def test_to_dict(self):
         embedder = HuggingFaceAPIDocumentEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
             api_params={"model": "BAAI/bge-small-en-v1.5"},
@@ -131,7 +127,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             },
         }
 
-    def test_from_dict(self, mock_check_valid_model):
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.embedders.huggingface_api.document_embedder"
             ".HuggingFaceAPIDocumentEmbedder",
@@ -165,6 +161,130 @@ class TestHuggingFaceAPIDocumentEmbedder:
         assert embedder.embedding_separator == " "
         assert embedder.concurrency_limit == 7
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_env_var("MISSING_HF_TOKEN"),
+        )
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            embedder.warm_up()
+
+    def test_invalid_model_is_checked_at_warm_up(self, mock_check_valid_model):
+        mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id", response=MagicMock())
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "invalid_model_id"}
+        )
+        with pytest.raises(RepositoryNotFoundError):
+            embedder.warm_up()
+
+    @patch("haystack_integrations.components.embedders.huggingface_api.document_embedder.InferenceClient")
+    def test_sync_lifecycle(self, mock_client_cls):
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_token("test-token"),
+        )
+        client = mock_client_cls.return_value
+
+        embedder.warm_up()
+        assert embedder._client is client
+        assert embedder._async_client is None
+
+        embedder.close()
+        client.close.assert_called_once_with()
+        assert embedder._client is None
+
+        embedder.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.huggingface_api.document_embedder.AsyncInferenceClient")
+    async def test_async_lifecycle(self, mock_client_cls):
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_token("test-token"),
+        )
+        client = MagicMock(close=AsyncMock())
+        mock_client_cls.return_value = client
+
+        await embedder.warm_up_async()
+        assert embedder._async_client is client
+        assert embedder._client is None
+
+        await embedder.close_async()
+        client.close.assert_awaited_once_with()
+        assert embedder._async_client is None
+
+        await embedder.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.huggingface_api.document_embedder.InferenceClient")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        embedder.warm_up()
+        embedder.warm_up()
+        mock_client_cls.assert_called_once_with(model="https://example.com", token=None)
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.huggingface_api.document_embedder.AsyncInferenceClient")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        await embedder.warm_up_async()
+        await embedder.warm_up_async()
+        mock_client_cls.assert_called_once_with(model="https://example.com", token=None)
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        embedder.close()
+        await embedder.close_async()
+        assert embedder._client is None
+        assert embedder._async_client is None
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.huggingface_api.document_embedder.AsyncInferenceClient")
+    @patch("haystack_integrations.components.embedders.huggingface_api.document_embedder.InferenceClient")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        sync_client = mock_sync_cls.return_value
+        async_client = MagicMock(close=AsyncMock())
+        mock_async_cls.return_value = async_client
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        embedder.warm_up()
+        await embedder.warm_up_async()
+
+        embedder.close()
+        assert embedder._client is None
+        assert embedder._async_client is async_client
+        async_client.close.assert_not_awaited()
+
+        await embedder.close_async()
+        assert embedder._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_prepare_texts_to_embed_w_metadata(self):
         documents = [
             Document(content=f"document number {i}: content", meta={"meta_field": f"meta_value {i}"}) for i in range(5)
@@ -188,7 +308,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             "meta_value 4 | document number 4: content",
         ]
 
-    def test_prepare_texts_to_embed_w_suffix(self, mock_check_valid_model):
+    def test_prepare_texts_to_embed_w_suffix(self):
         documents = [Document(content=f"document number {i}") for i in range(5)]
 
         embedder = HuggingFaceAPIDocumentEmbedder(
@@ -220,6 +340,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
                 api_params={"model": "BAAI/bge-small-en-v1.5"},
                 token=Secret.from_token("fake-api-token"),
             )
+            embedder.warm_up()
             embeddings = embedder._embed_batch(texts_to_embed=texts, batch_size=2)
 
             assert mock_embedding_patch.call_count == 3
@@ -248,6 +369,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
                 api_params={"model": "BAAI/bge-small-en-v1.5"},
                 token=Secret.from_token("fake-api-token"),
             )
+            embedder.warm_up()
 
             with pytest.raises(ValueError):
                 embedder._embed_batch(texts_to_embed=texts, batch_size=2)
@@ -261,6 +383,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
                 api_params={"model": "BAAI/bge-small-en-v1.5"},
                 token=Secret.from_token("fake-api-token"),
             )
+            embedder.warm_up()
 
             with pytest.raises(ValueError):
                 embedder._embed_batch(texts_to_embed=texts, batch_size=2)
@@ -376,67 +499,6 @@ class TestHuggingFaceAPIDocumentEmbedder:
         assert truncate is True
         assert normalize is False
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
-    def test_live_run_serverless(self):
-        docs = [
-            Document(content="I love cheese", meta={"topic": "Cuisine"}),
-            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
-        ]
-
-        embedder = HuggingFaceAPIDocumentEmbedder(
-            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
-            meta_fields_to_embed=["topic"],
-            embedding_separator=" | ",
-        )
-        embedder._client.timeout = 10  # we want to fail fast if the server is not responding
-        result = embedder.run(documents=docs)
-        documents_with_embeddings = result["documents"]
-
-        assert isinstance(documents_with_embeddings, list)
-        assert len(documents_with_embeddings) == len(docs)
-        for doc in documents_with_embeddings:
-            assert isinstance(doc, Document)
-            assert isinstance(doc.embedding, list)
-            assert len(doc.embedding) == 384
-            assert all(isinstance(x, float) for x in doc.embedding)
-
-    @pytest.mark.asyncio
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
-    async def test_live_run_serverless_async(self) -> None:
-        docs = [
-            Document(content="I love cheese", meta={"topic": "Cuisine"}),
-            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
-        ]
-
-        embedder = HuggingFaceAPIDocumentEmbedder(
-            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
-            meta_fields_to_embed=["topic"],
-            embedding_separator=" | ",
-        )
-        embedder._async_client.timeout = 10  # we want to fail fast if the server is not responding
-        result = await embedder.run_async(documents=docs)
-        documents_with_embeddings = result["documents"]
-
-        assert isinstance(documents_with_embeddings, list)
-        assert len(documents_with_embeddings) == len(docs)
-        for doc in documents_with_embeddings:
-            assert isinstance(doc, Document)
-            assert isinstance(doc.embedding, list)
-            assert len(doc.embedding) == 384
-            assert all(isinstance(x, float) for x in doc.embedding)
-
     @pytest.mark.asyncio
     async def test_embed_batch_async(self, mock_check_valid_model, caplog):
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
@@ -450,6 +512,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
                 token=Secret.from_token("fake-api-token"),
                 concurrency_limit=4,
             )
+            await embedder.warm_up_async()
             embeddings = await embedder._embed_batch_async(texts_to_embed=texts, batch_size=2)
 
             assert mock_embedding_patch.call_count == 3
@@ -480,6 +543,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
                 token=Secret.from_token("fake-api-token"),
                 concurrency_limit=1,
             )
+            await embedder.warm_up_async()
 
             with pytest.raises(ValueError):
                 await embedder._embed_batch_async(texts_to_embed=texts, batch_size=2)
@@ -494,6 +558,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
                 token=Secret.from_token("fake-api-token"),
                 concurrency_limit=1,
             )
+            await embedder.warm_up_async()
 
             with pytest.raises(ValueError):
                 await embedder._embed_batch_async(texts_to_embed=texts, batch_size=2)
@@ -589,6 +654,66 @@ class TestHuggingFaceAPIDocumentEmbedder:
 
             assert mock_embedding_patch.call_count == 2
 
+        documents_with_embeddings = result["documents"]
+
+        assert isinstance(documents_with_embeddings, list)
+        assert len(documents_with_embeddings) == len(docs)
+        for doc in documents_with_embeddings:
+            assert isinstance(doc, Document)
+            assert isinstance(doc.embedding, list)
+            assert len(doc.embedding) == 384
+            assert all(isinstance(x, float) for x in doc.embedding)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestIntegration:
+    def test_live_run_serverless(self):
+        docs = [
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
+        ]
+
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
+            meta_fields_to_embed=["topic"],
+            embedding_separator=" | ",
+        )
+        embedder.warm_up()
+        assert embedder._client is not None
+        embedder._client.timeout = 10  # we want to fail fast if the server is not responding
+        result = embedder.run(documents=docs)
+        documents_with_embeddings = result["documents"]
+
+        assert isinstance(documents_with_embeddings, list)
+        assert len(documents_with_embeddings) == len(docs)
+        for doc in documents_with_embeddings:
+            assert isinstance(doc, Document)
+            assert isinstance(doc.embedding, list)
+            assert len(doc.embedding) == 384
+            assert all(isinstance(x, float) for x in doc.embedding)
+
+    @pytest.mark.asyncio
+    async def test_live_run_serverless_async(self) -> None:
+        docs = [
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
+        ]
+
+        embedder = HuggingFaceAPIDocumentEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
+            meta_fields_to_embed=["topic"],
+            embedding_separator=" | ",
+        )
+        await embedder.warm_up_async()
+        assert embedder._async_client is not None
+        embedder._async_client.timeout = 10  # we want to fail fast if the server is not responding
+        result = await embedder.run_async(documents=docs)
         documents_with_embeddings = result["documents"]
 
         assert isinstance(documents_with_embeddings, list)

--- a/integrations/huggingface_api/tests/test_document_embedder.py
+++ b/integrations/huggingface_api/tests/test_document_embedder.py
@@ -525,7 +525,6 @@ class TestIntegration:
             embedding_separator=" | ",
         )
         embedder.warm_up()
-        assert embedder._client is not None
         embedder._client.timeout = 10  # we want to fail fast if the server is not responding
         result = embedder.run(documents=docs)
         documents_with_embeddings = result["documents"]
@@ -552,7 +551,6 @@ class TestIntegration:
             embedding_separator=" | ",
         )
         await embedder.warm_up_async()
-        assert embedder._async_client is not None
         embedder._async_client.timeout = 10  # we want to fail fast if the server is not responding
         result = await embedder.run_async(documents=docs)
         documents_with_embeddings = result["documents"]

--- a/integrations/huggingface_api/tests/test_text_embedder.py
+++ b/integrations/huggingface_api/tests/test_text_embedder.py
@@ -4,8 +4,7 @@
 
 import os
 import random
-import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from haystack.utils.auth import Secret
@@ -25,12 +24,12 @@ def mock_check_valid_model():
         yield mock
 
 
-class TestHuggingFaceAPITextEmbedder:
+class TestInitializationAndSerialization:
     def test_init_invalid_api_type(self):
         with pytest.raises(ValueError):
             HuggingFaceAPITextEmbedder(api_type="invalid_api_type", api_params={})
 
-    def test_init_serverless(self, mock_check_valid_model):
+    def test_init_serverless(self):
         model = "BAAI/bge-small-en-v1.5"
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": model}
@@ -42,13 +41,8 @@ class TestHuggingFaceAPITextEmbedder:
         assert embedder.suffix == ""
         assert embedder.truncate
         assert not embedder.normalize
-
-    def test_init_serverless_invalid_model(self, mock_check_valid_model):
-        mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id", response=MagicMock())
-        with pytest.raises(RepositoryNotFoundError):
-            HuggingFaceAPITextEmbedder(
-                api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "invalid_model_id"}
-            )
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init_serverless_no_model(self):
         with pytest.raises(ValueError):
@@ -69,6 +63,8 @@ class TestHuggingFaceAPITextEmbedder:
         assert embedder.suffix == ""
         assert embedder.truncate
         assert not embedder.normalize
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init_tei_invalid_url(self):
         with pytest.raises(ValueError):
@@ -82,7 +78,7 @@ class TestHuggingFaceAPITextEmbedder:
                 api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE, api_params={"param": "irrelevant"}
             )
 
-    def test_to_dict(self, mock_check_valid_model):
+    def test_to_dict(self):
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
             api_params={"model": "BAAI/bge-small-en-v1.5"},
@@ -108,7 +104,7 @@ class TestHuggingFaceAPITextEmbedder:
             },
         }
 
-    def test_from_dict(self, mock_check_valid_model):
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.embedders.huggingface_api.text_embedder"
             ".HuggingFaceAPITextEmbedder",
@@ -132,6 +128,128 @@ class TestHuggingFaceAPITextEmbedder:
         assert not embedder.truncate
         assert embedder.normalize
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_env_var("MISSING_HF_TOKEN"),
+        )
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            embedder.warm_up()
+
+    def test_invalid_model_is_checked_at_warm_up(self, mock_check_valid_model):
+        mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id", response=MagicMock())
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "invalid_model_id"}
+        )
+        with pytest.raises(RepositoryNotFoundError):
+            embedder.warm_up()
+
+    @patch("haystack_integrations.components.embedders.huggingface_api.text_embedder.InferenceClient")
+    def test_sync_lifecycle(self, mock_client_cls):
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_token("test-token"),
+        )
+        client = mock_client_cls.return_value
+
+        embedder.warm_up()
+        assert embedder._client is client
+        assert embedder._async_client is None
+
+        embedder.close()
+        client.close.assert_called_once_with()
+        assert embedder._client is None
+
+        embedder.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.huggingface_api.text_embedder.AsyncInferenceClient")
+    async def test_async_lifecycle(self, mock_client_cls):
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=Secret.from_token("test-token"),
+        )
+        client = MagicMock(close=AsyncMock())
+        mock_client_cls.return_value = client
+
+        await embedder.warm_up_async()
+        assert embedder._async_client is client
+        assert embedder._client is None
+
+        await embedder.close_async()
+        client.close.assert_awaited_once_with()
+        assert embedder._async_client is None
+
+        await embedder.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.huggingface_api.text_embedder.InferenceClient")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        embedder.warm_up()
+        embedder.warm_up()
+        mock_client_cls.assert_called_once_with(model="https://example.com", token=None)
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.huggingface_api.text_embedder.AsyncInferenceClient")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        await embedder.warm_up_async()
+        await embedder.warm_up_async()
+        mock_client_cls.assert_called_once_with(model="https://example.com", token=None)
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE,
+            api_params={"url": "https://example.com"},
+            token=None,
+        )
+        embedder.close()
+        await embedder.close_async()
+        assert embedder._client is None
+        assert embedder._async_client is None
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.huggingface_api.text_embedder.AsyncInferenceClient")
+    @patch("haystack_integrations.components.embedders.huggingface_api.text_embedder.InferenceClient")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        sync_client = mock_sync_cls.return_value
+        async_client = MagicMock(close=AsyncMock())
+        mock_async_cls.return_value = async_client
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE, api_params={"url": "https://example.com"}
+        )
+        embedder.warm_up()
+        await embedder.warm_up_async()
+
+        embedder.close()
+        assert embedder._client is None
+        assert embedder._async_client is async_client
+        async_client.close.assert_not_awaited()
+
+        await embedder.close_async()
+        assert embedder._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_run_wrong_input_format(self, mock_check_valid_model):
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "BAAI/bge-small-en-v1.5"}
@@ -218,35 +336,36 @@ class TestHuggingFaceAPITextEmbedder:
             with pytest.raises(ValueError):
                 embedder.run(text="The food was delicious")
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_TOKEN", None),
-        reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
-    )
-    @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN", None),
+    reason="Export an env var called HF_TOKEN containing the Hugging Face token to run this test.",
+)
+class TestIntegration:
     def test_live_run_serverless(self):
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
             api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
         )
+        embedder.warm_up()
+        assert embedder._client is not None
         embedder._client.timeout = 10  # we want to fail fast if the server is not responding
         result = embedder.run(text="The food was delicious")
 
         assert len(result["embedding"]) == 384
         assert all(isinstance(x, float) for x in result["embedding"])
 
-    @pytest.mark.integration
     @pytest.mark.asyncio
-    @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
-    @pytest.mark.skipif(os.environ.get("HF_TOKEN", "") == "", reason="HF_TOKEN is not set")
-    @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
     async def test_live_run_async_serverless(self):
         model_name = "sentence-transformers/all-MiniLM-L6-v2"
 
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": model_name}
         )
-        embedder._client.timeout = 10  # we want to fail fast if the server is not responding
+        await embedder.warm_up_async()
+        assert embedder._async_client is not None
+        embedder._async_client.timeout = 10  # we want to fail fast if the server is not responding
 
         text = "This is a test sentence for embedding."
         result = await embedder.run_async(text=text)

--- a/integrations/huggingface_api/tests/test_text_embedder.py
+++ b/integrations/huggingface_api/tests/test_text_embedder.py
@@ -17,10 +17,16 @@ from haystack_integrations.components.embedders.huggingface_api import HuggingFa
 
 @pytest.fixture
 def mock_check_valid_model():
-    with patch(
-        "haystack_integrations.components.embedders.huggingface_api.text_embedder._check_valid_model",
-        MagicMock(return_value=None),
-    ) as mock:
+    with (
+        patch(
+            "haystack_integrations.components.embedders.huggingface_api.text_embedder._check_valid_model",
+            MagicMock(return_value=None),
+        ) as mock,
+        patch(
+            "haystack_integrations.components.embedders.huggingface_api.text_embedder._check_valid_model_async",
+            AsyncMock(return_value=None),
+        ),
+    ):
         yield mock
 
 

--- a/integrations/huggingface_api/tests/test_utils.py
+++ b/integrations/huggingface_api/tests/test_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from huggingface_hub.errors import RepositoryNotFoundError
@@ -12,6 +12,7 @@ from haystack_integrations.common.huggingface_api.utils import (
     HFGenerationAPIType,
     HFModelType,
     _check_valid_model,
+    _check_valid_model_async,
 )
 
 
@@ -47,3 +48,36 @@ class TestCheckValidModel:
         mock_hf_api.return_value.model_info.side_effect = RepositoryNotFoundError("not found", response=MagicMock())
         with pytest.raises(ValueError, match="not found on HuggingFace Hub"):
             _check_valid_model("invalid/model-id", HFModelType.GENERATION, token=None)
+
+
+class TestCheckValidModelAsync:
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.common.huggingface_api.utils.hf_raise_for_status")
+    @patch("haystack_integrations.common.huggingface_api.utils.get_async_session")
+    async def test_valid_model(self, mock_get_async_session, mock_raise_for_status):
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        response = MagicMock()
+        response.json.return_value = {"pipeline_tag": "feature-extraction"}
+        client.get = AsyncMock(return_value=response)
+        mock_get_async_session.return_value = client
+
+        await _check_valid_model_async("BAAI/bge-small-en-v1.5", HFModelType.EMBEDDING, token=None)
+
+        client.get.assert_awaited_once()
+        mock_raise_for_status.assert_called_once_with(response)
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.common.huggingface_api.utils.hf_raise_for_status")
+    @patch("haystack_integrations.common.huggingface_api.utils.get_async_session")
+    async def test_model_not_found(self, mock_get_async_session, mock_raise_for_status):
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.get = AsyncMock(return_value=MagicMock())
+        mock_get_async_session.return_value = client
+        mock_raise_for_status.side_effect = RepositoryNotFoundError("not found", response=MagicMock())
+
+        with pytest.raises(ValueError, match="not found on HuggingFace Hub"):
+            await _check_valid_model_async("invalid/model-id", HFModelType.GENERATION, token=None)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- implement lifecycle handling, following criteria in https://github.com/deepset-ai/haystack-private/issues/440#issuecomment-5526157817
  - secrets resolved, model validated (via API call) and client created in `warm_up`/`warm_up_async` instead of `__init__`
  - added closing methods
  - pin `huggingface_hub[inference]>=1.0.0`: `InferenceClient.close()` is only available starting from this version (released in October 2025)
- pin `haystack-ai>=3.0.0`


### How did you test it?
CI, new tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
