### PR TITLE
feat!: Ollama - add lifecycle handling

### DIFF
--- a/integrations/ollama/pyproject.toml
+++ b/integrations/ollama/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "ollama>=0.5.4", "pydantic>=2.12.0", "tenacity>=8.2.3"]
+dependencies = ["haystack-ai>=3.0.0", "ollama>=0.6.2", "pydantic>=2.12.0", "tenacity>=8.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ollama#readme"

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/document_embedder.py
@@ -96,8 +96,30 @@ class OllamaDocumentEmbedder:
         self.prefix = prefix
         self.dimensions = dimensions
 
-        self._client = Client(host=self.url, timeout=self.timeout)
-        self._async_client = AsyncClient(host=self.url, timeout=self.timeout)
+        self._client: Client | None = None
+        self._async_client: AsyncClient | None = None
+
+    def warm_up(self) -> None:
+        """Create the synchronous Ollama client."""
+        if self._client is None:
+            self._client = Client(host=self.url, timeout=self.timeout)
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Ollama client."""
+        if self._async_client is None:
+            self._async_client = AsyncClient(host=self.url, timeout=self.timeout)
+
+    def close(self) -> None:
+        """Close the synchronous Ollama client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous Ollama client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def _prepare_input(self, documents: list[Document]) -> list[Document]:
         """
@@ -141,6 +163,7 @@ class OllamaDocumentEmbedder:
         Internal method to embed a batch of texts.
         """
 
+        assert self._client is not None  # noqa: S101
         all_embeddings = []
 
         for i in tqdm(
@@ -164,6 +187,7 @@ class OllamaDocumentEmbedder:
         """
         Internal method to embed a batch of texts asynchronously.
         """
+        assert self._async_client is not None  # noqa: S101
         all_embeddings = []
 
         batches = [texts_to_embed[i : i + batch_size] for i in range(0, len(texts_to_embed), batch_size)]
@@ -206,6 +230,9 @@ class OllamaDocumentEmbedder:
             - `documents`: Documents with embedding information attached
             - `meta`: The metadata collected during the embedding process
         """
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
+
         documents = self._prepare_input(documents=documents)
 
         if not documents:
@@ -240,6 +267,9 @@ class OllamaDocumentEmbedder:
             - `documents`: Documents with embedding information attached
             - `meta`: The metadata collected during the embedding process
         """
+
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
 
         documents = self._prepare_input(documents=documents)
 

--- a/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
+++ b/integrations/ollama/src/haystack_integrations/components/embedders/ollama/text_embedder.py
@@ -62,8 +62,30 @@ class OllamaTextEmbedder:
         self.model = model
         self.dimensions = dimensions
 
-        self._client = Client(host=self.url, timeout=self.timeout)
-        self._async_client = AsyncClient(host=self.url, timeout=self.timeout)
+        self._client: Client | None = None
+        self._async_client: AsyncClient | None = None
+
+    def warm_up(self) -> None:
+        """Create the synchronous Ollama client."""
+        if self._client is None:
+            self._client = Client(host=self.url, timeout=self.timeout)
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Ollama client."""
+        if self._async_client is None:
+            self._async_client = AsyncClient(host=self.url, timeout=self.timeout)
+
+    def close(self) -> None:
+        """Close the synchronous Ollama client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous Ollama client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     @component.output_types(embedding=list[float], meta=dict[str, Any])
     def run(
@@ -82,6 +104,9 @@ class OllamaTextEmbedder:
             - `embedding`: The computed embeddings
             - `meta`: The metadata collected during the embedding process
         """
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
+
         result = self._client.embed(
             model=self.model,
             input=text,
@@ -109,6 +134,9 @@ class OllamaTextEmbedder:
             - `embedding`: The computed embeddings
             - `meta`: The metadata collected during the embedding process
         """
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
+
         result = await self._async_client.embed(
             model=self.model,
             input=text,

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -318,8 +318,30 @@ class OllamaChatGenerator:
         self.think = think
         self.response_format = response_format
 
-        self._client = Client(host=self.url, timeout=self.timeout)
-        self._async_client = AsyncClient(host=self.url, timeout=self.timeout)
+        self._client: Client | None = None
+        self._async_client: AsyncClient | None = None
+
+    def warm_up(self) -> None:
+        """Create the synchronous Ollama client."""
+        if self._client is None:
+            self._client = Client(host=self.url, timeout=self.timeout)
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous Ollama client."""
+        if self._async_client is None:
+            self._async_client = AsyncClient(host=self.url, timeout=self.timeout)
+
+    def close(self) -> None:
+        """Close the synchronous Ollama client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous Ollama client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -543,6 +565,7 @@ class OllamaChatGenerator:
         is_stream: bool,
         generation_kwargs: dict[str, Any],
     ) -> ChatResponse | Iterator[ChatResponse]:
+        assert self._client is not None  # noqa: S101
         return self._client.chat(
             model=self.model,
             messages=messages,
@@ -568,6 +591,7 @@ class OllamaChatGenerator:
         is_stream: bool,
         generation_kwargs: dict[str, Any],
     ) -> ChatResponse | AsyncIterator[ChatResponse]:
+        assert self._async_client is not None  # noqa: S101
         return await self._async_client.chat(
             model=self.model,
             messages=messages,
@@ -609,6 +633,9 @@ class OllamaChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: A list of ChatMessages containing the model's response
         """
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
+
         messages = _normalize_messages(messages)
 
         # Validate and select the streaming callback
@@ -667,6 +694,9 @@ class OllamaChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: A list of ChatMessages containing the model's response
         """
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
+
         messages = _normalize_messages(messages)
 
         # Validate and select the streaming callback

--- a/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
+++ b/integrations/ollama/src/haystack_integrations/components/generators/ollama/chat/chat_generator.py
@@ -519,7 +519,7 @@ class OllamaChatGenerator:
                     arg_by_index[key] = args
 
             if callback is not None:
-                # sync callbacks are allowed in async contexts with Haystack >= 3.0, so only await async ones
+                # Sync callbacks are allowed in async contexts, so only await async ones.
                 callback_result = callback(chunk)
                 if inspect.isawaitable(callback_result):
                     await callback_result

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -738,6 +738,8 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
         assert component.tools is None
         assert component.keep_alive is None
         assert component.response_format is None
+        assert component._client is None
+        assert component._async_client is None
 
     def test_init(self, tools):
         component = OllamaChatGenerator(
@@ -971,6 +973,78 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
         # Check that the Toolset contains the population tool
         assert len(tools_list[1]) == 1
         assert tools_list[1][0].name == "population"
+
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
+    def test_sync_lifecycle(self, mock_client_cls):
+        generator = OllamaChatGenerator()
+        client = mock_client_cls.return_value
+
+        generator.warm_up()
+        assert generator._client is client
+        assert generator._async_client is None
+
+        generator.close()
+        client.close.assert_called_once_with()
+        assert generator._client is None
+
+        generator.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.AsyncClient")
+    async def test_async_lifecycle(self, mock_client_cls):
+        generator = OllamaChatGenerator()
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await generator.warm_up_async()
+        assert generator._async_client is client
+        assert generator._client is None
+
+        await generator.close_async()
+        client.close.assert_awaited_once_with()
+        assert generator._async_client is None
+
+        await generator.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        generator = OllamaChatGenerator()
+        generator.warm_up()
+        generator.warm_up()
+        mock_client_cls.assert_called_once_with(host=generator.url, timeout=generator.timeout)
+
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.AsyncClient")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        generator = OllamaChatGenerator()
+        await generator.warm_up_async()
+        await generator.warm_up_async()
+        mock_client_cls.assert_called_once_with(host=generator.url, timeout=generator.timeout)
+
+    async def test_close_is_safe_without_warm_up(self):
+        generator = OllamaChatGenerator()
+        generator.close()
+        await generator.close_async()
+        assert generator._client is None
+        assert generator._async_client is None
+
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.AsyncClient")
+    @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        generator = OllamaChatGenerator()
+        mock_async_cls.return_value.close = AsyncMock()
+        generator.warm_up()
+        await generator.warm_up_async()
+
+        generator.close()
+        mock_sync_cls.return_value.close.assert_called_once_with()
+        assert generator._client is None
+        assert generator._async_client is mock_async_cls.return_value
+
+        await generator.close_async()
+        assert generator._async_client is None
 
 
 class TestOllamaChatGeneratorRun:

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -4,11 +4,6 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from haystack.components.generators.utils import print_streaming_chunk
-
-try:
-    from haystack.components.tools import ToolInvoker
-except ImportError:  # ToolInvoker was removed in Haystack 3.0
-    ToolInvoker = None
 from haystack.dataclasses import (
     ChatMessage,
     ChatRole,
@@ -435,11 +430,8 @@ class TestUtils:
             "arguments": '{"expression": "7 * (4 + 2)"}',
             "id": None,
             "tool_name": "calculator",
+            "extra": None,
         }
-        # We add extra to the expected dict if it exists in the result for comparison
-        # This was added in PR https://github.com/deepset-ai/haystack/pull/10018 and released in Haystack 2.20.0
-        if "extra" in streaming_chunks[0].tool_calls[0].to_dict():
-            expected["extra"] = streaming_chunks[0].tool_calls[0].to_dict()["extra"]
         assert streaming_chunks[0].tool_calls[0].to_dict() == expected
 
         expected = {
@@ -447,11 +439,8 @@ class TestUtils:
             "tool_name": "factorial",
             "arguments": '{"n": 5}',
             "id": None,
+            "extra": None,
         }
-        # We add extra to the expected dict if it exists in the result for comparison
-        # This was added in PR https://github.com/deepset-ai/haystack/pull/10018 and released in Haystack 2.20.0
-        if "extra" in streaming_chunks[1].tool_calls[0].to_dict():
-            expected["extra"] = streaming_chunks[1].tool_calls[0].to_dict()["extra"]
         assert streaming_chunks[1].tool_calls[0].to_dict() == expected
         assert len(streaming_chunks[2].tool_calls) == 0
 
@@ -717,12 +706,9 @@ class TestUtils:
             "arguments": '{"a": 2, "b": 2}',
             "id": None,
             "tool_name": "add_two_numbers",
+            "extra": None,
         }
         serialized_dict = streaming_chunks[12].tool_calls[0].to_dict()
-        # We add extra to the expected dict if it exists in the result for comparison
-        # This was added in PR https://github.com/deepset-ai/haystack/pull/10018 and released in Haystack 2.20.0
-        if "extra" in serialized_dict:
-            expected["extra"] = serialized_dict["extra"]
         assert serialized_dict == expected
 
 
@@ -1568,7 +1554,6 @@ class TestIntegration:
         if streaming_callback:
             streaming_callback.assert_called()
 
-    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_live_run_with_thinking_and_tools(self):
         @tool
         def add(a: int, b: int) -> int:
@@ -1581,7 +1566,6 @@ class TestIntegration:
             return a * b
 
         chat_generator = OllamaChatGenerator(model="qwen3:0.6b", think=True, tools=[add, multiply])
-        tool_invoker = ToolInvoker(tools=[add, multiply])
 
         sys_message = ChatMessage.from_system("Use the tools to answer the question.")
         message = ChatMessage.from_user("2+3?")
@@ -1594,7 +1578,8 @@ class TestIntegration:
         assert response.tool_calls[0].tool_name == "add"
         assert response.tool_calls[0].arguments == {"a": 2, "b": 3}
 
-        tool_result = tool_invoker.run(messages=[response])["tool_messages"][0]
+        tool_call = response.tool_calls[0]
+        tool_result = ChatMessage.from_tool(tool_result=str(add.invoke(**tool_call.arguments)), origin=tool_call)
 
         new_message = ChatMessage.from_user("Now multiply the result by 10.")
         new_response = chat_generator.run([sys_message, message, response, tool_result, new_message])["replies"][0]
@@ -1606,10 +1591,8 @@ class TestIntegration:
         assert new_response.tool_calls[0].arguments == {"a": 5, "b": 10}
 
     @pytest.mark.parametrize("streaming_callback", [None, print_streaming_chunk])
-    @pytest.mark.skipif(ToolInvoker is None, reason="ToolInvoker is not available in the installed haystack-ai version")
     def test_live_run_with_repeated_tool_calls(self, tools, streaming_callback):
         component = OllamaChatGenerator(model="qwen3:0.6b", tools=tools, streaming_callback=streaming_callback)
-        tool_invoker = ToolInvoker(tools=tools)
 
         messages = [
             ChatMessage.from_system("Use the tools to answer the question."),
@@ -1631,7 +1614,13 @@ class TestIntegration:
         assert any("paris" in c for c in cities)
         assert any("london" in c for c in cities)
 
-        tool_messages = tool_invoker.run(messages=[assistant_msg])["tool_messages"]
+        tools_by_name = {tool.name: tool for tool in tools}
+        tool_messages = [
+            ChatMessage.from_tool(
+                tool_result=str(tools_by_name[tool_call.tool_name].invoke(**tool_call.arguments)), origin=tool_call
+            )
+            for tool_call in assistant_msg.tool_calls
+        ]
         final_response = component.run([*messages, assistant_msg, *tool_messages])
         assert len(final_response["replies"]) == 1
         assert final_response["replies"][0].text

--- a/integrations/ollama/tests/test_chat_generator.py
+++ b/integrations/ollama/tests/test_chat_generator.py
@@ -726,7 +726,7 @@ class TestUtils:
         assert serialized_dict == expected
 
 
-class TestOllamaChatGeneratorInitSerializeDeserialize:
+class TestInitialization:
     def test_init_default(self):
         component = OllamaChatGenerator()
         assert component.model == "qwen3:0.6b"
@@ -778,6 +778,33 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
         generator = OllamaChatGenerator(model="llama3", tools=toolset)
         assert generator.tools == toolset
 
+    def test_init_with_mixed_tools(self, tools):
+        """Test that the OllamaChatGenerator can be initialized with mixed Tool and Toolset objects."""
+
+        @tool
+        def population(city: Annotated[str, "The city to get the population for"]) -> str:
+            """Get the population of a given city."""
+            return f"The population of {city} is 1 million"
+
+        population_toolset = Toolset([population])
+
+        # Mix individual Tool and Toolset
+        mixed_tools = [tools[0], population_toolset]
+        generator = OllamaChatGenerator(model="qwen3", tools=mixed_tools)
+
+        # The tools should be stored as the original ToolsType
+        assert isinstance(generator.tools, list)
+        assert len(generator.tools) == 2
+        # Check that we have a Tool and a Toolset
+        assert isinstance(generator.tools[0], Tool)
+        assert isinstance(generator.tools[1], Toolset)
+        assert generator.tools[0].name == "weather"
+        # Check that the Toolset contains the population tool
+        assert len(generator.tools[1]) == 1
+        assert generator.tools[1][0].name == "population"
+
+
+class TestSerialization:
     def test_to_dict_with_toolset(self, tools):
         """Test that the OllamaChatGenerator can be serialized to a dictionary with a Toolset."""
         toolset = Toolset(tools)
@@ -922,58 +949,6 @@ class TestOllamaChatGeneratorInitSerializeDeserialize:
             "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
         }
 
-    def test_init_with_mixed_tools(self, tools):
-        """Test that the OllamaChatGenerator can be initialized with mixed Tool and Toolset objects."""
-
-        @tool
-        def population(city: Annotated[str, "The city to get the population for"]) -> str:
-            """Get the population of a given city."""
-            return f"The population of {city} is 1 million"
-
-        population_toolset = Toolset([population])
-
-        # Mix individual Tool and Toolset
-        mixed_tools = [tools[0], population_toolset]
-        generator = OllamaChatGenerator(model="qwen3", tools=mixed_tools)
-
-        # The tools should be stored as the original ToolsType
-        assert isinstance(generator.tools, list)
-        assert len(generator.tools) == 2
-        # Check that we have a Tool and a Toolset
-        assert isinstance(generator.tools[0], Tool)
-        assert isinstance(generator.tools[1], Toolset)
-        assert generator.tools[0].name == "weather"
-        # Check that the Toolset contains the population tool
-        assert len(generator.tools[1]) == 1
-        assert generator.tools[1][0].name == "population"
-
-    def test_run_with_mixed_tools(self, tools):
-        """Test that the OllamaChatGenerator can run with mixed Tool and Toolset objects."""
-
-        @tool
-        def population(city: Annotated[str, "The city to get the population for"]) -> str:
-            """Get the population of a given city."""
-            return f"The population of {city} is 1 million"
-
-        population_toolset = Toolset([population])
-
-        # Mix individual Tool and Toolset
-        mixed_tools = [tools[0], population_toolset]
-        generator = OllamaChatGenerator(model="qwen3", tools=mixed_tools)
-
-        # Test that the tools are stored as the original ToolsType
-        tools_list = generator.tools
-        assert len(tools_list) == 2
-        # Check that we have a Tool and a Toolset
-        assert isinstance(tools_list[0], Tool)
-        assert isinstance(tools_list[1], Toolset)
-
-        # Verify tool names
-        assert tools_list[0].name == "weather"
-        # Check that the Toolset contains the population tool
-        assert len(tools_list[1]) == 1
-        assert tools_list[1][0].name == "population"
-
 
 class TestComponentLifecycle:
     @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
@@ -1047,7 +1022,7 @@ class TestComponentLifecycle:
         assert generator._async_client is None
 
 
-class TestOllamaChatGeneratorRun:
+class TestRun:
     @patch("haystack_integrations.components.generators.ollama.chat.chat_generator.Client")
     def test_run(self, mock_client):
         generator = OllamaChatGenerator()
@@ -1481,7 +1456,7 @@ class TestOllamaChatGeneratorRun:
 
 
 @pytest.mark.integration
-class TestOllamaChatGeneratorLiveInference:
+class TestIntegration:
     def test_live_run_model_unavailable(self):
         component = OllamaChatGenerator(model="unknown_model")
 
@@ -1723,7 +1698,7 @@ class TestOllamaChatGeneratorLiveInference:
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-class TestOllamaChatGeneratorAsync:
+class TestAsyncIntegration:
     async def test_run_async_basic(self):
         """Test basic async functionality."""
         chat_generator = OllamaChatGenerator(model="qwen3:0.6b")

--- a/integrations/ollama/tests/test_document_embedder.py
+++ b/integrations/ollama/tests/test_document_embedder.py
@@ -8,7 +8,7 @@ from ollama._types import ResponseError
 from haystack_integrations.components.embedders.ollama import OllamaDocumentEmbedder
 
 
-class TestOllamaDocumentEmbedder:
+class TestInitialization:
     def test_init_defaults(self):
         embedder = OllamaDocumentEmbedder()
 
@@ -35,51 +35,6 @@ class TestOllamaDocumentEmbedder:
         assert embedder.url == "http://my-custom-endpoint:11434"
         assert embedder.model == "nomic-embed-text"
 
-    @pytest.mark.integration
-    def test_model_not_found(self):
-        embedder = OllamaDocumentEmbedder(model="cheese")
-
-        with pytest.raises(ResponseError):
-            embedder.run([Document("hello")])
-
-    @pytest.mark.integration
-    def import_text_in_embedder(self):
-        embedder = OllamaDocumentEmbedder(model="all-minilm")
-
-        with pytest.raises(TypeError):
-            embedder.run("This is a text string. This should not work.")
-
-    @pytest.mark.integration
-    def test_run(self):
-        embedder = OllamaDocumentEmbedder(model="all-minilm", batch_size=2)
-        list_of_docs = [
-            Document(content="Llamas are amazing animals known for their soft wool and gentle demeanor."),
-            Document(content="The Andes mountains are the natural habitat of many llamas."),
-            Document(content="Llamas have been used as pack animals for centuries, especially in South America."),
-        ]
-        result = embedder.run(list_of_docs)
-
-        assert result["meta"]["model"] == "all-minilm"
-        documents = result["documents"]
-        assert len(documents) == 3
-        assert all(isinstance(element, float) for document in documents for element in document.embedding)
-
-    @pytest.mark.asyncio
-    @pytest.mark.integration
-    async def test_run_async(self):
-        embedder = OllamaDocumentEmbedder(model="all-minilm", batch_size=2)
-        list_of_docs = [
-            Document(content="Llamas are amazing animals known for their soft wool and gentle demeanor."),
-            Document(content="The Andes mountains are the natural habitat of many llamas."),
-            Document(content="Llamas have been used as pack animals for centuries, especially in South America."),
-        ]
-        result = await embedder.run_async(list_of_docs)
-
-        assert result["meta"]["model"] == "all-minilm"
-        documents = result["documents"]
-        assert len(documents) == 3
-        assert all(isinstance(element, float) for document in documents for element in document.embedding)
-
     def test_dimensions_default_is_none(self):
         embedder = OllamaDocumentEmbedder()
         assert embedder.dimensions is None
@@ -88,43 +43,8 @@ class TestOllamaDocumentEmbedder:
         embedder = OllamaDocumentEmbedder(dimensions=512)
         assert embedder.dimensions == 512
 
-    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
-    def test_dimensions_passed_to_embed_client(self, mock_client_cls):
-        embedder = OllamaDocumentEmbedder(dimensions=512)
-        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        mock_client_cls.return_value.embed.return_value = mock_response
-        embedder.warm_up()
 
-        embedder._embed_batch(["hello world"], batch_size=32)
-
-        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
-        assert call_kwargs["dimensions"] == 512
-
-    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
-    def test_none_dimensions_passed_to_embed_client(self, mock_client_cls):
-        embedder = OllamaDocumentEmbedder(dimensions=None)
-        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        mock_client_cls.return_value.embed.return_value = mock_response
-        embedder.warm_up()
-
-        embedder._embed_batch(["hello"], batch_size=32)
-
-        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
-        assert call_kwargs["dimensions"] is None
-
-    @pytest.mark.asyncio
-    @patch("haystack_integrations.components.embedders.ollama.document_embedder.AsyncClient")
-    async def test_dimensions_passed_to_async_embed_client(self, mock_client_cls):
-        embedder = OllamaDocumentEmbedder(dimensions=256)
-        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        mock_client_cls.return_value.embed = AsyncMock(return_value=mock_response)
-        await embedder.warm_up_async()
-
-        await embedder._embed_batch_async(["hello"], batch_size=32)
-
-        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
-        assert call_kwargs["dimensions"] == 256
-
+class TestSerialization:
     def test_to_dict_contains_dimensions(self):
         embedder = OllamaDocumentEmbedder(dimensions=512)
         embedder_dict = default_to_dict(
@@ -246,3 +166,86 @@ class TestComponentLifecycle:
 
         await embedder.close_async()
         assert embedder._async_client is None
+
+
+class TestRun:
+    def test_rejects_string_input(self):
+        embedder = OllamaDocumentEmbedder(model="all-minilm")
+
+        with pytest.raises(TypeError):
+            embedder.run("This is a text string. This should not work.")
+
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
+    def test_dimensions_passed_to_embed_client(self, mock_client_cls):
+        embedder = OllamaDocumentEmbedder(dimensions=512)
+        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
+        mock_client_cls.return_value.embed.return_value = mock_response
+        embedder.warm_up()
+
+        embedder._embed_batch(["hello world"], batch_size=32)
+
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
+        assert call_kwargs["dimensions"] == 512
+
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
+    def test_none_dimensions_passed_to_embed_client(self, mock_client_cls):
+        embedder = OllamaDocumentEmbedder(dimensions=None)
+        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
+        mock_client_cls.return_value.embed.return_value = mock_response
+        embedder.warm_up()
+
+        embedder._embed_batch(["hello"], batch_size=32)
+
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
+        assert call_kwargs["dimensions"] is None
+
+    @pytest.mark.asyncio
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.AsyncClient")
+    async def test_dimensions_passed_to_async_embed_client(self, mock_client_cls):
+        embedder = OllamaDocumentEmbedder(dimensions=256)
+        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
+        mock_client_cls.return_value.embed = AsyncMock(return_value=mock_response)
+        await embedder.warm_up_async()
+
+        await embedder._embed_batch_async(["hello"], batch_size=32)
+
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
+        assert call_kwargs["dimensions"] == 256
+
+
+@pytest.mark.integration
+class TestIntegration:
+    def test_model_not_found(self):
+        embedder = OllamaDocumentEmbedder(model="cheese")
+
+        with pytest.raises(ResponseError):
+            embedder.run([Document("hello")])
+
+    def test_run(self):
+        embedder = OllamaDocumentEmbedder(model="all-minilm", batch_size=2)
+        list_of_docs = [
+            Document(content="Llamas are amazing animals known for their soft wool and gentle demeanor."),
+            Document(content="The Andes mountains are the natural habitat of many llamas."),
+            Document(content="Llamas have been used as pack animals for centuries, especially in South America."),
+        ]
+        result = embedder.run(list_of_docs)
+
+        assert result["meta"]["model"] == "all-minilm"
+        documents = result["documents"]
+        assert len(documents) == 3
+        assert all(isinstance(element, float) for document in documents for element in document.embedding)
+
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        embedder = OllamaDocumentEmbedder(model="all-minilm", batch_size=2)
+        list_of_docs = [
+            Document(content="Llamas are amazing animals known for their soft wool and gentle demeanor."),
+            Document(content="The Andes mountains are the natural habitat of many llamas."),
+            Document(content="Llamas have been used as pack animals for centuries, especially in South America."),
+        ]
+        result = await embedder.run_async(list_of_docs)
+
+        assert result["meta"]["model"] == "all-minilm"
+        documents = result["documents"]
+        assert len(documents) == 3
+        assert all(isinstance(element, float) for document in documents for element in document.embedding)

--- a/integrations/ollama/tests/test_document_embedder.py
+++ b/integrations/ollama/tests/test_document_embedder.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from haystack import Document
@@ -17,6 +17,8 @@ class TestOllamaDocumentEmbedder:
         assert embedder.generation_kwargs == {}
         assert embedder.url == "http://localhost:11434"
         assert embedder.model == "nomic-embed-text"
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init(self):
         embedder = OllamaDocumentEmbedder(
@@ -86,35 +88,41 @@ class TestOllamaDocumentEmbedder:
         embedder = OllamaDocumentEmbedder(dimensions=512)
         assert embedder.dimensions == 512
 
-    def test_dimensions_passed_to_embed_client(self):
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
+    def test_dimensions_passed_to_embed_client(self, mock_client_cls):
         embedder = OllamaDocumentEmbedder(dimensions=512)
         mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        embedder._client.embed = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value.embed.return_value = mock_response
+        embedder.warm_up()
 
         embedder._embed_batch(["hello world"], batch_size=32)
 
-        call_kwargs = embedder._client.embed.call_args.kwargs
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
         assert call_kwargs["dimensions"] == 512
 
-    def test_none_dimensions_passed_to_embed_client(self):
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
+    def test_none_dimensions_passed_to_embed_client(self, mock_client_cls):
         embedder = OllamaDocumentEmbedder(dimensions=None)
         mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        embedder._client.embed = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value.embed.return_value = mock_response
+        embedder.warm_up()
 
         embedder._embed_batch(["hello"], batch_size=32)
 
-        call_kwargs = embedder._client.embed.call_args.kwargs
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
         assert call_kwargs["dimensions"] is None
 
     @pytest.mark.asyncio
-    async def test_dimensions_passed_to_async_embed_client(self):
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.AsyncClient")
+    async def test_dimensions_passed_to_async_embed_client(self, mock_client_cls):
         embedder = OllamaDocumentEmbedder(dimensions=256)
         mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        embedder._async_client.embed = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value.embed = AsyncMock(return_value=mock_response)
+        await embedder.warm_up_async()
 
         await embedder._embed_batch_async(["hello"], batch_size=32)
 
-        call_kwargs = embedder._async_client.embed.call_args.kwargs
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
         assert call_kwargs["dimensions"] == 256
 
     def test_to_dict_contains_dimensions(self):
@@ -166,3 +174,75 @@ class TestOllamaDocumentEmbedder:
         }
         embedder = default_from_dict(OllamaDocumentEmbedder, embedder_dict)
         assert embedder.dimensions == 512
+
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
+    def test_sync_lifecycle(self, mock_client_cls):
+        embedder = OllamaDocumentEmbedder()
+        client = mock_client_cls.return_value
+
+        embedder.warm_up()
+        assert embedder._client is client
+        assert embedder._async_client is None
+
+        embedder.close()
+        client.close.assert_called_once_with()
+        assert embedder._client is None
+
+        embedder.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.AsyncClient")
+    async def test_async_lifecycle(self, mock_client_cls):
+        embedder = OllamaDocumentEmbedder()
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await embedder.warm_up_async()
+        assert embedder._async_client is client
+        assert embedder._client is None
+
+        await embedder.close_async()
+        client.close.assert_awaited_once_with()
+        assert embedder._async_client is None
+
+        await embedder.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        embedder = OllamaDocumentEmbedder()
+        embedder.warm_up()
+        embedder.warm_up()
+        mock_client_cls.assert_called_once_with(host=embedder.url, timeout=embedder.timeout)
+
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.AsyncClient")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        embedder = OllamaDocumentEmbedder()
+        await embedder.warm_up_async()
+        await embedder.warm_up_async()
+        mock_client_cls.assert_called_once_with(host=embedder.url, timeout=embedder.timeout)
+
+    async def test_close_is_safe_without_warm_up(self):
+        embedder = OllamaDocumentEmbedder()
+        embedder.close()
+        await embedder.close_async()
+        assert embedder._client is None
+        assert embedder._async_client is None
+
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.AsyncClient")
+    @patch("haystack_integrations.components.embedders.ollama.document_embedder.Client")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        embedder = OllamaDocumentEmbedder()
+        mock_async_cls.return_value.close = AsyncMock()
+        embedder.warm_up()
+        await embedder.warm_up_async()
+
+        embedder.close()
+        mock_sync_cls.return_value.close.assert_called_once_with()
+        assert embedder._client is None
+        assert embedder._async_client is mock_async_cls.return_value
+
+        await embedder.close_async()
+        assert embedder._async_client is None

--- a/integrations/ollama/tests/test_text_embedder.py
+++ b/integrations/ollama/tests/test_text_embedder.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from haystack.core.serialization import default_from_dict, default_to_dict
@@ -17,6 +17,8 @@ class TestOllamaTextEmbedder:
         assert embedder.generation_kwargs == {}
         assert embedder.url == "http://localhost:11434"
         assert embedder.model == "nomic-embed-text"
+        assert embedder._client is None
+        assert embedder._async_client is None
 
     def test_init(self):
         embedder = OllamaTextEmbedder(
@@ -71,37 +73,37 @@ class TestOllamaTextEmbedder:
         embedder = OllamaTextEmbedder(dimensions=256)
         assert embedder.dimensions == 256
 
-    def test_dimensions_passed_to_embed_client(self):
-
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
+    def test_dimensions_passed_to_embed_client(self, mock_client_cls):
         embedder = OllamaTextEmbedder(dimensions=256)
         mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        embedder._client.embed = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value.embed.return_value = mock_response
 
         embedder.run(text="hello world")
 
-        call_kwargs = embedder._client.embed.call_args.kwargs
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
         assert call_kwargs["dimensions"] == 256
 
-    def test_none_dimensions_passed_to_embed_client(self):
-
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
+    def test_none_dimensions_passed_to_embed_client(self, mock_client_cls):
         embedder = OllamaTextEmbedder(dimensions=None)
         mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        embedder._client.embed = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value.embed.return_value = mock_response
 
         embedder.run(text="hello")
 
-        call_kwargs = embedder._client.embed.call_args.kwargs
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
         assert call_kwargs["dimensions"] is None
 
-    def test_dimensions_passed_to_async_embed_client(self):
-
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.AsyncClient")
+    def test_dimensions_passed_to_async_embed_client(self, mock_client_cls):
         embedder = OllamaTextEmbedder(dimensions=128)
         mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        embedder._async_client.embed = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value.embed = AsyncMock(return_value=mock_response)
 
         asyncio.run(embedder.run_async(text="hello"))
 
-        call_kwargs = embedder._async_client.embed.call_args.kwargs
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
         assert call_kwargs["dimensions"] == 128
 
     def test_to_dict_contains_dimensions(self):
@@ -144,3 +146,75 @@ class TestOllamaTextEmbedder:
         }
         embedder = default_from_dict(OllamaTextEmbedder, embedder_dict)
         assert embedder.dimensions == 256
+
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
+    def test_sync_lifecycle(self, mock_client_cls):
+        embedder = OllamaTextEmbedder()
+        client = mock_client_cls.return_value
+
+        embedder.warm_up()
+        assert embedder._client is client
+        assert embedder._async_client is None
+
+        embedder.close()
+        client.close.assert_called_once_with()
+        assert embedder._client is None
+
+        embedder.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.AsyncClient")
+    async def test_async_lifecycle(self, mock_client_cls):
+        embedder = OllamaTextEmbedder()
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await embedder.warm_up_async()
+        assert embedder._async_client is client
+        assert embedder._client is None
+
+        await embedder.close_async()
+        client.close.assert_awaited_once_with()
+        assert embedder._async_client is None
+
+        await embedder.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        embedder = OllamaTextEmbedder()
+        embedder.warm_up()
+        embedder.warm_up()
+        mock_client_cls.assert_called_once_with(host=embedder.url, timeout=embedder.timeout)
+
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.AsyncClient")
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        embedder = OllamaTextEmbedder()
+        await embedder.warm_up_async()
+        await embedder.warm_up_async()
+        mock_client_cls.assert_called_once_with(host=embedder.url, timeout=embedder.timeout)
+
+    async def test_close_is_safe_without_warm_up(self):
+        embedder = OllamaTextEmbedder()
+        embedder.close()
+        await embedder.close_async()
+        assert embedder._client is None
+        assert embedder._async_client is None
+
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.AsyncClient")
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        embedder = OllamaTextEmbedder()
+        mock_async_cls.return_value.close = AsyncMock()
+        embedder.warm_up()
+        await embedder.warm_up_async()
+
+        embedder.close()
+        mock_sync_cls.return_value.close.assert_called_once_with()
+        assert embedder._client is None
+        assert embedder._async_client is mock_async_cls.return_value
+
+        await embedder.close_async()
+        assert embedder._async_client is None

--- a/integrations/ollama/tests/test_text_embedder.py
+++ b/integrations/ollama/tests/test_text_embedder.py
@@ -8,7 +8,7 @@ from ollama._types import ResponseError
 from haystack_integrations.components.embedders.ollama import OllamaTextEmbedder
 
 
-class TestOllamaTextEmbedder:
+class TestInitialization:
     def test_init_defaults(self):
         embedder = OllamaTextEmbedder()
 
@@ -35,36 +35,6 @@ class TestOllamaTextEmbedder:
         assert embedder.url == "http://my-custom-endpoint:11434"
         assert embedder.model == "llama2"
 
-    @pytest.mark.integration
-    def test_model_not_found(self):
-        embedder = OllamaTextEmbedder(model="cheese")
-
-        with pytest.raises(ResponseError):
-            embedder.run("hello")
-
-    @pytest.mark.integration
-    def test_run(self):
-        embedder = OllamaTextEmbedder(model="all-minilm")
-
-        text = "hello"
-        reply = embedder.run(text=text)
-
-        assert isinstance(reply, dict)
-        assert all(isinstance(element, float) for element in reply["embedding"])
-        assert reply["meta"]["model"] == "all-minilm"
-
-    @pytest.mark.asyncio
-    @pytest.mark.integration
-    async def test_run_async(self):
-        embedder = OllamaTextEmbedder(model="all-minilm")
-
-        text = "hello"
-        reply = await embedder.run_async(text=text)
-
-        assert isinstance(reply, dict)
-        assert all(isinstance(element, float) for element in reply["embedding"])
-        assert reply["meta"]["model"] == "all-minilm"
-
     def test_dimensions_default_is_none(self):
         embedder = OllamaTextEmbedder()
         assert embedder.dimensions is None
@@ -73,39 +43,8 @@ class TestOllamaTextEmbedder:
         embedder = OllamaTextEmbedder(dimensions=256)
         assert embedder.dimensions == 256
 
-    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
-    def test_dimensions_passed_to_embed_client(self, mock_client_cls):
-        embedder = OllamaTextEmbedder(dimensions=256)
-        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        mock_client_cls.return_value.embed.return_value = mock_response
 
-        embedder.run(text="hello world")
-
-        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
-        assert call_kwargs["dimensions"] == 256
-
-    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
-    def test_none_dimensions_passed_to_embed_client(self, mock_client_cls):
-        embedder = OllamaTextEmbedder(dimensions=None)
-        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        mock_client_cls.return_value.embed.return_value = mock_response
-
-        embedder.run(text="hello")
-
-        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
-        assert call_kwargs["dimensions"] is None
-
-    @patch("haystack_integrations.components.embedders.ollama.text_embedder.AsyncClient")
-    def test_dimensions_passed_to_async_embed_client(self, mock_client_cls):
-        embedder = OllamaTextEmbedder(dimensions=128)
-        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
-        mock_client_cls.return_value.embed = AsyncMock(return_value=mock_response)
-
-        asyncio.run(embedder.run_async(text="hello"))
-
-        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
-        assert call_kwargs["dimensions"] == 128
-
+class TestSerialization:
     def test_to_dict_contains_dimensions(self):
 
         embedder = OllamaTextEmbedder(dimensions=256)
@@ -218,3 +157,68 @@ class TestComponentLifecycle:
 
         await embedder.close_async()
         assert embedder._async_client is None
+
+
+class TestRun:
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
+    def test_dimensions_passed_to_embed_client(self, mock_client_cls):
+        embedder = OllamaTextEmbedder(dimensions=256)
+        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
+        mock_client_cls.return_value.embed.return_value = mock_response
+
+        embedder.run(text="hello world")
+
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
+        assert call_kwargs["dimensions"] == 256
+
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.Client")
+    def test_none_dimensions_passed_to_embed_client(self, mock_client_cls):
+        embedder = OllamaTextEmbedder(dimensions=None)
+        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
+        mock_client_cls.return_value.embed.return_value = mock_response
+
+        embedder.run(text="hello")
+
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
+        assert call_kwargs["dimensions"] is None
+
+    @patch("haystack_integrations.components.embedders.ollama.text_embedder.AsyncClient")
+    def test_dimensions_passed_to_async_embed_client(self, mock_client_cls):
+        embedder = OllamaTextEmbedder(dimensions=128)
+        mock_response = {"embeddings": [[0.1, 0.2, 0.3]]}
+        mock_client_cls.return_value.embed = AsyncMock(return_value=mock_response)
+
+        asyncio.run(embedder.run_async(text="hello"))
+
+        call_kwargs = mock_client_cls.return_value.embed.call_args.kwargs
+        assert call_kwargs["dimensions"] == 128
+
+
+@pytest.mark.integration
+class TestIntegration:
+    def test_model_not_found(self):
+        embedder = OllamaTextEmbedder(model="cheese")
+
+        with pytest.raises(ResponseError):
+            embedder.run("hello")
+
+    def test_run(self):
+        embedder = OllamaTextEmbedder(model="all-minilm")
+
+        text = "hello"
+        reply = embedder.run(text=text)
+
+        assert isinstance(reply, dict)
+        assert all(isinstance(element, float) for element in reply["embedding"])
+        assert reply["meta"]["model"] == "all-minilm"
+
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        embedder = OllamaTextEmbedder(model="all-minilm")
+
+        text = "hello"
+        reply = await embedder.run_async(text=text)
+
+        assert isinstance(reply, dict)
+        assert all(isinstance(element, float) for element in reply["embedding"])
+        assert reply["meta"]["model"] == "all-minilm"


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- implement lifecycle handling, following criteria in https://github.com/deepset-ai/haystack-private/issues/440#issuecomment-5526157817
  - clients created in `warm_up`/`warm_up_async` instead of `__init__`
  - added closing methods
  - separated sync and async lifecycle
- pin `haystack-ai>=3.0.0` (removed compatibility code for <3)
- reorganized a bit the test suite

### How did you test it?
CI, new tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
