### PR TITLE
feat!: Tavily - add lifecycle handling

### DIFF
--- a/integrations/tavily/pyproject.toml
+++ b/integrations/tavily/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.24.1", "tavily-python>=0.7.24"]
+dependencies = ["haystack-ai>=3.0.0", "tavily-python>=0.7.24"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/tavily#readme"

--- a/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
+++ b/integrations/tavily/src/haystack_integrations/components/fetchers/tavily/tavily_fetcher.py
@@ -74,14 +74,29 @@ class TavilyFetcher:
 
     def warm_up(self) -> None:
         """
-        Initialize the Tavily sync and async clients.
+        Initialize the Tavily sync client.
 
         Called automatically on first use. Can be called explicitly to avoid cold-start latency.
         """
         if self._tavily_client is None:
             self._tavily_client = TavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
+
+    async def warm_up_async(self) -> None:
+        """Initialize the Tavily async client."""
         if self._async_tavily_client is None:
             self._async_tavily_client = AsyncTavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
+
+    def close(self) -> None:
+        """Close the Tavily sync client."""
+        if self._tavily_client is not None:
+            self._tavily_client.close()
+            self._tavily_client = None
+
+    async def close_async(self) -> None:
+        """Close the Tavily async client."""
+        if self._async_tavily_client is not None:
+            await self._async_tavily_client.close()
+            self._async_tavily_client = None
 
     @component.output_types(documents=list[Document], meta=dict[str, Any])
     def run(
@@ -103,11 +118,11 @@ class TavilyFetcher:
             - `meta`: Request-level metadata containing `"response_time"`, `"usage"`,
               `"request_id"`, and `"failed_results"` for URLs that could not be processed.
         """
-        if self._tavily_client is None:
-            self.warm_up()
+        self.warm_up()
+        assert self._tavily_client is not None  # noqa: S101
 
         params = (extract_params if extract_params is not None else self.extract_params or {}).copy()
-        response = self._tavily_client.extract(  # type: ignore[union-attr]
+        response = self._tavily_client.extract(
             urls=urls,
             extract_depth=self.extract_depth,
             include_images=self.include_images,
@@ -135,11 +150,11 @@ class TavilyFetcher:
             - `meta`: Request-level metadata containing `"response_time"`, `"usage"`,
               `"request_id"`, and `"failed_results"` for URLs that could not be processed.
         """
-        if self._async_tavily_client is None:
-            self.warm_up()
+        await self.warm_up_async()
+        assert self._async_tavily_client is not None  # noqa: S101
 
         params = (extract_params if extract_params is not None else self.extract_params or {}).copy()
-        response = await self._async_tavily_client.extract(  # type: ignore[union-attr]
+        response = await self._async_tavily_client.extract(
             urls=urls,
             extract_depth=self.extract_depth,
             include_images=self.include_images,

--- a/integrations/tavily/src/haystack_integrations/components/websearch/tavily/tavily_websearch.py
+++ b/integrations/tavily/src/haystack_integrations/components/websearch/tavily/tavily_websearch.py
@@ -66,14 +66,29 @@ class TavilyWebSearch:
 
     def warm_up(self) -> None:
         """
-        Initialize the Tavily sync and async clients.
+        Initialize the Tavily sync client.
 
         Called automatically on first use. Can be called explicitly to avoid cold-start latency.
         """
         if self._tavily_client is None:
             self._tavily_client = TavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
+
+    async def warm_up_async(self) -> None:
+        """Initialize the Tavily async client."""
         if self._async_tavily_client is None:
             self._async_tavily_client = AsyncTavilyClient(api_key=self.api_key.resolve_value(), client_name="haystack")
+
+    def close(self) -> None:
+        """Close the Tavily sync client."""
+        if self._tavily_client is not None:
+            self._tavily_client.close()
+            self._tavily_client = None
+
+    async def close_async(self) -> None:
+        """Close the Tavily async client."""
+        if self._async_tavily_client is not None:
+            await self._async_tavily_client.close()
+            self._async_tavily_client = None
 
     @component.output_types(documents=list[Document], links=list[str])
     def run(
@@ -92,11 +107,8 @@ class TavilyWebSearch:
             - `documents`: List of Documents containing search result content.
             - `links`: List of URLs from the search results.
         """
-        if self._tavily_client is None:
-            self.warm_up()
-        if self._tavily_client is None:
-            msg = "TavilyWebSearch client failed to initialize."
-            raise RuntimeError(msg)
+        self.warm_up()
+        assert self._tavily_client is not None  # noqa: S101
 
         params = (search_params if search_params is not None else self.search_params or {}).copy()
         if "max_results" not in params and self.top_k is not None:
@@ -122,11 +134,8 @@ class TavilyWebSearch:
             - `documents`: List of Documents containing search result content.
             - `links`: List of URLs from the search results.
         """
-        if self._async_tavily_client is None:
-            self.warm_up()
-        if self._async_tavily_client is None:
-            msg = "TavilyWebSearch async client failed to initialize."
-            raise RuntimeError(msg)
+        await self.warm_up_async()
+        assert self._async_tavily_client is not None  # noqa: S101
 
         params = (search_params if search_params is not None else self.search_params or {}).copy()
         if "max_results" not in params and self.top_k is not None:

--- a/integrations/tavily/tests/test_tavily_fetcher.py
+++ b/integrations/tavily/tests/test_tavily_fetcher.py
@@ -13,7 +13,137 @@ from haystack.utils import Secret
 from haystack_integrations.components.fetchers.tavily import TavilyFetcher
 
 
-class TestTavilyFetcher:
+class TestInitializationAndSerialization:
+    def test_init_default(self):
+        fetcher = TavilyFetcher()
+        assert fetcher.extract_depth == "basic"
+        assert fetcher.include_images is False
+        assert fetcher.extract_params is None
+        assert fetcher.api_key == Secret.from_env_var("TAVILY_API_KEY")
+        assert fetcher._tavily_client is None
+        assert fetcher._async_tavily_client is None
+
+    def test_init_with_params(self):
+        fetcher = TavilyFetcher(
+            api_key=Secret.from_token("custom-key"),
+            extract_depth="advanced",
+            include_images=True,
+            extract_params={"format": "text"},
+        )
+        assert fetcher.extract_depth == "advanced"
+        assert fetcher.include_images is True
+        assert fetcher.extract_params == {"format": "text"}
+
+    def test_to_dict(self):
+        fetcher = TavilyFetcher(extract_depth="advanced", extract_params={"format": "text"})
+        data = component_to_dict(fetcher, "TavilyFetcher")
+        assert data["type"] == "haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyFetcher"
+        assert data["init_parameters"]["extract_depth"] == "advanced"
+        assert data["init_parameters"]["extract_params"] == {"format": "text"}
+
+    def test_from_dict(self):
+        data = {
+            "type": "haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyFetcher",
+            "init_parameters": {
+                "extract_depth": "advanced",
+                "include_images": True,
+                "extract_params": {"format": "text"},
+                "api_key": {"env_vars": ["TAVILY_API_KEY"], "strict": True, "type": "env_var"},
+            },
+        }
+        fetcher = component_from_dict(TavilyFetcher, data, "TavilyFetcher")
+        assert fetcher.extract_depth == "advanced"
+        assert fetcher.include_images is True
+        assert fetcher.extract_params == {"format": "text"}
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        component = TavilyFetcher()
+
+        with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient")
+    def test_sync_lifecycle(self, mock_client_cls):
+        component = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        client = mock_client_cls.return_value
+
+        component.warm_up()
+        assert component._tavily_client is client
+        assert component._async_tavily_client is None
+
+        component.close()
+        client.close.assert_called_once_with()
+        assert component._tavily_client is None
+
+        component.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient")
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self, mock_client_cls):
+        component = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await component.warm_up_async()
+        assert component._async_tavily_client is client
+        assert component._tavily_client is None
+
+        await component.close_async()
+        client.close.assert_awaited_once_with()
+        assert component._async_tavily_client is None
+
+        await component.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        component.warm_up()
+        component.warm_up()
+        mock_client_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+    @patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient")
+    @pytest.mark.asyncio
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        await component.warm_up_async()
+        await component.warm_up_async()
+        mock_client_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        component = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        component.close()
+        await component.close_async()
+        assert component._tavily_client is None
+        assert component._async_tavily_client is None
+
+    @patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient")
+    @patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient")
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        component = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        sync_client = mock_sync_cls.return_value
+        async_client = mock_async_cls.return_value
+        async_client.close = AsyncMock()
+        component.warm_up()
+        await component.warm_up_async()
+
+        component.close()
+        assert component._tavily_client is None
+        assert component._async_tavily_client is async_client
+        async_client.close.assert_not_awaited()
+
+        await component.close_async()
+        assert component._async_tavily_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     @pytest.fixture
     def extract_response(self):
         return {
@@ -41,49 +171,6 @@ class TestTavilyFetcher:
         client = MagicMock()
         client.extract = AsyncMock(return_value=extract_response)
         return client
-
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
-        fetcher = TavilyFetcher()
-        assert fetcher.extract_depth == "basic"
-        assert fetcher.include_images is False
-        assert fetcher.extract_params is None
-        assert fetcher.api_key.resolve_value() == "test-key"
-
-    def test_init_with_params(self):
-        fetcher = TavilyFetcher(
-            api_key=Secret.from_token("custom-key"),
-            extract_depth="advanced",
-            include_images=True,
-            extract_params={"format": "text"},
-        )
-        assert fetcher.extract_depth == "advanced"
-        assert fetcher.include_images is True
-        assert fetcher.extract_params == {"format": "text"}
-
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
-        fetcher = TavilyFetcher(extract_depth="advanced", extract_params={"format": "text"})
-        data = component_to_dict(fetcher, "TavilyFetcher")
-        assert data["type"] == "haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyFetcher"
-        assert data["init_parameters"]["extract_depth"] == "advanced"
-        assert data["init_parameters"]["extract_params"] == {"format": "text"}
-
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
-        data = {
-            "type": "haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyFetcher",
-            "init_parameters": {
-                "extract_depth": "advanced",
-                "include_images": True,
-                "extract_params": {"format": "text"},
-                "api_key": {"env_vars": ["TAVILY_API_KEY"], "strict": True, "type": "env_var"},
-            },
-        }
-        fetcher = component_from_dict(TavilyFetcher, data, "TavilyFetcher")
-        assert fetcher.extract_depth == "advanced"
-        assert fetcher.include_images is True
-        assert fetcher.extract_params == {"format": "text"}
 
     def test_run_returns_documents_and_meta(self, mock_client):
         fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
@@ -208,19 +295,8 @@ class TestTavilyFetcher:
 
         assert result["documents"] == []
 
-    def test_warm_up_initializes_clients(self):
-        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
-        assert fetcher._tavily_client is None
-        assert fetcher._async_tavily_client is None
-        fetcher.warm_up()
-        assert fetcher._tavily_client is not None
-        assert fetcher._async_tavily_client is not None
-
     def test_run_triggers_warm_up(self, extract_response):
-        with (
-            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient") as mock_cls,
-            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient"),
-        ):
+        with patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient") as mock_cls:
             mock_cls.return_value.extract.return_value = extract_response
             fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
             fetcher.run(urls=["https://example.com"])
@@ -239,10 +315,7 @@ class TestTavilyFetcher:
 
     @pytest.mark.asyncio
     async def test_run_async_triggers_warm_up(self, extract_response):
-        with (
-            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient"),
-            patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient") as mock_cls,
-        ):
+        with patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient") as mock_cls:
             mock_cls.return_value.extract = AsyncMock(return_value=extract_response)
             fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
             await fetcher.run_async(urls=["https://example.com"])
@@ -257,11 +330,13 @@ class TestTavilyFetcher:
         with pytest.raises(Exception, match="API error"):
             await fetcher.run_async(urls=["https://example.com"])
 
-    @pytest.mark.skipif(
-        not os.environ.get("TAVILY_API_KEY"),
-        reason="Export TAVILY_API_KEY to run integration tests.",
-    )
-    @pytest.mark.integration
+
+@pytest.mark.skipif(
+    not os.environ.get("TAVILY_API_KEY"),
+    reason="Export TAVILY_API_KEY to run integration tests.",
+)
+@pytest.mark.integration
+class TestIntegration:
     def test_run_integration(self):
         fetcher = TavilyFetcher(api_key=Secret.from_env_var("TAVILY_API_KEY"))
         result = fetcher.run(urls=["https://haystack.deepset.ai"])
@@ -270,11 +345,6 @@ class TestTavilyFetcher:
         assert result["documents"][0].content
         assert result["meta"]["response_time"] is not None
 
-    @pytest.mark.skipif(
-        not os.environ.get("TAVILY_API_KEY"),
-        reason="Export TAVILY_API_KEY to run integration tests.",
-    )
-    @pytest.mark.integration
     def test_run_integration_pdf(self):
         # Attention Is All You Need — stable public arXiv PDF
         fetcher = TavilyFetcher(api_key=Secret.from_env_var("TAVILY_API_KEY"))
@@ -284,11 +354,6 @@ class TestTavilyFetcher:
         assert result["documents"][0].content
         assert result["meta"]["response_time"] is not None
 
-    @pytest.mark.skipif(
-        not os.environ.get("TAVILY_API_KEY"),
-        reason="Export TAVILY_API_KEY to run integration tests.",
-    )
-    @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_run_async_integration(self):
         fetcher = TavilyFetcher(api_key=Secret.from_env_var("TAVILY_API_KEY"))

--- a/integrations/tavily/tests/test_tavily_fetcher.py
+++ b/integrations/tavily/tests/test_tavily_fetcher.py
@@ -295,12 +295,14 @@ class TestRun:
 
         assert result["documents"] == []
 
-    def test_run_triggers_warm_up(self, extract_response):
-        with patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.TavilyClient") as mock_cls:
-            mock_cls.return_value.extract.return_value = extract_response
-            fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+    def test_run_triggers_warm_up(self, mock_client):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._tavily_client = mock_client
+
+        with patch.object(fetcher, "warm_up", wraps=fetcher.warm_up) as mock_warm_up:
             fetcher.run(urls=["https://example.com"])
-            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+        mock_warm_up.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_run_async(self, mock_async_client):
@@ -314,12 +316,14 @@ class TestRun:
         mock_async_client.extract.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_run_async_triggers_warm_up(self, extract_response):
-        with patch("haystack_integrations.components.fetchers.tavily.tavily_fetcher.AsyncTavilyClient") as mock_cls:
-            mock_cls.return_value.extract = AsyncMock(return_value=extract_response)
-            fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+    async def test_run_async_triggers_warm_up(self, mock_async_client):
+        fetcher = TavilyFetcher(api_key=Secret.from_token("test-key"))
+        fetcher._async_tavily_client = mock_async_client
+
+        with patch.object(fetcher, "warm_up_async", wraps=fetcher.warm_up_async) as mock_warm_up:
             await fetcher.run_async(urls=["https://example.com"])
-            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+        mock_warm_up.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_run_async_raises_on_error(self, mock_async_client):

--- a/integrations/tavily/tests/test_tavily_websearch.py
+++ b/integrations/tavily/tests/test_tavily_websearch.py
@@ -13,7 +13,132 @@ from haystack.utils import Secret
 from haystack_integrations.components.websearch.tavily import TavilyWebSearch
 
 
-class TestTavilyWebSearch:
+class TestInitializationAndSerialization:
+    def test_init_default(self):
+        ws = TavilyWebSearch()
+        assert ws.top_k == 10
+        assert ws.search_params is None
+        assert ws.api_key == Secret.from_env_var("TAVILY_API_KEY")
+        assert ws._tavily_client is None
+        assert ws._async_tavily_client is None
+
+    def test_init_with_params(self):
+        ws = TavilyWebSearch(
+            api_key=Secret.from_token("custom-key"),
+            top_k=5,
+            search_params={"search_depth": "advanced"},
+        )
+        assert ws.top_k == 5
+        assert ws.search_params == {"search_depth": "advanced"}
+
+    def test_to_dict(self):
+        ws = TavilyWebSearch(top_k=5, search_params={"search_depth": "advanced"})
+        data = component_to_dict(ws, "TavilyWebSearch")
+        assert data["type"] == "haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyWebSearch"
+        assert data["init_parameters"]["top_k"] == 5
+        assert data["init_parameters"]["search_params"] == {"search_depth": "advanced"}
+
+    def test_from_dict(self):
+        data = {
+            "type": "haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyWebSearch",
+            "init_parameters": {
+                "top_k": 3,
+                "search_params": {"include_answer": True},
+                "api_key": {"env_vars": ["TAVILY_API_KEY"], "strict": True, "type": "env_var"},
+            },
+        }
+        ws = component_from_dict(TavilyWebSearch, data, "TavilyWebSearch")
+        assert ws.top_k == 3
+        assert ws.search_params == {"include_answer": True}
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        component = TavilyWebSearch()
+
+        with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyClient")
+    def test_sync_lifecycle(self, mock_client_cls):
+        component = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        client = mock_client_cls.return_value
+
+        component.warm_up()
+        assert component._tavily_client is client
+        assert component._async_tavily_client is None
+
+        component.close()
+        client.close.assert_called_once_with()
+        assert component._tavily_client is None
+
+        component.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.websearch.tavily.tavily_websearch.AsyncTavilyClient")
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self, mock_client_cls):
+        component = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        client = mock_client_cls.return_value
+        client.close = AsyncMock()
+
+        await component.warm_up_async()
+        assert component._async_tavily_client is client
+        assert component._tavily_client is None
+
+        await component.close_async()
+        client.close.assert_awaited_once_with()
+        assert component._async_tavily_client is None
+
+        await component.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyClient")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        component.warm_up()
+        component.warm_up()
+        mock_client_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+    @patch("haystack_integrations.components.websearch.tavily.tavily_websearch.AsyncTavilyClient")
+    @pytest.mark.asyncio
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        await component.warm_up_async()
+        await component.warm_up_async()
+        mock_client_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        component = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        component.close()
+        await component.close_async()
+        assert component._tavily_client is None
+        assert component._async_tavily_client is None
+
+    @patch("haystack_integrations.components.websearch.tavily.tavily_websearch.AsyncTavilyClient")
+    @patch("haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyClient")
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self, mock_sync_cls, mock_async_cls):
+        component = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        sync_client = mock_sync_cls.return_value
+        async_client = mock_async_cls.return_value
+        async_client.close = AsyncMock()
+        component.warm_up()
+        await component.warm_up_async()
+
+        component.close()
+        assert component._tavily_client is None
+        assert component._async_tavily_client is async_client
+        async_client.close.assert_not_awaited()
+
+        await component.close_async()
+        assert component._async_tavily_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     @pytest.fixture
     def search_response(self):
         return {
@@ -33,44 +158,6 @@ class TestTavilyWebSearch:
         client = MagicMock()
         client.search = AsyncMock(return_value=search_response)
         return client
-
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
-        ws = TavilyWebSearch()
-        assert ws.top_k == 10
-        assert ws.search_params is None
-        assert ws.api_key.resolve_value() == "test-key"
-
-    def test_init_with_params(self):
-        ws = TavilyWebSearch(
-            api_key=Secret.from_token("custom-key"),
-            top_k=5,
-            search_params={"search_depth": "advanced"},
-        )
-        assert ws.top_k == 5
-        assert ws.search_params == {"search_depth": "advanced"}
-
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
-        ws = TavilyWebSearch(top_k=5, search_params={"search_depth": "advanced"})
-        data = component_to_dict(ws, "TavilyWebSearch")
-        assert data["type"] == "haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyWebSearch"
-        assert data["init_parameters"]["top_k"] == 5
-        assert data["init_parameters"]["search_params"] == {"search_depth": "advanced"}
-
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
-        data = {
-            "type": "haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyWebSearch",
-            "init_parameters": {
-                "top_k": 3,
-                "search_params": {"include_answer": True},
-                "api_key": {"env_vars": ["TAVILY_API_KEY"], "strict": True, "type": "env_var"},
-            },
-        }
-        ws = component_from_dict(TavilyWebSearch, data, "TavilyWebSearch")
-        assert ws.top_k == 3
-        assert ws.search_params == {"include_answer": True}
 
     def test_run_returns_documents_and_links(self, mock_client):
         ws = TavilyWebSearch(api_key=Secret.from_token("test-key"), top_k=10)
@@ -127,19 +214,8 @@ class TestTavilyWebSearch:
         with pytest.raises(Exception, match="API error"):
             await ws.run_async(query="test")
 
-    def test_warm_up_initializes_clients(self):
-        ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
-        assert ws._tavily_client is None
-        assert ws._async_tavily_client is None
-        ws.warm_up()
-        assert ws._tavily_client is not None
-        assert ws._async_tavily_client is not None
-
     def test_run_triggers_warm_up(self, search_response):
-        with (
-            patch("haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyClient") as mock_cls,
-            patch("haystack_integrations.components.websearch.tavily.tavily_websearch.AsyncTavilyClient"),
-        ):
+        with patch("haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyClient") as mock_cls:
             mock_cls.return_value.search.return_value = search_response
             ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
             ws.run(query="test")
@@ -147,10 +223,7 @@ class TestTavilyWebSearch:
 
     @pytest.mark.asyncio
     async def test_run_async_triggers_warm_up(self, search_response):
-        with (
-            patch("haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyClient"),
-            patch("haystack_integrations.components.websearch.tavily.tavily_websearch.AsyncTavilyClient") as mock_cls,
-        ):
+        with patch("haystack_integrations.components.websearch.tavily.tavily_websearch.AsyncTavilyClient") as mock_cls:
             mock_cls.return_value.search = AsyncMock(return_value=search_response)
             ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
             await ws.run_async(query="test")
@@ -164,24 +237,13 @@ class TestTavilyWebSearch:
         assert result["documents"] == []
         assert result["links"] == []
 
-    def test_run_raises_runtime_error_when_warm_up_fails_to_initialize_client(self, monkeypatch):
-        ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
-        monkeypatch.setattr(ws, "warm_up", lambda: None)
-        with pytest.raises(RuntimeError, match="TavilyWebSearch client failed to initialize"):
-            ws.run(query="test")
 
-    @pytest.mark.asyncio
-    async def test_run_async_raises_runtime_error_when_warm_up_fails_to_initialize_client(self, monkeypatch):
-        ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
-        monkeypatch.setattr(ws, "warm_up", lambda: None)
-        with pytest.raises(RuntimeError, match="TavilyWebSearch async client failed to initialize"):
-            await ws.run_async(query="test")
-
-    @pytest.mark.skipif(
-        not os.environ.get("TAVILY_API_KEY"),
-        reason="Export TAVILY_API_KEY to run integration tests.",
-    )
-    @pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("TAVILY_API_KEY"),
+    reason="Export TAVILY_API_KEY to run integration tests.",
+)
+@pytest.mark.integration
+class TestIntegration:
     def test_run_integration(self):
         ws = TavilyWebSearch(api_key=Secret.from_env_var("TAVILY_API_KEY"), top_k=3)
         result = ws.run(query="What is Haystack by deepset?")
@@ -189,11 +251,6 @@ class TestTavilyWebSearch:
         assert len(result["links"]) > 0
         assert isinstance(result["documents"][0], Document)
 
-    @pytest.mark.skipif(
-        not os.environ.get("TAVILY_API_KEY"),
-        reason="Export TAVILY_API_KEY to run integration tests.",
-    )
-    @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_run_async_integration(self):
         ws = TavilyWebSearch(api_key=Secret.from_env_var("TAVILY_API_KEY"), top_k=3)

--- a/integrations/tavily/tests/test_tavily_websearch.py
+++ b/integrations/tavily/tests/test_tavily_websearch.py
@@ -214,20 +214,24 @@ class TestRun:
         with pytest.raises(Exception, match="API error"):
             await ws.run_async(query="test")
 
-    def test_run_triggers_warm_up(self, search_response):
-        with patch("haystack_integrations.components.websearch.tavily.tavily_websearch.TavilyClient") as mock_cls:
-            mock_cls.return_value.search.return_value = search_response
-            ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+    def test_run_triggers_warm_up(self, mock_client):
+        ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        ws._tavily_client = mock_client
+
+        with patch.object(ws, "warm_up", wraps=ws.warm_up) as mock_warm_up:
             ws.run(query="test")
-            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+        mock_warm_up.assert_called_once_with()
 
     @pytest.mark.asyncio
-    async def test_run_async_triggers_warm_up(self, search_response):
-        with patch("haystack_integrations.components.websearch.tavily.tavily_websearch.AsyncTavilyClient") as mock_cls:
-            mock_cls.return_value.search = AsyncMock(return_value=search_response)
-            ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+    async def test_run_async_triggers_warm_up(self, mock_async_client):
+        ws = TavilyWebSearch(api_key=Secret.from_token("test-key"))
+        ws._async_tavily_client = mock_async_client
+
+        with patch.object(ws, "warm_up_async", wraps=ws.warm_up_async) as mock_warm_up:
             await ws.run_async(query="test")
-            mock_cls.assert_called_once_with(api_key="test-key", client_name="haystack")
+
+        mock_warm_up.assert_awaited_once_with()
 
     def test_run_empty_results(self, mock_client):
         mock_client.search.return_value = {"results": []}

--- a/integrations/tavily/tests/test_tavily_websearch_tool.py
+++ b/integrations/tavily/tests/test_tavily_websearch_tool.py
@@ -40,8 +40,7 @@ class TestTavilyWebSearchTool:
             ]
         }
 
-    def test_init_default(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+    def test_init_default(self):
         tool = TavilyWebSearchTool()
 
         assert tool.api_key is None
@@ -54,7 +53,7 @@ class TestTavilyWebSearchTool:
         assert tool.parameters["properties"]["query"]["type"] == "string"
         # unset parameters fall back to the component defaults
         assert tool._component.top_k == 10
-        assert tool._component.api_key.resolve_value() == "test-key"
+        assert tool._component.api_key == Secret.from_env_var("TAVILY_API_KEY")
         assert tool._component.search_params is None
 
     def test_init_with_params(self):
@@ -92,8 +91,7 @@ class TestTavilyWebSearchTool:
             "description": tool.description,
         }
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.tools.tavily.websearch_tool.TavilyWebSearchTool",
             "data": {


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- implement lifecycle handling, following criteria in https://github.com/deepset-ai/haystack-private/issues/440#issuecomment-5526157817
  - separated sync and async lifecycle
  - added closing methods
- pin `haystack-ai>=3.0.0`

### How did you test it?
CI, new tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
