### PR TITLE
fix: serialize timeout in NvidiaGenerator.to_dict

### DIFF
--- a/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
+++ b/integrations/nvidia/src/haystack_integrations/components/generators/nvidia/generator.py
@@ -155,6 +155,7 @@ class NvidiaGenerator:
             api_url=self.api_url,
             api_key=self._api_key.to_dict() if self._api_key else None,
             model_arguments=self._model_arguments,
+            timeout=self.timeout,
         )
 
     @property

--- a/integrations/nvidia/tests/test_generator.py
+++ b/integrations/nvidia/tests/test_generator.py
@@ -89,6 +89,7 @@ class TestNvidiaGenerator:
                 "api_key": {"env_vars": ["NVIDIA_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "playground_nemotron_steerlm_8b",
                 "model_arguments": {},
+                "timeout": 60.0,
             },
         }
 
@@ -105,6 +106,7 @@ class TestNvidiaGenerator:
                 "bad": None,
                 "stop": None,
             },
+            timeout=10.0,
         )
         data = generator.to_dict()
         assert data == {
@@ -121,8 +123,15 @@ class TestNvidiaGenerator:
                     "bad": None,
                     "stop": None,
                 },
+                "timeout": 10.0,
             },
         }
+
+    def test_to_dict_from_dict_roundtrip_preserves_timeout(self, monkeypatch):
+        monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
+        generator = NvidiaGenerator("meta/llama-3.1-8b-instruct", timeout=12.5)
+        restored = NvidiaGenerator.from_dict(generator.to_dict())
+        assert restored.timeout == 12.5
 
     def test_setting_timeout(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")
@@ -285,12 +294,14 @@ class TestNvidiaGenerator:
                 "api_url": "https://my.url.com/v1",
                 "model": "meta/llama-3.1-8b-instruct",
                 "model_arguments": {"temperature": 0.5},
+                "timeout": 10.0,
             },
         }
         generator = NvidiaGenerator.from_dict(data)
         assert generator._model == "meta/llama-3.1-8b-instruct"
         assert generator.api_url == "https://my.url.com/v1"
         assert generator._model_arguments == {"temperature": 0.5}
+        assert generator.timeout == 10.0
 
     def test_run(self, monkeypatch, mock_local_chat_completion):  # noqa: ARG002
         monkeypatch.setenv("NVIDIA_API_KEY", "fake-api-key")


### PR DESCRIPTION
## Summary

`NvidiaGenerator` accepts a `timeout` in `__init__` and stores it on
`self.timeout`, but `to_dict()` does not serialize it:

```python
return default_to_dict(
    self,
    model=self._model,
    api_url=self.api_url,
    api_key=self._api_key.to_dict() if self._api_key else None,
    model_arguments=self._model_arguments,
)
```

A pipeline serialized with a non-default timeout loses it on load — `from_dict`
runs `__init__` with `timeout=None`, which falls back to the `NVIDIA_TIMEOUT`
env var or the hard-coded `60.0`.

The other four Nvidia components already serialize `timeout` the same way:
`NvidiaTextEmbedder`, `NvidiaDocumentEmbedder`, `NvidiaRanker` and
`NvidiaChatGenerator`. This PR brings `NvidiaGenerator` in line.

(`NvidiaGenerator` is deprecated in favour of `NvidiaChatGenerator` but is still
shipped and serializable.)

## Testing

- `test_to_dict` / `test_to_dict_with_custom_init_parameters` / `test_from_dict`
  updated to include `timeout`, matching `test_text_embedder.py`.
- New `test_to_dict_from_dict_roundtrip_preserves_timeout` fails on `main`
  (`assert 60.0 == 12.5`) and passes with this change.
- `hatch run test:unit` — 212 passed, 18 deselected. `hatch run fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
