### PR TITLE
fix: serialize include_search_metadata in AzureAISearchDocumentStore.to_dict

### DIFF
--- a/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
+++ b/integrations/azure_ai_search/src/haystack_integrations/document_stores/azure_ai_search/document_store.py
@@ -356,6 +356,7 @@ class AzureAISearchDocumentStore:
             embedding_dimension=self._embedding_dimension,
             metadata_fields={key: value.as_dict() for key, value in self._metadata_fields.items()},
             vector_search_configuration=self._vector_search_configuration.as_dict(),
+            include_search_metadata=self._include_search_metadata,
             **self._serialize_index_creation_kwargs(self._index_creation_kwargs),
         )
 

--- a/integrations/azure_ai_search/tests/test_bm25_retriever.py
+++ b/integrations/azure_ai_search/tests/test_bm25_retriever.py
@@ -59,6 +59,7 @@ def test_to_dict():
                             }
                         ],
                     },
+                    "include_search_metadata": False,
                     "hosts": "some fake host",
                 },
             },

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -94,6 +94,7 @@ def test_to_dict_with_params(monkeypatch):
         },
         encryption_key=encryption_key,
         analyzers=[analyzer],
+        include_search_metadata=True,
     )
 
     res = document_store.to_dict()
@@ -131,21 +132,9 @@ def test_to_dict_with_params(monkeypatch):
                     }
                 ],
             },
-            "include_search_metadata": False,
+            "include_search_metadata": True,
         },
     }
-
-
-def test_to_dict_round_trip_preserves_include_search_metadata(monkeypatch):
-    monkeypatch.setenv("AZURE_AI_SEARCH_API_KEY", "test-api-key")
-    monkeypatch.setenv("AZURE_AI_SEARCH_ENDPOINT", "test-endpoint")
-
-    document_store = AzureAISearchDocumentStore(include_search_metadata=True)
-
-    assert document_store.to_dict()["init_parameters"]["include_search_metadata"] is True
-
-    reloaded = AzureAISearchDocumentStore.from_dict(document_store.to_dict())
-    assert reloaded._include_search_metadata is True
 
 
 def test_to_dict_emits_warning_when_token_credential_is_used(
@@ -233,6 +222,7 @@ def test_from_dict_with_params(monkeypatch):
                     }
                 ],
             },
+            "include_search_metadata": True,
         },
     }
     document_store = AzureAISearchDocumentStore.from_dict(data)
@@ -249,6 +239,7 @@ def test_from_dict_with_params(monkeypatch):
     assert document_store._index_creation_kwargs["analyzers"][0].token_filters == ["lowercase"]
     assert "CustomAnalyzer" in document_store._index_creation_kwargs["analyzers"][0].odata_type
     assert document_store._vector_search_configuration.as_dict() == DEFAULT_VECTOR_SEARCH.as_dict()
+    assert document_store._include_search_metadata is True
 
 
 @patch("haystack_integrations.document_stores.azure_ai_search.document_store.AzureAISearchDocumentStore")

--- a/integrations/azure_ai_search/tests/test_document_store.py
+++ b/integrations/azure_ai_search/tests/test_document_store.py
@@ -67,6 +67,7 @@ def test_to_dict(monkeypatch):
                     }
                 ],
             },
+            "include_search_metadata": False,
         },
     }
 
@@ -130,8 +131,21 @@ def test_to_dict_with_params(monkeypatch):
                     }
                 ],
             },
+            "include_search_metadata": False,
         },
     }
+
+
+def test_to_dict_round_trip_preserves_include_search_metadata(monkeypatch):
+    monkeypatch.setenv("AZURE_AI_SEARCH_API_KEY", "test-api-key")
+    monkeypatch.setenv("AZURE_AI_SEARCH_ENDPOINT", "test-endpoint")
+
+    document_store = AzureAISearchDocumentStore(include_search_metadata=True)
+
+    assert document_store.to_dict()["init_parameters"]["include_search_metadata"] is True
+
+    reloaded = AzureAISearchDocumentStore.from_dict(document_store.to_dict())
+    assert reloaded._include_search_metadata is True
 
 
 def test_to_dict_emits_warning_when_token_credential_is_used(

--- a/integrations/azure_ai_search/tests/test_embedding_retriever.py
+++ b/integrations/azure_ai_search/tests/test_embedding_retriever.py
@@ -60,6 +60,7 @@ def test_to_dict():
                             }
                         ],
                     },
+                    "include_search_metadata": False,
                     "hosts": "some fake host",
                 },
             },

--- a/integrations/azure_ai_search/tests/test_hybrid_retriever.py
+++ b/integrations/azure_ai_search/tests/test_hybrid_retriever.py
@@ -60,6 +60,7 @@ def test_to_dict():
                             }
                         ],
                     },
+                    "include_search_metadata": False,
                     "hosts": "some fake host",
                 },
             },


### PR DESCRIPTION
### Related Issues

- No issue. Same defect class as #3808 and #3873, in one more integration.

### Proposed Changes:

`AzureAISearchDocumentStore` accepts `include_search_metadata`, stores it as
`self._include_search_metadata`, and reads it in `_convert_search_result_to_documents`
to decide whether every field Azure returns (`@search.score`, `@search.reranker_score`,
`@search.highlights`, `@search.captions`, ...) is copied into `Document.meta`, or only
the configured index fields are. `to_dict` left it out, so a store built with
`include_search_metadata=True` comes back from `from_dict` with it `False` and returns
a different `meta` shape after a serialization round trip.

One line in `to_dict`. No `from_dict` change: it already passes the key through.

The parameter was added in #1907 (June 2025); the `to_dict` omission dates from there.

### How did you test it?

`integrations/azure_ai_search` (`test_document_store.py`): 37 passed, 92 deselected.
3 fail without the fix:

- `test_to_dict` and `test_to_dict_with_params` — the expected dicts now include the key.
- `test_to_dict_round_trip_preserves_include_search_metadata` — new: asserts
  `include_search_metadata=True` survives `from_dict(to_dict())`. Fails with
  `KeyError: 'include_search_metadata'` when the `to_dict` line is reverted.

`hatch run fmt-check` clean.

### Notes for the reviewer

Found with the same AST script used for #3873, run against `main` after the two PRs on
this defect class. Everything else it flagged in the integrations was a false positive
(serialized via a parent `to_dict`, folded into another kwarg at `__init__`, or
introspected dynamically like `QdrantDocumentStore`) except `NvidiaGenerator.timeout`,
which is #3923, and `google_vertex`, which is archived.

This PR was generated with an AI assistant. I have reviewed the changes and run the tests locally.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have run pre-commit hooks and fixed any issue.
