### PR TITLE
refactor!: Optimum - move resources creation to warm_up

### DIFF
--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.22.0",
+  "haystack-ai>=3.0.0",
   "optimum[onnxruntime]>=1.21.0",
   # The main export function of Optimum into ONNX has hidden dependencies.
   # It depends on either "sentence-transformers", "diffusers" or "timm", based

--- a/integrations/optimum/pyproject.toml
+++ b/integrations/optimum/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=3.0.0",
+  "haystack-ai>=2.22.0",
   "optimum[onnxruntime]>=1.21.0",
   # The main export function of Optimum into ONNX has hidden dependencies.
   # It depends on either "sentence-transformers", "diffusers" or "timm", based

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/_backend.py
@@ -89,12 +89,14 @@ class _EmbedderParams:
             out[field] = copy.deepcopy(getattr(self, field))
 
         # Fixups.
-        assert isinstance(self.pooling_mode, OptimumEmbedderPooling)
-        out["pooling_mode"] = str(self.pooling_mode)
+        out["pooling_mode"] = str(self.pooling_mode) if self.pooling_mode is not None else None
         out["token"] = self.token.to_dict() if self.token else None
         out["optimizer_settings"] = self.optimizer_settings.to_dict() if self.optimizer_settings else None
         out["quantizer_settings"] = self.quantizer_settings.to_dict() if self.quantizer_settings else None
 
+        out["model_kwargs"] = out["model_kwargs"] or {}
+        out["model_kwargs"].setdefault("model_id", self.model)
+        out["model_kwargs"].setdefault("provider", self.onnx_execution_provider)
         out["model_kwargs"].pop("use_auth_token", None)
         out["model_kwargs"].pop("token", None)
         serialize_hf_model_kwargs(out["model_kwargs"])
@@ -102,7 +104,8 @@ class _EmbedderParams:
 
     @classmethod
     def deserialize_inplace(cls, data: dict[str, Any]) -> dict[str, Any]:
-        data["pooling_mode"] = OptimumEmbedderPooling.from_str(data["pooling_mode"])
+        if data["pooling_mode"] is not None:
+            data["pooling_mode"] = OptimumEmbedderPooling.from_str(data["pooling_mode"])
         if data["optimizer_settings"] is not None:
             data["optimizer_settings"] = OptimumEmbedderOptimizationConfig.from_dict(data["optimizer_settings"])
         if data["quantizer_settings"] is not None:
@@ -149,6 +152,9 @@ class _EmbedderBackend:
         self.pooling_layer: SentenceTransformerPoolingLayer | None = None
 
     def warm_up(self) -> None:
+        if self.model is not None:
+            return
+
         assert self.params.model_kwargs
         model_kwargs = copy.deepcopy(self.params.model_kwargs)
         model = ORTModelForFeatureExtraction.from_pretrained(**model_kwargs, export=True)

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimum_document_embedder.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimum_document_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 from dataclasses import replace
 from typing import Any
 
@@ -121,7 +122,7 @@ class OptimumDocumentEmbedder:
         :param embedding_separator:
             Separator used to concatenate the meta fields to the Document text.
         """
-        params = _EmbedderParams(
+        self._params = _EmbedderParams(
             model=model,
             token=token,
             prefix=prefix,
@@ -139,18 +140,18 @@ class OptimumDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
-        self._backend = _EmbedderBackend(params)
-        self._initialized = False
+        self._backend: _EmbedderBackend | None = None
 
     def warm_up(self) -> None:
         """
         Initializes the component.
         """
-        if self._initialized:
+        if self._backend is not None:
             return
 
-        self._backend.warm_up()
-        self._initialized = True
+        backend = _EmbedderBackend(copy.deepcopy(self._params))
+        backend.warm_up()
+        self._backend = backend
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -159,7 +160,7 @@ class OptimumDocumentEmbedder:
         :returns:
             Dictionary with serialized data.
         """
-        init_params = self._backend.parameters.serialize()
+        init_params = self._params.serialize()
         init_params["meta_fields_to_embed"] = self.meta_fields_to_embed
         init_params["embedding_separator"] = self.embedding_separator
         return default_to_dict(self, **init_params)
@@ -188,9 +189,9 @@ class OptimumDocumentEmbedder:
             ]
 
             text_to_embed = (
-                self._backend.parameters.prefix
+                self._params.prefix
                 + self.embedding_separator.join([*meta_values_to_embed, doc.content or ""])
-                + self._backend.parameters.suffix
+                + self._params.suffix
             )
 
             texts_to_embed.append(text_to_embed)
@@ -210,9 +211,6 @@ class OptimumDocumentEmbedder:
         :raises TypeError:
             If the input is not a list of Documents.
         """
-        if not self._initialized:
-            self.warm_up()
-
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = (
                 "OptimumDocumentEmbedder expects a list of Documents as input."
@@ -223,6 +221,9 @@ class OptimumDocumentEmbedder:
         # Return empty list if no documents
         if not documents:
             return {"documents": []}
+
+        self.warm_up()
+        assert self._backend is not None
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
         embeddings = self._backend.embed_texts(texts_to_embed)

--- a/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimum_text_embedder.py
+++ b/integrations/optimum/src/haystack_integrations/components/embedders/optimum/optimum_text_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
@@ -104,7 +105,7 @@ class OptimumTextEmbedder:
             Configuration for Optimum Embedder Quantization.
             If `None`, no quantization is be applied.
         """
-        params = _EmbedderParams(
+        self._params = _EmbedderParams(
             model=model,
             token=token,
             prefix=prefix,
@@ -119,18 +120,18 @@ class OptimumTextEmbedder:
             optimizer_settings=optimizer_settings,
             quantizer_settings=quantizer_settings,
         )
-        self._backend = _EmbedderBackend(params)
-        self._initialized = False
+        self._backend: _EmbedderBackend | None = None
 
     def warm_up(self) -> None:
         """
         Initializes the component.
         """
-        if self._initialized:
+        if self._backend is not None:
             return
 
-        self._backend.warm_up()
-        self._initialized = True
+        backend = _EmbedderBackend(copy.deepcopy(self._params))
+        backend.warm_up()
+        self._backend = backend
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -139,7 +140,7 @@ class OptimumTextEmbedder:
         :returns:
             Dictionary with serialized data.
         """
-        init_params = self._backend.parameters.serialize()
+        init_params = self._params.serialize()
         # Remove init params that are not provided to the text embedder.
         init_params.pop("batch_size")
         init_params.pop("progress_bar")
@@ -170,9 +171,6 @@ class OptimumTextEmbedder:
         :raises TypeError:
             If the input is not a string.
         """
-        if not self._initialized:
-            self.warm_up()
-
         if not isinstance(text, str):
             msg = (
                 "OptimumTextEmbedder expects a string as an input. "
@@ -180,6 +178,9 @@ class OptimumTextEmbedder:
             )
             raise TypeError(msg)
 
-        text_to_embed = self._backend.parameters.prefix + text + self._backend.parameters.suffix
+        self.warm_up()
+        assert self._backend is not None
+
+        text_to_embed = self._params.prefix + text + self._params.suffix
         embedding = self._backend.embed_texts(text_to_embed)
         return {"embedding": embedding}

--- a/integrations/optimum/tests/test_optimum_document_embedder.py
+++ b/integrations/optimum/tests/test_optimum_document_embedder.py
@@ -32,38 +32,25 @@ def mock_check_valid_model():
         yield mock
 
 
-@pytest.fixture
-def mock_get_pooling_mode():
-    with patch(
-        "haystack_integrations.components.embedders.optimum._backend._pooling_from_model_config",
-        MagicMock(return_value=OptimumEmbedderPooling.MEAN),
-    ) as mock:
-        yield mock
-
-
-class TestOptimumDocumentEmbedder:
-    def test_init_default(self, monkeypatch, mock_check_valid_model, mock_get_pooling_mode):  # noqa: ARG002
-        monkeypatch.setenv("HF_API_TOKEN", "fake-api-token")
+class TestInitializationSerialization:
+    def test_init_default(self):
         embedder = OptimumDocumentEmbedder()
 
-        assert embedder._backend.parameters.model == "sentence-transformers/all-mpnet-base-v2"
-        assert embedder._backend.parameters.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
-        assert embedder._backend.parameters.prefix == ""
-        assert embedder._backend.parameters.suffix == ""
-        assert embedder._backend.parameters.normalize_embeddings is True
-        assert embedder._backend.parameters.onnx_execution_provider == "CPUExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MEAN
-        assert embedder._backend.parameters.batch_size == 32
-        assert embedder._backend.parameters.progress_bar is True
+        assert embedder._params.model == "sentence-transformers/all-mpnet-base-v2"
+        assert embedder._params.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert embedder._params.prefix == ""
+        assert embedder._params.suffix == ""
+        assert embedder._params.normalize_embeddings is True
+        assert embedder._params.onnx_execution_provider == "CPUExecutionProvider"
+        assert embedder._params.pooling_mode is None
+        assert embedder._params.batch_size == 32
+        assert embedder._params.progress_bar is True
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
-        assert embedder._backend.parameters.model_kwargs == {
-            "model_id": "sentence-transformers/all-mpnet-base-v2",
-            "provider": "CPUExecutionProvider",
-            "token": "fake-api-token",
-        }
+        assert embedder._params.model_kwargs is None
+        assert embedder._backend is None
 
-    def test_init_with_parameters(self, mock_check_valid_model):  # noqa: ARG002
+    def test_init_with_parameters(self):
         embedder = OptimumDocumentEmbedder(
             model="sentence-transformers/all-minilm-l6-v2",
             token=Secret.from_token("fake-api-token"),
@@ -82,30 +69,24 @@ class TestOptimumDocumentEmbedder:
             quantizer_settings=None,
         )
 
-        assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
-        assert embedder._backend.parameters.token == Secret.from_token("fake-api-token")
-        assert embedder._backend.parameters.prefix == "prefix"
-        assert embedder._backend.parameters.suffix == "suffix"
-        assert embedder._backend.parameters.batch_size == 64
-        assert embedder._backend.parameters.progress_bar is False
+        assert embedder._params.model == "sentence-transformers/all-minilm-l6-v2"
+        assert embedder._params.token == Secret.from_token("fake-api-token")
+        assert embedder._params.prefix == "prefix"
+        assert embedder._params.suffix == "suffix"
+        assert embedder._params.batch_size == 64
+        assert embedder._params.progress_bar is False
         assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
-        assert embedder._backend.parameters.normalize_embeddings is False
-        assert embedder._backend.parameters.onnx_execution_provider == "CUDAExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MAX
-        assert embedder._backend.parameters.model_kwargs == {
-            "trust_remote_code": True,
-            "model_id": "sentence-transformers/all-minilm-l6-v2",
-            "provider": "CUDAExecutionProvider",
-            "token": "fake-api-token",
-        }
-        assert embedder._backend.parameters.working_dir == "working_dir"
-        assert embedder._backend.parameters.optimizer_settings is None
-        assert embedder._backend.parameters.quantizer_settings is None
+        assert embedder._params.normalize_embeddings is False
+        assert embedder._params.onnx_execution_provider == "CUDAExecutionProvider"
+        assert embedder._params.pooling_mode == "max"
+        assert embedder._params.model_kwargs == {"trust_remote_code": True}
+        assert embedder._params.working_dir == "working_dir"
+        assert embedder._params.optimizer_settings is None
+        assert embedder._params.quantizer_settings is None
+        assert embedder._backend is None
 
-    def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode, monkeypatch):  # noqa: ARG002
-        monkeypatch.delenv("HF_API_TOKEN", raising=False)
-        monkeypatch.delenv("HF_TOKEN", raising=False)
+    def test_to_and_from_dict(self):
         component = OptimumDocumentEmbedder()
         data = component.to_dict()
 
@@ -122,7 +103,7 @@ class TestOptimumDocumentEmbedder:
                 "embedding_separator": "\n",
                 "normalize_embeddings": True,
                 "onnx_execution_provider": "CPUExecutionProvider",
-                "pooling_mode": "mean",
+                "pooling_mode": None,
                 "model_kwargs": {
                     "model_id": "sentence-transformers/all-mpnet-base-v2",
                     "provider": "CPUExecutionProvider",
@@ -134,27 +115,27 @@ class TestOptimumDocumentEmbedder:
         }
 
         embedder = OptimumDocumentEmbedder.from_dict(data)
-        assert embedder._backend.parameters.model == "sentence-transformers/all-mpnet-base-v2"
-        assert embedder._backend.parameters.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
-        assert embedder._backend.parameters.prefix == ""
-        assert embedder._backend.parameters.suffix == ""
-        assert embedder._backend.parameters.normalize_embeddings is True
-        assert embedder._backend.parameters.onnx_execution_provider == "CPUExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MEAN
-        assert embedder._backend.parameters.batch_size == 32
-        assert embedder._backend.parameters.progress_bar is True
+        assert embedder._params.model == "sentence-transformers/all-mpnet-base-v2"
+        assert embedder._params.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert embedder._params.prefix == ""
+        assert embedder._params.suffix == ""
+        assert embedder._params.normalize_embeddings is True
+        assert embedder._params.onnx_execution_provider == "CPUExecutionProvider"
+        assert embedder._params.pooling_mode is None
+        assert embedder._params.batch_size == 32
+        assert embedder._params.progress_bar is True
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
-        assert embedder._backend.parameters.model_kwargs == {
+        assert embedder._params.model_kwargs == {
             "model_id": "sentence-transformers/all-mpnet-base-v2",
             "provider": "CPUExecutionProvider",
-            "token": None,
         }
-        assert embedder._backend.parameters.working_dir is None
-        assert embedder._backend.parameters.optimizer_settings is None
-        assert embedder._backend.parameters.quantizer_settings is None
+        assert embedder._params.working_dir is None
+        assert embedder._params.optimizer_settings is None
+        assert embedder._params.quantizer_settings is None
+        assert embedder._backend is None
 
-    def test_to_and_from_dict_with_custom_init_parameters(self, mock_check_valid_model, mock_get_pooling_mode):
+    def test_to_and_from_dict_with_custom_init_parameters(self):
         component = OptimumDocumentEmbedder(
             model="sentence-transformers/all-minilm-l6-v2",
             token=Secret.from_env_var("ENV_VAR", strict=False),
@@ -202,42 +183,109 @@ class TestOptimumDocumentEmbedder:
         }
 
         embedder = OptimumDocumentEmbedder.from_dict(data)
-        assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
-        assert embedder._backend.parameters.token == Secret.from_env_var("ENV_VAR", strict=False)
-        assert embedder._backend.parameters.prefix == "prefix"
-        assert embedder._backend.parameters.suffix == "suffix"
-        assert embedder._backend.parameters.batch_size == 64
-        assert embedder._backend.parameters.progress_bar is False
+        assert embedder._params.model == "sentence-transformers/all-minilm-l6-v2"
+        assert embedder._params.token == Secret.from_env_var("ENV_VAR", strict=False)
+        assert embedder._params.prefix == "prefix"
+        assert embedder._params.suffix == "suffix"
+        assert embedder._params.batch_size == 64
+        assert embedder._params.progress_bar is False
         assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
-        assert embedder._backend.parameters.normalize_embeddings is False
-        assert embedder._backend.parameters.onnx_execution_provider == "CUDAExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MAX
-        assert embedder._backend.parameters.model_kwargs == {
+        assert embedder._params.normalize_embeddings is False
+        assert embedder._params.onnx_execution_provider == "CUDAExecutionProvider"
+        assert embedder._params.pooling_mode == OptimumEmbedderPooling.MAX
+        assert embedder._params.model_kwargs == {
             "trust_remote_code": True,
             "model_id": "sentence-transformers/all-minilm-l6-v2",
             "provider": "CUDAExecutionProvider",
-            "token": None,
         }
-        assert embedder._backend.parameters.working_dir == "working_dir"
-        assert embedder._backend.parameters.optimizer_settings == OptimumEmbedderOptimizationConfig(
+        assert embedder._params.working_dir == "working_dir"
+        assert embedder._params.optimizer_settings == OptimumEmbedderOptimizationConfig(
             OptimumEmbedderOptimizationMode.O1, for_gpu=True
         )
-        assert embedder._backend.parameters.quantizer_settings == OptimumEmbedderQuantizationConfig(
+        assert embedder._params.quantizer_settings == OptimumEmbedderQuantizationConfig(
             OptimumEmbedderQuantizationMode.ARM64, per_channel=True
         )
+        assert embedder._backend is None
 
-    def test_initialize_with_invalid_model(self, mock_check_valid_model):
+    def test_from_dict_with_legacy_serialization(self):
+        data = {
+            "type": "haystack_integrations.components.embedders.optimum.optimum_document_embedder.OptimumDocumentEmbedder",
+            "init_parameters": {
+                "model": "sentence-transformers/all-mpnet-base-v2",
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
+                "prefix": "",
+                "suffix": "",
+                "batch_size": 32,
+                "progress_bar": True,
+                "meta_fields_to_embed": [],
+                "embedding_separator": "\n",
+                "normalize_embeddings": True,
+                "onnx_execution_provider": "CPUExecutionProvider",
+                "pooling_mode": "mean",
+                "model_kwargs": {
+                    "model_id": "sentence-transformers/all-mpnet-base-v2",
+                    "provider": "CPUExecutionProvider",
+                },
+                "working_dir": None,
+                "optimizer_settings": None,
+                "quantizer_settings": None,
+            },
+        }
+
+        embedder = OptimumDocumentEmbedder.from_dict(data)
+
+        assert embedder._params.pooling_mode == OptimumEmbedderPooling.MEAN
+        assert embedder._params.model_kwargs == {
+            "model_id": "sentence-transformers/all-mpnet-base-v2",
+            "provider": "CPUExecutionProvider",
+        }
+        assert embedder._params.batch_size == 32
+        assert embedder._backend is None
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)
+        embedder = OptimumDocumentEmbedder(
+            token=Secret.from_env_var("HF_API_TOKEN"),
+            pooling_mode="mean",
+        )
+
+        assert embedder._backend is None
+        with pytest.raises(ValueError, match="None of the following authentication environment variables are set"):
+            embedder.warm_up()
+        assert embedder._backend is None
+
+    def test_warm_up_is_idempotent(self):
+        backend = MagicMock()
+        with patch(
+            "haystack_integrations.components.embedders.optimum.optimum_document_embedder._EmbedderBackend",
+            return_value=backend,
+        ) as backend_class:
+            embedder = OptimumDocumentEmbedder(pooling_mode="mean")
+            embedder.warm_up()
+            embedder.warm_up()
+
+        backend_class.assert_called_once()
+        backend.warm_up.assert_called_once()
+        assert embedder._backend is backend
+
+    def test_warm_up_with_invalid_model(self, mock_check_valid_model):
         mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id")
+        embedder = OptimumDocumentEmbedder(model="invalid_model_id")
         with pytest.raises(RepositoryNotFoundError):
-            OptimumDocumentEmbedder(model="invalid_model_id")
+            embedder.warm_up()
 
-    def test_initialize_with_invalid_pooling_mode(self, mock_check_valid_model):  # noqa: ARG002
-        mock_get_pooling_mode.side_effect = ValueError("Invalid pooling mode")
+    def test_warm_up_with_invalid_pooling_mode(self, mock_check_valid_model):  # noqa: ARG002
+        embedder = OptimumDocumentEmbedder(
+            model="sentence-transformers/all-mpnet-base-v2", pooling_mode="Invalid_pooling_mode"
+        )
         with pytest.raises(ValueError):
-            OptimumDocumentEmbedder(
-                model="sentence-transformers/all-mpnet-base-v2", pooling_mode="Invalid_pooling_mode"
-            )
+            embedder.warm_up()
+
+
+class TestRun:
 
     def test_infer_pooling_mode_from_str(self, mock_check_valid_model):  # noqa: ARG002
         """
@@ -249,17 +297,18 @@ class TestOptimumDocumentEmbedder:
                 model="sentence-transformers/all-minilm-l6-v2",
                 pooling_mode=pooling_mode.value,
             )
+            with patch("haystack_integrations.components.embedders.optimum._backend._EmbedderBackend.warm_up"):
+                embedder.warm_up()
 
+            assert embedder._backend is not None
             assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
             assert embedder._backend.parameters.pooling_mode == pooling_mode
 
     @pytest.mark.integration
     def test_default_pooling_mode_when_config_not_found(self, mock_check_valid_model):  # noqa: ARG002
+        embedder = OptimumDocumentEmbedder(model="embedding_model_finetuned", pooling_mode=None)
         with pytest.raises(ValueError):
-            OptimumDocumentEmbedder(
-                model="embedding_model_finetuned",
-                pooling_mode=None,
-            )
+            embedder.warm_up()
 
     @pytest.mark.integration
     def test_infer_pooling_mode_from_hf(self):
@@ -267,11 +316,13 @@ class TestOptimumDocumentEmbedder:
             model="sentence-transformers/all-minilm-l6-v2",
             pooling_mode=None,
         )
+        embedder.warm_up()
 
+        assert embedder._backend is not None
         assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
         assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MEAN
 
-    def test_prepare_texts_to_embed_w_metadata(self, mock_check_valid_model):  # noqa: ARG002
+    def test_prepare_texts_to_embed_w_metadata(self):
         documents = [
             Document(content=f"document number {i}: content", meta={"meta_field": f"meta_value {i}"}) for i in range(5)
         ]
@@ -293,7 +344,7 @@ class TestOptimumDocumentEmbedder:
             "meta_value 4 | document number 4: content",
         ]
 
-    def test_prepare_texts_to_embed_w_suffix(self, mock_check_valid_model):  # noqa: ARG002
+    def test_prepare_texts_to_embed_w_suffix(self):
         documents = [Document(content=f"document number {i}") for i in range(5)]
 
         embedder = OptimumDocumentEmbedder(
@@ -313,9 +364,8 @@ class TestOptimumDocumentEmbedder:
             "my_prefix document number 4 my_suffix",
         ]
 
-    def test_run_wrong_input_format(self, mock_check_valid_model):  # noqa: ARG002
+    def test_run_wrong_input_format(self):
         embedder = OptimumDocumentEmbedder(model="sentence-transformers/all-mpnet-base-v2", pooling_mode="mean")
-        embedder._initialized = True
         # wrong formats
         string_input = "text"
         list_integers_input = [1, 2, 3]
@@ -326,11 +376,10 @@ class TestOptimumDocumentEmbedder:
         with pytest.raises(TypeError, match="OptimumDocumentEmbedder expects a list of Documents as input"):
             embedder.run(documents=list_integers_input)
 
-    def test_run_on_empty_list(self, mock_check_valid_model, mock_get_pooling_mode):  # noqa: ARG002
+    def test_run_on_empty_list(self):
         embedder = OptimumDocumentEmbedder(
             model="sentence-transformers/paraphrase-albert-small-v2",
         )
-        embedder._initialized = True
         empty_list_input = []
         result = embedder.run(documents=empty_list_input)
 

--- a/integrations/optimum/tests/test_optimum_document_embedder.py
+++ b/integrations/optimum/tests/test_optimum_document_embedder.py
@@ -235,12 +235,24 @@ class TestInitializationSerialization:
 
         embedder = OptimumDocumentEmbedder.from_dict(data)
 
+        assert embedder._params.model == "sentence-transformers/all-mpnet-base-v2"
+        assert embedder._params.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert embedder._params.prefix == ""
+        assert embedder._params.suffix == ""
+        assert embedder._params.normalize_embeddings is True
+        assert embedder._params.onnx_execution_provider == "CPUExecutionProvider"
         assert embedder._params.pooling_mode == OptimumEmbedderPooling.MEAN
         assert embedder._params.model_kwargs == {
             "model_id": "sentence-transformers/all-mpnet-base-v2",
             "provider": "CPUExecutionProvider",
         }
         assert embedder._params.batch_size == 32
+        assert embedder._params.progress_bar is True
+        assert embedder._params.working_dir is None
+        assert embedder._params.optimizer_settings is None
+        assert embedder._params.quantizer_settings is None
+        assert embedder.meta_fields_to_embed == []
+        assert embedder.embedding_separator == "\n"
         assert embedder._backend is None
 
 

--- a/integrations/optimum/tests/test_optimum_text_embedder.py
+++ b/integrations/optimum/tests/test_optimum_text_embedder.py
@@ -196,11 +196,22 @@ class TestInitializationSerialization:
 
         embedder = OptimumTextEmbedder.from_dict(data)
 
+        assert embedder._params.model == "sentence-transformers/all-mpnet-base-v2"
+        assert embedder._params.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert embedder._params.prefix == ""
+        assert embedder._params.suffix == ""
+        assert embedder._params.normalize_embeddings is True
+        assert embedder._params.onnx_execution_provider == "CPUExecutionProvider"
+        assert embedder._params.batch_size == 1
+        assert embedder._params.progress_bar is False
         assert embedder._params.pooling_mode == OptimumEmbedderPooling.MEAN
         assert embedder._params.model_kwargs == {
             "model_id": "sentence-transformers/all-mpnet-base-v2",
             "provider": "CPUExecutionProvider",
         }
+        assert embedder._params.working_dir is None
+        assert embedder._params.optimizer_settings is None
+        assert embedder._params.quantizer_settings is None
         assert embedder._backend is None
 
 

--- a/integrations/optimum/tests/test_optimum_text_embedder.py
+++ b/integrations/optimum/tests/test_optimum_text_embedder.py
@@ -29,34 +29,21 @@ def mock_check_valid_model():
         yield mock
 
 
-@pytest.fixture
-def mock_get_pooling_mode():
-    with patch(
-        "haystack_integrations.components.embedders.optimum._backend._pooling_from_model_config",
-        MagicMock(return_value=OptimumEmbedderPooling.MEAN),
-    ) as mock:
-        yield mock
-
-
-class TestOptimumTextEmbedder:
-    def test_init_default(self, monkeypatch, mock_check_valid_model, mock_get_pooling_mode):  # noqa: ARG002
-        monkeypatch.setenv("HF_API_TOKEN", "fake-api-token")
+class TestInitializationSerialization:
+    def test_init_default(self):
         embedder = OptimumTextEmbedder()
 
-        assert embedder._backend.parameters.model == "sentence-transformers/all-mpnet-base-v2"
-        assert embedder._backend.parameters.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
-        assert embedder._backend.parameters.prefix == ""
-        assert embedder._backend.parameters.suffix == ""
-        assert embedder._backend.parameters.normalize_embeddings is True
-        assert embedder._backend.parameters.onnx_execution_provider == "CPUExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MEAN
-        assert embedder._backend.parameters.model_kwargs == {
-            "model_id": "sentence-transformers/all-mpnet-base-v2",
-            "provider": "CPUExecutionProvider",
-            "token": "fake-api-token",
-        }
+        assert embedder._params.model == "sentence-transformers/all-mpnet-base-v2"
+        assert embedder._params.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert embedder._params.prefix == ""
+        assert embedder._params.suffix == ""
+        assert embedder._params.normalize_embeddings is True
+        assert embedder._params.onnx_execution_provider == "CPUExecutionProvider"
+        assert embedder._params.pooling_mode is None
+        assert embedder._params.model_kwargs is None
+        assert embedder._backend is None
 
-    def test_init_with_parameters(self, mock_check_valid_model):  # noqa: ARG002
+    def test_init_with_parameters(self):
         embedder = OptimumTextEmbedder(
             model="sentence-transformers/all-minilm-l6-v2",
             token=Secret.from_token("fake-api-token"),
@@ -71,26 +58,20 @@ class TestOptimumTextEmbedder:
             quantizer_settings=None,
         )
 
-        assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
-        assert embedder._backend.parameters.token == Secret.from_token("fake-api-token")
-        assert embedder._backend.parameters.prefix == "prefix"
-        assert embedder._backend.parameters.suffix == "suffix"
-        assert embedder._backend.parameters.normalize_embeddings is False
-        assert embedder._backend.parameters.onnx_execution_provider == "CUDAExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MAX
-        assert embedder._backend.parameters.model_kwargs == {
-            "trust_remote_code": True,
-            "model_id": "sentence-transformers/all-minilm-l6-v2",
-            "provider": "CUDAExecutionProvider",
-            "token": "fake-api-token",
-        }
-        assert embedder._backend.parameters.working_dir == "working_dir"
-        assert embedder._backend.parameters.optimizer_settings is None
-        assert embedder._backend.parameters.quantizer_settings is None
+        assert embedder._params.model == "sentence-transformers/all-minilm-l6-v2"
+        assert embedder._params.token == Secret.from_token("fake-api-token")
+        assert embedder._params.prefix == "prefix"
+        assert embedder._params.suffix == "suffix"
+        assert embedder._params.normalize_embeddings is False
+        assert embedder._params.onnx_execution_provider == "CUDAExecutionProvider"
+        assert embedder._params.pooling_mode == "max"
+        assert embedder._params.model_kwargs == {"trust_remote_code": True}
+        assert embedder._params.working_dir == "working_dir"
+        assert embedder._params.optimizer_settings is None
+        assert embedder._params.quantizer_settings is None
+        assert embedder._backend is None
 
-    def test_to_and_from_dict(self, mock_check_valid_model, mock_get_pooling_mode, monkeypatch):  # noqa: ARG002
-        monkeypatch.delenv("HF_API_TOKEN", raising=False)
-        monkeypatch.delenv("HF_TOKEN", raising=False)
+    def test_to_and_from_dict(self):
         component = OptimumTextEmbedder()
         data = component.to_dict()
 
@@ -103,7 +84,7 @@ class TestOptimumTextEmbedder:
                 "suffix": "",
                 "normalize_embeddings": True,
                 "onnx_execution_provider": "CPUExecutionProvider",
-                "pooling_mode": "mean",
+                "pooling_mode": None,
                 "working_dir": None,
                 "model_kwargs": {
                     "model_id": "sentence-transformers/all-mpnet-base-v2",
@@ -115,23 +96,23 @@ class TestOptimumTextEmbedder:
         }
 
         embedder = OptimumTextEmbedder.from_dict(data)
-        assert embedder._backend.parameters.model == "sentence-transformers/all-mpnet-base-v2"
-        assert embedder._backend.parameters.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
-        assert embedder._backend.parameters.prefix == ""
-        assert embedder._backend.parameters.suffix == ""
-        assert embedder._backend.parameters.normalize_embeddings is True
-        assert embedder._backend.parameters.onnx_execution_provider == "CPUExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MEAN
-        assert embedder._backend.parameters.model_kwargs == {
+        assert embedder._params.model == "sentence-transformers/all-mpnet-base-v2"
+        assert embedder._params.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert embedder._params.prefix == ""
+        assert embedder._params.suffix == ""
+        assert embedder._params.normalize_embeddings is True
+        assert embedder._params.onnx_execution_provider == "CPUExecutionProvider"
+        assert embedder._params.pooling_mode is None
+        assert embedder._params.model_kwargs == {
             "model_id": "sentence-transformers/all-mpnet-base-v2",
             "provider": "CPUExecutionProvider",
-            "token": None,
         }
-        assert embedder._backend.parameters.working_dir is None
-        assert embedder._backend.parameters.optimizer_settings is None
-        assert embedder._backend.parameters.quantizer_settings is None
+        assert embedder._params.working_dir is None
+        assert embedder._params.optimizer_settings is None
+        assert embedder._params.quantizer_settings is None
+        assert embedder._backend is None
 
-    def test_to_and_from_dict_with_custom_init_parameters(self, mock_check_valid_model):  # noqa: ARG002
+    def test_to_and_from_dict_with_custom_init_parameters(self):
         component = OptimumTextEmbedder(
             model="sentence-transformers/all-minilm-l6-v2",
             token=Secret.from_env_var("ENV_VAR", strict=False),
@@ -171,36 +152,100 @@ class TestOptimumTextEmbedder:
         }
 
         embedder = OptimumTextEmbedder.from_dict(data)
-        assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
-        assert embedder._backend.parameters.token == Secret.from_env_var("ENV_VAR", strict=False)
-        assert embedder._backend.parameters.prefix == "prefix"
-        assert embedder._backend.parameters.suffix == "suffix"
-        assert embedder._backend.parameters.normalize_embeddings is False
-        assert embedder._backend.parameters.onnx_execution_provider == "CUDAExecutionProvider"
-        assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MAX
-        assert embedder._backend.parameters.model_kwargs == {
+        assert embedder._params.model == "sentence-transformers/all-minilm-l6-v2"
+        assert embedder._params.token == Secret.from_env_var("ENV_VAR", strict=False)
+        assert embedder._params.prefix == "prefix"
+        assert embedder._params.suffix == "suffix"
+        assert embedder._params.normalize_embeddings is False
+        assert embedder._params.onnx_execution_provider == "CUDAExecutionProvider"
+        assert embedder._params.pooling_mode == OptimumEmbedderPooling.MAX
+        assert embedder._params.model_kwargs == {
             "trust_remote_code": True,
             "model_id": "sentence-transformers/all-minilm-l6-v2",
             "provider": "CUDAExecutionProvider",
-            "token": None,
         }
-        assert embedder._backend.parameters.working_dir == "working_dir"
-        assert embedder._backend.parameters.optimizer_settings == OptimumEmbedderOptimizationConfig(
+        assert embedder._params.working_dir == "working_dir"
+        assert embedder._params.optimizer_settings == OptimumEmbedderOptimizationConfig(
             OptimumEmbedderOptimizationMode.O1, for_gpu=True
         )
-        assert embedder._backend.parameters.quantizer_settings == OptimumEmbedderQuantizationConfig(
+        assert embedder._params.quantizer_settings == OptimumEmbedderQuantizationConfig(
             OptimumEmbedderQuantizationMode.ARM64, per_channel=True
         )
+        assert embedder._backend is None
 
-    def test_initialize_with_invalid_model(self, mock_check_valid_model):
+    def test_from_dict_with_legacy_serialization(self):
+        data = {
+            "type": "haystack_integrations.components.embedders.optimum.optimum_text_embedder.OptimumTextEmbedder",
+            "init_parameters": {
+                "model": "sentence-transformers/all-mpnet-base-v2",
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
+                "prefix": "",
+                "suffix": "",
+                "normalize_embeddings": True,
+                "onnx_execution_provider": "CPUExecutionProvider",
+                "pooling_mode": "mean",
+                "working_dir": None,
+                "model_kwargs": {
+                    "model_id": "sentence-transformers/all-mpnet-base-v2",
+                    "provider": "CPUExecutionProvider",
+                },
+                "optimizer_settings": None,
+                "quantizer_settings": None,
+            },
+        }
+
+        embedder = OptimumTextEmbedder.from_dict(data)
+
+        assert embedder._params.pooling_mode == OptimumEmbedderPooling.MEAN
+        assert embedder._params.model_kwargs == {
+            "model_id": "sentence-transformers/all-mpnet-base-v2",
+            "provider": "CPUExecutionProvider",
+        }
+        assert embedder._backend is None
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)
+        embedder = OptimumTextEmbedder(
+            token=Secret.from_env_var("HF_API_TOKEN"),
+            pooling_mode="mean",
+        )
+
+        assert embedder._backend is None
+        with pytest.raises(ValueError, match="None of the following authentication environment variables are set"):
+            embedder.warm_up()
+        assert embedder._backend is None
+
+    def test_warm_up_is_idempotent(self):
+        backend = MagicMock()
+        with patch(
+            "haystack_integrations.components.embedders.optimum.optimum_text_embedder._EmbedderBackend",
+            return_value=backend,
+        ) as backend_class:
+            embedder = OptimumTextEmbedder(pooling_mode="mean")
+            embedder.warm_up()
+            embedder.warm_up()
+
+        backend_class.assert_called_once()
+        backend.warm_up.assert_called_once()
+        assert embedder._backend is backend
+
+    def test_warm_up_with_invalid_model(self, mock_check_valid_model):
         mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id")
+        embedder = OptimumTextEmbedder(model="invalid_model_id", pooling_mode="max")
         with pytest.raises(RepositoryNotFoundError):
-            OptimumTextEmbedder(model="invalid_model_id", pooling_mode="max")
+            embedder.warm_up()
 
-    def test_initialize_with_invalid_pooling_mode(self, mock_check_valid_model):  # noqa: ARG002
-        mock_get_pooling_mode.side_effect = ValueError("Invalid pooling mode")
+    def test_warm_up_with_invalid_pooling_mode(self, mock_check_valid_model):  # noqa: ARG002
+        embedder = OptimumTextEmbedder(
+            model="sentence-transformers/all-mpnet-base-v2", pooling_mode="Invalid_pooling_mode"
+        )
         with pytest.raises(ValueError):
-            OptimumTextEmbedder(model="sentence-transformers/all-mpnet-base-v2", pooling_mode="Invalid_pooling_mode")
+            embedder.warm_up()
+
+
+class TestRun:
 
     def test_infer_pooling_mode_from_str(self, mock_check_valid_model):  # noqa: ARG002
         """
@@ -208,21 +253,19 @@ class TestOptimumTextEmbedder:
         The pooling mode is "mean" as per the model config.
         """
         for pooling_mode in OptimumEmbedderPooling:
-            embedder = OptimumTextEmbedder(
-                model="sentence-transformers/all-minilm-l6-v2",
-                pooling_mode=pooling_mode.value,
-            )
+            embedder = OptimumTextEmbedder(model="sentence-transformers/all-minilm-l6-v2", pooling_mode=pooling_mode.value)
+            with patch("haystack_integrations.components.embedders.optimum._backend._EmbedderBackend.warm_up"):
+                embedder.warm_up()
 
+            assert embedder._backend is not None
             assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
             assert embedder._backend.parameters.pooling_mode == pooling_mode
 
     @pytest.mark.integration
     def test_default_pooling_mode_when_config_not_found(self, mock_check_valid_model):  # noqa: ARG002
+        embedder = OptimumTextEmbedder(model="embedding_model_finetuned", pooling_mode=None)
         with pytest.raises(ValueError):
-            OptimumTextEmbedder(
-                model="embedding_model_finetuned",
-                pooling_mode=None,
-            )
+            embedder.warm_up()
 
     @pytest.mark.integration
     def test_infer_pooling_mode_from_hf(self):
@@ -230,18 +273,18 @@ class TestOptimumTextEmbedder:
             model="sentence-transformers/all-minilm-l6-v2",
             pooling_mode=None,
         )
+        embedder.warm_up()
 
+        assert embedder._backend is not None
         assert embedder._backend.parameters.model == "sentence-transformers/all-minilm-l6-v2"
         assert embedder._backend.parameters.pooling_mode == OptimumEmbedderPooling.MEAN
 
-    def test_run_wrong_input_format(self, mock_check_valid_model):  # noqa: ARG002
+    def test_run_wrong_input_format(self):
         embedder = OptimumTextEmbedder(
             model="sentence-transformers/paraphrase-albert-small-v2",
             token=Secret.from_token("fake-api-token"),
             pooling_mode="mean",
         )
-        embedder._initialized = True
-
         list_integers_input = [1, 2, 3]
 
         with pytest.raises(TypeError, match="OptimumTextEmbedder expects a string as an input"):


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- for the embedders, make `__init__` store only configuration and move everything else to `warm_up`: model validation via HTTP, model loading...
  - to do this minimally, in each embedder's `warm_up`, I both create and warm up the embedding backend
  - this also changes serialization. I added a test to make sure that the legacy serialization format can still be deserialized.

### How did you test it?
CI, new tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
