### PR TITLE
fix(pinecone): infer boolean for list-valued bool metadata

### DIFF
--- a/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
+++ b/integrations/pinecone/src/haystack_integrations/document_stores/pinecone/document_store.py
@@ -828,12 +828,13 @@ class PineconeDocumentStore:
                         # For lists, check the type of elements if list is non-empty
                         if value:
                             # Sample first element to determine list type
-                            if isinstance(value[0], str):
+                            # bool before int/float here too, same reason as above
+                            if isinstance(value[0], bool):
+                                field_samples[field].add("boolean")
+                            elif isinstance(value[0], str):
                                 field_samples[field].add("keyword")
                             elif isinstance(value[0], (int, float)):
                                 field_samples[field].add("long")
-                            elif isinstance(value[0], bool):
-                                field_samples[field].add("boolean")
                         else:
                             # Empty list, default to keyword
                             field_samples[field].add("keyword")

--- a/integrations/pinecone/tests/test_document_store.py
+++ b/integrations/pinecone/tests/test_document_store.py
@@ -277,6 +277,11 @@ def test_convert_meta_to_int():
             None,
         ),
         (
+            [Document(content=None, meta={"flags": [True, False]})],
+            {"flags": {"type": "boolean"}},
+            None,
+        ),
+        (
             [Document(content=None, meta={"empty": []})],
             {"empty": {"type": "keyword"}},
             None,


### PR DESCRIPTION
## Problem

`PineconeDocumentStore._get_metadata_fields_info_impl` states the rule itself:

```python
# Note: bool check MUST come before int/float because bool is a subclass of int in Python
if isinstance(value, bool):
    field_samples[field].add("boolean")
elif isinstance(value, (int, float)):
    field_samples[field].add("long")
```

…and then breaks it a few lines below, in the branch that handles list values:

```python
if isinstance(value[0], str):
    field_samples[field].add("keyword")
elif isinstance(value[0], (int, float)):
    field_samples[field].add("long")
elif isinstance(value[0], bool):        # unreachable
    field_samples[field].add("boolean")
```

Because `bool` is a subclass of `int`, a metadata field holding a list of bools — `Document(meta={"flags": [True, False]})` — is reported as `{"type": "long"}` instead of `{"type": "boolean"}`, and the `bool` branch is dead code.

It also poisons fields that mix the two shapes across documents: one document with `{"f": True}` and another with `{"f": [True]}` collects `{"boolean", "long"}`, which trips the "mixed types" path and degrades the field to `keyword` with a warning.

## Fix

Reorder the list branch to match the scalar one, with a short comment pointing back at the note above.

## Test

`test_get_metadata_fields_info_impl_type_inference` already parametrizes list-of-str and list-of-int; this adds the missing list-of-bool case.

## Verification

The function was extracted from `document_store.py` with `ast.get_source_segment` (no hand-copying) and run against a `Document` stub before and after the patch:

| case | unpatched | patched | changed |
|---|---|---|---|
| `meta={"is_public": True}` (scalar, control) | `boolean` | `boolean` | – |
| `meta={"flags": [True, False]}` | `long` | `boolean` | **YES** |
| `meta={"nums": [1, 2]}` | `long` | `long` | – |
| `meta={"tags": ["a", "b"]}` | `keyword` | `keyword` | – |
| `meta={"scores": [1.5]}` | `long` | `long` | – |
| `meta={"empty": []}` | `keyword` | `keyword` | – |
| `meta={"pi": 3.14}` | `long` | `long` | – |
| `{"f": True}` + `{"f": [True]}` | `keyword` + "mixed types" warning | `boolean` | **YES** |

Every existing expectation in `test_get_metadata_fields_info_impl_type_inference` is unchanged; only bool-valued lists move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
