### PR TITLE
feat: Add multihop rag eval to agent pack

### DIFF
--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -13,8 +13,9 @@
 # - Retrieval: recall over the documents the question's evidence lives in, from the run's accumulated `documents`.
 # - Process: whether metadata was inspected before any retrieval, per-tool call counts, how many retrievals used
 #   a filter, tool errors, steps, and wall-clock time. An eval case fails when it exceeds its tool budget.
-# - Answer: the ground-truth answer must be mentioned when a substring check on it means anything, and every
-#   `[doc <short-id>]` citation must resolve to a document the run returned.
+# - Citations: the answer must cite every document the question's evidence lives in, and every
+#   `[doc <short-id>]` it carries must resolve to a document the run returned. Whether the answer is *right* is
+#   not checked; that needs a judge this harness does not have yet.
 # - Token usage, per eval case and totalled, for comparing models and reasoning efforts.
 #
 # Run from `integrations/agent_pack` with `OPENAI_API_KEY` set. The corpus requires `datasets`:
@@ -50,22 +51,24 @@ RETRIEVAL_TOOLS = ("search_documents", "fetch_documents_by_filter")
 METADATA_TOOLS = ("list_metadata_fields", "get_metadata_field_values", "get_metadata_field_range")
 _CITATION_RE = re.compile(r"\[doc ([0-9a-f]{4,16})\]")
 
-# Answers shorter than this are words like "Yes" or "No", which a reply can contain by coincidence.
-MIN_ASSERTABLE_ANSWER_CHARS = 5
-
 
 @dataclass
 class EvalCase:
-    """One eval case: a question, the documents that answer it, and the budgets the run may spend."""
+    """
+    One eval case: a question, the documents that answer it, and the budgets the run may spend.
+
+    :param question: The question to put to the agent.
+    :param evidence: Ground truth, as `{chunk id: the quote found in that chunk}`. The keys are the documents the
+        answer needs, and the values are what the answer should be based on. For example,
+        {"a1b2c3...": "Tyreek Hill now needs to ...", "d4e5f6...": "The Dolphins went on to ..."}
+    :param tool_budgets: How many times the run may call a tool, or a group of tools sharing one allowance, as
+        `{tool name or names: limit}`. Exceeding any of them fails the eval case. Which tools these are depends
+        on the agent under evaluation, so the caller supplies them.
+    """
 
     question: str
-    # Ground truth: the quoted evidence an answer needs, by the chunk it was found in.
     evidence: dict[str, str]
-    # The ground-truth answer, checked case-insensitively when a substring check on it means anything.
-    answer_must_mention: tuple[str, ...] = ()
-    # Tool budgets. Exceeding either fails the eval case.
-    max_metadata_calls: int = 5
-    max_retrieval_calls: int = 5
+    tool_budgets: dict[str | tuple[str, ...], int]
 
     @property
     def expected_document_ids(self) -> frozenset[str]:
@@ -74,8 +77,8 @@ class EvalCase:
 
 
 @dataclass
-class RunStats:
-    """Tool-level statistics extracted from one agent run."""
+class ToolRunStats:
+    """The tool calls one agent run made, and what they add up to."""
 
     calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
     errors: int = 0
@@ -90,30 +93,25 @@ class RunStats:
                 return False
         return False
 
-    @property
-    def filtered_retrieval_calls(self) -> int:
-        """Number of retrieval tool calls that included a metadata filter."""
-        return sum(1 for name, args in self.calls if name in RETRIEVAL_TOOLS and args.get("filters"))
+    def calls_to(self, tools: str | tuple[str, ...]) -> int:
+        """
+        Count the calls made to one tool, or to any of a group of them.
 
-    @property
-    def metadata_calls(self) -> int:
-        """Number of metadata-inspection tool calls."""
-        return sum(1 for name, _ in self.calls if name in METADATA_TOOLS)
-
-    @property
-    def retrieval_calls(self) -> int:
-        """Number of retrieval tool calls."""
-        return sum(1 for name, _ in self.calls if name in RETRIEVAL_TOOLS)
+        :param tools: A tool name, or several sharing one allowance.
+        :returns: How many calls the run made to them.
+        """
+        wanted = {tools} if isinstance(tools, str) else set(tools)
+        return sum(1 for name, _ in self.calls if name in wanted)
 
 
-def extract_run_stats(messages: list[ChatMessage]) -> RunStats:
+def extract_tool_run_stats(messages: list[ChatMessage]) -> ToolRunStats:
     """
     Extract tool calls and error results from an agent run.
 
     :param messages: The messages returned by `agent.run(...)`.
     :returns: The extracted statistics.
     """
-    stats = RunStats()
+    stats = ToolRunStats()
     for message in messages:
         stats.calls.extend((tc.tool_name, tc.arguments or {}) for tc in message.tool_calls)
         stats.errors += sum(1 for res in message.tool_call_results if res.error)
@@ -148,7 +146,7 @@ def build_bm25_retriever(store: DocumentStore, top_k: int = 5):  # noqa: ANN201
     return OpenSearchBM25Retriever(document_store=store, top_k=top_k)
 
 
-def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
+def run_eval_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
     """
     Run the agent on one eval case and print its report.
 
@@ -161,7 +159,7 @@ def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
     elapsed = time.perf_counter() - started
 
     # Everything the report needs comes out of the one run: its messages, its answer and its token usage.
-    stats = extract_run_stats(result["messages"])
+    stats = extract_tool_run_stats(messages=result["messages"])
     answer = result["last_message"].text or ""
     usage = result.get("token_usage") or {}
 
@@ -170,36 +168,37 @@ def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
     retrieved_ids = {document.id for document in retrieved_docs}
     found = case.expected_document_ids & retrieved_ids
     recall = len(found) / len(case.expected_document_ids)
-    mentions_ok = all(term.lower() in answer.lower() for term in case.answer_must_mention)
 
-    # A [doc <short-id>] reference that matches nothing the run returned is a citation the reader cannot follow.
+    # Resolve each [doc <short-id>] the answer carries against what the run returned. A reference matching nothing
+    # is a citation the reader cannot follow, and one the answer never makes is evidence it did not use.
     cited_refs = _CITATION_RE.findall(answer)
     resolved = [ref for ref in cited_refs if any(document.id.startswith(ref) for document in retrieved_docs)]
+    cited_ids = {document.id for document in retrieved_docs if any(document.id.startswith(r) for r in cited_refs)}
     citations_ok = len(resolved) == len(cited_refs)
+    uncited = case.expected_document_ids - cited_ids
 
-    # An eval case passes only on all four: it found every expected document, said the answer, cited documents it
-    # actually returned, and stayed inside its tool budget.
-    within_budget = (
-        stats.metadata_calls <= case.max_metadata_calls and stats.retrieval_calls <= case.max_retrieval_calls
-    )
-    passed = recall == 1.0 and mentions_ok and citations_ok and within_budget
+    # An eval case passes only on all four: it found every expected document, cited every one of them, made no
+    # citation that does not resolve, and stayed inside its tool budget.
+    spent = {tools: stats.calls_to(tools=tools) for tools in case.tool_budgets}
+    within_budget = all(used <= case.tool_budgets[tools] for tools, used in spent.items())
+    passed = recall == 1.0 and not uncited and citations_ok and within_budget
 
     counts = Counter(name for name, _ in stats.calls)
     filters_used = [args["filters"] for name, args in stats.calls if name in RETRIEVAL_TOOLS and args.get("filters")]
     print(f"\n[{'PASS' if passed else 'FAIL'}] {case.question}")
     print(f"  tools: {dict(counts)}")
     print(
-        f"  inspected-first={stats.inspected_first}  filtered-retrievals={stats.filtered_retrieval_calls}"
+        f"  inspected-first={stats.inspected_first}  filtered-retrievals={len(filters_used)}"
         f"  errors={stats.errors}  steps={result['step_count']}  time={elapsed:.1f}s"
     )
-    print(
-        f"  budget: metadata {stats.metadata_calls}/{case.max_metadata_calls}, "
-        f"retrieval {stats.retrieval_calls}/{case.max_retrieval_calls} -> {'ok' if within_budget else 'EXCEEDED'}"
-    )
+    for tools, used in spent.items():
+        limit = case.tool_budgets[tools]
+        label = tools if isinstance(tools, str) else " + ".join(tools)
+        print(f"  budget: {label} {used}/{limit} -> {'ok' if used <= limit else 'EXCEEDED'}")
     print(
         f"  retrieved={len(retrieved_docs)}  recall={len(found)}/{len(case.expected_document_ids)}"
-        + (f"  answer-mentions-ok={mentions_ok}" if case.answer_must_mention else "")
-        + f"  citations={len(resolved)}/{len(cited_refs)} resolve"
+        f"  cited={len(case.expected_document_ids) - len(uncited)}/{len(case.expected_document_ids)} expected"
+        f"  citations={len(resolved)}/{len(cited_refs)} resolve"
     )
     for document in retrieved_docs:
         marker = "+" if document.id in case.expected_document_ids else "-"
@@ -207,6 +206,8 @@ def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
     for document_id in sorted(case.expected_document_ids - retrieved_ids):
         # Naming the quote that was missed, since the id alone says nothing about what the run failed to find.
         print(f"    MISSED [doc {document_id[:8]}] {case.evidence[document_id][:100]}")
+    for document_id in sorted(uncited & retrieved_ids):
+        print(f"    UNCITED [doc {document_id[:8]}] {case.evidence[document_id][:100]}")
     if usage:
         print(f"  tokens: { {k: v for k, v in usage.items() if isinstance(v, int)} }")
     for filters in filters_used:
@@ -232,27 +233,22 @@ def main() -> None:
     labelled: list[LabelledQuestion] = build_eval_cases(
         articles=articles, limit=arguments.max_cases, seed=arguments.case_seed
     )
-    # The dataset reports its answer verbatim; asserting on it is this harness's decision. A short answer like
-    # "Yes" is skipped, since finding that word in a reply can happen for reasons unrelated to being right.
+    # Budgets for the tools this agent has. Lenient on purpose: too many retrievals is better than too few.
+    budgets: dict[str | tuple[str, ...], int] = {METADATA_TOOLS: 5, RETRIEVAL_TOOLS: 5}
     cases = [
-        EvalCase(
-            question=question.question,
-            evidence=question.evidence,
-            answer_must_mention=(question.answer,) if len(question.answer) >= MIN_ASSERTABLE_ANSWER_CHARS else (),
-        )
-        for question in labelled
+        EvalCase(question=question.question, evidence=question.evidence, tool_budgets=budgets) for question in labelled
     ]
     expected = sum(len(case.expected_document_ids) for case in cases)
     print(f"eval cases: {len(cases)} labelled from evidence, expecting {expected} documents in total")
 
     agent = create_advanced_rag_agent(document_store=store, retriever=build_bm25_retriever(store=store))
 
-    results = [evaluate_case(agent=agent, case=case) for case in cases]
+    results = [run_eval_case(agent=agent, case=case) for case in cases]
 
     passed = sum(result["passed"] for result in results)
     total_usage: dict[str, int] = {}
     for result in results:
-        _sum_usage(total_usage, result["usage"])
+        _sum_usage(total=total_usage, usage=result["usage"])
     print(f"\n=== {passed}/{len(results)} eval cases passed ===")
     print(f"total time: {sum(result['time'] for result in results):.1f}s")
     if total_usage:

--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -2,104 +2,65 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Mini evaluation harness for the advanced RAG agent.
-
-Runs the agent on questions with known ground truth and reports, per case:
-
-- **Retrieval correctness**: the documents the agent saw (the run's accumulated `documents`
-  output) are checked against a ground-truth predicate over document metadata — full recall on
-  the small corpus (its expected sets are enumerable), constraint precision on the large one
-  (every retrieved doc must satisfy the constraints the question implies).
-- **Process metrics and budgets**: whether metadata was inspected before any retrieval, per-tool
-  call counts, how many retrievals used a filter, error tool results, steps, and wall-clock
-  time; a case fails when it exceeds its (deliberately lenient) per-case budget of
-  metadata-inspection or retrieval calls, even if the answer is right.
-- **Adversarial cases**: questions about fields/values absent from the corpus must be answered
-  by acknowledging the absence, not by hallucinating.
-- **Answer checks**: optional keywords the answer must mention, and every `[doc <short-id>]`
-  citation must resolve to a document in the run's returned `documents` list.
-- **Token usage**: per case and totalled, for comparing models/reasoning efforts.
-
-Run from the integration directory (`integrations/agent_pack`) with `OPENAI_API_KEY` set. In a
-fresh environment, install `agent-pack-haystack` and `arrow`; the `large` corpus additionally
-needs `datasets` (streams reviews from Hugging Face) and `--store opensearch` needs
-`opensearch-haystack`.
-
-    hatch run test:python examples/advanced_rag_eval.py small
-    hatch run test:python examples/advanced_rag_eval.py large
-
-To validate against a real database instead of `InMemoryDocumentStore`, pass `--store opensearch`
-(OpenSearch 2.x and 3.x both work). Set `OPENSEARCH_URL` if not
-http://localhost:9200, and `OPENSEARCH_USERNAME` / `OPENSEARCH_PASSWORD` for a security-enabled
-instance (use an https:// URL then). Start one locally with e.g.
-`docker run -p 9200:9200 -e discovery.type=single-node -e DISABLE_SECURITY_PLUGIN=true opensearchproject/opensearch:3`.
-An already-populated OpenSearch index is reused, so repeat runs skip re-indexing.
-"""
+# Mini evaluation harness for the Advanced RAG agent, run against the MultiHopRAG corpus.
+#
+# The corpus and its labelled questions come from `multihop_rag`, which chunks the news articles and works out
+# which chunks hold each question's quoted evidence. That gives exact ground truth: a case names the documents
+# an answer needs, so retrieval is scored as recall over those IDs rather than against a metadata predicate.
+#
+# Reported per case:
+#
+# - Retrieval: recall over the documents the question's evidence lives in, from the run's accumulated `documents`.
+# - Process: whether metadata was inspected before any retrieval, per-tool call counts, how many retrievals used
+#   a filter, tool errors, steps, and wall-clock time. A case fails when it exceeds its per-case tool budget.
+# - Answer: the ground-truth answer must be mentioned when a substring check on it means anything, and every
+#   `[doc <short-id>]` citation must resolve to a document the run returned.
+# - Token usage, per case and totalled, for comparing models and reasoning efforts.
+#
+# Run from `integrations/agent_pack` with `OPENAI_API_KEY` set. The corpus requires `datasets`:
+#
+#     hatch run test:python examples/advanced_rag_eval.py
+#     hatch run test:python examples/advanced_rag_eval.py --max-cases 5
+#     hatch run test:python examples/advanced_rag_eval.py --store opensearch
+#
+# `--store opensearch` reuses a populated index across runs, so repeat runs skip re-indexing. Set `OPENSEARCH_URL`
+# if it is not http://localhost:9200, and `OPENSEARCH_USERNAME` / `OPENSEARCH_PASSWORD` for a secured instance.
 
 import argparse
-import itertools
-import os
 import re
 import time
 from collections import Counter
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from haystack import Document
 from haystack.components.agents import Agent
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.dataclasses import ChatMessage
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack.document_stores.types import DocumentStore, DuplicatePolicy
+from haystack.document_stores.types import DocumentStore
+from haystack.lazy_imports import LazyImport
+from multihop_rag import CORPUS_KEY, LabelledQuestion, build_eval_cases, prepare_corpus
 
 from haystack_integrations.agent_pack.advanced_rag import create_advanced_rag_agent
+
+with LazyImport(message='Run "pip install opensearch-haystack" to use an OpenSearch store.') as opensearch_import:
+    from haystack_integrations.components.retrievers.opensearch import OpenSearchBM25Retriever
 
 RETRIEVAL_TOOLS = ("search_documents", "fetch_documents_by_filter")
 METADATA_TOOLS = ("list_metadata_fields", "get_metadata_field_values", "get_metadata_field_range")
 _CITATION_RE = re.compile(r"\[doc ([0-9a-f]{4,16})\]")
-# The system prompt instructs the agent to begin with this phrase when nothing matches; the regex
-# is a crude fallback for non-compliant answers (an LLM judge would do this properly).
-_ABSENCE_PHRASE = "no matching information was found"
-_ABSENCE_RE = re.compile(
-    r"\b(no|not|none|nothing|cannot|can't|couldn't|don't|doesn't|isn't|aren't|unable|unfortunately|missing|absent)\b"
-)
-
-
-def _acknowledges_absence(answer: str) -> bool:
-    """
-    Whether the answer acknowledges that the requested information is absent from the corpus.
-
-    :param answer: The agent's final answer.
-    :returns: True if the canonical absence phrase (or, as a fallback, a negation word) is present.
-    """
-    lowered = answer.lower()
-    return _ABSENCE_PHRASE in lowered or bool(_ABSENCE_RE.search(lowered))
 
 
 @dataclass
 class EvalCase:
-    """One evaluation case: a question plus ground truth."""
+    """One evaluation case: a question, the documents that answer it, and the budgets the run may spend."""
 
     question: str
-    # Ground truth: which documents answer the question, as a predicate over `Document.meta`.
-    predicate: Callable[[dict[str, Any]], bool]
-    # Check recall of the full expected set (small corpora only — the expected set must be enumerable).
-    check_recall: bool = True
-    # Minimum number of ground-truth-matching documents the agent must have retrieved.
-    min_docs: int = 1
-    # Keywords (case-insensitive) the final answer must mention.
+    # Ground truth: the chunks the question's quoted evidence was found in.
+    expected_document_ids: frozenset[str]
+    # The ground-truth answer, checked case-insensitively when a substring check on it means anything.
     answer_must_mention: tuple[str, ...] = ()
-    # Minimum constraint precision, gated only when `check_recall` is False (large corpora).
-    # Below 1.0 by design: extra broader retrievals are acceptable as long as the constrained
-    # documents dominate what the agent saw.
-    min_precision: float = 0.5
-    # Adversarial: the question asks about fields/values absent from the corpus; pass = the answer
-    # acknowledges the absence (retrieval metrics are skipped, the predicate matches nothing).
-    expect_absent: bool = False
-    # Efficiency budgets: maximum metadata-inspection and retrieval tool calls per run. Lenient on
-    # purpose — too many retrievals is better than too few.
+    # Efficiency budgets. Lenient on purpose — too many retrievals is better than too few.
     max_metadata_calls: int = 5
     max_retrieval_calls: int = 5
 
@@ -137,95 +98,6 @@ class RunStats:
         return sum(1 for name, _ in self.calls if name in RETRIEVAL_TOOLS)
 
 
-SMALL_CASES = [
-    EvalCase(
-        question="What scientific breakthroughs happened after 2015, according to the documents?",
-        predicate=lambda m: m.get("category") == "science" and m.get("year", 0) > 2015,
-        answer_must_mention=("quantum", "CRISPR"),
-    ),
-    EvalCase(
-        question="Which historical events in the documents happened before 1990?",
-        predicate=lambda m: m.get("category") == "history" and m.get("year", 9999) < 1990,
-        answer_must_mention=("Berlin", "Apollo"),
-    ),
-    EvalCase(
-        question="What does the German-language document describe?",
-        predicate=lambda m: m.get("language") == "de",
-        answer_must_mention=("Champions League",),
-    ),
-    EvalCase(
-        question="What does the single highest-rated document describe?",
-        predicate=lambda m: m.get("rating") == 5.0,
-        answer_must_mention=("Apollo",),
-    ),
-    EvalCase(
-        question="What do the documents say about sports events from 2020 onwards?",
-        predicate=lambda m: m.get("category") == "sports" and m.get("year", 0) >= 2020,
-        answer_must_mention=("Argentina",),
-    ),
-    EvalCase(
-        question="What is CRISPR used for according to the documents?",
-        predicate=lambda m: m.get("category") == "science" and m.get("year") == 2021,
-        answer_must_mention=("blindness",),
-    ),
-    # Adversarial: nonexistent category / language value — the agent should discover the absence.
-    EvalCase(
-        question="What do the documents in the 'food' category say about cooking?",
-        predicate=lambda _m: False,
-        expect_absent=True,
-    ),
-    EvalCase(question="Which of the documents are written in French?", predicate=lambda _m: False, expect_absent=True),
-]
-
-LARGE_CASES = [
-    EvalCase(
-        question=(
-            "What do verified purchasers complain about in low-rated (1-2 star) "
-            "beauty product reviews from 2022 or later?"
-        ),
-        predicate=lambda m: (
-            m.get("category") == "All_Beauty"
-            and m.get("rating", 5.0) <= 2.0
-            and m.get("year", 0) >= 2022
-            and m.get("verified_purchase") is True
-        ),
-        check_recall=False,
-        min_docs=3,
-    ),
-    EvalCase(
-        question="What did reviewers think of digital music purchases before 2010?",
-        predicate=lambda m: m.get("category") == "Digital_Music" and m.get("year", 9999) < 2010,
-        check_recall=False,
-        min_docs=3,
-    ),
-    EvalCase(
-        question="Summarize what the most helpful health product reviews (10 or more helpful votes) say.",
-        predicate=lambda m: m.get("category") == "Health_and_Personal_Care" and m.get("helpful_vote", 0) >= 10,
-        check_recall=False,
-        min_docs=3,
-    ),
-    EvalCase(
-        question="What are common themes in 5-star beauty product reviews from 2020?",
-        predicate=lambda m: m.get("category") == "All_Beauty" and m.get("rating") == 5.0 and m.get("year") == 2020,
-        check_recall=False,
-        min_docs=3,
-    ),
-    # Adversarial: nonexistent category / future year — the agent should discover the absence.
-    EvalCase(
-        question="What do reviews in the Electronics category say about laptop battery life?",
-        predicate=lambda _m: False,
-        check_recall=False,
-        expect_absent=True,
-    ),
-    EvalCase(
-        question="What do beauty product reviews from 2030 or later say?",
-        predicate=lambda _m: False,
-        check_recall=False,
-        expect_absent=True,
-    ),
-]
-
-
 def extract_run_stats(messages: list[ChatMessage]) -> RunStats:
     """
     Extract tool calls and error results from an agent run.
@@ -254,12 +126,25 @@ def _sum_usage(total: dict[str, int], usage: dict[str, Any]) -> dict[str, int]:
     return total
 
 
-def evaluate_case(agent: Agent, documents_by_id: dict[str, Any], case: EvalCase) -> dict[str, Any]:
+def build_bm25_retriever(store: DocumentStore, top_k: int = 5):  # noqa: ANN201
+    """
+    Build the matching BM25 retriever for a document store.
+
+    :param store: The store to retrieve from.
+    :param top_k: How many documents one retrieval returns.
+    :returns: The retriever.
+    """
+    if isinstance(store, InMemoryDocumentStore):
+        return InMemoryBM25Retriever(document_store=store, top_k=top_k)
+    opensearch_import.check()
+    return OpenSearchBM25Retriever(document_store=store, top_k=top_k)
+
+
+def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
     """
     Run the agent on one case and print its report.
 
     :param agent: The agent under evaluation.
-    :param documents_by_id: All documents in the store, keyed by id (the ground-truth universe).
     :param case: The case to evaluate.
     :returns: A dict with `passed` (bool), `usage` (the run's token_usage dict), and `time` (s).
     """
@@ -271,33 +156,21 @@ def evaluate_case(agent: Agent, documents_by_id: dict[str, Any], case: EvalCase)
     answer = result["last_message"].text or ""
     usage = result.get("token_usage") or {}
 
-    expected_ids = {doc_id for doc_id, doc in documents_by_id.items() if case.predicate(doc.meta)}
     retrieved_docs = result.get("documents") or []
-    retrieved_ids = {d.id for d in retrieved_docs}
-    matching = [d for d in retrieved_docs if case.predicate(d.meta)]
-
-    recall = len(expected_ids & retrieved_ids) / len(expected_ids) if expected_ids else 0.0
-    precision = len(matching) / len(retrieved_docs) if retrieved_docs else 0.0
-    mentions_ok = all(kw.lower() in answer.lower() for kw in case.answer_must_mention)
+    retrieved_ids = {document.id for document in retrieved_docs}
+    found = case.expected_document_ids & retrieved_ids
+    recall = len(found) / len(case.expected_document_ids)
+    mentions_ok = all(term.lower() in answer.lower() for term in case.answer_must_mention)
 
     # Every [doc <short-id>] reference in the answer must resolve to a returned document.
     cited_refs = _CITATION_RE.findall(answer)
-    resolved = [ref for ref in cited_refs if any(d.id.startswith(ref) for d in retrieved_docs)]
+    resolved = [ref for ref in cited_refs if any(document.id.startswith(ref) for document in retrieved_docs)]
     citations_ok = len(resolved) == len(cited_refs)
 
     within_budget = (
         stats.metadata_calls <= case.max_metadata_calls and stats.retrieval_calls <= case.max_retrieval_calls
     )
-    if case.expect_absent:
-        correct = _acknowledges_absence(answer)
-    else:
-        correct = (
-            len(matching) >= case.min_docs
-            and (recall == 1.0 if case.check_recall else precision >= case.min_precision)
-            and mentions_ok
-            and citations_ok
-        )
-    passed = stats.inspected_first and within_budget and correct
+    passed = recall == 1.0 and mentions_ok and citations_ok and within_budget
 
     counts = Counter(name for name, _ in stats.calls)
     filters_used = [args["filters"] for name, args in stats.calls if name in RETRIEVAL_TOOLS and args.get("filters")]
@@ -311,18 +184,16 @@ def evaluate_case(agent: Agent, documents_by_id: dict[str, Any], case: EvalCase)
         f"  budget: metadata {stats.metadata_calls}/{case.max_metadata_calls}, "
         f"retrieval {stats.retrieval_calls}/{case.max_retrieval_calls} -> {'ok' if within_budget else 'EXCEEDED'}"
     )
-    if case.expect_absent:
-        print(f"  expect-absent: acknowledged={correct}")
-    else:
-        print(
-            f"  retrieved={len(retrieved_docs)}  constraint-precision={precision:.2f}"
-            + (f"  recall={len(expected_ids & retrieved_ids)}/{len(expected_ids)}" if case.check_recall else "")
-            + (f"  answer-mentions-ok={mentions_ok}" if case.answer_must_mention else "")
-            + f"  citations={len(resolved)}/{len(cited_refs)} resolve"
-        )
-        for doc in retrieved_docs:
-            marker = "+" if case.predicate(doc.meta) else "-"
-            print(f"    {marker} [doc {doc.id[:8]}] {doc.meta}")
+    print(
+        f"  retrieved={len(retrieved_docs)}  recall={len(found)}/{len(case.expected_document_ids)}"
+        + (f"  answer-mentions-ok={mentions_ok}" if case.answer_must_mention else "")
+        + f"  citations={len(resolved)}/{len(cited_refs)} resolve"
+    )
+    for document in retrieved_docs:
+        marker = "+" if document.id in case.expected_document_ids else "-"
+        print(f"    {marker} [doc {document.id[:8]}] {document.meta.get('title')}")
+    for document_id in sorted(case.expected_document_ids - retrieved_ids):
+        print(f"    MISSED [doc {document_id[:8]}]")
     if usage:
         print(f"  tokens: { {k: v for k, v in usage.items() if isinstance(v, int)} }")
     for filters in filters_used:
@@ -333,187 +204,42 @@ def evaluate_case(agent: Agent, documents_by_id: dict[str, Any], case: EvalCase)
     return {"passed": passed, "usage": usage, "time": elapsed}
 
 
-# The small corpus: handcrafted documents with varied metadata (keyword, int, float, ISO date,
-# language), small enough that every case's expected document set is enumerable.
-SMALL_CORPUS = [
-    Document(
-        content="CRISPR-based gene editing was used to correct a hereditary blindness mutation in a clinical trial.",
-        meta={"category": "science", "year": 2021, "rating": 4.6, "date": "2021-03-11", "language": "en"},
-    ),
-    Document(
-        content="A quantum computer demonstrated error-corrected logical qubits outperforming physical qubits.",
-        meta={"category": "science", "year": 2023, "rating": 4.8, "date": "2023-12-06", "language": "en"},
-    ),
-    Document(
-        content="The LIGO observatory detected gravitational waves from two merging black holes for the first time.",
-        meta={"category": "science", "year": 2016, "rating": 4.9, "date": "2016-02-11", "language": "en"},
-    ),
-    Document(
-        content="Dolly the sheep became the first mammal cloned from an adult somatic cell.",
-        meta={"category": "science", "year": 1996, "rating": 4.2, "date": "1996-07-05", "language": "en"},
-    ),
-    Document(
-        content="The Berlin Wall fell, marking a decisive moment in the end of the Cold War.",
-        meta={"category": "history", "year": 1989, "rating": 4.7, "date": "1989-11-09", "language": "en"},
-    ),
-    Document(
-        content="The Apollo 11 mission landed the first humans on the Moon.",
-        meta={"category": "history", "year": 1969, "rating": 5.0, "date": "1969-07-20", "language": "en"},
-    ),
-    Document(
-        content="The Maastricht Treaty was signed, founding the European Union.",
-        meta={"category": "history", "year": 1992, "rating": 3.9, "date": "1992-02-07", "language": "en"},
-    ),
-    Document(
-        content="Leicester City won the Premier League despite 5000-1 preseason odds.",
-        meta={"category": "sports", "year": 2016, "rating": 4.8, "date": "2016-05-02", "language": "en"},
-    ),
-    Document(
-        content="Argentina won the FIFA World Cup final against France on penalties.",
-        meta={"category": "sports", "year": 2022, "rating": 4.9, "date": "2022-12-18", "language": "en"},
-    ),
-    Document(
-        content="Ein deutsches Team gewann die Champions League nach einem dramatischen Finale.",
-        meta={"category": "sports", "year": 2013, "rating": 4.1, "date": "2013-05-25", "language": "de"},
-    ),
-]
-
-# The large corpus: ~150k Amazon-Reviews-2023 reviews streamed from Hugging Face.
-LARGE_CORPUS_CATEGORIES = ("All_Beauty", "Digital_Music", "Health_and_Personal_Care")
-LARGE_CORPUS_DOCS_PER_CATEGORY = 50_000
-_WRITE_BATCH_SIZE = 10_000
-
-
-def build_document_store(backend: str, corpus: str) -> DocumentStore:
-    """
-    Build the (empty) document store for the chosen backend.
-
-    :param backend: "in_memory" or "opensearch" (requires the `opensearch-haystack` package and a
-        running OpenSearch, `OPENSEARCH_URL` or http://localhost:9200).
-    :param corpus: The corpus name, used as part of the OpenSearch index name.
-    :returns: The document store.
-    """
-    if backend == "opensearch":
-        from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore  # noqa: PLC0415
-
-        url = os.environ.get("OPENSEARCH_URL", "http://localhost:9200")
-        return OpenSearchDocumentStore(
-            hosts=url,
-            index=f"advanced-rag-eval-{corpus}",
-            # Credentials are read from OPENSEARCH_USERNAME / OPENSEARCH_PASSWORD by the store itself.
-            use_ssl=url.startswith("https"),
-            # Local docker instances use a self-signed certificate.
-            verify_certs=not url.startswith("https://localhost"),
-        )
-    return InMemoryDocumentStore()
-
-
-def build_retriever(store: DocumentStore):  # noqa: ANN201  (retriever type depends on the backend)
-    """
-    Build the matching BM25 retriever for the store.
-
-    :param store: The document store.
-    :returns: The retriever component.
-    """
-    if isinstance(store, InMemoryDocumentStore):
-        return InMemoryBM25Retriever(document_store=store, top_k=5)
-    from haystack_integrations.components.retrievers.opensearch import OpenSearchBM25Retriever  # noqa: PLC0415
-
-    return OpenSearchBM25Retriever(document_store=store, top_k=5)
-
-
-def populate_small_corpus(store: DocumentStore) -> None:
-    """
-    Write the small handcrafted corpus into the store.
-
-    :param store: The document store to populate.
-    """
-    store.write_documents(SMALL_CORPUS, policy=DuplicatePolicy.OVERWRITE)
-
-
-def _load_review_documents(category: str) -> list[Document]:
-    """
-    Stream one Amazon-Reviews-2023 category from Hugging Face and convert it to documents.
-
-    :param category: The review category subset to load.
-    :returns: Up to `LARGE_CORPUS_DOCS_PER_CATEGORY` documents with metadata for filtering.
-    """
-    from datasets import load_dataset  # noqa: PLC0415  (only needed for the `large` corpus)
-
-    # The dataset repo is script-based (unsupported by datasets>=3), so stream its raw JSONL directly.
-    dataset = load_dataset(
-        "json",
-        data_files=f"hf://datasets/McAuley-Lab/Amazon-Reviews-2023/raw/review_categories/{category}.jsonl",
-        split="train",
-        streaming=True,
-    )
-    documents = []
-    for row in itertools.islice(dataset, LARGE_CORPUS_DOCS_PER_CATEGORY):
-        text = (row.get("text") or "").strip()
-        if not text:
-            continue
-        documents.append(
-            Document(
-                content=f"{row.get('title') or ''}. {text}"[:5_000],
-                meta={
-                    "category": category,
-                    "rating": float(row["rating"]),
-                    "helpful_vote": int(row["helpful_vote"]),
-                    "verified_purchase": bool(row["verified_purchase"]),
-                    "year": time.gmtime(row["timestamp"] / 1000).tm_year,
-                    "asin": row["asin"],
-                },
-            )
-        )
-    return documents
-
-
-def populate_large_corpus(store: DocumentStore) -> None:
-    """
-    Write the large review corpus into the store (streams from Hugging Face; requires `datasets`).
-
-    :param store: The document store to populate.
-    """
-    for category in LARGE_CORPUS_CATEGORIES:
-        documents = _load_review_documents(category)
-        for batch_start in range(0, len(documents), _WRITE_BATCH_SIZE):
-            store.write_documents(
-                documents[batch_start : batch_start + _WRITE_BATCH_SIZE], policy=DuplicatePolicy.OVERWRITE
-            )
-        print(f"indexed {category}: {len(documents)} docs")
-
-
 def main() -> None:
-    """Run the selected eval set and print per-case reports plus a summary."""
-    parser = argparse.ArgumentParser(description="Mini evaluation harness for the advanced RAG agent.")
-    parser.add_argument("corpus", nargs="?", choices=("small", "large"), default="small")
+    """Run the eval set and print per-case reports plus a summary."""
+    parser = argparse.ArgumentParser(description="Mini evaluation harness for the Advanced RAG agent.")
     parser.add_argument("--store", choices=("in_memory", "opensearch"), default="in_memory")
-    args = parser.parse_args()
-    corpus = args.corpus
+    parser.add_argument("--max-cases", type=int, default=10, help="How many labelled questions to evaluate.")
+    parser.add_argument("--case-seed", type=int, default=0, help="Selects which cases are drawn from the dataset.")
+    arguments = parser.parse_args()
 
-    store = build_document_store(args.store, corpus)
-    # A persistent store (OpenSearch) keeps its index across runs — skip re-indexing when populated.
-    if store.count_documents() == 0:
-        populate_small_corpus(store) if corpus == "small" else populate_large_corpus(store)
-    else:
-        print("store already populated, skipping indexing")
-    print(f"corpus '{corpus}' on {args.store}: {store.count_documents()} docs")
+    store, articles = prepare_corpus(backend=arguments.store)
+    chunks = sum(len(article.chunks) for article in articles.values())
+    print(f"{CORPUS_KEY} on {arguments.store}: {chunks} chunks from {len(articles)} articles")
 
-    cases = SMALL_CASES if corpus == "small" else LARGE_CASES
-    # The full id -> document map is only needed for recall (small corpus); a persistent store's
-    # filter_documents() is capped (~10k on OpenSearch), so don't build it for the large corpus.
-    documents_by_id = {doc.id: doc for doc in store.filter_documents()} if corpus == "small" else {}
+    labelled: list[LabelledQuestion] = build_eval_cases(
+        articles=articles, limit=arguments.max_cases, seed=arguments.case_seed
+    )
+    cases = [
+        EvalCase(
+            question=question.question,
+            expected_document_ids=question.expected_document_ids,
+            answer_must_mention=question.answer_must_mention,
+        )
+        for question in labelled
+    ]
+    expected = sum(len(case.expected_document_ids) for case in cases)
+    print(f"cases: {len(cases)} labelled from evidence, expecting {expected} documents in total")
 
-    agent = create_advanced_rag_agent(document_store=store, retriever=build_retriever(store))
+    agent = create_advanced_rag_agent(document_store=store, retriever=build_bm25_retriever(store=store))
 
-    results = [evaluate_case(agent, documents_by_id, case) for case in cases]
+    results = [evaluate_case(agent=agent, case=case) for case in cases]
 
-    passed = sum(r["passed"] for r in results)
+    passed = sum(result["passed"] for result in results)
     total_usage: dict[str, int] = {}
-    for r in results:
-        _sum_usage(total_usage, r["usage"])
+    for result in results:
+        _sum_usage(total_usage, result["usage"])
     print(f"\n=== {passed}/{len(results)} cases passed ===")
-    print(f"total time: {sum(r['time'] for r in results):.1f}s")
+    print(f"total time: {sum(result['time'] for result in results):.1f}s")
     if total_usage:
         print(f"total tokens: {total_usage}")
     if passed < len(results):

--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -56,13 +56,18 @@ class EvalCase:
     """One evaluation case: a question, the documents that answer it, and the budgets the run may spend."""
 
     question: str
-    # Ground truth: the chunks the question's quoted evidence was found in.
-    expected_document_ids: frozenset[str]
+    # Ground truth: the quoted evidence an answer needs, by the chunk it was found in.
+    evidence: dict[str, str]
     # The ground-truth answer, checked case-insensitively when a substring check on it means anything.
     answer_must_mention: tuple[str, ...] = ()
     # Efficiency budgets. Lenient on purpose — too many retrievals is better than too few.
     max_metadata_calls: int = 5
     max_retrieval_calls: int = 5
+
+    @property
+    def expected_document_ids(self) -> frozenset[str]:
+        """The chunks an answer needs, which are the ones its evidence was found in."""
+        return frozenset(self.evidence)
 
 
 @dataclass
@@ -193,7 +198,8 @@ def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
         marker = "+" if document.id in case.expected_document_ids else "-"
         print(f"    {marker} [doc {document.id[:8]}] {document.meta.get('title')}")
     for document_id in sorted(case.expected_document_ids - retrieved_ids):
-        print(f"    MISSED [doc {document_id[:8]}]")
+        # Naming the quote that was missed, since the id alone says nothing about what the run failed to find.
+        print(f"    MISSED [doc {document_id[:8]}] {case.evidence[document_id][:100]}")
     if usage:
         print(f"  tokens: { {k: v for k, v in usage.items() if isinstance(v, int)} }")
     for filters in filters_used:
@@ -222,8 +228,8 @@ def main() -> None:
     cases = [
         EvalCase(
             question=question.question,
-            expected_document_ids=question.expected_document_ids,
-            answer_must_mention=question.answer_must_mention,
+            evidence=question.evidence,
+            answer_must_mention=(question.answer,) if question.answer else (),
         )
         for question in labelled
     ]

--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -78,30 +78,57 @@ class EvalCase:
 
 @dataclass
 class ToolRunStats:
-    """The tool calls one agent run made, and what they add up to."""
+    """
+    The tool calls one agent run made, and what they add up to.
+
+    :param calls: Every call the run made, in the order it made them, as `(tool name, the arguments it passed)`:
+
+            [("list_metadata_fields", {}), ("search_documents", {"query": "CRISPR", "filters": None})]
+
+    :param errors: The calls that came back an error, as `(tool name, what it said)`:
+
+            [("get_metadata_field_values", "field 'nope' does not exist in the store")]
+    """
 
     calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
-    errors: int = 0
+    errors: list[tuple[str, str]] = field(default_factory=list)
 
-    @property
-    def inspected_first(self) -> bool:
-        """Whether `list_metadata_fields` was called before any retrieval tool."""
-        for name, _ in self.calls:
-            if name == "list_metadata_fields":
-                return True
-            if name in RETRIEVAL_TOOLS:
-                return False
-        return False
+    @staticmethod
+    def _named(tools: str | tuple[str, ...]) -> set[str]:
+        """
+        Normalize one tool name or a group of them to a set.
+
+        :param tools: A tool name, or several of them.
+        :returns: The names as a set.
+        """
+        return {tools} if isinstance(tools, str) else set(tools)
 
     def calls_to(self, tools: str | tuple[str, ...]) -> int:
         """
         Count the calls made to one tool, or to any of a group of them.
 
-        :param tools: A tool name, or several sharing one allowance.
+        :param tools: A tool name, or several of them.
         :returns: How many calls the run made to them.
         """
-        wanted = {tools} if isinstance(tools, str) else set(tools)
+        wanted = self._named(tools=tools)
         return sum(1 for name, _ in self.calls if name in wanted)
+
+    def called_before(self, tools: str | tuple[str, ...], other: str | tuple[str, ...]) -> bool:
+        """
+        Whether the run reached for one tool before it reached for another.
+
+        :param tools: The tool, or tools, that should come first.
+        :param other: The tool, or tools, they should come before.
+        :returns: True when one of `tools` was called and none of `other` was called before it. False when
+            `other` came first, and when neither was called at all.
+        """
+        wanted, after = self._named(tools=tools), self._named(tools=other)
+        for name, _ in self.calls:
+            if name in wanted:
+                return True
+            if name in after:
+                return False
+        return False
 
 
 def extract_tool_run_stats(messages: list[ChatMessage]) -> ToolRunStats:
@@ -111,11 +138,15 @@ def extract_tool_run_stats(messages: list[ChatMessage]) -> ToolRunStats:
     :param messages: The messages returned by `agent.run(...)`.
     :returns: The extracted statistics.
     """
-    stats = ToolRunStats()
-    for message in messages:
-        stats.calls.extend((tc.tool_name, tc.arguments or {}) for tc in message.tool_calls)
-        stats.errors += sum(1 for res in message.tool_call_results if res.error)
-    return stats
+    return ToolRunStats(
+        calls=[(call.tool_name, call.arguments or {}) for message in messages for call in message.tool_calls],
+        errors=[
+            (result.origin.tool_name, result.result)
+            for message in messages
+            for result in message.tool_call_results
+            if result.error
+        ],
+    )
 
 
 def _sum_usage(total: dict[str, int], usage: dict[str, Any]) -> dict[str, int]:
@@ -146,12 +177,14 @@ def build_bm25_retriever(store: DocumentStore, top_k: int = 5):  # noqa: ANN201
     return OpenSearchBM25Retriever(document_store=store, top_k=top_k)
 
 
-def run_eval_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
+def run_eval_case(agent: Agent, case: EvalCase, position: int, total: int) -> dict[str, Any]:
     """
     Run the agent on one eval case and print its report.
 
     :param agent: The agent under evaluation.
     :param case: The eval case to evaluate.
+    :param position: Which eval case this is, for the report heading.
+    :param total: How many eval cases there are, for the report heading.
     :returns: A dict with `passed` (bool), `usage` (the run's token_usage dict), and `time` (s).
     """
     started = time.perf_counter()
@@ -159,18 +192,18 @@ def run_eval_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
     elapsed = time.perf_counter() - started
 
     # Everything the report needs comes out of the one run: its messages, its answer and its token usage.
-    stats = extract_tool_run_stats(messages=result["messages"])
+    tool_run_stats = extract_tool_run_stats(messages=result["messages"])
     answer = result["last_message"].text or ""
     usage = result.get("token_usage") or {}
 
-    # Recall over the chunks the question's evidence lives in.
+    # Recall on the retrieved documents: how many of the expected documents the Agent found.
     retrieved_docs = result.get("documents") or []
     retrieved_ids = {document.id for document in retrieved_docs}
     found = case.expected_document_ids & retrieved_ids
     recall = len(found) / len(case.expected_document_ids)
 
-    # Resolve each [doc <short-id>] the answer carries against what the run returned. A reference matching nothing
-    # is a citation the reader cannot follow, and one the answer never makes is evidence it did not use.
+    # Resolve each [doc <short-id>] the answer uses against what the Agent found. A reference matching nothing
+    # is a fake citation, and one the answer doesn't use is an uncited document. Both are failures.
     cited_refs = _CITATION_RE.findall(answer)
     resolved = [ref for ref in cited_refs if any(document.id.startswith(ref) for document in retrieved_docs)]
     cited_ids = {document.id for document in retrieved_docs if any(document.id.startswith(r) for r in cited_refs)}
@@ -179,39 +212,49 @@ def run_eval_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
 
     # An eval case passes only on all four: it found every expected document, cited every one of them, made no
     # citation that does not resolve, and stayed inside its tool budget.
-    spent = {tools: stats.calls_to(tools=tools) for tools in case.tool_budgets}
+    spent = {tools: tool_run_stats.calls_to(tools=tools) for tools in case.tool_budgets}
     within_budget = all(used <= case.tool_budgets[tools] for tools, used in spent.items())
     passed = recall == 1.0 and not uncited and citations_ok and within_budget
 
-    counts = Counter(name for name, _ in stats.calls)
-    filters_used = [args["filters"] for name, args in stats.calls if name in RETRIEVAL_TOOLS and args.get("filters")]
-    print(f"\n[{'PASS' if passed else 'FAIL'}] {case.question}")
-    print(f"  tools: {dict(counts)}")
+    inspected_first = tool_run_stats.called_before(tools="list_metadata_fields", other=RETRIEVAL_TOOLS)
+    counts = Counter(name for name, _ in tool_run_stats.calls)
+    filters_used = [
+        args["filters"] for name, args in tool_run_stats.calls if name in RETRIEVAL_TOOLS and args.get("filters")
+    ]
+    needed = len(case.expected_document_ids)
+    print(f"\n=== eval case {position}/{total}: {'PASS' if passed else 'FAIL'} ===")
+    print(f"  question: {case.question}")
+    print(f"  tools called: {dict(counts)}")
     print(
-        f"  inspected-first={stats.inspected_first}  filtered-retrievals={len(filters_used)}"
-        f"  errors={stats.errors}  steps={result['step_count']}  time={elapsed:.1f}s"
+        f"  inspected metadata first: {inspected_first}   retrievals with a filter: {len(filters_used)}   "
+        f"tool errors: {len(tool_run_stats.errors)}   steps: {result['step_count']}   time: {elapsed:.1f}s"
     )
     for tools, used in spent.items():
         limit = case.tool_budgets[tools]
         label = tools if isinstance(tools, str) else " + ".join(tools)
-        print(f"  budget: {label} {used}/{limit} -> {'ok' if used <= limit else 'EXCEEDED'}")
+        print(f"  tool budget: {label} {used}/{limit} -> {'ok' if used <= limit else 'EXCEEDED'}")
+    print(f"  retrieval: found {len(found)}/{needed} of the documents the answer needs, {len(retrieved_docs)} returned")
     print(
-        f"  retrieved={len(retrieved_docs)}  recall={len(found)}/{len(case.expected_document_ids)}"
-        f"  cited={len(case.expected_document_ids) - len(uncited)}/{len(case.expected_document_ids)} expected"
-        f"  citations={len(resolved)}/{len(cited_refs)} resolve"
+        f"  citations: cited {needed - len(uncited)}/{needed} of them, "
+        f"and {len(resolved)}/{len(cited_refs)} of the answer's references point at a returned document"
     )
+
+    print("  documents returned, and whether the answer needs them:")
     for document in retrieved_docs:
-        marker = "+" if document.id in case.expected_document_ids else "-"
-        print(f"    {marker} [doc {document.id[:8]}] {document.meta.get('title')}")
+        label = "needed" if document.id in case.expected_document_ids else "not needed"
+        print(f"    {label:>10}  [doc {document.id[:8]}] {document.meta.get('title')}")
+    # Naming the quote, since the id alone says nothing about what the run failed to find or failed to use.
     for document_id in sorted(case.expected_document_ids - retrieved_ids):
-        # Naming the quote that was missed, since the id alone says nothing about what the run failed to find.
-        print(f"    MISSED [doc {document_id[:8]}] {case.evidence[document_id][:100]}")
+        print(f"  needed but never retrieved: [doc {document_id[:8]}] {case.evidence[document_id][:96]}")
     for document_id in sorted(uncited & retrieved_ids):
-        print(f"    UNCITED [doc {document_id[:8]}] {case.evidence[document_id][:100]}")
+        print(f"  needed and retrieved but not cited: [doc {document_id[:8]}] {case.evidence[document_id][:96]}")
+
     if usage:
         print(f"  tokens: { {k: v for k, v in usage.items() if isinstance(v, int)} }")
+    for tool_name, message in tool_run_stats.errors:
+        print(f"  tool error: {tool_name} -> {message[:120]}")
     for filters in filters_used:
-        print(f"  filter: {filters}")
+        print(f"  retrieval filter: {filters}")
     print("  answer:")
     for line in answer.splitlines():
         print(f"    {line}")
@@ -235,26 +278,29 @@ def main() -> None:
     )
     # Budgets for the tools this agent has. Lenient on purpose: too many retrievals is better than too few.
     budgets: dict[str | tuple[str, ...], int] = {METADATA_TOOLS: 5, RETRIEVAL_TOOLS: 5}
-    cases = [
+    eval_cases = [
         EvalCase(question=question.question, evidence=question.evidence, tool_budgets=budgets) for question in labelled
     ]
-    expected = sum(len(case.expected_document_ids) for case in cases)
-    print(f"eval cases: {len(cases)} labelled from evidence, expecting {expected} documents in total")
+    expected = sum(len(case.expected_document_ids) for case in eval_cases)
+    print(f"eval cases: {len(eval_cases)} labelled from evidence, expecting {expected} documents in total")
 
+    # Build the advanced rag agent
     agent = create_advanced_rag_agent(document_store=store, retriever=build_bm25_retriever(store=store))
 
-    results = [run_eval_case(agent=agent, case=case) for case in cases]
+    # Run the eval cases
+    results = [run_eval_case(agent=agent, case=case) for case in eval_cases]
 
-    passed = sum(result["passed"] for result in results)
+    # Calculate total usage
     total_usage: dict[str, int] = {}
     for result in results:
         _sum_usage(total=total_usage, usage=result["usage"])
+
+    # Print the results
+    passed = sum(result["passed"] for result in results)
     print(f"\n=== {passed}/{len(results)} eval cases passed ===")
     print(f"total time: {sum(result['time'] for result in results):.1f}s")
     if total_usage:
         print(f"total tokens: {total_usage}")
-    if passed < len(results):
-        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -288,7 +288,10 @@ def main() -> None:
     agent = create_advanced_rag_agent(document_store=store, retriever=build_bm25_retriever(store=store))
 
     # Run the eval cases
-    results = [run_eval_case(agent=agent, case=case) for case in eval_cases]
+    results = [
+        run_eval_case(agent=agent, case=case, position=position, total=len(eval_cases))
+        for position, case in enumerate(eval_cases, start=1)
+    ]
 
     # Calculate total usage
     total_usage: dict[str, int] = {}

--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -34,6 +34,7 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any
 
+from haystack import Document
 from haystack.components.agents import Agent
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.dataclasses import ChatMessage
@@ -49,7 +50,7 @@ with LazyImport(message='Run "pip install opensearch-haystack" to use an OpenSea
 
 RETRIEVAL_TOOLS = ("search_documents", "fetch_documents_by_filter")
 METADATA_TOOLS = ("list_metadata_fields", "get_metadata_field_values", "get_metadata_field_range")
-_CITATION_RE = re.compile(r"\[doc ([0-9a-f]{4,16})\]")
+_CITATION_RE = re.compile(r"\[doc ([0-9a-f]{4,16})[^]]*\]")
 
 
 @dataclass
@@ -218,15 +219,15 @@ def run_eval_case(agent: Agent, case: EvalCase, position: int, total: int) -> di
 
     inspected_first = tool_run_stats.called_before(tools="list_metadata_fields", other=RETRIEVAL_TOOLS)
     counts = Counter(name for name, _ in tool_run_stats.calls)
-    filters_used = [
-        args["filters"] for name, args in tool_run_stats.calls if name in RETRIEVAL_TOOLS and args.get("filters")
-    ]
+    filtered_retrievals = sum(
+        1 for name, args in tool_run_stats.calls if name in RETRIEVAL_TOOLS and args.get("filters")
+    )
     needed = len(case.expected_document_ids)
     print(f"\n=== eval case {position}/{total}: {'PASS' if passed else 'FAIL'} ===")
     print(f"  question: {case.question}")
     print(f"  tools called: {dict(counts)}")
     print(
-        f"  inspected metadata first: {inspected_first}   retrievals with a filter: {len(filters_used)}   "
+        f"  inspected metadata first: {inspected_first}   retrievals with a filter: {filtered_retrievals}   "
         f"tool errors: {len(tool_run_stats.errors)}   steps: {result['step_count']}   time: {elapsed:.1f}s"
     )
     for tools, used in spent.items():
@@ -239,11 +240,21 @@ def run_eval_case(agent: Agent, case: EvalCase, position: int, total: int) -> di
         f"and {len(resolved)}/{len(cited_refs)} of the answer's references point at a returned document"
     )
 
-    print("  documents returned, and whether the answer needs them:")
+    # Chunks of one article all carry its title, so they are grouped under it and told apart by chunk number.
+    # Articles keep the order they were first returned in, which is the order the run ranked them.
+    by_article: dict[str, list[Document]] = {}
     for document in retrieved_docs:
-        label = "needed" if document.id in case.expected_document_ids else "not needed"
-        print(f"    {label:>10}  [doc {document.id[:8]}] {document.meta.get('title')}")
+        by_article.setdefault(document.meta.get("title", ""), []).append(document)
+
+    print("\n  documents returned, and whether the answer needs them:")
+    for title, documents in by_article.items():
+        print(f"    {title}")
+        for document in sorted(documents, key=lambda chunk: chunk.meta.get("split_id", 0)):
+            label = "needed" if document.id in case.expected_document_ids else "not needed"
+            preview = " ".join((document.content or "").split())[:80]
+            print(f"      {label:>10}  chunk {document.meta.get('split_id'):>3}  [doc {document.id[:8]}]  {preview}")
     # Naming the quote, since the id alone says nothing about what the run failed to find or failed to use.
+    print()
     for document_id in sorted(case.expected_document_ids - retrieved_ids):
         print(f"  needed but never retrieved: [doc {document_id[:8]}] {case.evidence[document_id][:96]}")
     for document_id in sorted(uncited & retrieved_ids):
@@ -253,8 +264,6 @@ def run_eval_case(agent: Agent, case: EvalCase, position: int, total: int) -> di
         print(f"  tokens: { {k: v for k, v in usage.items() if isinstance(v, int)} }")
     for tool_name, message in tool_run_stats.errors:
         print(f"  tool error: {tool_name} -> {message[:120]}")
-    for filters in filters_used:
-        print(f"  retrieval filter: {filters}")
     print("  answer:")
     for line in answer.splitlines():
         print(f"    {line}")
@@ -277,12 +286,13 @@ def main() -> None:
         articles=articles, limit=arguments.max_cases, seed=arguments.case_seed
     )
     # Budgets for the tools this agent has. Lenient on purpose: too many retrievals is better than too few.
-    budgets: dict[str | tuple[str, ...], int] = {METADATA_TOOLS: 5, RETRIEVAL_TOOLS: 5}
+    # Generous on purpose: a MultiHopRAG question needs evidence from several articles, so several searches are
+    # the expected shape of a good run rather than a sign of floundering.
+    budgets: dict[str | tuple[str, ...], int] = {METADATA_TOOLS: 8, RETRIEVAL_TOOLS: 12}
     eval_cases = [
         EvalCase(question=question.question, evidence=question.evidence, tool_budgets=budgets) for question in labelled
     ]
-    expected = sum(len(case.expected_document_ids) for case in eval_cases)
-    print(f"eval cases: {len(eval_cases)} labelled from evidence, expecting {expected} documents in total")
+    print(f"eval cases: {len(eval_cases)} labelled from evidence")
 
     # Build the advanced rag agent
     agent = create_advanced_rag_agent(document_store=store, retriever=build_bm25_retriever(store=store))

--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -132,6 +132,18 @@ class ToolRunStats:
         return False
 
 
+def _preview(text: str, limit: int) -> str:
+    """
+    Collapse text to one line and cut it, marking the cut so a reader knows there is more.
+
+    :param text: The text to preview.
+    :param limit: How many characters to keep.
+    :returns: The preview, ending in an ellipsis when anything was cut.
+    """
+    collapsed = " ".join((text or "").split())
+    return collapsed if len(collapsed) <= limit else f"{collapsed[:limit]}..."
+
+
 def extract_tool_run_stats(messages: list[ChatMessage]) -> ToolRunStats:
     """
     Extract tool calls and error results from an agent run.
@@ -246,24 +258,30 @@ def run_eval_case(agent: Agent, case: EvalCase, position: int, total: int) -> di
     for document in retrieved_docs:
         by_article.setdefault(document.meta.get("title", ""), []).append(document)
 
-    print("\n  documents returned, and whether the answer needs them:")
+    print("\n  documents returned, grouped by article. -> marks one the answer needs:")
     for title, documents in by_article.items():
-        print(f"    {title}")
+        print(f"    Title: {title}")
         for document in sorted(documents, key=lambda chunk: chunk.meta.get("split_id", 0)):
-            label = "needed" if document.id in case.expected_document_ids else "not needed"
-            preview = " ".join((document.content or "").split())[:80]
-            print(f"      {label:>10}  chunk {document.meta.get('split_id'):>3}  [doc {document.id[:8]}]  {preview}")
+            needed_here = "-> " if document.id in case.expected_document_ids else "   "
+            preview = _preview(text=document.content or "", limit=80)
+            print(f"      {needed_here}chunk {document.meta.get('split_id'):>2}  [doc {document.id[:8]}]  {preview}")
     # Naming the quote, since the id alone says nothing about what the run failed to find or failed to use.
     print()
     for document_id in sorted(case.expected_document_ids - retrieved_ids):
-        print(f"  needed but never retrieved: [doc {document_id[:8]}] {case.evidence[document_id][:96]}")
+        print(
+            f"  needed but never retrieved: [doc {document_id[:8]}] "
+            f"{_preview(text=case.evidence[document_id], limit=96)}"
+        )
     for document_id in sorted(uncited & retrieved_ids):
-        print(f"  needed and retrieved but not cited: [doc {document_id[:8]}] {case.evidence[document_id][:96]}")
+        print(
+            f"  needed and retrieved but not cited: [doc {document_id[:8]}] "
+            f"{_preview(text=case.evidence[document_id], limit=96)}"
+        )
 
     if usage:
         print(f"  tokens: { {k: v for k, v in usage.items() if isinstance(v, int)} }")
     for tool_name, message in tool_run_stats.errors:
-        print(f"  tool error: {tool_name} -> {message[:120]}")
+        print(f"  tool error: {tool_name} -> {_preview(text=message, limit=120)}")
     print("  answer:")
     for line in answer.splitlines():
         print(f"    {line}")

--- a/integrations/agent_pack/examples/advanced_rag_eval.py
+++ b/integrations/agent_pack/examples/advanced_rag_eval.py
@@ -5,17 +5,17 @@
 # Mini evaluation harness for the Advanced RAG agent, run against the MultiHopRAG corpus.
 #
 # The corpus and its labelled questions come from `multihop_rag`, which chunks the news articles and works out
-# which chunks hold each question's quoted evidence. That gives exact ground truth: a case names the documents
-# an answer needs, so retrieval is scored as recall over those IDs rather than against a metadata predicate.
+# which chunks hold each question's quoted evidence. That gives exact ground truth: an eval case names the
+# documents an answer needs, so retrieval is scored as recall over those IDs rather than a metadata predicate.
 #
-# Reported per case:
+# Reported per eval case:
 #
 # - Retrieval: recall over the documents the question's evidence lives in, from the run's accumulated `documents`.
 # - Process: whether metadata was inspected before any retrieval, per-tool call counts, how many retrievals used
-#   a filter, tool errors, steps, and wall-clock time. A case fails when it exceeds its per-case tool budget.
+#   a filter, tool errors, steps, and wall-clock time. An eval case fails when it exceeds its tool budget.
 # - Answer: the ground-truth answer must be mentioned when a substring check on it means anything, and every
 #   `[doc <short-id>]` citation must resolve to a document the run returned.
-# - Token usage, per case and totalled, for comparing models and reasoning efforts.
+# - Token usage, per eval case and totalled, for comparing models and reasoning efforts.
 #
 # Run from `integrations/agent_pack` with `OPENAI_API_KEY` set. The corpus requires `datasets`:
 #
@@ -50,17 +50,20 @@ RETRIEVAL_TOOLS = ("search_documents", "fetch_documents_by_filter")
 METADATA_TOOLS = ("list_metadata_fields", "get_metadata_field_values", "get_metadata_field_range")
 _CITATION_RE = re.compile(r"\[doc ([0-9a-f]{4,16})\]")
 
+# Answers shorter than this are words like "Yes" or "No", which a reply can contain by coincidence.
+MIN_ASSERTABLE_ANSWER_CHARS = 5
+
 
 @dataclass
 class EvalCase:
-    """One evaluation case: a question, the documents that answer it, and the budgets the run may spend."""
+    """One eval case: a question, the documents that answer it, and the budgets the run may spend."""
 
     question: str
     # Ground truth: the quoted evidence an answer needs, by the chunk it was found in.
     evidence: dict[str, str]
     # The ground-truth answer, checked case-insensitively when a substring check on it means anything.
     answer_must_mention: tuple[str, ...] = ()
-    # Efficiency budgets. Lenient on purpose — too many retrievals is better than too few.
+    # Tool budgets. Exceeding either fails the eval case.
     max_metadata_calls: int = 5
     max_retrieval_calls: int = 5
 
@@ -147,31 +150,35 @@ def build_bm25_retriever(store: DocumentStore, top_k: int = 5):  # noqa: ANN201
 
 def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
     """
-    Run the agent on one case and print its report.
+    Run the agent on one eval case and print its report.
 
     :param agent: The agent under evaluation.
-    :param case: The case to evaluate.
+    :param case: The eval case to evaluate.
     :returns: A dict with `passed` (bool), `usage` (the run's token_usage dict), and `time` (s).
     """
     started = time.perf_counter()
     result = agent.run(messages=[ChatMessage.from_user(case.question)])
     elapsed = time.perf_counter() - started
 
+    # Everything the report needs comes out of the one run: its messages, its answer and its token usage.
     stats = extract_run_stats(result["messages"])
     answer = result["last_message"].text or ""
     usage = result.get("token_usage") or {}
 
+    # Recall over the chunks the question's evidence lives in.
     retrieved_docs = result.get("documents") or []
     retrieved_ids = {document.id for document in retrieved_docs}
     found = case.expected_document_ids & retrieved_ids
     recall = len(found) / len(case.expected_document_ids)
     mentions_ok = all(term.lower() in answer.lower() for term in case.answer_must_mention)
 
-    # Every [doc <short-id>] reference in the answer must resolve to a returned document.
+    # A [doc <short-id>] reference that matches nothing the run returned is a citation the reader cannot follow.
     cited_refs = _CITATION_RE.findall(answer)
     resolved = [ref for ref in cited_refs if any(document.id.startswith(ref) for document in retrieved_docs)]
     citations_ok = len(resolved) == len(cited_refs)
 
+    # An eval case passes only on all four: it found every expected document, said the answer, cited documents it
+    # actually returned, and stayed inside its tool budget.
     within_budget = (
         stats.metadata_calls <= case.max_metadata_calls and stats.retrieval_calls <= case.max_retrieval_calls
     )
@@ -211,11 +218,11 @@ def evaluate_case(agent: Agent, case: EvalCase) -> dict[str, Any]:
 
 
 def main() -> None:
-    """Run the eval set and print per-case reports plus a summary."""
+    """Run the eval set and print per-eval-case reports plus a summary."""
     parser = argparse.ArgumentParser(description="Mini evaluation harness for the Advanced RAG agent.")
     parser.add_argument("--store", choices=("in_memory", "opensearch"), default="in_memory")
     parser.add_argument("--max-cases", type=int, default=10, help="How many labelled questions to evaluate.")
-    parser.add_argument("--case-seed", type=int, default=0, help="Selects which cases are drawn from the dataset.")
+    parser.add_argument("--case-seed", type=int, default=0, help="Selects which eval cases are drawn from the dataset.")
     arguments = parser.parse_args()
 
     store, articles = prepare_corpus(backend=arguments.store)
@@ -225,16 +232,18 @@ def main() -> None:
     labelled: list[LabelledQuestion] = build_eval_cases(
         articles=articles, limit=arguments.max_cases, seed=arguments.case_seed
     )
+    # The dataset reports its answer verbatim; asserting on it is this harness's decision. A short answer like
+    # "Yes" is skipped, since finding that word in a reply can happen for reasons unrelated to being right.
     cases = [
         EvalCase(
             question=question.question,
             evidence=question.evidence,
-            answer_must_mention=(question.answer,) if question.answer else (),
+            answer_must_mention=(question.answer,) if len(question.answer) >= MIN_ASSERTABLE_ANSWER_CHARS else (),
         )
         for question in labelled
     ]
     expected = sum(len(case.expected_document_ids) for case in cases)
-    print(f"cases: {len(cases)} labelled from evidence, expecting {expected} documents in total")
+    print(f"eval cases: {len(cases)} labelled from evidence, expecting {expected} documents in total")
 
     agent = create_advanced_rag_agent(document_store=store, retriever=build_bm25_retriever(store=store))
 
@@ -244,7 +253,7 @@ def main() -> None:
     total_usage: dict[str, int] = {}
     for result in results:
         _sum_usage(total_usage, result["usage"])
-    print(f"\n=== {passed}/{len(results)} cases passed ===")
+    print(f"\n=== {passed}/{len(results)} eval cases passed ===")
     print(f"total time: {sum(result['time'] for result in results):.1f}s")
     if total_usage:
         print(f"total tokens: {total_usage}")

--- a/integrations/agent_pack/examples/multihop_rag.py
+++ b/integrations/agent_pack/examples/multihop_rag.py
@@ -29,6 +29,12 @@ from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.document_stores.types import DocumentStore, DuplicatePolicy
 from haystack.lazy_imports import LazyImport
 
+with LazyImport(message='Run "pip install datasets" to build the MultiHopRAG evaluation set.') as datasets_import:
+    from datasets import load_dataset
+
+with LazyImport(message='Run "pip install opensearch-haystack" to use an OpenSearch store.') as opensearch_import:
+    from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
+
 
 @dataclass(frozen=True)
 class LabelledQuestion:
@@ -36,55 +42,45 @@ class LabelledQuestion:
     One question the dataset labels, with the evidence an answer needs.
 
     :param question: The question as the dataset asks it.
-    :param expected_document_ids: The chunks holding the evidence the answer is built from.
-    :param answer_must_mention: The ground-truth answer, when a substring check on it means anything.
+    :param evidence: The quoted evidence the answer is built from, by the chunk it was found in.
+    :param answer: The ground-truth answer, verbatim. How to check a reply against it is the harness's call: most
+        are a name or a number, but some are short words like "Yes", where a substring check may match for
+        reasons unrelated to the answer being right.
     """
 
     question: str
-    expected_document_ids: frozenset[str]
-    answer_must_mention: tuple[str, ...] = ()
+    evidence: dict[str, str]
+    answer: str = ""
 
+    @property
+    def expected_document_ids(self) -> frozenset[str]:
+        """The chunks an answer needs, which are the ones its evidence was found in."""
+        return frozenset(self.evidence)
 
-with LazyImport(message='Run "pip install datasets" to build the MultiHopRAG evaluation set.') as datasets_import:
-    from datasets import load_dataset
-
-with LazyImport(message='Run "pip install opensearch-haystack" to use an OpenSearch store.') as opensearch_import:
-    from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
 
 DATASET_ID = "yixuantt/MultiHopRAG"
 CORPUS_KEY = "multihop-rag"
 
 # Word-based splitting with overlap. Measured over the whole dataset at this setting: no evidence fact is split
-# across a chunk boundary, so every one of the 6,084 is contained wholly within a chunk. Overlap is what costs:
-# 926 of them sit in the region two adjacent chunks share, and a query touching one of those cannot name a single
-# expected document, so it is dropped rather than scored loosely. 1,432 of the 2,255 queries survive that.
+# across a chunk boundary, so every one of the 6,084 is contained wholly within a chunk. However, the overlap
+# means 926 of them are present in two adjacent chunks, so a query can no longer retrieve just a single expected
+# document, so the query is dropped rather than scored loosely. So we end up with 1,432 of the 2,255 queries as
+# valid eval points.
 SPLIT_BY = "word"
 SPLIT_LENGTH = 350
 SPLIT_OVERLAP = 90
 
-# Carried from the article onto each of its chunks, so the metadata tools see the same fields whichever chunk is
-# retrieved.
+# Carried from the article onto each of its chunks
 ARTICLE_METADATA = ("title", "category", "source", "author", "published_at", "url")
 
 # Queries whose evidence is present in the corpus. The dataset's fourth type, `null_query`, is deliberately
-# excluded: its answer is "Insufficient information." while topically related articles do exist, so scoring it
-# needs an expectation this harness does not have yet — retrieval is appropriate, but the answer must decline.
+# excluded for now to focus on answerable question types.
 ANSWERABLE_QUESTION_TYPES = ("comparison_query", "inference_query", "temporal_query")
-
-# A ground-truth answer is asserted only when a substring check means something. Most answers are a name or a
-# number, but many comparison answers are "Yes" or "No", where finding the word in a sentence proves nothing.
-_UNASSERTABLE_ANSWERS = frozenset({"yes", "no", "true", "false", "insufficient information."})
-_MIN_ASSERTABLE_ANSWER_CHARS = 5
 
 
 @dataclass(frozen=True)
 class Article:
-    """
-    One article's body alongside the chunks covering it, ordered by where each chunk starts.
-
-    An evidence quote is a span of the body, so which chunks hold it follows from arithmetic on the offsets
-    `DocumentSplitter` records rather than from searching each chunk for the text.
-    """
+    """One article's body and its chunks, in the order they appear in it."""
 
     body: str
     chunks: tuple[Document, ...]
@@ -154,22 +150,28 @@ def _covering_chunks(article: Article, fact: str) -> list[Document] | None:
     """
     Find the chunks a quoted evidence fact is contained in.
 
-    The quote is located in the article first, and every place it occurs is located, not just the first. A quote
-    appearing twice is ambiguous evidence, and resolving it to whichever copy came first would silently attach
-    the case to an arbitrary one of them.
+    A quote appearing more than once is ambiguous evidence, so if this occurs an empty list is returned to indicate
+    that this datapoint should be excluded.
 
     :param article: The article the fact is attributed to.
     :param fact: The quoted evidence.
-    :returns: The chunks containing every occurrence of the fact, or None when the quote is not in the article at
-        all. A quote that occurs but spans a chunk boundary is contained in no chunk, and returns an empty list.
+    :returns: The chunks holding every occurrence of the fact, or None when the quote is not in the article at
+        all. An empty list when the quote is there but no single chunk holds all of it: it either spans a chunk boundary
+        or is repeated in multiple chunks.
     """
+    # Find all occurrences of the fact in the article.
     occurrences = []
     position = article.body.find(fact)
     while position != -1:
         occurrences.append(position)
         position = article.body.find(fact, position + 1)
+
+    # If no occurrences we return None
     if not occurrences:
         return None
+
+    # Return all chunks that cover all occurrences of the fact. If a fact is split across two chunks, an empty list is
+    # returned.
     return [
         chunk
         for chunk in article.chunks
@@ -179,14 +181,6 @@ def _covering_chunks(article: Article, fact: str) -> list[Document] | None:
             for start in occurrences
         )
     ]
-
-
-def _answer_terms(answer: str) -> tuple[str, ...]:
-    """Return the ground-truth answer as an assertable term, or nothing when a substring check proves nothing."""
-    cleaned = (answer or "").strip()
-    if len(cleaned) < _MIN_ASSERTABLE_ANSWER_CHARS or cleaned.lower() in _UNASSERTABLE_ANSWERS:
-        return ()
-    return (cleaned,)
 
 
 def exact_eval_case_candidates(articles: dict[str, Article]) -> dict[str, list[LabelledQuestion]]:
@@ -209,25 +203,24 @@ def exact_eval_case_candidates(articles: dict[str, Article]) -> dict[str, list[L
     for row in load_dataset(DATASET_ID, "MultiHopRAG", split="train"):
         if row["question_type"] not in candidates:
             continue
-        expected: set[str] = set()
+        evidence: dict[str, str] = {}
         exact = bool(row["evidence_list"])
         for entry in row["evidence_list"]:
             article = articles.get(entry["title"])
-            holders = (
-                None if article is None else _covering_chunks(article=article, fact=(entry.get("fact") or "").strip())
-            )
+            fact = (entry.get("fact") or "").strip()
+            holders = None if article is None else _covering_chunks(article=article, fact=fact)
             missing += holders is None
             split_across_chunks += holders == []
             if holders is None or len(holders) != 1:
                 exact = False
                 continue
-            expected.add(holders[0].id)
-        if exact and expected:
+            evidence[holders[0].id] = fact
+        if exact and evidence:
             candidates[row["question_type"]].append(
                 LabelledQuestion(
                     question=row["query"],
-                    expected_document_ids=frozenset(expected),
-                    answer_must_mention=_answer_terms(answer=row["answer"]),
+                    evidence=evidence,
+                    answer=(row["answer"] or "").strip(),
                 )
             )
     if missing:
@@ -292,7 +285,7 @@ def _report(store: DocumentStore, articles: dict[str, Article], cases: list[Labe
     print(f"  published: {min(metadata['published_at'])} .. {max(metadata['published_at'])}")
     print(f"\n  cases selected: {len(cases)}")
     print(f"    expected documents per eval case: {sorted({len(case.expected_document_ids) for case in cases})}")
-    print(f"    with an assertable answer:   {sum(1 for case in cases if case.answer_must_mention)}")
+    print(f"    with a ground-truth answer:  {sum(1 for case in cases if case.answer)}")
     for case in cases[:3]:
         print(f"    - {case.question[:96]}")
 

--- a/integrations/agent_pack/examples/multihop_rag.py
+++ b/integrations/agent_pack/examples/multihop_rag.py
@@ -276,10 +276,14 @@ def _report(store: DocumentStore, articles: dict[str, Article], cases: list[Labe
     )
     print(f"  published: {min(metadata['published_at'])} .. {max(metadata['published_at'])}")
     print(f"\n  eval cases selected: {len(cases)}")
-    print(f"    expected documents per eval case: {sorted({len(case.expected_document_ids) for case in cases})}")
+    # Listed rather than given as a range, since the sizes present need not be contiguous.
+    sizes = sorted({len(case.expected_document_ids) for case in cases})
+    listed = str(sizes[0]) if len(sizes) == 1 else f"{', '.join(str(size) for size in sizes[:-1])} or {sizes[-1]}"
+    print(f"    expected documents per eval case: {listed}")
     print(f"    with a ground-truth answer:  {sum(1 for case in cases if case.answer)}")
+    print("    example questions:")
     for case in cases[:3]:
-        print(f"    - {case.question[:96]}")
+        print(f"      - {case.question[:96]}")
 
 
 def main() -> None:

--- a/integrations/agent_pack/examples/multihop_rag.py
+++ b/integrations/agent_pack/examples/multihop_rag.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: 2026-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Prepare the MultiHopRAG dataset as an evaluation set for harness optimization.
+#
+# The dataset pairs 609 news articles carrying real metadata — category, source, author, publication timestamp — with
+# 2,556 labelled queries whose supporting evidence is quoted verbatim and attributed to its article.
+#
+# Articles are long — a median of 7,836 characters, up to 71,034. So articles are split by word with overlap.
+#
+# Splitting would normally blur the ground truth, since evidence is attributed to an article and not a chunk.
+# So we ensure that a fact is contained wholly within a chunk. If a fact is split across two chunks, the query is
+# excluded from the evaluation set.
+#
+# Run this module directly to build the corpus and report what it produced:
+#
+#     hatch run test:python examples/multihop_rag.py
+
+import argparse
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from haystack import Document
+from haystack.components.preprocessors import DocumentSplitter
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.document_stores.types import DocumentStore, DuplicatePolicy
+from haystack.lazy_imports import LazyImport
+
+
+@dataclass(frozen=True)
+class LabelledQuestion:
+    """
+    One question the dataset labels, with the evidence an answer needs.
+
+    :param question: The question as the dataset asks it.
+    :param expected_document_ids: The chunks holding the evidence the answer is built from.
+    :param answer_must_mention: The ground-truth answer, when a substring check on it means anything.
+    """
+
+    question: str
+    expected_document_ids: frozenset[str]
+    answer_must_mention: tuple[str, ...] = ()
+
+
+with LazyImport(message='Run "pip install datasets" to build the MultiHopRAG evaluation set.') as datasets_import:
+    from datasets import load_dataset
+
+with LazyImport(message='Run "pip install opensearch-haystack" to use an OpenSearch store.') as opensearch_import:
+    from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
+
+DATASET_ID = "yixuantt/MultiHopRAG"
+CORPUS_KEY = "multihop-rag"
+
+# Word-based splitting with overlap. Measured over the whole dataset at this setting: no evidence fact is split
+# across a chunk boundary, so every one of the 6,084 is contained wholly within a chunk. Overlap is what costs:
+# 926 of them sit in the region two adjacent chunks share, and a query touching one of those cannot name a single
+# expected document, so it is dropped rather than scored loosely. 1,432 of the 2,255 queries survive that.
+SPLIT_BY = "word"
+SPLIT_LENGTH = 350
+SPLIT_OVERLAP = 90
+
+# Carried from the article onto each of its chunks, so the metadata tools see the same fields whichever chunk is
+# retrieved.
+ARTICLE_METADATA = ("title", "category", "source", "author", "published_at", "url")
+
+# Queries whose evidence is present in the corpus. The dataset's fourth type, `null_query`, is deliberately
+# excluded: its answer is "Insufficient information." while topically related articles do exist, so scoring it
+# needs an expectation this harness does not have yet — retrieval is appropriate, but the answer must decline.
+ANSWERABLE_QUESTION_TYPES = ("comparison_query", "inference_query", "temporal_query")
+
+# A ground-truth answer is asserted only when a substring check means something. Most answers are a name or a
+# number, but many comparison answers are "Yes" or "No", where finding the word in a sentence proves nothing.
+_UNASSERTABLE_ANSWERS = frozenset({"yes", "no", "true", "false", "insufficient information."})
+_MIN_ASSERTABLE_ANSWER_CHARS = 5
+
+
+@dataclass(frozen=True)
+class Article:
+    """
+    One article's body alongside the chunks covering it, ordered by where each chunk starts.
+
+    An evidence quote is a span of the body, so which chunks hold it follows from arithmetic on the offsets
+    `DocumentSplitter` records rather than from searching each chunk for the text.
+    """
+
+    body: str
+    chunks: tuple[Document, ...]
+
+
+def build_document_store(backend: str, index: str) -> DocumentStore:
+    """
+    Build an empty in-memory or OpenSearch document store under a named index.
+
+    :param backend: Either "in_memory" or "opensearch".
+    :param index: Names the index to open or create.
+    :returns: The empty store.
+    """
+    if backend == "opensearch":
+        opensearch_import.check()
+        url = os.environ.get("OPENSEARCH_URL", "http://localhost:9200")
+        return OpenSearchDocumentStore(
+            hosts=url,
+            index=index,
+            use_ssl=url.startswith("https"),
+            verify_certs=not url.startswith("https://localhost"),
+        )
+    return InMemoryDocumentStore(index=index)
+
+
+def prepare_corpus(
+    backend: Literal["in_memory", "opensearch"] = "in_memory", index: str = CORPUS_KEY
+) -> tuple[DocumentStore, dict[str, Article]]:
+    """
+    Build the chunked corpus and index it, reusing an already-populated store.
+
+    :param backend: Either "in_memory" or "opensearch".
+    :param index: Names the index holding the corpus.
+    :returns: The populated store and every article by title, each with the chunks covering it.
+    """
+    datasets_import.check()
+    store = build_document_store(backend=backend, index=index)
+
+    # Load the dataset, split the articles into chunks, and write them to the store.
+    documents = [
+        Document(content=row["body"], meta={field: row[field] for field in ARTICLE_METADATA})
+        for row in load_dataset(DATASET_ID, "corpus", split="train")
+        if (row["body"] or "").strip()
+    ]
+    splitter = DocumentSplitter(split_by=SPLIT_BY, split_length=SPLIT_LENGTH, split_overlap=SPLIT_OVERLAP)
+    chunks = splitter.run(documents=documents)["documents"]
+
+    # Write only when the store is empty or the corpus changed, so a repeated run does not reindex.
+    if store.count_documents() != len(chunks):
+        store.write_documents(documents=chunks, policy=DuplicatePolicy.OVERWRITE)
+
+    # Grouped on the id the splitter records, rather than on the title, so the mapping holds whatever the titles do.
+    by_source: dict[str, list[Document]] = {}
+    for chunk in chunks:
+        by_source.setdefault(chunk.meta["source_id"], []).append(chunk)
+    articles = {
+        document.meta["title"]: Article(
+            body=document.content or "",
+            chunks=tuple(sorted(by_source.get(document.id, []), key=lambda chunk: chunk.meta["split_idx_start"])),
+        )
+        for document in documents
+    }
+    return store, articles
+
+
+def _covering_chunks(article: Article, fact: str) -> list[Document] | None:
+    """
+    Find the chunks a quoted evidence fact is contained in.
+
+    The quote is located in the article first, and every place it occurs is located, not just the first. A quote
+    appearing twice is ambiguous evidence, and resolving it to whichever copy came first would silently attach
+    the case to an arbitrary one of them.
+
+    :param article: The article the fact is attributed to.
+    :param fact: The quoted evidence.
+    :returns: The chunks containing every occurrence of the fact, or None when the quote is not in the article at
+        all. A quote that occurs but spans a chunk boundary is contained in no chunk, and returns an empty list.
+    """
+    occurrences = []
+    position = article.body.find(fact)
+    while position != -1:
+        occurrences.append(position)
+        position = article.body.find(fact, position + 1)
+    if not occurrences:
+        return None
+    return [
+        chunk
+        for chunk in article.chunks
+        if all(
+            chunk.meta["split_idx_start"] <= start
+            and start + len(fact) <= chunk.meta["split_idx_start"] + len(chunk.content or "")
+            for start in occurrences
+        )
+    ]
+
+
+def _answer_terms(answer: str) -> tuple[str, ...]:
+    """Return the ground-truth answer as an assertable term, or nothing when a substring check proves nothing."""
+    cleaned = (answer or "").strip()
+    if len(cleaned) < _MIN_ASSERTABLE_ANSWER_CHARS or cleaned.lower() in _UNASSERTABLE_ANSWERS:
+        return ()
+    return (cleaned,)
+
+
+def exact_eval_case_candidates(articles: dict[str, Article]) -> dict[str, list[LabelledQuestion]]:
+    """
+    Build every eval case whose expected documents can be stated exactly, grouped by question type.
+
+    A query qualifies when each of its evidence facts is contained in exactly one chunk. Facts sitting in two
+    adjacent chunks are the price of overlap, and a case naming both would fail an Agent that retrieved either,
+    so those queries are left out rather than scored loosely.
+
+    :param articles: The corpus the eval cases will be scored against, by article title.
+    :returns: Eval cases per question type, ordered by question for reproducibility.
+    :raises ValueError: If any evidence fact is missing from the article it is attributed to, or is present but
+        split across chunks, since either means the corpus and the labels no longer correspond.
+    """
+    datasets_import.check()
+    candidates: dict[str, list[LabelledQuestion]] = {name: [] for name in ANSWERABLE_QUESTION_TYPES}
+    missing = 0
+    split_across_chunks = 0
+    for row in load_dataset(DATASET_ID, "MultiHopRAG", split="train"):
+        if row["question_type"] not in candidates:
+            continue
+        expected: set[str] = set()
+        exact = bool(row["evidence_list"])
+        for entry in row["evidence_list"]:
+            article = articles.get(entry["title"])
+            holders = (
+                None if article is None else _covering_chunks(article=article, fact=(entry.get("fact") or "").strip())
+            )
+            missing += holders is None
+            split_across_chunks += holders == []
+            if holders is None or len(holders) != 1:
+                exact = False
+                continue
+            expected.add(holders[0].id)
+        if exact and expected:
+            candidates[row["question_type"]].append(
+                LabelledQuestion(
+                    question=row["query"],
+                    expected_document_ids=frozenset(expected),
+                    answer_must_mention=_answer_terms(answer=row["answer"]),
+                )
+            )
+    if missing:
+        msg = (
+            f"{missing} evidence facts are not present in the article they are attributed to, so eval cases "
+            f"cannot be scored against this corpus. The dataset changed."
+        )
+        raise ValueError(msg)
+    if split_across_chunks:
+        msg = (
+            f"{split_across_chunks} evidence facts are present but split across chunks, so no single chunk holds "
+            f"them. Lower SPLIT_LENGTH or raise SPLIT_OVERLAP until every fact fits inside one chunk."
+        )
+        raise ValueError(msg)
+    return {name: sorted(cases, key=lambda case: case.question) for name, cases in candidates.items()}
+
+
+def build_eval_cases(articles: dict[str, Article], limit: int, seed: int = 0) -> list[LabelledQuestion]:
+    """
+    Build a reproducible set of eval cases, spread evenly across the question types.
+
+    :param articles: The corpus the eval cases will be scored against, by article title.
+    :param limit: How many eval cases to select. Each one costs an Agent run per candidate measured.
+    :param seed: Seed for the selection, so the same evaluation set is rebuilt every time.
+    :returns: The selected eval cases, interleaved by question type so a truncated set stays balanced.
+    :raises ValueError: If `limit` is below one.
+    """
+    if limit < 1:
+        msg = "limit must be at least 1."
+        raise ValueError(msg)
+    candidates = exact_eval_case_candidates(articles=articles)
+
+    def rank(case: LabelledQuestion) -> str:
+        """Order eval cases by a hash of the seed and the question."""
+        return hashlib.sha256(f"{seed}:{case.question}".encode()).hexdigest()
+
+    # Hashed rather than shuffled: the same seed has to rebuild the same evaluation set, and the ordering `random`
+    # produces for a given seed is not guaranteed to hold across Python versions.
+    ordered = {name: sorted(cases, key=rank) for name, cases in candidates.items()}
+
+    selected: list[LabelledQuestion] = []
+    for position in range(max(len(pool) for pool in ordered.values())):
+        for name in ANSWERABLE_QUESTION_TYPES:
+            if position < len(ordered[name]):
+                selected.append(ordered[name][position])
+            if len(selected) == limit:
+                return selected
+    return selected
+
+
+def _report(store: DocumentStore, articles: dict[str, Article], cases: list[LabelledQuestion]) -> None:
+    """Describe what was built, including the checks that make the eval cases scoreable."""
+    chunks = [chunk for article in articles.values() for chunk in article.chunks]
+    lengths = sorted(len(chunk.content or "") for chunk in chunks)
+    metadata: dict[str, Any] = {field: {chunk.meta.get(field) for chunk in chunks} for field in ARTICLE_METADATA}
+    print(f"  articles:  {len(articles)}")
+    print(f"  chunks:    {len(chunks)} indexed={store.count_documents()} (mean {sum(lengths) // len(lengths)} chars)")
+    print(
+        f"  metadata:  category={len(metadata['category'])} source={len(metadata['source'])} "
+        f"author={len(metadata['author'])} distinct values"
+    )
+    print(f"  published: {min(metadata['published_at'])} .. {max(metadata['published_at'])}")
+    print(f"\n  cases selected: {len(cases)}")
+    print(f"    expected documents per eval case: {sorted({len(case.expected_document_ids) for case in cases})}")
+    print(f"    with an assertable answer:   {sum(1 for case in cases if case.answer_must_mention)}")
+    for case in cases[:3]:
+        print(f"    - {case.question[:96]}")
+
+
+def main() -> None:
+    """Build the corpus and evaluation set, and report what came out."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--store", choices=("in_memory", "opensearch"), default="in_memory")
+    parser.add_argument("--max-cases", type=int, default=20)
+    parser.add_argument("--case-seed", type=int, default=0)
+    arguments = parser.parse_args()
+
+    print(f"=== preparing {DATASET_ID} on {arguments.store} ===")
+    store, articles = prepare_corpus(backend=arguments.store)
+    cases = build_eval_cases(articles=articles, limit=arguments.max_cases, seed=arguments.case_seed)
+    _report(store=store, articles=articles, cases=cases)
+
+    available = exact_eval_case_candidates(articles=articles)
+    print(f"\n  cases available in total: {sum(len(pool) for pool in available.values())}")
+    for name, pool in available.items():
+        print(f"    {name:<20} {len(pool)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/agent_pack/examples/multihop_rag.py
+++ b/integrations/agent_pack/examples/multihop_rag.py
@@ -132,7 +132,7 @@ def prepare_corpus(
     if store.count_documents() != len(chunks):
         store.write_documents(documents=chunks, policy=DuplicatePolicy.OVERWRITE)
 
-    # Grouped on the id the splitter records, rather than on the title, so the mapping holds whatever the titles do.
+    # Group the chunks under the article they were split from, using the id the splitter records on each.
     by_source: dict[str, list[Document]] = {}
     for chunk in chunks:
         by_source.setdefault(chunk.meta["source_id"], []).append(chunk)
@@ -187,48 +187,39 @@ def exact_eval_case_candidates(articles: dict[str, Article]) -> dict[str, list[L
     """
     Build every eval case whose expected documents can be stated exactly, grouped by question type.
 
-    A query qualifies when each of its evidence facts is contained in exactly one chunk. Facts sitting in two
-    adjacent chunks are the price of overlap, and a case naming both would fail an Agent that retrieved either,
-    so those queries are left out rather than scored loosely.
+    A query is kept when each of its evidence facts is contained in exactly one chunk. Overlap puts some facts in
+    two adjacent chunks, and those queries are dropped.
 
     :param articles: The corpus the eval cases will be scored against, by article title.
     :returns: Eval cases per question type, ordered by question for reproducibility.
-    :raises ValueError: If any evidence fact is missing from the article it is attributed to, or is present but
-        split across chunks, since either means the corpus and the labels no longer correspond.
+    :raises ValueError: If any evidence fact is split across chunks, since no single chunk then holds it.
     """
     datasets_import.check()
     candidates: dict[str, list[LabelledQuestion]] = {name: [] for name in ANSWERABLE_QUESTION_TYPES}
-    missing = 0
     split_across_chunks = 0
     for row in load_dataset(DATASET_ID, "MultiHopRAG", split="train"):
         if row["question_type"] not in candidates:
             continue
+
+        # Locate every fact this query cites. One chunk per fact keeps the query; anything else drops it.
         evidence: dict[str, str] = {}
-        exact = bool(row["evidence_list"])
+        exact = True
         for entry in row["evidence_list"]:
-            article = articles.get(entry["title"])
-            fact = (entry.get("fact") or "").strip()
-            holders = None if article is None else _covering_chunks(article=article, fact=fact)
-            missing += holders is None
+            fact = entry["fact"]
+            holders = _covering_chunks(article=articles[entry["title"]], fact=fact)
+            # holders is [] when the fact is in the article but split across chunks, or present in several
             split_across_chunks += holders == []
             if holders is None or len(holders) != 1:
                 exact = False
                 continue
             evidence[holders[0].id] = fact
+
         if exact and evidence:
             candidates[row["question_type"]].append(
-                LabelledQuestion(
-                    question=row["query"],
-                    evidence=evidence,
-                    answer=(row["answer"] or "").strip(),
-                )
+                LabelledQuestion(question=row["query"], evidence=evidence, answer=row["answer"])
             )
-    if missing:
-        msg = (
-            f"{missing} evidence facts are not present in the article they are attributed to, so eval cases "
-            f"cannot be scored against this corpus. The dataset changed."
-        )
-        raise ValueError(msg)
+
+    # The splitting settings decide this, so it is reachable by editing them.
     if split_across_chunks:
         msg = (
             f"{split_across_chunks} evidence facts are present but split across chunks, so no single chunk holds "
@@ -254,13 +245,14 @@ def build_eval_cases(articles: dict[str, Article], limit: int, seed: int = 0) ->
     candidates = exact_eval_case_candidates(articles=articles)
 
     def rank(case: LabelledQuestion) -> str:
-        """Order eval cases by a hash of the seed and the question."""
+        """Order eval cases by a hash of the seed and the question, which the same seed reproduces exactly."""
         return hashlib.sha256(f"{seed}:{case.question}".encode()).hexdigest()
 
-    # Hashed rather than shuffled: the same seed has to rebuild the same evaluation set, and the ordering `random`
-    # produces for a given seed is not guaranteed to hold across Python versions.
+    # Sorted by a hash rather than seeded with `random`, whose ordering for a given seed can change between Python
+    # versions.
     ordered = {name: sorted(cases, key=rank) for name, cases in candidates.items()}
 
+    # Take one eval case per question type in turn, so stopping at the limit still leaves the types balanced.
     selected: list[LabelledQuestion] = []
     for position in range(max(len(pool) for pool in ordered.values())):
         for name in ANSWERABLE_QUESTION_TYPES:
@@ -283,7 +275,7 @@ def _report(store: DocumentStore, articles: dict[str, Article], cases: list[Labe
         f"author={len(metadata['author'])} distinct values"
     )
     print(f"  published: {min(metadata['published_at'])} .. {max(metadata['published_at'])}")
-    print(f"\n  cases selected: {len(cases)}")
+    print(f"\n  eval cases selected: {len(cases)}")
     print(f"    expected documents per eval case: {sorted({len(case.expected_document_ids) for case in cases})}")
     print(f"    with a ground-truth answer:  {sum(1 for case in cases if case.answer)}")
     for case in cases[:3]:
@@ -304,7 +296,7 @@ def main() -> None:
     _report(store=store, articles=articles, cases=cases)
 
     available = exact_eval_case_candidates(articles=articles)
-    print(f"\n  cases available in total: {sum(len(pool) for pool in available.values())}")
+    print(f"\n  eval cases available in total: {sum(len(pool) for pool in available.values())}")
     for name, pool in available.items():
         print(f"    {name:<20} {len(pool)}")
 


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/498
- related to https://github.com/deepset-ai/haystack-core-integrations/pull/3932

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Replace the old datasets in the examples folder with the multihop rag dataset which is a more challenging retrieval dataset and is more similar to the types of problems we solve for clients. 

This is part of the work done in the PR https://github.com/deepset-ai/haystack-core-integrations/pull/3932 to work on an optimizer agent that would use an evaluation dataset like multihop rag to improve a retrieval pipeline or a rag agent. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Ran the scripts locally, but no tests since this is the example folder.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

This is an example output of one data point when running the eval script

```
=== eval case 2/5: PASS ===
  question: Which company, discussed in articles from both 'The Verge' and 'TechCrunch', has been the subject of legal scrutiny for its default search engine deals with other corporations and for its alleged anticompetitive behavior affecting news publishers' content and revenue?
  tools called: {'list_metadata_fields': 1, 'get_metadata_field_values': 1, 'search_documents': 2}
  inspected metadata first: True   retrievals with a filter: 2   tool errors: 0   steps: 4   time: 8.4s
  tool budget: list_metadata_fields + get_metadata_field_values + get_metadata_field_range 2/8 -> ok
  tool budget: search_documents + fetch_documents_by_filter 2/12 -> ok
  retrieval: found 2/2 of the documents the answer needs, 10 returned
  citations: cited 2/2 of them, and 4/4 of the answer's references point at a returned document

  documents returned, grouped by article. -> marks one the answer needs:
    Title: Apple defends Google Search deal in court: ‘There wasn’t a valid alternative’
         chunk  0  [doc 8311b474]  Eddy Cue, in a dark suit, peered down at the monitor in front of him. The screen...
      -> chunk  1  [doc 7b11325e]  iteration with Google CEO Sundar Pichai in 2016. In testimony today, the Justice...
         chunk  2  [doc ffbdd6ef]  on the deals Google makes — with Apple but also with Samsung and Mozilla and man...
         chunk  4  [doc 5c2047c6]  and a history of the Safari browser. Cue noted that Safari’s combination of URL ...
    Title: The people who ruined the internet
         chunk  8  [doc 401e49cc]  an explorer in a small but finite kingdom. “I had surfed the entire internet. Th...
    Title: News publisher files class action antitrust suit against Google, citing AI’s harms to their bottom line
      -> chunk  0  [doc c6c508ed]  A new class action lawsuit filed this week in the U.S. District Court in D.C. ac...
         chunk  2  [doc ea017af5]  2023 report from the News Media Alliance and a Washington Post article about AI ...
         chunk  3  [doc ff348007]  technologies, and references the 2020 Justice Department’s civil antitrust suit ...
    Title: More from the US v Google trial: vertical search, pre-installs and the case of Firefox/Yahoo
         chunk  1  [doc d4f80f32]  16 times more data than Bing does everyday. Enforcers want to show that antitrus...
    Title: Why Mozilla is betting on a decentralized social networking future
         chunk  3  [doc b599a300]  interacting with. It also sees a role for its read-it-later app Pocket in this e...

  tokens: {'input_tokens': 13744, 'output_tokens': 389, 'total_tokens': 14133}
  answer:
    The company is **Google**. In **The Verge**, Google is described as being at the center of the DOJ’s antitrust case over the deals it makes with Apple, Samsung, Mozilla, and others to remain the default search engine [doc 8311b474] [doc 7b11325e]. In **TechCrunch**, Google is the company accused by news publishers of anticompetitive conduct that siphons off publishers’ content, readers, and ad revenue [doc c6c508ed] [doc ea017af5]
```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
