### PR TITLE
feat!: Mistral - add lifecycle handling

### DIFF
--- a/integrations/mistral/pyproject.toml
+++ b/integrations/mistral/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 # mistralai 2.4.6 is excluded because of security issue https://github.com/mistralai/client-python/security/advisories/GHSA-wx9m-wx4f-4cmg
-dependencies = ["haystack-ai>=2.30.0", "mistralai>=2.0.0,!=2.4.6"]
+dependencies = ["haystack-ai>=3.0.0", "mistralai>=2.0.0,!=2.4.6"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mistral#readme"

--- a/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
+++ b/integrations/mistral/src/haystack_integrations/components/converters/mistral/ocr_document_converter.py
@@ -149,8 +149,18 @@ class MistralOCRDocumentConverter:
         self.image_min_size = image_min_size
         self.cleanup_uploaded_files = cleanup_uploaded_files
 
-        # Initialize Mistral client
-        self.client = Mistral(api_key=self.api_key.resolve_value())
+        self.client: Mistral | None = None
+
+    def warm_up(self) -> None:
+        """Initialize the Mistral client."""
+        if self.client is None:
+            self.client = Mistral(api_key=self.api_key.resolve_value())
+
+    def close(self) -> None:
+        """Close the Mistral client."""
+        if self.client is not None:
+            self.client.__exit__(None, None, None)
+            self.client = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -229,6 +239,9 @@ class MistralOCRDocumentConverter:
                 List of dictionaries containing raw OCR responses from Mistral API (one per source).
                 Each response includes per-page details, images, annotations, and usage info.
         """
+        self.warm_up()
+        assert self.client is not None
+
         # Convert Pydantic models to Mistral ResponseFormat schemas
         bbox_annotation_format = (
             response_format_from_pydantic_model(bbox_annotation_schema) if bbox_annotation_schema else None
@@ -294,6 +307,7 @@ class MistralOCRDocumentConverter:
             A tuple of (Document|None, raw_response_dict|None, uploaded_file_id|None).
             Returns (None, None, uploaded_file_id) if processing fails but file was uploaded.
         """
+        assert self.client is not None
         uploaded_file_id = None
         try:
             chunk = self._convert_source_to_chunk(source)
@@ -333,6 +347,7 @@ class MistralOCRDocumentConverter:
         if not self.cleanup_uploaded_files or not file_ids:
             return
 
+        assert self.client is not None
         for file_id in file_ids:
             try:
                 self.client.files.delete(file_id=file_id)
@@ -362,6 +377,8 @@ class MistralOCRDocumentConverter:
         # If already a Mistral chunk type, return as-is
         if isinstance(source, (DocumentURLChunk, FileChunk, ImageURLChunk)):
             return source
+
+        assert self.client is not None
 
         # Convert str/Path/ByteStream to ByteStream
         bytestream = get_bytestream_from_source(source=source)

--- a/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
+++ b/integrations/mistral/src/haystack_integrations/components/embedders/mistral/document_embedder.py
@@ -105,9 +105,6 @@ class MistralDocumentEmbedder(OpenAIDocumentEmbedder):
             max_retries=max_retries,
             http_client_kwargs=http_client_kwargs,
         )
-        # We add these since they were only added in Haystack 2.14.0
-        self.timeout = timeout
-        self.max_retries = max_retries
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/mistral/src/haystack_integrations/components/embedders/mistral/text_embedder.py
+++ b/integrations/mistral/src/haystack_integrations/components/embedders/mistral/text_embedder.py
@@ -87,9 +87,6 @@ class MistralTextEmbedder(OpenAITextEmbedder):
             max_retries=max_retries,
             http_client_kwargs=http_client_kwargs,
         )
-        # We add these since they were only added in Haystack 2.14.0
-        self.timeout = timeout
-        self.max_retries = max_retries
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -430,11 +430,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         messages = _normalize_messages(messages)
-        if hasattr(self, "warm_up_async"):
-            # haystack-ai >= 3.0 initializes the async client on the running event loop
-            await self.warm_up_async()
-        else:
-            self.warm_up()
+        await self.warm_up_async()
 
         if len(messages) == 0:
             return {"replies": []}

--- a/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
+++ b/integrations/mistral/src/haystack_integrations/components/generators/mistral/chat/chat_generator.py
@@ -359,6 +359,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
         """
         messages = _normalize_messages(messages)
         self.warm_up()
+        assert self.client is not None
 
         if len(messages) == 0:
             return {"replies": []}
@@ -385,12 +386,11 @@ class MistralChatGenerator(OpenAIChatGenerator):
         )
         openai_endpoint = api_args.pop("openai_endpoint")
 
-        # with haystack-ai >= 3.0 the client is Optional and built by warm_up above
         if streaming_callback is not None:
-            chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)  # type: ignore[union-attr]
+            chat_completion = getattr(self.client.chat.completions, openai_endpoint)(**api_args)
             completions = self._handle_stream_response(chat_completion, streaming_callback)
         else:
-            raw_response = getattr(self.client.chat.completions.with_raw_response, openai_endpoint)(**api_args)  # type: ignore[union-attr]
+            raw_response = getattr(self.client.chat.completions.with_raw_response, openai_endpoint)(**api_args)
             completions = _convert_mistral_response_to_chat_messages(raw_response.text)
 
         for message in completions:
@@ -431,6 +431,7 @@ class MistralChatGenerator(OpenAIChatGenerator):
         """
         messages = _normalize_messages(messages)
         await self.warm_up_async()
+        assert self.async_client is not None
 
         if len(messages) == 0:
             return {"replies": []}
@@ -457,13 +458,12 @@ class MistralChatGenerator(OpenAIChatGenerator):
         )
         openai_endpoint = api_args.pop("openai_endpoint")
 
-        # with haystack-ai >= 3.0 the client is Optional and built by warm_up above
         if streaming_callback is not None:
-            chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)  # type: ignore[union-attr]
+            chat_completion = await getattr(self.async_client.chat.completions, openai_endpoint)(**api_args)
             completions = await self._handle_async_stream_response(chat_completion, streaming_callback)
         else:
             raw_response = await getattr(
-                self.async_client.chat.completions.with_raw_response,  # type: ignore[union-attr]
+                self.async_client.chat.completions.with_raw_response,
                 openai_endpoint,
             )(**api_args)
             completions = _convert_mistral_response_to_chat_messages(raw_response.text)

--- a/integrations/mistral/tests/conftest.py
+++ b/integrations/mistral/tests/conftest.py
@@ -6,6 +6,6 @@ def allow_deserialization_of_test_modules(monkeypatch):
     """
     haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
     trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
-    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
+    allowlist, so trust them explicitly.
     """
     monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/mistral/tests/conftest.py
+++ b/integrations/mistral/tests/conftest.py
@@ -6,6 +6,6 @@ def allow_deserialization_of_test_modules(monkeypatch):
     """
     haystack-ai >= 3.0 refuses to deserialize classes and callables from modules outside its
     trusted-module allowlist. Tools and callbacks defined in the test modules live outside that
-    allowlist, so trust them explicitly.
+    allowlist, so trust them explicitly; haystack-ai 2.x ignores this environment variable.
     """
     monkeypatch.setenv("HAYSTACK_DESERIALIZATION_ALLOWLIST", "tests,test_*")

--- a/integrations/mistral/tests/test_mistral_chat_generator.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator.py
@@ -6,11 +6,6 @@ from unittest.mock import ANY, AsyncMock, patch
 import pytest
 from haystack import Pipeline
 from haystack.components.generators.utils import print_streaming_chunk
-
-try:
-    from haystack.components.tools import ToolInvoker
-except ImportError:  # ToolInvoker was removed in Haystack 3.0
-    ToolInvoker = None
 from haystack.dataclasses import (
     ChatMessage,
     ChatRole,
@@ -146,13 +141,13 @@ class TestMistralChatGenerator:
     def test_warm_up(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
         component = MistralChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+        component.warm_up()
         assert component.client.api_key == "test-api-key"
+        assert component.client is not None
 
-    def test_init_fail_wo_api_key(self, monkeypatch):
+    def test_warm_up_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
         with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            # haystack-ai 2.x raises at init; haystack-ai >= 3.0 raises when the client is created in warm_up
             component = MistralChatGenerator()
             component.warm_up()
 
@@ -719,36 +714,6 @@ class TestMistralChatGenerator:
         assert sorted(arguments, key=lambda x: x["city"]) == [{"city": "Berlin"}, {"city": "Paris"}]
         assert tool_message.meta["finish_reason"] == "tool_calls"
 
-    @pytest.mark.skipif(
-        not os.environ.get("MISTRAL_API_KEY", None),
-        reason="Export an env var called MISTRAL_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
-    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
-    def test_pipeline_with_mistral_chat_generator(self, tools):
-        """
-        Test that the MistralChatGenerator component can be used in a pipeline
-        """
-        pipeline = Pipeline()
-        pipeline.add_component("generator", MistralChatGenerator(tools=tools))
-        pipeline.add_component("tool_invoker", ToolInvoker(tools=tools))
-
-        pipeline.connect("generator", "tool_invoker")
-
-        results = pipeline.run(
-            data={
-                "generator": {
-                    "messages": [ChatMessage.from_user("What's the weather like in Paris?")],
-                    "generation_kwargs": {"tool_choice": "any"},
-                }
-            }
-        )
-
-        assert (
-            "The weather in Paris is sunny and 32°C"
-            == results["tool_invoker"]["tool_messages"][0].tool_call_result.result
-        )
-
     def test_serde_in_pipeline(self, monkeypatch):
         """
         Test serialization/deserialization of MistralChatGenerator in a Pipeline,
@@ -805,9 +770,6 @@ class TestMistralChatGenerator:
             },
             "connections": [],
         }
-
-        if not hasattr(pipeline, "_connection_type_validation"):
-            expected_dict.pop("connection_type_validation")
 
         assert pipeline_dict == expected_dict
 

--- a/integrations/mistral/tests/test_mistral_chat_generator_async.py
+++ b/integrations/mistral/tests/test_mistral_chat_generator_async.py
@@ -82,9 +82,7 @@ class TestMistralChatGeneratorAsync:
     async def test_warm_up_async(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
         component = MistralChatGenerator()
-        if hasattr(component, "warm_up_async"):
-            # haystack-ai >= 3.0 creates the async client during async warm-up
-            await component.warm_up_async()
+        await component.warm_up_async()
 
         assert isinstance(component.async_client, AsyncOpenAI)
         assert component.async_client.api_key == "test-api-key"

--- a/integrations/mistral/tests/test_ocr_document_converter.py
+++ b/integrations/mistral/tests/test_ocr_document_converter.py
@@ -16,11 +16,7 @@ from haystack_integrations.components.converters.mistral import (
 )
 
 
-class TestMistralOCRDocumentConverter:
-    CLASS_TYPE = (
-        "haystack_integrations.components.converters.mistral.ocr_document_converter.MistralOCRDocumentConverter"
-    )
-
+class TestInitialization:
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = MistralOCRDocumentConverter.SUPPORTED_MODELS
@@ -38,6 +34,7 @@ class TestMistralOCRDocumentConverter:
         assert converter.pages is None
         assert converter.image_limit is None
         assert converter.image_min_size is None
+        assert converter.client is None
 
     def test_init_with_all_optional_parameters(self):
         converter = MistralOCRDocumentConverter(
@@ -55,6 +52,12 @@ class TestMistralOCRDocumentConverter:
         assert converter.pages == [0, 1, 2]
         assert converter.image_limit == 10
         assert converter.image_min_size == 100
+
+
+class TestSerialization:
+    CLASS_TYPE = (
+        "haystack_integrations.components.converters.mistral.ocr_document_converter.MistralOCRDocumentConverter"
+    )
 
     def test_to_dict(self, monkeypatch):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-api-key")
@@ -164,6 +167,52 @@ class TestMistralOCRDocumentConverter:
         assert converter.image_min_size == 100
         assert converter.cleanup_uploaded_files is False
 
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.converters.mistral.ocr_document_converter.Mistral")
+    def test_key_resolved_at_warm_up_not_init(self, mock_mistral, monkeypatch):
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+
+        converter = MistralOCRDocumentConverter()
+
+        assert converter.client is None
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            converter.warm_up()
+        mock_mistral.assert_not_called()
+
+    @patch("haystack_integrations.components.converters.mistral.ocr_document_converter.Mistral")
+    def test_sync_lifecycle(self, mock_mistral):
+        converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
+        client = mock_mistral.return_value
+
+        converter.warm_up()
+        assert converter.client is client
+
+        converter.close()
+        client.__exit__.assert_called_once_with(None, None, None)
+        assert converter.client is None
+
+        converter.warm_up()
+        assert mock_mistral.call_count == 2
+
+    @patch("haystack_integrations.components.converters.mistral.ocr_document_converter.Mistral")
+    def test_warm_up_is_idempotent(self, mock_mistral):
+        converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
+
+        converter.warm_up()
+        converter.warm_up()
+
+        mock_mistral.assert_called_once_with(api_key="test-api-key")
+
+    def test_close_is_safe_without_warm_up(self):
+        converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
+
+        converter.close()
+
+        assert converter.client is None
+
+
+class TestRun:
     @pytest.fixture
     def mock_ocr_response(self):
         """Create a mock OCR response"""
@@ -216,16 +265,18 @@ class TestMistralOCRDocumentConverter:
         """Test processing with remote chunk types (DocumentURLChunk, FileChunk, ImageURLChunk)"""
         converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-            result = converter.run(sources=[source])
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-            assert len(result["documents"]) == 1
-            assert isinstance(result["documents"][0], Document)
-            assert result["documents"][0].content == "# Sample Document\n\nThis is page 1."
-            # Metadata assertions apply to all chunk types
-            if isinstance(source, DocumentURLChunk):
-                assert result["documents"][0].meta["source_page_count"] == 1
-                assert result["documents"][0].meta["source_total_images"] == 0
+        result = converter.run(sources=[source])
+
+        assert len(result["documents"]) == 1
+        assert isinstance(result["documents"][0], Document)
+        assert result["documents"][0].content == "# Sample Document\n\nThis is page 1."
+        # Metadata assertions apply to all chunk types
+        if isinstance(source, DocumentURLChunk):
+            assert result["documents"][0].meta["source_page_count"] == 1
+            assert result["documents"][0].meta["source_total_images"] == 0
 
     @pytest.mark.parametrize(
         "source_type",
@@ -251,16 +302,17 @@ class TestMistralOCRDocumentConverter:
         mock_uploaded_file = MagicMock()
         mock_uploaded_file.id = "uploaded-file-123"
 
-        with patch.object(converter.client.files, "upload", return_value=mock_uploaded_file):
-            with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-                with patch.object(converter.client.files, "delete"):
-                    result = converter.run(sources=[source])
+        converter.client = MagicMock()
+        converter.client.files.upload.return_value = mock_uploaded_file
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-                    assert len(result["documents"]) == 1
-                    assert isinstance(result["documents"][0], Document)
-                    # Verify file was uploaded for local sources
-                    if source_type == "file_path_str":
-                        converter.client.files.upload.assert_called_once()
+        result = converter.run(sources=[source])
+
+        assert len(result["documents"]) == 1
+        assert isinstance(result["documents"][0], Document)
+        # Verify file was uploaded for local sources
+        if source_type == "file_path_str":
+            converter.client.files.upload.assert_called_once()
 
     def test_run_with_multiple_sources(self, mock_ocr_response, tmp_path):
         """Test processing with multiple mixed source types"""
@@ -273,18 +325,19 @@ class TestMistralOCRDocumentConverter:
         mock_uploaded_file = MagicMock()
         mock_uploaded_file.id = "uploaded-file-123"
 
-        with patch.object(converter.client.files, "upload", return_value=mock_uploaded_file):
-            with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-                with patch.object(converter.client.files, "delete"):
-                    sources = [
-                        DocumentURLChunk(document_url="https://example.com/doc.pdf"),
-                        FileChunk(file_id="file-123"),
-                        str(test_file),
-                    ]
-                    result = converter.run(sources=sources)
+        converter.client = MagicMock()
+        converter.client.files.upload.return_value = mock_uploaded_file
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-                    assert len(result["documents"]) == 3
-                    assert all(isinstance(doc, Document) for doc in result["documents"])
+        sources = [
+            DocumentURLChunk(document_url="https://example.com/doc.pdf"),
+            FileChunk(file_id="file-123"),
+            str(test_file),
+        ]
+        result = converter.run(sources=sources)
+
+        assert len(result["documents"]) == 3
+        assert all(isinstance(doc, Document) for doc in result["documents"])
 
     def test_run_with_bbox_annotations(self):
         """Test processing with bbox annotation schema"""
@@ -311,13 +364,15 @@ class TestMistralOCRDocumentConverter:
             "document_annotation": None,
         }
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_response):
-            sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
-            result = converter.run(sources=sources, bbox_annotation_schema=ImageAnnotation)
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_response
 
-            assert len(result["documents"]) == 1
-            # Check that image annotation was enriched in content
-            assert "Image Annotation:" in result["documents"][0].content
+        sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
+        result = converter.run(sources=sources, bbox_annotation_schema=ImageAnnotation)
+
+        assert len(result["documents"]) == 1
+        # Check that image annotation was enriched in content
+        assert "Image Annotation:" in result["documents"][0].content
 
     def test_run_with_document_annotations(self):
         """Test processing with document annotation schema"""
@@ -341,14 +396,16 @@ class TestMistralOCRDocumentConverter:
             "document_annotation": '{"language": "en", "topics": ["AI", "ML"]}',
         }
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_response):
-            sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
-            result = converter.run(sources=sources, document_annotation_schema=DocumentAnnotation)
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_response
 
-            assert len(result["documents"]) == 1
-            # Check that document annotations are in metadata
-            assert result["documents"][0].meta["source_language"] == "en"
-            assert result["documents"][0].meta["source_topics"] == ["AI", "ML"]
+        sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
+        result = converter.run(sources=sources, document_annotation_schema=DocumentAnnotation)
+
+        assert len(result["documents"]) == 1
+        # Check that document annotations are in metadata
+        assert result["documents"][0].meta["source_language"] == "en"
+        assert result["documents"][0].meta["source_topics"] == ["AI", "ML"]
 
     def test_run_with_both_annotations(self):
         """Test processing with both bbox and document annotation schemas"""
@@ -377,114 +434,123 @@ class TestMistralOCRDocumentConverter:
             "document_annotation": '{"language": "en"}',
         }
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_response):
-            sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
-            result = converter.run(
-                sources=sources,
-                bbox_annotation_schema=ImageAnnotation,
-                document_annotation_schema=DocumentAnnotation,
-            )
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_response
 
-            assert len(result["documents"]) == 1
-            assert "Image Annotation:" in result["documents"][0].content
-            assert result["documents"][0].meta["source_language"] == "en"
+        sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
+        result = converter.run(
+            sources=sources,
+            bbox_annotation_schema=ImageAnnotation,
+            document_annotation_schema=DocumentAnnotation,
+        )
+
+        assert len(result["documents"]) == 1
+        assert "Image Annotation:" in result["documents"][0].content
+        assert result["documents"][0].meta["source_language"] == "en"
 
     def test_run_with_pages_parameter(self, mock_ocr_response):
         """Test that pages parameter is passed to API"""
         converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"), pages=[0, 1])
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response) as mock_process:
-            sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
-            result = converter.run(sources=sources)
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-            # Verify pages parameter was passed
-            call_args = mock_process.call_args
-            assert call_args.kwargs["pages"] == [0, 1]
-            assert len(result["documents"]) == 1
+        sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
+        result = converter.run(sources=sources)
+
+        # Verify pages parameter was passed
+        call_args = converter.client.ocr.process.call_args
+        assert call_args.kwargs["pages"] == [0, 1]
+        assert len(result["documents"]) == 1
 
     def test_run_handles_api_error(self, mock_ocr_response):
         """Test error handling when API fails"""
         converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
 
-        with patch.object(converter.client.ocr, "process") as mock_process:
-            # First call succeeds, second fails, third succeeds
-            mock_process.side_effect = [
-                mock_ocr_response,
-                Exception("API Error"),
-                mock_ocr_response,
-            ]
+        converter.client = MagicMock()
+        converter.client.ocr.process.side_effect = [
+            mock_ocr_response,
+            Exception("API Error"),
+            mock_ocr_response,
+        ]
 
-            sources = [
-                DocumentURLChunk(document_url="https://example.com/doc1.pdf"),
-                DocumentURLChunk(document_url="https://example.com/doc2.pdf"),
-                DocumentURLChunk(document_url="https://example.com/doc3.pdf"),
-            ]
-            result = converter.run(sources=sources)
+        sources = [
+            DocumentURLChunk(document_url="https://example.com/doc1.pdf"),
+            DocumentURLChunk(document_url="https://example.com/doc2.pdf"),
+            DocumentURLChunk(document_url="https://example.com/doc3.pdf"),
+        ]
+        result = converter.run(sources=sources)
 
-            # Should only return 2 documents (failed source skipped)
-            assert len(result["documents"]) == 2
-            assert len(result["raw_mistral_response"]) == 2
+        # Should only return 2 documents (failed source skipped)
+        assert len(result["documents"]) == 2
+        assert len(result["raw_mistral_response"]) == 2
 
     def test_run_with_meta_single_dict(self, mock_ocr_response):
         """Test that meta parameter with single dict is applied to all documents"""
         converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-            sources = [
-                DocumentURLChunk(document_url="https://example.com/doc1.pdf"),
-                DocumentURLChunk(document_url="https://example.com/doc2.pdf"),
-            ]
-            result = converter.run(sources=sources, meta={"department": "engineering", "year": 2024})
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-            assert len(result["documents"]) == 2
-            # Both documents should have the same metadata
-            for doc in result["documents"]:
-                assert doc.meta["department"] == "engineering"
-                assert doc.meta["year"] == 2024
-                # Automatic metadata should still be present
-                assert "source_page_count" in doc.meta
-                assert "source_total_images" in doc.meta
+        sources = [
+            DocumentURLChunk(document_url="https://example.com/doc1.pdf"),
+            DocumentURLChunk(document_url="https://example.com/doc2.pdf"),
+        ]
+        result = converter.run(sources=sources, meta={"department": "engineering", "year": 2024})
+
+        assert len(result["documents"]) == 2
+        # Both documents should have the same metadata
+        for doc in result["documents"]:
+            assert doc.meta["department"] == "engineering"
+            assert doc.meta["year"] == 2024
+            # Automatic metadata should still be present
+            assert "source_page_count" in doc.meta
+            assert "source_total_images" in doc.meta
 
     def test_run_with_meta_list_of_dicts(self, mock_ocr_response):
         """Test that meta parameter with list of dicts applies each dict to corresponding document"""
         converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-            sources = [
-                DocumentURLChunk(document_url="https://example.com/doc1.pdf"),
-                DocumentURLChunk(document_url="https://example.com/doc2.pdf"),
-            ]
-            result = converter.run(
-                sources=sources,
-                meta=[
-                    {"author": "Alice", "category": "report"},
-                    {"author": "Bob", "category": "invoice"},
-                ],
-            )
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-            assert len(result["documents"]) == 2
-            # First document
-            assert result["documents"][0].meta["author"] == "Alice"
-            assert result["documents"][0].meta["category"] == "report"
-            # Second document
-            assert result["documents"][1].meta["author"] == "Bob"
-            assert result["documents"][1].meta["category"] == "invoice"
-            # Automatic metadata should still be present in both
-            assert "source_page_count" in result["documents"][0].meta
-            assert "source_page_count" in result["documents"][1].meta
+        sources = [
+            DocumentURLChunk(document_url="https://example.com/doc1.pdf"),
+            DocumentURLChunk(document_url="https://example.com/doc2.pdf"),
+        ]
+        result = converter.run(
+            sources=sources,
+            meta=[
+                {"author": "Alice", "category": "report"},
+                {"author": "Bob", "category": "invoice"},
+            ],
+        )
+
+        assert len(result["documents"]) == 2
+        # First document
+        assert result["documents"][0].meta["author"] == "Alice"
+        assert result["documents"][0].meta["category"] == "report"
+        # Second document
+        assert result["documents"][1].meta["author"] == "Bob"
+        assert result["documents"][1].meta["category"] == "invoice"
+        # Automatic metadata should still be present in both
+        assert "source_page_count" in result["documents"][0].meta
+        assert "source_page_count" in result["documents"][1].meta
 
     def test_run_with_meta_none(self, mock_ocr_response):
         """Test that meta parameter with None works correctly"""
         converter = MistralOCRDocumentConverter(api_key=Secret.from_token("test-api-key"))
 
-        with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-            sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
-            result = converter.run(sources=sources, meta=None)
+        converter.client = MagicMock()
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-            assert len(result["documents"]) == 1
-            # Only automatic metadata should be present
-            assert "source_page_count" in result["documents"][0].meta
-            assert "source_total_images" in result["documents"][0].meta
+        sources = [DocumentURLChunk(document_url="https://example.com/doc.pdf")]
+        result = converter.run(sources=sources, meta=None)
+
+        assert len(result["documents"]) == 1
+        # Only automatic metadata should be present
+        assert "source_page_count" in result["documents"][0].meta
+        assert "source_total_images" in result["documents"][0].meta
 
     def test_run_with_meta_list_length_mismatch(self):
         """Test that meta parameter with list length mismatch raises ValueError"""
@@ -548,16 +614,17 @@ class TestMistralOCRDocumentConverter:
         mock_uploaded_file = MagicMock()
         mock_uploaded_file.id = "uploaded-file-123"
 
-        with patch.object(converter.client.files, "upload", return_value=mock_uploaded_file):
-            with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-                with patch.object(converter.client.files, "delete") as mock_delete:
-                    sources = [str(test_file)]
-                    result = converter.run(sources=sources)
+        converter.client = MagicMock()
+        converter.client.files.upload.return_value = mock_uploaded_file
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-                    # Verify file was uploaded but NOT deleted
-                    assert len(result["documents"]) == 1
-                    converter.client.files.upload.assert_called_once()
-                    mock_delete.assert_not_called()
+        sources = [str(test_file)]
+        result = converter.run(sources=sources)
+
+        # Verify file was uploaded but NOT deleted
+        assert len(result["documents"]) == 1
+        converter.client.files.upload.assert_called_once()
+        converter.client.files.delete.assert_not_called()
 
     def test_run_cleanup_happens_on_ocr_failure(self, tmp_path):
         """Test that cleanup happens even when OCR processing fails"""
@@ -570,16 +637,17 @@ class TestMistralOCRDocumentConverter:
         mock_uploaded_file = MagicMock()
         mock_uploaded_file.id = "uploaded-file-123"
 
-        with patch.object(converter.client.files, "upload", return_value=mock_uploaded_file):
-            with patch.object(converter.client.ocr, "process", side_effect=Exception("OCR failed")):
-                with patch.object(converter.client.files, "delete") as mock_delete:
-                    sources = [str(test_file)]
-                    result = converter.run(sources=sources)
+        converter.client = MagicMock()
+        converter.client.files.upload.return_value = mock_uploaded_file
+        converter.client.ocr.process.side_effect = Exception("OCR failed")
 
-                    # Verify no documents returned due to failure
-                    assert len(result["documents"]) == 0
-                    # But file should still be deleted
-                    mock_delete.assert_called_once_with(file_id="uploaded-file-123")
+        sources = [str(test_file)]
+        result = converter.run(sources=sources)
+
+        # Verify no documents returned due to failure
+        assert len(result["documents"]) == 0
+        # But file should still be deleted
+        converter.client.files.delete.assert_called_once_with(file_id="uploaded-file-123")
 
     def test_run_cleanup_failure_does_not_break_flow(self, mock_ocr_response, tmp_path):
         """Test that cleanup failures don't break the main flow"""
@@ -592,20 +660,18 @@ class TestMistralOCRDocumentConverter:
         mock_uploaded_file = MagicMock()
         mock_uploaded_file.id = "uploaded-file-123"
 
-        with patch.object(converter.client.files, "upload", return_value=mock_uploaded_file):
-            with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-                with patch.object(
-                    converter.client.files,
-                    "delete",
-                    side_effect=Exception("Delete failed"),
-                ):
-                    sources = [str(test_file)]
-                    # Should not raise an exception
-                    result = converter.run(sources=sources)
+        converter.client = MagicMock()
+        converter.client.files.upload.return_value = mock_uploaded_file
+        converter.client.ocr.process.return_value = mock_ocr_response
+        converter.client.files.delete.side_effect = Exception("Delete failed")
 
-                    # Verify document was still processed successfully
-                    assert len(result["documents"]) == 1
-                    assert isinstance(result["documents"][0], Document)
+        sources = [str(test_file)]
+        # Should not raise an exception
+        result = converter.run(sources=sources)
+
+        # Verify document was still processed successfully
+        assert len(result["documents"]) == 1
+        assert isinstance(result["documents"][0], Document)
 
     def test_run_mixed_sources_only_uploaded_files_deleted(self, mock_ocr_response, tmp_path):
         """Test that only uploaded files are deleted, not user-provided chunks"""
@@ -618,20 +684,21 @@ class TestMistralOCRDocumentConverter:
         mock_uploaded_file = MagicMock()
         mock_uploaded_file.id = "uploaded-file-123"
 
-        with patch.object(converter.client.files, "upload", return_value=mock_uploaded_file):
-            with patch.object(converter.client.ocr, "process", return_value=mock_ocr_response):
-                with patch.object(converter.client.files, "delete") as mock_delete:
-                    sources = [
-                        str(test_file),  # This will be uploaded
-                        FileChunk(file_id="user-file-123"),  # User-provided
-                        DocumentURLChunk(document_url="https://example.com/doc.pdf"),  # URL
-                    ]
-                    result = converter.run(sources=sources)
+        converter.client = MagicMock()
+        converter.client.files.upload.return_value = mock_uploaded_file
+        converter.client.ocr.process.return_value = mock_ocr_response
 
-                    # Verify all sources processed
-                    assert len(result["documents"]) == 3
-                    # Only the uploaded file should be deleted
-                    mock_delete.assert_called_once_with(file_id="uploaded-file-123")
+        sources = [
+            str(test_file),  # This will be uploaded
+            FileChunk(file_id="user-file-123"),  # User-provided
+            DocumentURLChunk(document_url="https://example.com/doc.pdf"),  # URL
+        ]
+        result = converter.run(sources=sources)
+
+        # Verify all sources processed
+        assert len(result["documents"]) == 3
+        # Only the uploaded file should be deleted
+        converter.client.files.delete.assert_called_once_with(file_id="uploaded-file-123")
 
     @pytest.mark.skipif(
         not os.environ.get("MISTRAL_API_KEY"),


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- implement lifecycle handling, following criteria in https://github.com/deepset-ai/haystack-private/issues/440#issuecomment-5526157817
  - Chat Generator and Embedder were overall already OK since they inherit from OpenAI
  - OCR Document Converter: create the client in `warm_up` and add a `close` method
- pin `haystack-ai>=3.0.0` and remove compatibility code with previous versions of Haystack


### How did you test it?
CI, new tests

### Notes for the reviewer
Most of the diff consists of test adaptations

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
