### PR TITLE
feat!: Perplexity - add lifecycle handling

### DIFF
--- a/integrations/perplexity/pyproject.toml
+++ b/integrations/perplexity/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "httpx>=0.27.0"]
+dependencies = ["haystack-ai>=3.0.0", "httpx>=0.27.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/perplexity#readme"

--- a/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
+++ b/integrations/perplexity/src/haystack_integrations/components/embedders/perplexity/document_embedder.py
@@ -158,6 +158,7 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
 
         doc_ids_to_embeddings: dict[str, list[float]] = {}
         meta: dict[str, Any] = {}
+        assert self.client is not None  # noqa: S101
         for batch in tqdm(
             batched(texts_to_embed.items(), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
         ):
@@ -168,8 +169,7 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
             }
 
             try:
-                # with haystack-ai >= 3.0 the client is Optional and built by the warm_up call in run
-                response = self.client.embeddings.create(**args)  # type: ignore[union-attr]
+                response = self.client.embeddings.create(**args)
             except APIError as exc:
                 ids = ", ".join(b[0] for b in batch)
                 msg = "Failed embedding of documents {ids} caused by {exc}"
@@ -200,6 +200,7 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
 
         doc_ids_to_embeddings: dict[str, list[float]] = {}
         meta: dict[str, Any] = {}
+        assert self.async_client is not None  # noqa: S101
 
         batches: Iterable[tuple[tuple[str, str], ...]] = list(batched(texts_to_embed.items(), batch_size))
         if self.progress_bar:
@@ -213,8 +214,7 @@ class PerplexityDocumentEmbedder(OpenAIDocumentEmbedder):
             }
 
             try:
-                # with haystack-ai >= 3.0 the client is Optional and built by the warm_up_async call in run_async
-                response = await self.async_client.embeddings.create(**args)  # type: ignore[union-attr]
+                response = await self.async_client.embeddings.create(**args)
             except APIError as exc:
                 ids = ", ".join(b[0] for b in batch)
                 msg = "Failed embedding of documents {ids} caused by {exc}"

--- a/integrations/perplexity/src/haystack_integrations/components/generators/perplexity/chat/chat_generator.py
+++ b/integrations/perplexity/src/haystack_integrations/components/generators/perplexity/chat/chat_generator.py
@@ -130,9 +130,8 @@ class PerplexityChatGenerator(OpenAIResponsesChatGenerator):
             tools_strict=tools_strict,
             http_client_kwargs=_http_client_kwargs_with_headers(http_client_kwargs, extra_headers),
         )
-        # self.http_client_kwargs carries the attribution (and extra) headers so that the parent bakes them into
-        # the httpx client whether it is built eagerly (haystack-ai 2.x) or at warm-up (haystack-ai >= 3.0);
-        # the user-provided value is preserved for serialization
+        # self.http_client_kwargs carries the attribution (and extra) headers so that the parent includes them when
+        # building the HTTP clients at warm-up; the user-provided value is preserved for serialization
         self._http_client_kwargs = http_client_kwargs
 
     def to_dict(self) -> dict[str, Any]:

--- a/integrations/perplexity/src/haystack_integrations/components/websearch/perplexity/perplexity_websearch.py
+++ b/integrations/perplexity/src/haystack_integrations/components/websearch/perplexity/perplexity_websearch.py
@@ -99,14 +99,29 @@ class PerplexityWebSearch:
 
     def warm_up(self) -> None:
         """
-        Initialize the sync and async HTTP clients.
+        Initialize the synchronous HTTP client.
 
         Called automatically on first use. Can be called explicitly to avoid cold-start latency.
         """
         if self._client is None:
             self._client = httpx.Client(timeout=self.timeout)
+
+    async def warm_up_async(self) -> None:
+        """Initialize the asynchronous HTTP client."""
         if self._async_client is None:
             self._async_client = httpx.AsyncClient(timeout=self.timeout)
+
+    def close(self) -> None:
+        """Release the synchronous HTTP client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Release the asynchronous HTTP client."""
+        if self._async_client is not None:
+            await self._async_client.aclose()
+            self._async_client = None
 
     @component.output_types(documents=list[Document], links=list[str])
     def run(
@@ -125,10 +140,10 @@ class PerplexityWebSearch:
             - `documents`: List of Documents containing search result content.
             - `links`: List of URLs from the search results.
         """
-        if self._client is None:
-            self.warm_up()
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
 
-        response = self._client.post(  # type: ignore[union-attr]
+        response = self._client.post(
             PERPLEXITY_SEARCH_URL,
             headers=self._build_headers(),
             json=self._build_body(query, search_params),
@@ -153,10 +168,10 @@ class PerplexityWebSearch:
             - `documents`: List of Documents containing search result content.
             - `links`: List of URLs from the search results.
         """
-        if self._async_client is None:
-            self.warm_up()
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
 
-        response = await self._async_client.post(  # type: ignore[union-attr]
+        response = await self._async_client.post(
             PERPLEXITY_SEARCH_URL,
             headers=self._build_headers(),
             json=self._build_body(query, search_params),

--- a/integrations/perplexity/tests/test_perplexity_chat_generator.py
+++ b/integrations/perplexity/tests/test_perplexity_chat_generator.py
@@ -80,16 +80,16 @@ class TestPerplexityChatGenerator:
 
         assert chat_generator_module._attribution_header() == "haystack/unknown"
 
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
-
+    def test_init_default(self):
         component = PerplexityChatGenerator()
 
-        assert component.api_key.resolve_value() == "test-api-key"
+        assert component.api_key == Secret.from_env_var("PERPLEXITY_API_KEY")
         assert component.model == "openai/gpt-5.4"
         assert component.api_base_url == "https://api.perplexity.ai/v1"
         assert component.streaming_callback is None
         assert not component.generation_kwargs
+        assert component.client is None
+        assert component.async_client is None
 
     def test_init_with_parameters(self):
         component = PerplexityChatGenerator(
@@ -126,12 +126,14 @@ class TestPerplexityChatGenerator:
     def test_warm_up(self, monkeypatch):
         monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
         component = PerplexityChatGenerator()
-        component.warm_up()  # with haystack-ai >= 3.0 the client is created during warm-up
+
+        component.warm_up()
+
+        assert component.client is not None
         assert component.client.api_key == "test-api-key"
 
-    def test_to_dict_default_round_trip(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
 
+    def test_to_dict_default_round_trip(self):
         component = PerplexityChatGenerator()
         data = component.to_dict()
 
@@ -161,8 +163,7 @@ class TestPerplexityChatGenerator:
         assert deserialized.api_key == Secret.from_env_var("PERPLEXITY_API_KEY")
         assert deserialized.extra_headers is None
 
-    def test_to_dict_with_parameters_round_trip(self, monkeypatch):
-        monkeypatch.setenv("ENV_VAR", "test-api-key")
+    def test_to_dict_with_parameters_round_trip(self):
         component = PerplexityChatGenerator(
             api_key=Secret.from_env_var("ENV_VAR"),
             model="xai/grok-4-1",

--- a/integrations/perplexity/tests/test_perplexity_chat_generator.py
+++ b/integrations/perplexity/tests/test_perplexity_chat_generator.py
@@ -132,7 +132,6 @@ class TestPerplexityChatGenerator:
         assert component.client is not None
         assert component.client.api_key == "test-api-key"
 
-
     def test_to_dict_default_round_trip(self):
         component = PerplexityChatGenerator()
         data = component.to_dict()

--- a/integrations/perplexity/tests/test_perplexity_document_embedder.py
+++ b/integrations/perplexity/tests/test_perplexity_document_embedder.py
@@ -82,9 +82,7 @@ class TestPerplexityDocumentEmbedder:
         models = PerplexityDocumentEmbedder.SUPPORTED_MODELS
         assert models == ["pplx-embed-v1-0.6b", "pplx-embed-v1-4b"]
 
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
-
+    def test_init_default(self):
         embedder = PerplexityDocumentEmbedder()
 
         assert embedder.api_key == Secret.from_env_var(["PERPLEXITY_API_KEY"])
@@ -97,6 +95,8 @@ class TestPerplexityDocumentEmbedder:
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
         assert embedder.encoding_format == "base64_int8"
+        assert embedder.client is None
+        assert embedder.async_client is None
 
     def test_init_with_parameters(self):
         embedder = PerplexityDocumentEmbedder(
@@ -130,9 +130,7 @@ class TestPerplexityDocumentEmbedder:
                 encoding_format="float",
             )
 
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
-
+    def test_to_dict(self):
         embedder = PerplexityDocumentEmbedder()
         component_dict = embedder.to_dict()
 
@@ -158,8 +156,7 @@ class TestPerplexityDocumentEmbedder:
             },
         }
 
-    def test_to_dict_with_custom_init_parameters(self, monkeypatch):
-        monkeypatch.setenv("ENV_VAR", "test-secret-key")
+    def test_to_dict_with_custom_init_parameters(self):
         embedder = PerplexityDocumentEmbedder(
             api_key=Secret.from_env_var("ENV_VAR", strict=False),
             model="pplx-embed-v1-4b",
@@ -199,8 +196,7 @@ class TestPerplexityDocumentEmbedder:
             },
         }
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "fake-api-key")
+    def test_from_dict(self):
         data = {
             "type": (
                 "haystack_integrations.components.embedders.perplexity.document_embedder.PerplexityDocumentEmbedder"

--- a/integrations/perplexity/tests/test_perplexity_text_embedder.py
+++ b/integrations/perplexity/tests/test_perplexity_text_embedder.py
@@ -64,9 +64,7 @@ class TestPerplexityTextEmbedder:
         models = PerplexityTextEmbedder.SUPPORTED_MODELS
         assert models == ["pplx-embed-v1-0.6b", "pplx-embed-v1-4b"]
 
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
-
+    def test_init_default(self):
         embedder = PerplexityTextEmbedder()
 
         assert embedder.api_key == Secret.from_env_var(["PERPLEXITY_API_KEY"])
@@ -75,6 +73,8 @@ class TestPerplexityTextEmbedder:
         assert embedder.prefix == ""
         assert embedder.suffix == ""
         assert embedder.encoding_format == "base64_int8"
+        assert embedder.client is None
+        assert embedder.async_client is None
 
     def test_init_with_parameters(self):
         embedder = PerplexityTextEmbedder(
@@ -99,9 +99,7 @@ class TestPerplexityTextEmbedder:
                 encoding_format="float",
             )
 
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
-
+    def test_to_dict(self):
         embedder = PerplexityTextEmbedder()
         component_dict = embedder.to_dict()
 
@@ -121,8 +119,7 @@ class TestPerplexityTextEmbedder:
             },
         }
 
-    def test_to_dict_with_custom_init_parameters(self, monkeypatch):
-        monkeypatch.setenv("ENV_VAR", "test-secret-key")
+    def test_to_dict_with_custom_init_parameters(self):
         embedder = PerplexityTextEmbedder(
             api_key=Secret.from_env_var("ENV_VAR", strict=False),
             model="pplx-embed-v1-4b",
@@ -152,8 +149,7 @@ class TestPerplexityTextEmbedder:
             },
         }
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "fake-api-key")
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.embedders.perplexity.text_embedder.PerplexityTextEmbedder",
             "init_parameters": {

--- a/integrations/perplexity/tests/test_perplexity_websearch.py
+++ b/integrations/perplexity/tests/test_perplexity_websearch.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -46,14 +47,15 @@ def _make_transport(captured: list[httpx.Request], response: dict | None = None,
     return httpx.MockTransport(handler)
 
 
-class TestPerplexityWebSearch:
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+class TestInitialization:
+    def test_init_default(self):
         ws = PerplexityWebSearch()
         assert ws.top_k == 10
         assert ws.search_params is None
         assert ws.timeout == 30.0
-        assert ws.api_key.resolve_value() == "test-key"
+        assert ws.api_key == Secret.from_env_var("PERPLEXITY_API_KEY")
+        assert ws._client is None
+        assert ws._async_client is None
 
     def test_init_with_params(self):
         ws = PerplexityWebSearch(
@@ -66,8 +68,9 @@ class TestPerplexityWebSearch:
         assert ws.search_params == {"search_recency_filter": "week"}
         assert ws.timeout == 10.0
 
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+
+class TestSerialization:
+    def test_to_dict(self):
         ws = PerplexityWebSearch(top_k=5, search_params={"country": "US"})
         data = component_to_dict(ws, "PerplexityWebSearch")
         expected_type = "haystack_integrations.components.websearch.perplexity.perplexity_websearch.PerplexityWebSearch"
@@ -76,8 +79,7 @@ class TestPerplexityWebSearch:
         assert data["init_parameters"]["top_k"] == 5
         assert data["init_parameters"]["search_params"] == {"country": "US"}
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+    def test_from_dict(self):
         data = {
             "type": ("haystack_integrations.components.websearch.perplexity.perplexity_websearch.PerplexityWebSearch"),
             "init_parameters": {
@@ -96,6 +98,68 @@ class TestPerplexityWebSearch:
         assert ws.search_params == {"search_recency_filter": "day"}
         assert ws.timeout == 15.0
 
+
+class TestComponentLifecycle:
+    @patch("haystack_integrations.components.websearch.perplexity.perplexity_websearch.httpx.Client")
+    def test_sync_lifecycle(self, mock_client_cls):
+        client = MagicMock()
+        mock_client_cls.return_value = client
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-key"))
+
+        ws.close()
+        ws.warm_up()
+        ws.warm_up()
+        assert ws._client is client
+        assert ws._async_client is None
+        mock_client_cls.assert_called_once_with(timeout=30.0)
+
+        ws.close()
+        client.close.assert_called_once_with()
+        assert ws._client is None
+
+        ws.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.websearch.perplexity.perplexity_websearch.httpx.AsyncClient")
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self, mock_client_cls):
+        client = MagicMock(aclose=AsyncMock())
+        mock_client_cls.return_value = client
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-key"))
+
+        await ws.close_async()
+        await ws.warm_up_async()
+        await ws.warm_up_async()
+        assert ws._async_client is client
+        assert ws._client is None
+        mock_client_cls.assert_called_once_with(timeout=30.0)
+
+        await ws.close_async()
+        client.aclose.assert_awaited_once_with()
+        assert ws._async_client is None
+
+        await ws.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self):
+        sync_client = MagicMock()
+        async_client = MagicMock(aclose=AsyncMock())
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-key"))
+        ws._client = sync_client
+        ws._async_client = async_client
+
+        ws.close()
+        assert ws._client is None
+        assert ws._async_client is async_client
+        async_client.aclose.assert_not_awaited()
+
+        await ws.close_async()
+        assert ws._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_run_returns_documents_and_links(self):
         captured: list[httpx.Request] = []
         ws = PerplexityWebSearch(api_key=Secret.from_token("test-key"), top_k=10)
@@ -198,31 +262,6 @@ class TestPerplexityWebSearch:
         with pytest.raises(httpx.HTTPStatusError):
             await ws.run_async(query="test")
 
-    def test_warm_up_initializes_clients(self):
-        ws = PerplexityWebSearch(api_key=Secret.from_token("test-key"))
-        assert ws._client is None
-        assert ws._async_client is None
-        ws.warm_up()
-        assert ws._client is not None
-        assert ws._async_client is not None
-
-    def test_run_triggers_warm_up(self, monkeypatch):
-        ws = PerplexityWebSearch(api_key=Secret.from_token("test-key"))
-        captured: list[httpx.Request] = []
-
-        original_client_init = httpx.Client.__init__
-
-        def patched_init(self, *args, **kwargs):
-            kwargs["transport"] = _make_transport(captured)
-            original_client_init(self, *args, **kwargs)
-
-        monkeypatch.setattr(httpx.Client, "__init__", patched_init)
-
-        assert ws._client is None
-        ws.run(query="test")
-        assert ws._client is not None
-        assert len(captured) == 1
-
     def test_run_empty_results(self):
         captured: list[httpx.Request] = []
         ws = PerplexityWebSearch(api_key=Secret.from_token("test-key"))
@@ -248,11 +287,13 @@ class TestPerplexityWebSearch:
         assert "country" not in body
         assert body["search_recency_filter"] == "month"
 
-    @pytest.mark.skipif(
-        not os.environ.get("PERPLEXITY_API_KEY"),
-        reason="Export PERPLEXITY_API_KEY to run integration tests.",
-    )
-    @pytest.mark.integration
+
+@pytest.mark.skipif(
+    not os.environ.get("PERPLEXITY_API_KEY"),
+    reason="Export PERPLEXITY_API_KEY to run integration tests.",
+)
+@pytest.mark.integration
+class TestIntegration:
     def test_run_integration(self):
         ws = PerplexityWebSearch(api_key=Secret.from_env_var("PERPLEXITY_API_KEY"), top_k=3)
         result = ws.run(query="What is Haystack by deepset?")
@@ -260,11 +301,6 @@ class TestPerplexityWebSearch:
         assert len(result["links"]) > 0
         assert isinstance(result["documents"][0], Document)
 
-    @pytest.mark.skipif(
-        not os.environ.get("PERPLEXITY_API_KEY"),
-        reason="Export PERPLEXITY_API_KEY to run integration tests.",
-    )
-    @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_run_async_integration(self):
         ws = PerplexityWebSearch(api_key=Secret.from_env_var("PERPLEXITY_API_KEY"), top_k=3)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- implement lifecycle handling, following criteria in https://github.com/deepset-ai/haystack-private/issues/440#issuecomment-5526157817
  - Websearch component: separated sync and async lifecycle + added closing methods
  - other components do not need updates or lifecycle tests since they inherit from OpenAI
- pin `haystack-ai>=3.0.0`

### How did you test it?
CI, new tests.
Integration tests are failing due to exceeded quota

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
