### PR TITLE
fix: batch CohereDocumentEmbedder.run_async like the sync path

### DIFF
--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/document_embedder.py
@@ -249,6 +249,8 @@ class CohereDocumentEmbedder:
             model_name=self.model,
             input_type=self.input_type,
             truncate=self.truncate,
+            batch_size=self.batch_size,
+            progress_bar=self.progress_bar,
             embedding_type=self.embedding_type,
         )
 

--- a/integrations/cohere/src/haystack_integrations/components/embedders/cohere/utils.py
+++ b/integrations/cohere/src/haystack_integrations/components/embedders/cohere/utils.py
@@ -16,6 +16,8 @@ async def get_async_response(
     model_name: str,
     input_type: str,
     truncate: str,
+    batch_size: int = 32,
+    progress_bar: bool = False,
     embedding_type: EmbeddingTypes | None = None,
 ) -> tuple[list[list[float]], dict[str, Any]]:
     """
@@ -27,6 +29,9 @@ async def get_async_response(
     :param input_type: one of "classification", "clustering", "search_document", "search_query".
         The type of input text provided to embed.
     :param truncate: one of "NONE", "START", "END". How the API handles text longer than the maximum token length.
+    :param batch_size: the batch size to use. The Cohere embed endpoint caps the number of texts per call, so the
+        texts are sent in batches just like the synchronous path.
+    :param progress_bar: if `True`, show a progress bar
     :param embedding_type: the type of embeddings to return. Defaults to float embeddings.
 
     :returns: A tuple of the embeddings and metadata.
@@ -35,24 +40,28 @@ async def get_async_response(
     """
     all_embeddings: list[list[float]] = []
     metadata: dict[str, Any] = {}
-
     embedding_type = embedding_type or EmbeddingTypes.FLOAT
-    response = await cohere_async_client.embed(
-        texts=texts,
-        model=model_name,
-        input_type=input_type,
-        truncate=truncate,
-        embedding_types=[embedding_type.value],
-    )
-    if response.meta is not None:
-        metadata = response.meta.model_dump()
-    for emb_tuple in response.embeddings:
-        # emb_tuple[0] is a str denoting the embedding type (e.g. "float", "int8", etc.)
-        if emb_tuple[1] is not None:
-            # ok we have embeddings for this type, let's take all
-            # the embeddings (a list of embeddings) and break the loop
-            all_embeddings.extend(emb_tuple[1])
-            break
+
+    for i in tqdm(
+        range(0, len(texts), batch_size),
+        disable=not progress_bar,
+        desc="Calculating embeddings",
+    ):
+        batch = texts[i : i + batch_size]
+        response = await cohere_async_client.embed(
+            texts=batch,
+            model=model_name,
+            input_type=input_type,
+            truncate=truncate,
+            embedding_types=[embedding_type.value],
+        )
+        for emb_tuple in response.embeddings:
+            # emb_tuple[0] is a str denoting the embedding type (e.g. "float", "int8", etc.)
+            if emb_tuple[1] is not None:
+                # ok we have embeddings for this type, let's take all the embeddings (a list of embeddings)
+                all_embeddings.extend(emb_tuple[1])
+        if response.meta is not None:
+            metadata = response.meta.model_dump()
 
     return all_embeddings, metadata
 

--- a/integrations/cohere/tests/test_document_embedder.py
+++ b/integrations/cohere/tests/test_document_embedder.py
@@ -247,6 +247,35 @@ class TestRun:
             assert doc_with_embedding.meta == doc.meta
             assert doc_with_embedding.embedding == embedding
 
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.cohere.document_embedder.AsyncClientV2")
+    async def test_run_async_sends_texts_in_batches(self, mock_async_client_cls):
+        """
+        run_async must honour batch_size like run does. The Cohere embed endpoint caps the number of
+        texts per call, so sending every text in a single request breaks on larger inputs.
+        """
+        batch_sizes: list[int] = []
+
+        class _Response:
+            def __init__(self, n: int) -> None:
+                self.embeddings = [("float", [[0.1, 0.2, 0.3]] * n)]
+                self.meta = None
+
+        async def fake_embed(*, texts, **_kwargs):
+            batch_sizes.append(len(texts))
+            return _Response(len(texts))
+
+        mock_async_client_cls.return_value.embed = fake_embed
+
+        embedder = CohereDocumentEmbedder(api_key=Secret.from_token("test-api-key"), batch_size=2)
+        docs = [Document(content=f"doc {i}") for i in range(5)]
+
+        result = await embedder.run_async(docs)
+
+        assert batch_sizes == [2, 2, 1]
+        assert len(result["documents"]) == 5
+        assert all(doc.embedding == [0.1, 0.2, 0.3] for doc in result["documents"])
+
     @patch("haystack_integrations.components.embedders.cohere.document_embedder.get_response")
     def test_run_does_not_modify_original_documents(self, mock_get_response):
         embedder = CohereDocumentEmbedder(api_key=Secret.from_token("test-api-key"))


### PR DESCRIPTION
### Related Issues

- No issue. Sync/async parity defect, same class as haystack #12358.

### Proposed Changes:

`CohereDocumentEmbedder` has a sync `run` and an async `run_async`. They call two helpers:

- `get_response` (sync) loops over `texts` in slices of `batch_size` (default 32) and calls `client.embed(texts=batch, ...)` per slice.
- `get_async_response` (async) had no `batch_size` parameter and called `await client.embed(texts=texts, ...)` **once with every text**.

So `run_async`:
- ignored the configured `batch_size` (and `progress_bar`);
- sent all texts in a single request, which the Cohere embed endpoint rejects above its per-call text cap — `run_async` fails on inputs where `run` on the same documents succeeds.

`get_async_response` now takes `batch_size` and `progress_bar` and loops over batches exactly like `get_response` — sequential `await`s, mirroring the sync loop (no `asyncio.gather`, so the request rate is unchanged). `run_async` passes `self.batch_size` and `self.progress_bar`.

`CohereTextEmbedder` also calls `get_async_response`, but only ever with a single string, so its behaviour is unchanged (one batch).

### How did you test it?

`integrations/cohere` (`test_document_embedder.py`): 15 passed, 2 deselected; full unit suite 98 passed.

New `test_run_async_sends_texts_in_batches`: a fake `AsyncClientV2` records the size of each `embed` call; `run_async` on 5 docs with `batch_size=2` must issue calls of `[2, 2, 1]`. Fails as `[5] == [2, 2, 1]` with the fix reverted. `hatch run fmt-check` clean.

### Notes for the reviewer

Batches run sequentially to keep this a behaviour-parity fix and not change the request rate; running them concurrently with a bounded gather would be a reasonable follow-up.

`CohereDocumentImageEmbedder` is not affected — its `run` and `run_async` are already symmetric (one image per call, no batching either side).

This PR was generated with an AI assistant. I have reviewed the changes and run the tests locally.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have run pre-commit hooks and fixed any issue.
