### PR TITLE
refactor!: Transformers - lifecycle refactor

### DIFF
--- a/integrations/transformers/pyproject.toml
+++ b/integrations/transformers/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "transformers[torch,sentencepiece]>=4.57.0"]
+dependencies = ["haystack-ai>=3.0.0", "transformers[torch,sentencepiece]>=5.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/transformers#readme"

--- a/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
+++ b/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
@@ -10,9 +10,7 @@ from typing import Any
 import torch
 from haystack import logging
 from haystack.dataclasses import ComponentInfo, StreamingCallbackT, StreamingChunk, SyncStreamingCallbackT
-from haystack.utils.auth import Secret
 from haystack.utils.device import ComponentDevice
-from huggingface_hub import model_info
 
 from transformers import (
     PreTrainedTokenizer,
@@ -62,10 +60,9 @@ def _resolve_hf_device_map(device: ComponentDevice | None, model_kwargs: dict[st
 def _resolve_hf_pipeline_kwargs(
     huggingface_pipeline_kwargs: dict[str, Any],
     model: str,
-    task: str | None,
+    task: str,
     supported_tasks: list[str],
     device: ComponentDevice | None,
-    token: Secret | None,
 ) -> dict[str, Any]:
     """
     Resolve the HuggingFace pipeline keyword arguments based on explicit user inputs.
@@ -78,23 +75,15 @@ def _resolve_hf_pipeline_kwargs(
         is not present within this list then a ValueError is thrown.
     :param device: The device on which the model is loaded. If `None`, the default device is automatically
         selected. If a device/device map is specified in `huggingface_pipeline_kwargs`, it overrides this parameter.
-    :param token: The token to use as HTTP bearer authorization for remote files.
-        If the token is also specified in the `huggingface_pipeline_kwargs`, this parameter will be ignored.
     """
-    resolved_token = token.resolve_value() if token else None
     # check if the huggingface_pipeline_kwargs contain the essential parameters
     # otherwise, populate them with values from other init parameters
     huggingface_pipeline_kwargs.setdefault("model", model)
-    huggingface_pipeline_kwargs.setdefault("token", resolved_token)
 
     resolved_device = ComponentDevice.resolve_device(device)
     resolved_device.update_hf_kwargs(huggingface_pipeline_kwargs, overwrite=False)
 
-    # task identification and validation
-    task = task or huggingface_pipeline_kwargs.get("task")
-    if task is None and isinstance(huggingface_pipeline_kwargs["model"], str):
-        task = model_info(huggingface_pipeline_kwargs["model"], token=huggingface_pipeline_kwargs["token"]).pipeline_tag
-
+    # task validation
     if task not in supported_tasks:
         msg = f"Task '{task}' is not supported. The supported tasks are: {', '.join(supported_tasks)}."
         raise ValueError(msg)

--- a/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
+++ b/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import copy
 import inspect
 from typing import Any
 
@@ -54,7 +53,7 @@ def _resolve_hf_device_map(device: ComponentDevice | None, model_kwargs: dict[st
     :param model_kwargs: Additional HF keyword arguments passed to `AutoModel.from_pretrained`.
         For details on what kwargs you can pass, see the model's documentation.
     """
-    model_kwargs = copy.copy(model_kwargs) or {}
+    model_kwargs = dict(model_kwargs or {})
     if model_kwargs.get("device_map"):
         if device is not None:
             logger.warning(
@@ -77,7 +76,6 @@ def _resolve_hf_pipeline_kwargs(
     huggingface_pipeline_kwargs: dict[str, Any],
     model: str,
     task: str,
-    supported_tasks: list[str],
     device: ComponentDevice | None,
 ) -> dict[str, Any]:
     """
@@ -87,11 +85,11 @@ def _resolve_hf_pipeline_kwargs(
         Hugging Face pipeline.
     :param model: The name or path of a Hugging Face model for on the HuggingFace Hub.
     :param task: The task for the Hugging Face pipeline.
-    :param supported_tasks: The list of supported tasks to check the task of the model against. If the task of the model
-        is not present within this list then a ValueError is thrown.
     :param device: The device on which the model is loaded. If `None`, the default device is automatically
         selected. If a device/device map is specified in `huggingface_pipeline_kwargs`, it overrides this parameter.
     """
+    huggingface_pipeline_kwargs = huggingface_pipeline_kwargs.copy()
+
     # check if the huggingface_pipeline_kwargs contain the essential parameters
     # otherwise, populate them with values from other init parameters
     huggingface_pipeline_kwargs.setdefault("model", model)
@@ -99,10 +97,6 @@ def _resolve_hf_pipeline_kwargs(
     resolved_device = ComponentDevice.resolve_device(device)
     resolved_device.update_hf_kwargs(huggingface_pipeline_kwargs, overwrite=False)
 
-    # task validation
-    if task not in supported_tasks:
-        msg = f"Task '{task}' is not supported. The supported tasks are: {', '.join(supported_tasks)}."
-        raise ValueError(msg)
     huggingface_pipeline_kwargs["task"] = task
     return huggingface_pipeline_kwargs
 

--- a/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
+++ b/integrations/transformers/src/haystack_integrations/common/transformers/utils.py
@@ -10,6 +10,7 @@ from typing import Any
 import torch
 from haystack import logging
 from haystack.dataclasses import ComponentInfo, StreamingCallbackT, StreamingChunk, SyncStreamingCallbackT
+from haystack.utils.auth import Secret
 from haystack.utils.device import ComponentDevice
 
 from transformers import (
@@ -21,6 +22,21 @@ from transformers import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _with_hf_token(hf_kwargs: dict[str, Any], token: Secret | None) -> dict[str, Any]:
+    """
+    Return a copy of Hugging Face keyword arguments with a resolved token.
+
+    An explicitly provided `token` in `hf_kwargs` takes precedence over the `Secret`.
+
+    :param hf_kwargs: Keyword arguments passed to a Hugging Face API.
+    :param token: The token to resolve when `hf_kwargs` does not already contain one.
+    """
+    resolved_kwargs = hf_kwargs.copy()
+    if "token" not in resolved_kwargs:
+        resolved_kwargs["token"] = token.resolve_value() if token else None
+    return resolved_kwargs
 
 
 def _resolve_hf_device_map(device: ComponentDevice | None, model_kwargs: dict[str, Any] | None) -> dict[str, Any]:

--- a/integrations/transformers/src/haystack_integrations/components/classifiers/transformers/zero_shot_document_classifier.py
+++ b/integrations/transformers/src/haystack_integrations/components/classifiers/transformers/zero_shot_document_classifier.py
@@ -125,7 +125,6 @@ class TransformersZeroShotDocumentClassifier:
             task="zero-shot-classification",
             supported_tasks=["zero-shot-classification"],
             device=device,
-            token=token,
         )
 
         self.huggingface_pipeline_kwargs = huggingface_pipeline_kwargs
@@ -144,7 +143,9 @@ class TransformersZeroShotDocumentClassifier:
         Initializes the component.
         """
         if self.pipeline is None:
-            self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
+            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
+            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            self.pipeline = pipeline(**pipeline_kwargs)
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -201,8 +202,8 @@ class TransformersZeroShotDocumentClassifier:
             - `documents`: A list of documents with an added metadata field called `classification`.
         """
 
-        if self.pipeline is None:
-            self.warm_up()
+        self.warm_up()
+        assert self.pipeline is not None  # noqa: S101
 
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             msg = (
@@ -229,10 +230,7 @@ class TransformersZeroShotDocumentClassifier:
             for doc in documents
         ]
 
-        # mypy doesn't know this is set in warm_up
-        predictions = self.pipeline(  # type: ignore[misc]
-            texts, self.labels, multi_label=self.multi_label, batch_size=batch_size
-        )
+        predictions = self.pipeline(texts, self.labels, multi_label=self.multi_label, batch_size=batch_size)
 
         new_documents = []
         for prediction, document in zip(predictions, documents, strict=True):

--- a/integrations/transformers/src/haystack_integrations/components/classifiers/transformers/zero_shot_document_classifier.py
+++ b/integrations/transformers/src/haystack_integrations/components/classifiers/transformers/zero_shot_document_classifier.py
@@ -9,7 +9,7 @@ from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.utils import ComponentDevice, Secret
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
-from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs
+from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs, _with_hf_token
 from transformers import Pipeline as HfPipeline
 from transformers import pipeline
 
@@ -143,8 +143,7 @@ class TransformersZeroShotDocumentClassifier:
         Initializes the component.
         """
         if self.pipeline is None:
-            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
-            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
             self.pipeline = pipeline(**pipeline_kwargs)
 
     def to_dict(self) -> dict[str, Any]:

--- a/integrations/transformers/src/haystack_integrations/components/classifiers/transformers/zero_shot_document_classifier.py
+++ b/integrations/transformers/src/haystack_integrations/components/classifiers/transformers/zero_shot_document_classifier.py
@@ -123,7 +123,6 @@ class TransformersZeroShotDocumentClassifier:
             huggingface_pipeline_kwargs=huggingface_pipeline_kwargs or {},
             model=model,
             task="zero-shot-classification",
-            supported_tasks=["zero-shot-classification"],
             device=device,
         )
 
@@ -142,9 +141,11 @@ class TransformersZeroShotDocumentClassifier:
         """
         Initializes the component.
         """
-        if self.pipeline is None:
-            pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
-            self.pipeline = pipeline(**pipeline_kwargs)
+        if self.pipeline is not None:
+            return
+
+        pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
+        self.pipeline = pipeline(**pipeline_kwargs)
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/transformers/src/haystack_integrations/components/extractors/transformers/named_entity_extractor.py
+++ b/integrations/transformers/src/haystack_integrations/components/extractors/transformers/named_entity_extractor.py
@@ -10,9 +10,9 @@ from haystack.utils.auth import Secret
 from haystack.utils.device import ComponentDevice
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
-from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs
-from transformers import AutoModelForTokenClassification, AutoTokenizer, pipeline
+from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs, _with_hf_token
 from transformers import Pipeline as HfPipeline
+from transformers import pipeline
 
 
 @dataclass
@@ -101,8 +101,6 @@ class TransformersNamedEntityExtractor:
             device=self.device,
         )
 
-        self.tokenizer: Any = None
-        self.model: AutoModelForTokenClassification | None = None
         self.pipeline: HfPipeline | None = None
 
     def warm_up(self) -> None:
@@ -116,24 +114,9 @@ class TransformersNamedEntityExtractor:
             return
 
         try:
-            pipeline_kwargs = self.pipeline_kwargs.copy()
-            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
-            token = pipeline_kwargs["token"]
-            tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=token)
-            model = AutoModelForTokenClassification.from_pretrained(self.model_name_or_path, token=token)
-
-            pipeline_params: dict[str, Any] = {
-                "task": "ner",
-                "model": model,
-                "tokenizer": tokenizer,
-                "aggregation_strategy": "simple",
-            }
-            pipeline_params.update({k: v for k, v in pipeline_kwargs.items() if k not in pipeline_params})
-            self.device.update_hf_kwargs(pipeline_params, overwrite=False)
-            hf_pipeline = pipeline(**pipeline_params)
-            self.tokenizer = tokenizer
-            self.model = model
-            self.pipeline = hf_pipeline
+            pipeline_kwargs = _with_hf_token(self.pipeline_kwargs, self.token)
+            pipeline_kwargs.setdefault("aggregation_strategy", "simple")
+            self.pipeline = pipeline(**pipeline_kwargs)
         except Exception as e:
             msg = f"{self.__class__.__name__} failed to initialize."
             raise ComponentError(msg) from e
@@ -248,7 +231,7 @@ class TransformersNamedEntityExtractor:
         """
         Returns if the extractor is ready to annotate text.
         """
-        return (self.tokenizer is not None and self.model is not None) or self.pipeline is not None
+        return self.pipeline is not None
 
     @classmethod
     def get_stored_annotations(cls, document: Document) -> list[NamedEntityAnnotation] | None:

--- a/integrations/transformers/src/haystack_integrations/components/extractors/transformers/named_entity_extractor.py
+++ b/integrations/transformers/src/haystack_integrations/components/extractors/transformers/named_entity_extractor.py
@@ -99,13 +99,11 @@ class TransformersNamedEntityExtractor:
             task="ner",
             supported_tasks=["ner"],
             device=self.device,
-            token=token,
         )
 
         self.tokenizer: Any = None
         self.model: AutoModelForTokenClassification | None = None
         self.pipeline: HfPipeline | None = None
-        self._warmed_up: bool = False
 
     def warm_up(self) -> None:
         """
@@ -114,24 +112,28 @@ class TransformersNamedEntityExtractor:
         :raises ComponentError:
             If the component fails to initialize successfully.
         """
-        if self._warmed_up:
+        if self.pipeline is not None:
             return
 
         try:
-            token = self.pipeline_kwargs.get("token", None)
-            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=token)
-            self.model = AutoModelForTokenClassification.from_pretrained(self.model_name_or_path, token=token)
+            pipeline_kwargs = self.pipeline_kwargs.copy()
+            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            token = pipeline_kwargs["token"]
+            tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=token)
+            model = AutoModelForTokenClassification.from_pretrained(self.model_name_or_path, token=token)
 
             pipeline_params: dict[str, Any] = {
                 "task": "ner",
-                "model": self.model,
-                "tokenizer": self.tokenizer,
+                "model": model,
+                "tokenizer": tokenizer,
                 "aggregation_strategy": "simple",
             }
-            pipeline_params.update({k: v for k, v in self.pipeline_kwargs.items() if k not in pipeline_params})
+            pipeline_params.update({k: v for k, v in pipeline_kwargs.items() if k not in pipeline_params})
             self.device.update_hf_kwargs(pipeline_params, overwrite=False)
-            self.pipeline = pipeline(**pipeline_params)
-            self._warmed_up = True
+            hf_pipeline = pipeline(**pipeline_params)
+            self.tokenizer = tokenizer
+            self.model = model
+            self.pipeline = hf_pipeline
         except Exception as e:
             msg = f"{self.__class__.__name__} failed to initialize."
             raise ComponentError(msg) from e
@@ -150,8 +152,8 @@ class TransformersNamedEntityExtractor:
         :raises ComponentError:
             If the model fails to process a document.
         """
-        if not self._warmed_up:
-            self.warm_up()
+        self.warm_up()
+        assert self.pipeline is not None  # noqa: S101
 
         texts = [doc.content if doc.content is not None else "" for doc in documents]
         annotations = self._annotate(texts, batch_size=batch_size)

--- a/integrations/transformers/src/haystack_integrations/components/extractors/transformers/named_entity_extractor.py
+++ b/integrations/transformers/src/haystack_integrations/components/extractors/transformers/named_entity_extractor.py
@@ -97,7 +97,6 @@ class TransformersNamedEntityExtractor:
             huggingface_pipeline_kwargs=pipeline_kwargs or {},
             model=model,
             task="ner",
-            supported_tasks=["ner"],
             device=self.device,
         )
 
@@ -167,11 +166,10 @@ class TransformersNamedEntityExtractor:
         :returns:
             NER annotations.
         """
-        if not self.initialized:
+        if self.pipeline is None:
             msg = "NER model was not initialized - Did you call `warm_up()`?"
             raise ComponentError(msg)
 
-        assert self.pipeline is not None  # noqa: S101
         outputs = self.pipeline(texts, batch_size=batch_size)
         return [
             [

--- a/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
+++ b/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
@@ -200,7 +200,6 @@ class TransformersChatGenerator:
         task = task or huggingface_pipeline_kwargs.get("task")
         if task is not None:
             huggingface_pipeline_kwargs["task"] = task
-        self._task = task
 
         # if not specified, set return_full_text to False for text-generation
         # only generated text is returned (excluding prompt)
@@ -256,7 +255,6 @@ class TransformersChatGenerator:
             if self.tools:
                 warm_up_tools(self.tools)
             self.pipeline = hf_pipeline
-            self._task = task
 
         if self._owns_executor and self.executor is None:
             self.executor = ThreadPoolExecutor(
@@ -364,8 +362,6 @@ class TransformersChatGenerator:
                 component_info=ComponentInfo.from_component(self),
             )
 
-        # We know it's not None because we check it in _prepare_inputs
-        assert self.pipeline is not None  # noqa: S101
         # Generate responses
         output = self.pipeline(prepared_inputs["prepared_prompt"], **prepared_inputs["generation_kwargs"])
 
@@ -541,6 +537,8 @@ class TransformersChatGenerator:
         :returns: A dictionary containing the prepared prompt, tokenizer, generation kwargs, and tools.
         :raises ValueError: If both tools and streaming_callback are provided.
         """
+        assert self.pipeline is not None  # noqa: S101
+
         tools = tools or self.tools
         if tools and streaming_callback is not None:
             msg = "Using tools and streaming at the same time is not supported. Please choose one."
@@ -548,12 +546,11 @@ class TransformersChatGenerator:
         flat_tools = flatten_tools_or_toolsets(tools)
         _check_duplicate_tool_names(flat_tools)
 
-        # mypy doesn't know this is set in warm_up
-        tokenizer = self.pipeline.tokenizer  # type: ignore[union-attr]
+        tokenizer = self.pipeline.tokenizer
 
         # Check and update generation parameters
         generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
-        if self._task == "text-generation":
+        if self.pipeline.task == "text-generation":
             generation_kwargs.setdefault("return_full_text", False)
 
         # If streaming_callback is provided, ensure that num_return_sequences is set to 1
@@ -576,7 +573,7 @@ class TransformersChatGenerator:
             _StopWordsCriteria(
                 tokenizer,  # type: ignore[arg-type]
                 stop_words,
-                self.pipeline.device,  # type: ignore[union-attr]
+                self.pipeline.device,
             )
             if stop_words
             else None

--- a/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
+++ b/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
@@ -33,6 +33,7 @@ from haystack_integrations.common.transformers.utils import (
     _AsyncHFTokenStreamingHandler,
     _HFTokenStreamingHandler,
     _StopWordsCriteria,
+    _with_hf_token,
 )
 from transformers import Pipeline as HfPipeline
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, StoppingCriteriaList, pipeline
@@ -241,8 +242,7 @@ class TransformersChatGenerator:
         Initializes the component and warms up tools if provided.
         """
         if self.pipeline is None:
-            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
-            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
             task = pipeline_kwargs.get("task")
             if task is None and isinstance(pipeline_kwargs["model"], str):
                 task = model_info(pipeline_kwargs["model"], token=pipeline_kwargs["token"]).pipeline_tag

--- a/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
+++ b/integrations/transformers/src/haystack_integrations/components/generators/transformers/chat/chat_generator.py
@@ -28,9 +28,7 @@ from haystack.tools.utils import warm_up_tools
 from haystack.utils import ComponentDevice, Secret, deserialize_callable, serialize_callable
 from haystack.utils.hf import convert_message_to_hf_format, deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 from huggingface_hub import model_info
-from packaging.version import Version
 
-import transformers
 from haystack_integrations.common.transformers.utils import (
     _AsyncHFTokenStreamingHandler,
     _HFTokenStreamingHandler,
@@ -41,7 +39,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, StoppingC
 
 logger = logging.getLogger(__name__)
 
-PIPELINE_SUPPORTED_TASKS = ["text-generation", "text2text-generation", "image-text-to-text"]
+PIPELINE_SUPPORTED_TASKS = ["text-generation", "image-text-to-text"]
 
 DEFAULT_TOOL_PATTERN = (
     r"(?:<tool_call>)?"
@@ -119,7 +117,7 @@ class TransformersChatGenerator:
     def __init__(
         self,
         model: str = "Qwen/Qwen3-0.6B",
-        task: Literal["text-generation", "text2text-generation", "image-text-to-text"] | None = None,
+        task: Literal["text-generation", "image-text-to-text"] | None = None,
         device: ComponentDevice | None = None,
         token: Secret | None = Secret.from_env_var(["HF_API_TOKEN", "HF_TOKEN"], strict=False),
         chat_template: str | None = None,
@@ -143,8 +141,6 @@ class TransformersChatGenerator:
             If the model is specified in `huggingface_pipeline_kwargs`, this parameter is ignored.
         :param task: The task for the Hugging Face pipeline. Possible options:
             - `text-generation`: Supported by decoder models, like GPT.
-            - `text2text-generation`: Deprecated as of Transformers v5; use `text-generation` instead.
-              Previously supported by encoder-decoder models such as T5.
             - `image-text-to-text`: Supported by vision-language models.
             If the task is specified in `huggingface_pipeline_kwargs`, this parameter is ignored.
             If not specified, the component calls the Hugging Face API to infer the task from the model name.
@@ -192,32 +188,18 @@ class TransformersChatGenerator:
         generation_kwargs = generation_kwargs or {}
 
         self.token = token
-        token = token.resolve_value() if token else None
 
         # check if the huggingface_pipeline_kwargs contain the essential parameters
         # otherwise, populate them with values from other init parameters
         huggingface_pipeline_kwargs.setdefault("model", model)
-        huggingface_pipeline_kwargs.setdefault("token", token)
 
         device = ComponentDevice.resolve_device(device)
         device.update_hf_kwargs(huggingface_pipeline_kwargs, overwrite=False)
 
-        # task identification and validation
-        if task is None:
-            if "task" in huggingface_pipeline_kwargs:
-                task = huggingface_pipeline_kwargs["task"]
-            elif isinstance(huggingface_pipeline_kwargs["model"], str):
-                task = model_info(
-                    huggingface_pipeline_kwargs["model"], token=huggingface_pipeline_kwargs["token"]
-                ).pipeline_tag  # type: ignore[assignment]  # we'll check below if task is in supported tasks
-
-        if task not in PIPELINE_SUPPORTED_TASKS:
-            msg = f"Task '{task}' is not supported. The supported tasks are: {', '.join(PIPELINE_SUPPORTED_TASKS)}."
-            raise ValueError(msg)
-        if task == "text2text-generation" and Version(transformers.__version__) >= Version("5.0.0"):
-            msg = "Task 'text2text-generation' is not supported with transformers v5 or higher."
-            raise ValueError(msg)
-        huggingface_pipeline_kwargs["task"] = task
+        task = task or huggingface_pipeline_kwargs.get("task")
+        if task is not None:
+            huggingface_pipeline_kwargs["task"] = task
+        self._task = task
 
         # if not specified, set return_full_text to False for text-generation
         # only generated text is returned (excluding prompt)
@@ -244,26 +226,7 @@ class TransformersChatGenerator:
         self.enable_thinking = enable_thinking
 
         self._owns_executor = async_executor is None
-        self.executor = (
-            ThreadPoolExecutor(thread_name_prefix=f"async-TransformersChatGenerator-executor-{id(self)}", max_workers=1)
-            if async_executor is None
-            else async_executor
-        )
-        self._is_warmed_up = False
-
-    def __del__(self) -> None:
-        """
-        Cleanup when the instance is being destroyed.
-        """
-        if hasattr(self, "_owns_executor") and self._owns_executor and hasattr(self, "executor"):
-            self.executor.shutdown(wait=True)
-
-    def shutdown(self) -> None:
-        """
-        Explicitly shutdown the executor if we own it.
-        """
-        if self._owns_executor:
-            self.executor.shutdown(wait=True)
+        self.executor = async_executor
 
     def _get_telemetry_data(self) -> dict[str, Any]:
         """
@@ -277,18 +240,36 @@ class TransformersChatGenerator:
         """
         Initializes the component and warms up tools if provided.
         """
-        if self._is_warmed_up:
-            return
-
-        # Initialize the pipeline
         if self.pipeline is None:
-            self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
+            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
+            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            task = pipeline_kwargs.get("task")
+            if task is None and isinstance(pipeline_kwargs["model"], str):
+                task = model_info(pipeline_kwargs["model"], token=pipeline_kwargs["token"]).pipeline_tag
 
-        # Warm up tools
-        if self.tools:
-            warm_up_tools(self.tools)
+            if task not in PIPELINE_SUPPORTED_TASKS:
+                msg = f"Task '{task}' is not supported. The supported tasks are: {', '.join(PIPELINE_SUPPORTED_TASKS)}."
+                raise ValueError(msg)
+            pipeline_kwargs["task"] = task
 
-        self._is_warmed_up = True
+            hf_pipeline = pipeline(**pipeline_kwargs)
+            if self.tools:
+                warm_up_tools(self.tools)
+            self.pipeline = hf_pipeline
+            self._task = task
+
+        if self._owns_executor and self.executor is None:
+            self.executor = ThreadPoolExecutor(
+                thread_name_prefix=f"async-TransformersChatGenerator-executor-{id(self)}", max_workers=1
+            )
+
+    def close(self) -> None:
+        """
+        Close the executor owned by the component.
+        """
+        if self._owns_executor and self.executor is not None:
+            self.executor.shutdown(wait=True)
+            self.executor = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -362,8 +343,8 @@ class TransformersChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
-        if self.pipeline is None:
-            self.warm_up()
+        self.warm_up()
+        assert self.pipeline is not None  # noqa: S101
 
         messages = _normalize_messages(messages)
 
@@ -483,8 +464,9 @@ class TransformersChatGenerator:
         :returns: A dictionary with the following keys:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
-        if self.pipeline is None:
-            self.warm_up()
+        self.warm_up()
+        assert self.pipeline is not None  # noqa: S101
+        assert self.executor is not None  # noqa: S101
 
         messages = _normalize_messages(messages)
 
@@ -571,6 +553,8 @@ class TransformersChatGenerator:
 
         # Check and update generation parameters
         generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+        if self._task == "text-generation":
+            generation_kwargs.setdefault("return_full_text", False)
 
         # If streaming_callback is provided, ensure that num_return_sequences is set to 1
         if streaming_callback:

--- a/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
+++ b/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
@@ -178,19 +178,21 @@ class TransformersExtractiveReader:
         """
         # Take the first device used by `accelerate`. Needed to pass inputs from the tokenizer to the correct device.
         if self.model is None:
-            self.model = AutoModelForQuestionAnswering.from_pretrained(
-                self.model_name_or_path, token=self.token.resolve_value() if self.token else None, **self.model_kwargs
+            token = self.token.resolve_value() if self.token else None
+            model = AutoModelForQuestionAnswering.from_pretrained(
+                self.model_name_or_path, token=token, **self.model_kwargs
             )
-            self.tokenizer = AutoTokenizer.from_pretrained(
-                self.model_name_or_path, token=self.token.resolve_value() if self.token else None
-            )
-            assert self.model is not None  # noqa: S101 # mypy doesn't know this is set in the line above
+            tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=token)
             # hf_device_map appears to only be set now when mixed devices are actually used.
             # So if it's missing then we can use the device attribute which is set even for single-device models.
-            if hf_device_map := getattr(self.model, "hf_device_map", None):
-                self.device = ComponentDevice.from_multiple(device_map=DeviceMap.from_hf(hf_device_map))
+            if hf_device_map := getattr(model, "hf_device_map", None):
+                device = ComponentDevice.from_multiple(device_map=DeviceMap.from_hf(hf_device_map))
             else:
-                self.device = ComponentDevice.from_single(Device.from_str(str(self.model.device)))
+                device = ComponentDevice.from_single(Device.from_str(str(model.device)))
+
+            self.model = model
+            self.tokenizer = tokenizer
+            self.device = device
 
     @staticmethod
     def _flatten_documents(

--- a/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
+++ b/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
@@ -583,8 +583,10 @@ class TransformersExtractiveReader:
         :returns:
             List of answers sorted by (desc.) answer score.
         """
-        if self.model is None:
-            self.warm_up()
+        self.warm_up()
+        assert self.model is not None  # noqa: S101
+        assert self.tokenizer is not None  # noqa: S101
+        assert self.device is not None  # noqa: S101
 
         if not documents:
             return {"answers": []}

--- a/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
+++ b/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
@@ -176,23 +176,23 @@ class TransformersExtractiveReader:
         """
         Initializes the component.
         """
-        # Take the first device used by `accelerate`. Needed to pass inputs from the tokenizer to the correct device.
-        if self.model is None:
-            token = self.token.resolve_value() if self.token else None
-            model = AutoModelForQuestionAnswering.from_pretrained(
-                self.model_name_or_path, token=token, **self.model_kwargs
-            )
-            tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=token)
-            # hf_device_map appears to only be set now when mixed devices are actually used.
-            # So if it's missing then we can use the device attribute which is set even for single-device models.
-            if hf_device_map := getattr(model, "hf_device_map", None):
-                device = ComponentDevice.from_multiple(device_map=DeviceMap.from_hf(hf_device_map))
-            else:
-                device = ComponentDevice.from_single(Device.from_str(str(model.device)))
+        if self.model is not None:
+            return
 
-            self.model = model
-            self.tokenizer = tokenizer
-            self.device = device
+        # Take the first device used by `accelerate`. Needed to pass inputs from the tokenizer to the correct device.
+        token = self.token.resolve_value() if self.token else None
+        model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, token=token, **self.model_kwargs)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=token)
+        # hf_device_map appears to only be set now when mixed devices are actually used.
+        # So if it's missing then we can use the device attribute which is set even for single-device models.
+        if hf_device_map := getattr(model, "hf_device_map", None):
+            device = ComponentDevice.from_multiple(device_map=DeviceMap.from_hf(hf_device_map))
+        else:
+            device = ComponentDevice.from_single(Device.from_str(str(model.device)))
+
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
 
     @staticmethod
     def _flatten_documents(

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/text_router.py
@@ -92,7 +92,6 @@ class TransformersTextRouter:
             huggingface_pipeline_kwargs=huggingface_pipeline_kwargs or {},
             model=model,
             task="text-classification",
-            supported_tasks=["text-classification"],
             device=device,
         )
         self.huggingface_pipeline_kwargs = huggingface_pipeline_kwargs
@@ -119,21 +118,23 @@ class TransformersTextRouter:
         """
         Initializes the component.
         """
-        if self.pipeline is None:
-            pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
-            hf_pipeline = pipeline(**pipeline_kwargs)
+        if self.pipeline is not None:
+            return
 
-            # Verify labels from the model configuration file match provided labels
-            label2id = hf_pipeline.model.config.label2id
-            if label2id is not None:
-                labels = set(label2id.keys())
-                if set(self.labels) != labels:
-                    msg = (
-                        f"The provided labels do not match the labels in the model configuration file. "
-                        f"Provided labels: {self.labels}. Model labels: {labels}"
-                    )
-                    raise ValueError(msg)
-            self.pipeline = hf_pipeline
+        pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
+        hf_pipeline = pipeline(**pipeline_kwargs)
+
+        # Verify labels from the model configuration file match provided labels
+        label2id = hf_pipeline.model.config.label2id
+        if label2id is not None:
+            labels = set(label2id.keys())
+            if set(self.labels) != labels:
+                msg = (
+                    f"The provided labels do not match the labels in the model configuration file. "
+                    f"Provided labels: {self.labels}. Model labels: {labels}"
+                )
+                raise ValueError(msg)
+        self.pipeline = hf_pipeline
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/text_router.py
@@ -94,14 +94,13 @@ class TransformersTextRouter:
             task="text-classification",
             supported_tasks=["text-classification"],
             device=device,
-            token=token,
         )
         self.huggingface_pipeline_kwargs = huggingface_pipeline_kwargs
 
         if labels is None:
-            config = AutoConfig.from_pretrained(
-                huggingface_pipeline_kwargs["model"], token=huggingface_pipeline_kwargs["token"]
-            )
+            pipeline_kwargs = huggingface_pipeline_kwargs.copy()
+            pipeline_kwargs.setdefault("token", token.resolve_value() if token else None)
+            config = AutoConfig.from_pretrained(pipeline_kwargs["model"], token=pipeline_kwargs["token"])
             self.labels = list(config.label2id.keys())
         else:
             self.labels = labels
@@ -122,18 +121,21 @@ class TransformersTextRouter:
         Initializes the component.
         """
         if self.pipeline is None:
-            self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
+            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
+            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            hf_pipeline = pipeline(**pipeline_kwargs)
 
-        # Verify labels from the model configuration file match provided labels
-        label2id = self.pipeline.model.config.label2id
-        if label2id is not None:
-            labels = set(label2id.keys())
-            if set(self.labels) != labels:
-                msg = (
-                    f"The provided labels do not match the labels in the model configuration file. "
-                    f"Provided labels: {self.labels}. Model labels: {labels}"
-                )
-                raise ValueError(msg)
+            # Verify labels from the model configuration file match provided labels
+            label2id = hf_pipeline.model.config.label2id
+            if label2id is not None:
+                labels = set(label2id.keys())
+                if set(self.labels) != labels:
+                    msg = (
+                        f"The provided labels do not match the labels in the model configuration file. "
+                        f"Provided labels: {self.labels}. Model labels: {labels}"
+                    )
+                    raise ValueError(msg)
+            self.pipeline = hf_pipeline
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -181,16 +183,13 @@ class TransformersTextRouter:
         :raises TypeError:
             If the input is not a str.
         """
-        if self.pipeline is None:
-            self.warm_up()
+        self.warm_up()
+        assert self.pipeline is not None  # noqa: S101
 
         if not isinstance(text, str):
             msg = "TransformersTextRouter expects a str as input."
             raise TypeError(msg)
 
-        # mypy doesn't know this is set in warm_up
-        prediction = self.pipeline(  # type: ignore[misc]
-            [text], return_all_scores=False, function_to_apply="none"
-        )
+        prediction = self.pipeline([text], return_all_scores=False, function_to_apply="none")
         label = prediction[0]["label"]
         return {label: text}

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/text_router.py
@@ -8,7 +8,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import ComponentDevice, Secret
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
-from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs
+from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs, _with_hf_token
 from transformers import AutoConfig, Pipeline, pipeline
 
 
@@ -98,8 +98,7 @@ class TransformersTextRouter:
         self.huggingface_pipeline_kwargs = huggingface_pipeline_kwargs
 
         if labels is None:
-            pipeline_kwargs = huggingface_pipeline_kwargs.copy()
-            pipeline_kwargs.setdefault("token", token.resolve_value() if token else None)
+            pipeline_kwargs = _with_hf_token(huggingface_pipeline_kwargs, token)
             config = AutoConfig.from_pretrained(pipeline_kwargs["model"], token=pipeline_kwargs["token"])
             self.labels = list(config.label2id.keys())
         else:
@@ -121,8 +120,7 @@ class TransformersTextRouter:
         Initializes the component.
         """
         if self.pipeline is None:
-            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
-            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
             hf_pipeline = pipeline(**pipeline_kwargs)
 
             # Verify labels from the model configuration file match provided labels

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
@@ -128,7 +128,6 @@ class TransformersZeroShotTextRouter:
             task="zero-shot-classification",
             supported_tasks=["zero-shot-classification"],
             device=device,
-            token=token,
         )
         self.huggingface_pipeline_kwargs = huggingface_pipeline_kwargs
         self.pipeline: HfPipeline | None = None
@@ -146,7 +145,9 @@ class TransformersZeroShotTextRouter:
         Initializes the component.
         """
         if self.pipeline is None:
-            self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
+            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
+            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            self.pipeline = pipeline(**pipeline_kwargs)
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -194,17 +195,14 @@ class TransformersZeroShotTextRouter:
         :raises TypeError:
             If the input is not a str.
         """
-        if self.pipeline is None:
-            self.warm_up()
+        self.warm_up()
+        assert self.pipeline is not None  # noqa: S101
 
         if not isinstance(text, str):
             msg = "TransformersZeroShotTextRouter expects a str as input."
             raise TypeError(msg)
 
-        # mypy doesn't know this is set in warm_up
-        prediction = self.pipeline(  # type: ignore[misc]
-            [text], candidate_labels=self.labels, multi_label=self.multi_label
-        )
+        prediction = self.pipeline([text], candidate_labels=self.labels, multi_label=self.multi_label)
         predicted_scores = prediction[0]["scores"]
         max_score_index = max(range(len(predicted_scores)), key=predicted_scores.__getitem__)
         label = prediction[0]["labels"][max_score_index]

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
@@ -126,7 +126,6 @@ class TransformersZeroShotTextRouter:
             huggingface_pipeline_kwargs=huggingface_pipeline_kwargs or {},
             model=model,
             task="zero-shot-classification",
-            supported_tasks=["zero-shot-classification"],
             device=device,
         )
         self.huggingface_pipeline_kwargs = huggingface_pipeline_kwargs
@@ -144,9 +143,11 @@ class TransformersZeroShotTextRouter:
         """
         Initializes the component.
         """
-        if self.pipeline is None:
-            pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
-            self.pipeline = pipeline(**pipeline_kwargs)
+        if self.pipeline is not None:
+            return
+
+        pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
+        self.pipeline = pipeline(**pipeline_kwargs)
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
+++ b/integrations/transformers/src/haystack_integrations/components/routers/transformers/zero_shot_text_router.py
@@ -8,7 +8,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import ComponentDevice, Secret
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
-from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs
+from haystack_integrations.common.transformers.utils import _resolve_hf_pipeline_kwargs, _with_hf_token
 from transformers import Pipeline as HfPipeline
 from transformers import pipeline
 
@@ -145,8 +145,7 @@ class TransformersZeroShotTextRouter:
         Initializes the component.
         """
         if self.pipeline is None:
-            pipeline_kwargs = self.huggingface_pipeline_kwargs.copy()
-            pipeline_kwargs.setdefault("token", self.token.resolve_value() if self.token else None)
+            pipeline_kwargs = _with_hf_token(self.huggingface_pipeline_kwargs, self.token)
             self.pipeline = pipeline(**pipeline_kwargs)
 
     def to_dict(self) -> dict[str, Any]:

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -79,7 +79,7 @@ def custom_tool_parser(text: str) -> list[ToolCall] | None:
 
 
 class TestInitializationAndSerialization:
-    def test_initialize_with_valid_model_and_generation_parameters(self, model_info_mock):
+    def test_initialize_with_valid_model_and_generation_parameters(self):
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"n": 1}
         stop_words = ["stop"]
@@ -95,7 +95,7 @@ class TestInitializationAndSerialization:
         assert generator.generation_kwargs == {**generation_kwargs, "stop_sequences": ["stop"]}
         assert generator.streaming_callback == streaming_callback
 
-    def test_init_custom_token(self, model_info_mock):
+    def test_init_custom_token(self):
         generator = TransformersChatGenerator(
             model="mistralai/Mistral-7B-Instruct-v0.2",
             task="text-generation",
@@ -109,7 +109,7 @@ class TestInitializationAndSerialization:
             "device": "cpu",
         }
 
-    def test_init_custom_device(self, model_info_mock):
+    def test_init_custom_device(self):
         generator = TransformersChatGenerator(
             model="mistralai/Mistral-7B-Instruct-v0.2",
             task="text-generation",
@@ -123,7 +123,7 @@ class TestInitializationAndSerialization:
             "device": "cpu",
         }
 
-    def test_init_task_parameter(self, model_info_mock):
+    def test_init_task_parameter(self):
         generator = TransformersChatGenerator(
             task="text-generation", device=ComponentDevice.from_str("cpu"), token=None
         )
@@ -134,7 +134,7 @@ class TestInitializationAndSerialization:
             "device": "cpu",
         }
 
-    def test_init_task_in_huggingface_pipeline_kwargs(self, model_info_mock):
+    def test_init_task_in_huggingface_pipeline_kwargs(self):
         generator = TransformersChatGenerator(
             huggingface_pipeline_kwargs={"task": "text-generation"}, device=ComponentDevice.from_str("cpu"), token=None
         )
@@ -145,23 +145,21 @@ class TestInitializationAndSerialization:
             "device": "cpu",
         }
 
-    def test_transformers_chat_generator_with_toolset_initialization(
-        self, model_info_mock, mock_pipeline_with_tokenizer, tools
-    ):
+    def test_transformers_chat_generator_with_toolset_initialization(self, mock_pipeline_with_tokenizer, tools):
         """Test that the TransformersChatGenerator can be initialized with a Toolset."""
         toolset = Toolset(tools)
         generator = TransformersChatGenerator(model="irrelevant", tools=toolset)
         generator.pipeline = mock_pipeline_with_tokenizer
         assert generator.tools == toolset
 
-    def test_init_image_text_to_text(self, model_info_mock):
+    def test_init_image_text_to_text(self):
         llm = TransformersChatGenerator(model="Qwen/Qwen2-VL-2B-Instruct")
 
         assert llm
         assert isinstance(llm, TransformersChatGenerator)
         assert "model" in llm.huggingface_pipeline_kwargs
 
-    def test_init_image_text_to_text_task(self, model_info_mock):
+    def test_init_image_text_to_text_task(self):
         generator = TransformersChatGenerator(
             model="Qwen/Qwen2-VL-2B-Instruct",
             task="image-text-to-text",
@@ -175,7 +173,7 @@ class TestInitializationAndSerialization:
             "device": "cpu",
         }
 
-    def test_to_dict(self, model_info_mock, tools):
+    def test_to_dict(self, tools):
         generator = TransformersChatGenerator(
             model="NousResearch/Llama-2-7b-chat-hf",
             token=Secret.from_env_var("ENV_VAR", strict=False),
@@ -208,7 +206,7 @@ class TestInitializationAndSerialization:
         loaded = TransformersChatGenerator.from_dict(result)
         assert loaded.tools == tools
 
-    def test_from_dict(self, model_info_mock, tools):
+    def test_from_dict(self, tools):
         generator = TransformersChatGenerator(
             model="NousResearch/Llama-2-7b-chat-hf",
             generation_kwargs={"n": 5},
@@ -241,7 +239,7 @@ class TestInitializationAndSerialization:
             "required": ["city"],
         }
 
-    def test_to_dict_with_toolset(self, model_info_mock, mock_pipeline_with_tokenizer, tools):
+    def test_to_dict_with_toolset(self, mock_pipeline_with_tokenizer, tools):
         """Test that the TransformersChatGenerator can be serialized to a dictionary with a Toolset."""
         toolset = Toolset(tools)
         generator = TransformersChatGenerator(huggingface_pipeline_kwargs={"model": "irrelevant"}, tools=toolset)
@@ -253,7 +251,7 @@ class TestInitializationAndSerialization:
         assert isinstance(loaded.tools, Toolset)
         assert list(loaded.tools) == list(toolset)
 
-    def test_from_dict_with_toolset(self, model_info_mock, tools):
+    def test_from_dict_with_toolset(self, tools):
         """Test that the TransformersChatGenerator can be deserialized from a dictionary with a Toolset."""
         toolset = Toolset(tools)
         component = TransformersChatGenerator(model="irrelevant", tools=toolset)
@@ -351,7 +349,7 @@ class TestComponentLifecycle:
             generator.warm_up()
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up(self, pipeline_mock, del_hf_env_vars_if_empty):
+    def test_warm_up(self, pipeline_mock):
         generator = TransformersChatGenerator(
             model="mistralai/Mistral-7B-Instruct-v0.2", task="text-generation", device=ComponentDevice.from_str("cpu")
         )
@@ -368,7 +366,7 @@ class TestComponentLifecycle:
         )
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up_with_tools(self, pipeline_mock, del_hf_env_vars_if_empty):
+    def test_warm_up_with_tools(self, pipeline_mock):
         """Test that warm_up() calls warm_up on tools and is idempotent."""
 
         # Create a mock tool that tracks if warm_up() was called
@@ -422,7 +420,7 @@ class TestComponentLifecycle:
         pipeline_mock.assert_called_once()
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up_with_no_tools(self, pipeline_mock, del_hf_env_vars_if_empty):
+    def test_warm_up_with_no_tools(self, pipeline_mock):
         """Test that warm_up() works when no tools are provided."""
 
         generator = TransformersChatGenerator(
@@ -447,7 +445,7 @@ class TestComponentLifecycle:
         pipeline_mock.assert_called_once()
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
-    def test_warm_up_with_multiple_tools(self, pipeline_mock, del_hf_env_vars_if_empty):
+    def test_warm_up_with_multiple_tools(self, pipeline_mock):
         """Test that warm_up() works with multiple tools."""
 
         # Track warm_up calls
@@ -496,7 +494,7 @@ class TestComponentLifecycle:
 
 
 class TestRun:
-    def test_run(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+    def test_run(self, mock_pipeline_with_tokenizer, chat_messages):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
 
         # Use the mocked pipeline from the fixture and simulate warm_up
@@ -510,7 +508,7 @@ class TestRun:
         assert chat_message.is_from(ChatRole.ASSISTANT)
         assert chat_message.text == "Berlin is cool"
 
-    def test_run_with_string_input(self, model_info_mock, mock_pipeline_with_tokenizer):
+    def test_run_with_string_input(self, mock_pipeline_with_tokenizer):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
         generator.pipeline = mock_pipeline_with_tokenizer
 
@@ -523,7 +521,7 @@ class TestRun:
         assert isinstance(results["replies"][0], ChatMessage)
         assert results["replies"][0].is_from(ChatRole.ASSISTANT)
 
-    def test_run_with_custom_generation_parameters(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+    def test_run_with_custom_generation_parameters(self, mock_pipeline_with_tokenizer, chat_messages):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
 
         # Use the mocked pipeline from the fixture and simulate warm_up
@@ -547,7 +545,7 @@ class TestRun:
         assert chat_message.is_from(ChatRole.ASSISTANT)
         assert chat_message.text == "Berlin is cool"
 
-    def test_run_with_generation_kwargs(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+    def test_run_with_generation_kwargs(self, mock_pipeline_with_tokenizer, chat_messages):
         generator = TransformersChatGenerator(
             model="meta-llama/Llama-2-13b-chat-hf",
             generation_kwargs={"max_new_tokens": 100, "temperature": 0.5},
@@ -560,7 +558,7 @@ class TestRun:
         assert kwargs["max_new_tokens"] == 100
         assert kwargs["temperature"] == 0.9
 
-    def test_run_with_streaming_callback(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+    def test_run_with_streaming_callback(self, mock_pipeline_with_tokenizer, chat_messages):
         # Define the streaming callback function
         def streaming_callback_fn(chunk: StreamingChunk): ...
 
@@ -581,9 +579,7 @@ class TestRun:
         generator.pipeline.assert_called_once()
         assert generator.pipeline.call_args[1]["streamer"].token_handler == streaming_callback_fn
 
-    def test_run_with_streaming_callback_in_run_method(
-        self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages
-    ):
+    def test_run_with_streaming_callback_in_run_method(self, mock_pipeline_with_tokenizer, chat_messages):
         # Define the streaming callback function
         def streaming_callback_fn(chunk: StreamingChunk): ...
 
@@ -603,7 +599,7 @@ class TestRun:
         assert generator.pipeline.call_args[1]["streamer"].token_handler == streaming_callback_fn
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.convert_message_to_hf_format")
-    def test_messages_conversion_is_called(self, mock_convert, model_info_mock):
+    def test_messages_conversion_is_called(self, mock_convert):
         generator = TransformersChatGenerator(model="fake-model")
 
         messages = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi there")]
@@ -630,13 +626,13 @@ class TestValidationAndTools:
     def test_default_tool_parser_returns_none_for_invalid_input(self, generated_text):
         assert default_tool_parser(generated_text) is None
 
-    def test_init_fail_with_stop_words_and_stopping_criteria(self, model_info_mock):
+    def test_init_fail_with_stop_words_and_stopping_criteria(self):
         with pytest.raises(ValueError, match="Found both the `stop_words` init parameter"):
             TransformersChatGenerator(
                 model="irrelevant", stop_words=["stop"], generation_kwargs={"stopping_criteria": "fake-criteria"}
             )
 
-    def test_run_with_stop_words_removed_from_replies(self, model_info_mock, mock_pipeline_with_tokenizer):
+    def test_run_with_stop_words_removed_from_replies(self, mock_pipeline_with_tokenizer):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf", stop_words=["unambiguously"])
         mock_pipeline_with_tokenizer.return_value = [{"generated_text": "Berlin is cool unambiguously"}]
         # tokenizer without a pad token: _StopWordsCriteria falls back to the eos token
@@ -649,16 +645,16 @@ class TestValidationAndTools:
         assert results["replies"][0].text == "Berlin is cool"
         assert "stopping_criteria" in generator.pipeline.call_args[1]
 
-    def test_init_fail_with_duplicate_tool_names(self, model_info_mock, tools):
+    def test_init_fail_with_duplicate_tool_names(self, tools):
         duplicate_tools = [tools[0], tools[0]]
         with pytest.raises(ValueError, match="Duplicate tool names found"):
             TransformersChatGenerator(model="irrelevant", tools=duplicate_tools)
 
-    def test_init_fail_with_tools_and_streaming(self, model_info_mock, tools):
+    def test_init_fail_with_tools_and_streaming(self, tools):
         with pytest.raises(ValueError, match="Using tools and streaming at the same time is not supported"):
             TransformersChatGenerator(model="irrelevant", tools=tools, streaming_callback=streaming_callback_handler)
 
-    def test_run_with_tools(self, model_info_mock, tools):
+    def test_run_with_tools(self, tools):
         generator = TransformersChatGenerator(model="Qwen/Qwen3-0.6B", tools=tools)
 
         # Mock pipeline and tokenizer
@@ -682,7 +678,7 @@ class TestValidationAndTools:
         assert tool_call.arguments == {"city": "Paris"}
         assert message.meta["finish_reason"] == "tool_calls"
 
-    def test_run_with_tools_in_run_method(self, model_info_mock, tools):
+    def test_run_with_tools_in_run_method(self, tools):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
 
         # Mock pipeline and tokenizer
@@ -706,7 +702,7 @@ class TestValidationAndTools:
         assert tool_call.arguments == {"city": "Paris"}
         assert message.meta["finish_reason"] == "tool_calls"
 
-    def test_run_with_tools_and_tool_response(self, model_info_mock, tools):
+    def test_run_with_tools_and_tool_response(self):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
 
         # Mock pipeline and tokenizer
@@ -732,7 +728,7 @@ class TestValidationAndTools:
         assert "22°C" in message.text
         assert message.meta["finish_reason"] == "stop"
 
-    def test_run_with_custom_tool_parser(self, model_info_mock, mock_pipeline_with_tokenizer, tools):
+    def test_run_with_custom_tool_parser(self, mock_pipeline_with_tokenizer, tools):
         """Test that a custom tool parsing function works correctly."""
         generator = TransformersChatGenerator(
             model="meta-llama/Llama-2-13b-chat-hf", tools=tools, tool_parsing_function=custom_tool_parser
@@ -747,7 +743,7 @@ class TestValidationAndTools:
         assert results["replies"][0].tool_calls[0].tool_name == "weather"
         assert results["replies"][0].tool_calls[0].arguments == {"city": "Berlin"}
 
-    def test_default_tool_parser(self, model_info_mock, tools):
+    def test_default_tool_parser(self, tools):
         """Test that the default tool parser works correctly with valid tool call format."""
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf", tools=tools)
         generator.pipeline = Mock(
@@ -771,7 +767,7 @@ class TestRunAsync:
     """Async tests for TransformersChatGenerator"""
 
     @pytest.mark.asyncio
-    async def test_run_async(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+    async def test_run_async(self, mock_pipeline_with_tokenizer, chat_messages):
         """Test basic async functionality"""
         generator = TransformersChatGenerator(model="mocked-model")
         generator.pipeline = mock_pipeline_with_tokenizer
@@ -786,7 +782,7 @@ class TestRunAsync:
         generator.close()
 
     @pytest.mark.asyncio
-    async def test_run_async_with_generation_kwargs(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+    async def test_run_async_with_generation_kwargs(self, mock_pipeline_with_tokenizer, chat_messages):
         generator = TransformersChatGenerator(
             model="meta-llama/Llama-2-13b-chat-hf",
             generation_kwargs={"max_new_tokens": 100, "temperature": 0.5},
@@ -801,7 +797,7 @@ class TestRunAsync:
         generator.close()
 
     @pytest.mark.asyncio
-    async def test_run_async_with_string_input(self, model_info_mock, mock_pipeline_with_tokenizer):
+    async def test_run_async_with_string_input(self, mock_pipeline_with_tokenizer):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
         generator.pipeline = mock_pipeline_with_tokenizer
 
@@ -816,7 +812,7 @@ class TestRunAsync:
         generator.close()
 
     @pytest.mark.asyncio
-    async def test_run_async_with_tools(self, model_info_mock, mock_pipeline_with_tokenizer, tools):
+    async def test_run_async_with_tools(self, mock_pipeline_with_tokenizer, tools):
         """Test async functionality with tools"""
         generator = TransformersChatGenerator(model="mocked-model", tools=tools)
         # Create a new mock with return_value set in constructor to avoid thread-safety issues
@@ -837,7 +833,7 @@ class TestRunAsync:
         generator.close()
 
     @pytest.mark.asyncio
-    async def test_concurrent_async_requests(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
+    async def test_concurrent_async_requests(self, mock_pipeline_with_tokenizer, chat_messages):
         """Test handling of multiple concurrent async requests"""
         generator = TransformersChatGenerator(model="mocked-model")
         generator.pipeline = mock_pipeline_with_tokenizer
@@ -853,7 +849,7 @@ class TestRunAsync:
         generator.close()
 
     @pytest.mark.asyncio
-    async def test_async_error_handling(self, model_info_mock, mock_pipeline_with_tokenizer):
+    async def test_async_error_handling(self, mock_pipeline_with_tokenizer):
         """Test error handling in async context"""
         generator = TransformersChatGenerator(model="mocked-model")
 
@@ -867,7 +863,7 @@ class TestRunAsync:
             )
 
     @pytest.mark.asyncio
-    async def test_run_async_with_streaming_callback(self, model_info_mock, mock_pipeline_with_tokenizer):
+    async def test_run_async_with_streaming_callback(self, mock_pipeline_with_tokenizer):
         streaming_chunks = []
 
         async def streaming_callback(chunk: StreamingChunk) -> None:

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -907,7 +907,6 @@ class TestRunAsync:
 
 class TestIntegration:
     @pytest.mark.integration
-    @pytest.mark.flaky(reruns=3, reruns_delay=10)
     def test_live_run(self, del_hf_env_vars_if_empty):
         """Test live run with default behavior (no thinking)."""
         messages = [ChatMessage.from_user("Please create a summary about the following topic: Climate change")]
@@ -925,7 +924,6 @@ class TestIntegration:
         assert "climate change" in result["replies"][0].text.lower()
 
     @pytest.mark.integration
-    @pytest.mark.flaky(reruns=3, reruns_delay=10)
     def test_live_run_thinking(self, del_hf_env_vars_if_empty):
         """Test live run with enable_thinking=True."""
         messages = [ChatMessage.from_user("What is 2+2?")]
@@ -951,7 +949,6 @@ class TestIntegration:
 
 class TestAsyncIntegration:
     @pytest.mark.integration
-    @pytest.mark.flaky(reruns=3, reruns_delay=10)
     @pytest.mark.asyncio
     async def test_live_run_async_with_streaming(self, del_hf_env_vars_if_empty):
         """Test async streaming with a live model."""

--- a/integrations/transformers/tests/test_chat_generator.py
+++ b/integrations/transformers/tests/test_chat_generator.py
@@ -6,14 +6,12 @@ import asyncio
 from unittest.mock import Mock, patch
 
 import pytest
-import transformers
 from haystack.dataclasses import ChatMessage, ChatRole, ToolCall
 from haystack.dataclasses.streaming_chunk import StreamingChunk
 from haystack.tools import Tool
 from haystack.tools.toolset import Toolset
 from haystack.utils import ComponentDevice
 from haystack.utils.auth import Secret
-from packaging.version import Version
 from transformers import PreTrainedTokenizer
 
 from haystack_integrations.components.generators.transformers import TransformersChatGenerator
@@ -80,7 +78,7 @@ def custom_tool_parser(text: str) -> list[ToolCall] | None:
     return [ToolCall(tool_name="weather", arguments={"city": "Berlin"})]
 
 
-class TestTransformersChatGenerator:
+class TestInitializationAndSerialization:
     def test_initialize_with_valid_model_and_generation_parameters(self, model_info_mock):
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"n": 1}
@@ -108,7 +106,6 @@ class TestTransformersChatGenerator:
         assert generator.huggingface_pipeline_kwargs == {
             "model": "mistralai/Mistral-7B-Instruct-v0.2",
             "task": "text-generation",
-            "token": "test-token",
             "device": "cpu",
         }
 
@@ -123,7 +120,6 @@ class TestTransformersChatGenerator:
         assert generator.huggingface_pipeline_kwargs == {
             "model": "mistralai/Mistral-7B-Instruct-v0.2",
             "task": "text-generation",
-            "token": None,
             "device": "cpu",
         }
 
@@ -135,7 +131,6 @@ class TestTransformersChatGenerator:
         assert generator.huggingface_pipeline_kwargs == {
             "model": "Qwen/Qwen3-0.6B",
             "task": "text-generation",
-            "token": None,
             "device": "cpu",
         }
 
@@ -147,35 +142,38 @@ class TestTransformersChatGenerator:
         assert generator.huggingface_pipeline_kwargs == {
             "model": "Qwen/Qwen3-0.6B",
             "task": "text-generation",
-            "token": None,
             "device": "cpu",
         }
 
-    def test_init_task_inferred_from_model_name(self, model_info_mock):
+    def test_transformers_chat_generator_with_toolset_initialization(
+        self, model_info_mock, mock_pipeline_with_tokenizer, tools
+    ):
+        """Test that the TransformersChatGenerator can be initialized with a Toolset."""
+        toolset = Toolset(tools)
+        generator = TransformersChatGenerator(model="irrelevant", tools=toolset)
+        generator.pipeline = mock_pipeline_with_tokenizer
+        assert generator.tools == toolset
+
+    def test_init_image_text_to_text(self, model_info_mock):
+        llm = TransformersChatGenerator(model="Qwen/Qwen2-VL-2B-Instruct")
+
+        assert llm
+        assert isinstance(llm, TransformersChatGenerator)
+        assert "model" in llm.huggingface_pipeline_kwargs
+
+    def test_init_image_text_to_text_task(self, model_info_mock):
         generator = TransformersChatGenerator(
-            model="mistralai/Mistral-7B-Instruct-v0.2", device=ComponentDevice.from_str("cpu"), token=None
+            model="Qwen/Qwen2-VL-2B-Instruct",
+            task="image-text-to-text",
+            device=ComponentDevice.from_str("cpu"),
+            token=None,
         )
 
         assert generator.huggingface_pipeline_kwargs == {
-            "model": "mistralai/Mistral-7B-Instruct-v0.2",
-            "task": "text-generation",
-            "token": None,
+            "model": "Qwen/Qwen2-VL-2B-Instruct",
+            "task": "image-text-to-text",
             "device": "cpu",
         }
-
-    def test_init_invalid_task(self):
-        with pytest.raises(ValueError, match=r"is not supported\."):
-            TransformersChatGenerator(task="text-classification")
-
-    @pytest.mark.skipif(
-        Version(transformers.__version__) < Version("5.0.0"),
-        reason="The task 'text2text-generation' is only rejected with transformers v5 or higher",
-    )
-    def test_init_text2text_generation_raises_error(self):
-        with pytest.raises(
-            ValueError, match=r"Task 'text2text-generation' is not supported with transformers v5 or higher\."
-        ):
-            TransformersChatGenerator(task="text2text-generation")
 
     def test_to_dict(self, model_info_mock, tools):
         generator = TransformersChatGenerator(
@@ -201,7 +199,6 @@ class TestTransformersChatGenerator:
             "max_new_tokens": 512,
             "n": 5,
             "stop_sequences": ["stop", "words"],
-            "return_full_text": False,
         }
         assert init_params["streaming_callback"] is None
         assert init_params["chat_template"] == "irrelevant"
@@ -231,7 +228,6 @@ class TestTransformersChatGenerator:
             "max_new_tokens": 512,
             "n": 5,
             "stop_sequences": ["stop", "words"],
-            "return_full_text": False,
         }
         assert generator_2.streaming_callback is None
         assert generator_2.chat_template == "irrelevant"
@@ -244,6 +240,115 @@ class TestTransformersChatGenerator:
             "properties": {"city": {"type": "string"}},
             "required": ["city"],
         }
+
+    def test_to_dict_with_toolset(self, model_info_mock, mock_pipeline_with_tokenizer, tools):
+        """Test that the TransformersChatGenerator can be serialized to a dictionary with a Toolset."""
+        toolset = Toolset(tools)
+        generator = TransformersChatGenerator(huggingface_pipeline_kwargs={"model": "irrelevant"}, tools=toolset)
+        generator.pipeline = mock_pipeline_with_tokenizer
+        data = generator.to_dict()
+
+        # deserializing the serialized component must reproduce the original toolset
+        loaded = TransformersChatGenerator.from_dict(data)
+        assert isinstance(loaded.tools, Toolset)
+        assert list(loaded.tools) == list(toolset)
+
+    def test_from_dict_with_toolset(self, model_info_mock, tools):
+        """Test that the TransformersChatGenerator can be deserialized from a dictionary with a Toolset."""
+        toolset = Toolset(tools)
+        component = TransformersChatGenerator(model="irrelevant", tools=toolset)
+        data = component.to_dict()
+
+        deserialized_component = TransformersChatGenerator.from_dict(data)
+
+        assert isinstance(deserialized_component.tools, Toolset)
+        assert len(deserialized_component.tools) == len(tools)
+        assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        generator = TransformersChatGenerator(task="text-generation", token=Secret.from_env_var("MISSING_HF_TOKEN"))
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            generator.warm_up()
+
+    @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.ThreadPoolExecutor")
+    @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
+    def test_sync_lifecycle(self, pipeline_mock, executor_cls_mock):
+        generator = TransformersChatGenerator(task="text-generation", token=None)
+        executor = executor_cls_mock.return_value
+
+        generator.warm_up()
+        assert generator.pipeline is pipeline_mock.return_value
+        assert generator.executor is executor
+
+        generator.close()
+        executor.shutdown.assert_called_once_with(wait=True)
+        assert generator.executor is None
+        assert generator.pipeline is pipeline_mock.return_value
+
+        generator.warm_up()
+        assert executor_cls_mock.call_count == 2
+        pipeline_mock.assert_called_once()
+
+    @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.ThreadPoolExecutor")
+    @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
+    def test_warm_up_is_idempotent(self, pipeline_mock, executor_cls_mock):
+        generator = TransformersChatGenerator(task="text-generation", token=None)
+
+        generator.warm_up()
+        generator.warm_up()
+
+        pipeline_mock.assert_called_once()
+        executor_cls_mock.assert_called_once()
+
+    def test_close_is_safe_without_warm_up(self):
+        generator = TransformersChatGenerator(task="text-generation", token=None)
+
+        generator.close()
+
+        assert generator.executor is None
+
+    @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
+    def test_close_does_not_shutdown_user_supplied_executor(self, pipeline_mock):
+        executor = Mock()
+        generator = TransformersChatGenerator(task="text-generation", token=None, async_executor=executor)
+        generator.warm_up()
+
+        generator.close()
+
+        executor.shutdown.assert_not_called()
+        assert generator.executor is executor
+
+    @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
+    def test_task_inferred_at_warm_up_not_init(self, pipeline_mock, model_info_mock):
+        generator = TransformersChatGenerator(
+            model="mistralai/Mistral-7B-Instruct-v0.2", device=ComponentDevice.from_str("cpu"), token=None
+        )
+
+        assert generator.huggingface_pipeline_kwargs == {
+            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "device": "cpu",
+        }
+        generation_kwargs = generator.generation_kwargs.copy()
+        model_info_mock.assert_not_called()
+
+        generator.warm_up()
+
+        assert generator.generation_kwargs == generation_kwargs
+        model_info_mock.assert_called_once_with("mistralai/Mistral-7B-Instruct-v0.2", token=None)
+        pipeline_mock.assert_called_once_with(
+            model="mistralai/Mistral-7B-Instruct-v0.2", device="cpu", token=None, task="text-generation"
+        )
+        generator.close()
+
+    def test_warm_up_invalid_task(self):
+        generator = TransformersChatGenerator(task="text-classification")
+
+        with pytest.raises(ValueError, match=r"is not supported\."):
+            generator.warm_up()
 
     @patch("haystack_integrations.components.generators.transformers.chat.chat_generator.pipeline")
     def test_warm_up(self, pipeline_mock, del_hf_env_vars_if_empty):
@@ -295,14 +400,14 @@ class TestTransformersChatGenerator:
 
         # Verify initial state - warm_up not called yet
         assert MockTool.warm_up_call_count == 0
-        assert not generator._is_warmed_up
+        assert generator.pipeline is None
 
         # Call warm_up() on the generator
         generator.warm_up()
 
         # Assert that the tool's warm_up() was called
         assert MockTool.warm_up_call_count == 1
-        assert generator._is_warmed_up
+        assert generator.pipeline is not None
 
         # Verify pipeline was initialized
         pipeline_mock.assert_called_once()
@@ -312,7 +417,7 @@ class TestTransformersChatGenerator:
 
         # The tool's warm_up should still only have been called once
         assert MockTool.warm_up_call_count == 1
-        assert generator._is_warmed_up
+        assert generator.pipeline is not None
         # Pipeline should still only have been called once
         pipeline_mock.assert_called_once()
 
@@ -325,19 +430,19 @@ class TestTransformersChatGenerator:
         )
 
         # Verify initial state
-        assert not generator._is_warmed_up
+        assert generator.pipeline is None
         assert generator.tools is None
 
         # Call warm_up() - should not raise an error
         generator.warm_up()
 
         # Verify the component is warmed up
-        assert generator._is_warmed_up
+        assert generator.pipeline is not None
         pipeline_mock.assert_called_once()
 
         # Call warm_up() again - should be idempotent
         generator.warm_up()
-        assert generator._is_warmed_up
+        assert generator.pipeline is not None
         # Pipeline should still only have been called once
         pipeline_mock.assert_called_once()
 
@@ -377,7 +482,7 @@ class TestTransformersChatGenerator:
         # Assert that both tools' warm_up() were called
         assert "tool1" in warm_up_calls
         assert "tool2" in warm_up_calls
-        assert generator._is_warmed_up
+        assert generator.pipeline is not None
         pipeline_mock.assert_called_once()
 
         # Track count
@@ -389,6 +494,8 @@ class TestTransformersChatGenerator:
         # Pipeline should still only have been called once
         pipeline_mock.assert_called_once()
 
+
+class TestRun:
     def test_run(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
         generator = TransformersChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
 
@@ -511,48 +618,8 @@ class TestTransformersChatGenerator:
         mock_convert.assert_any_call(messages[0])
         mock_convert.assert_any_call(messages[1])
 
-    @pytest.mark.integration
-    @pytest.mark.flaky(reruns=3, reruns_delay=10)
-    def test_live_run(self, del_hf_env_vars_if_empty):
-        """Test live run with default behavior (no thinking)."""
-        messages = [ChatMessage.from_user("Please create a summary about the following topic: Climate change")]
 
-        llm = TransformersChatGenerator(
-            model="Qwen/Qwen3-0.6B",
-            generation_kwargs={"max_new_tokens": 50},
-            device=ComponentDevice.from_str("cpu"),
-        )
-
-        result = llm.run(messages)
-
-        assert "replies" in result
-        assert isinstance(result["replies"][0], ChatMessage)
-        assert "climate change" in result["replies"][0].text.lower()
-
-    @pytest.mark.integration
-    @pytest.mark.flaky(reruns=3, reruns_delay=10)
-    def test_live_run_thinking(self, del_hf_env_vars_if_empty):
-        """Test live run with enable_thinking=True."""
-        messages = [ChatMessage.from_user("What is 2+2?")]
-
-        llm = TransformersChatGenerator(
-            model="Qwen/Qwen3-0.6B",
-            generation_kwargs={"max_new_tokens": 450},
-            enable_thinking=True,
-            device=ComponentDevice.from_str("cpu"),
-        )
-
-        result = llm.run(messages)
-
-        assert "replies" in result
-        assert isinstance(result["replies"][0], ChatMessage)
-        reply_text = result["replies"][0].text
-        assert reply_text is not None
-        assert "<think>" in reply_text
-        assert "</think>" in reply_text
-        assert len(reply_text) > 0
-        assert "4" in reply_text.lower()
-
+class TestValidationAndTools:
     @pytest.mark.parametrize(
         "generated_text",
         [
@@ -700,7 +767,7 @@ class TestTransformersChatGenerator:
         assert results["replies"][0].tool_calls[0].arguments == {"city": "Berlin"}
 
 
-class TestTransformersChatGeneratorAsync:
+class TestRunAsync:
     """Async tests for TransformersChatGenerator"""
 
     @pytest.mark.asyncio
@@ -716,7 +783,7 @@ class TestTransformersChatGeneratorAsync:
         chat_message = results["replies"][0]
         assert chat_message.is_from(ChatRole.ASSISTANT)
         assert chat_message.text == "Berlin is cool"
-        generator.shutdown()
+        generator.close()
 
     @pytest.mark.asyncio
     async def test_run_async_with_generation_kwargs(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
@@ -731,7 +798,7 @@ class TestTransformersChatGeneratorAsync:
         _, kwargs = generator.pipeline.call_args
         assert kwargs["max_new_tokens"] == 100
         assert kwargs["temperature"] == 0.9
-        generator.shutdown()
+        generator.close()
 
     @pytest.mark.asyncio
     async def test_run_async_with_string_input(self, model_info_mock, mock_pipeline_with_tokenizer):
@@ -746,7 +813,7 @@ class TestTransformersChatGeneratorAsync:
         assert "replies" in results
         assert isinstance(results["replies"][0], ChatMessage)
         assert results["replies"][0].is_from(ChatRole.ASSISTANT)
-        generator.shutdown()
+        generator.close()
 
     @pytest.mark.asyncio
     async def test_run_async_with_tools(self, model_info_mock, mock_pipeline_with_tokenizer, tools):
@@ -767,7 +834,7 @@ class TestTransformersChatGeneratorAsync:
         assert isinstance(tool_call, ToolCall)
         assert tool_call.tool_name == "weather"
         assert tool_call.arguments == {"city": "Berlin"}
-        generator.shutdown()
+        generator.close()
 
     @pytest.mark.asyncio
     async def test_concurrent_async_requests(self, model_info_mock, mock_pipeline_with_tokenizer, chat_messages):
@@ -783,7 +850,7 @@ class TestTransformersChatGeneratorAsync:
             assert "replies" in result
             assert isinstance(result["replies"][0], ChatMessage)
             assert result["replies"][0].text == "Berlin is cool"
-        generator.shutdown()
+        generator.close()
 
     @pytest.mark.asyncio
     async def test_async_error_handling(self, model_info_mock, mock_pipeline_with_tokenizer):
@@ -798,39 +865,6 @@ class TestTransformersChatGeneratorAsync:
                 streaming_callback=lambda _: None,
                 tools=[Tool(name="test", description="test", parameters={}, function=lambda: None)],
             )
-
-    def test_transformers_chat_generator_with_toolset_initialization(
-        self, model_info_mock, mock_pipeline_with_tokenizer, tools
-    ):
-        """Test that the TransformersChatGenerator can be initialized with a Toolset."""
-        toolset = Toolset(tools)
-        generator = TransformersChatGenerator(model="irrelevant", tools=toolset)
-        generator.pipeline = mock_pipeline_with_tokenizer
-        assert generator.tools == toolset
-
-    def test_from_dict_with_toolset(self, model_info_mock, tools):
-        """Test that the TransformersChatGenerator can be deserialized from a dictionary with a Toolset."""
-        toolset = Toolset(tools)
-        component = TransformersChatGenerator(model="irrelevant", tools=toolset)
-        data = component.to_dict()
-
-        deserialized_component = TransformersChatGenerator.from_dict(data)
-
-        assert isinstance(deserialized_component.tools, Toolset)
-        assert len(deserialized_component.tools) == len(tools)
-        assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
-
-    def test_to_dict_with_toolset(self, model_info_mock, mock_pipeline_with_tokenizer, tools):
-        """Test that the TransformersChatGenerator can be serialized to a dictionary with a Toolset."""
-        toolset = Toolset(tools)
-        generator = TransformersChatGenerator(huggingface_pipeline_kwargs={"model": "irrelevant"}, tools=toolset)
-        generator.pipeline = mock_pipeline_with_tokenizer
-        data = generator.to_dict()
-
-        # deserializing the serialized component must reproduce the original toolset
-        loaded = TransformersChatGenerator.from_dict(data)
-        assert isinstance(loaded.tools, Toolset)
-        assert list(loaded.tools) == list(toolset)
 
     @pytest.mark.asyncio
     async def test_run_async_with_streaming_callback(self, model_info_mock, mock_pipeline_with_tokenizer):
@@ -868,8 +902,54 @@ class TestTransformersChatGeneratorAsync:
         assert len(response["replies"]) == 1
         assert isinstance(response["replies"][0], ChatMessage)
         assert response["replies"][0].text == "Berlin is cool"
-        generator.shutdown()
+        generator.close()
 
+
+class TestIntegration:
+    @pytest.mark.integration
+    @pytest.mark.flaky(reruns=3, reruns_delay=10)
+    def test_live_run(self, del_hf_env_vars_if_empty):
+        """Test live run with default behavior (no thinking)."""
+        messages = [ChatMessage.from_user("Please create a summary about the following topic: Climate change")]
+
+        llm = TransformersChatGenerator(
+            model="Qwen/Qwen3-0.6B",
+            generation_kwargs={"max_new_tokens": 50},
+            device=ComponentDevice.from_str("cpu"),
+        )
+
+        result = llm.run(messages)
+
+        assert "replies" in result
+        assert isinstance(result["replies"][0], ChatMessage)
+        assert "climate change" in result["replies"][0].text.lower()
+
+    @pytest.mark.integration
+    @pytest.mark.flaky(reruns=3, reruns_delay=10)
+    def test_live_run_thinking(self, del_hf_env_vars_if_empty):
+        """Test live run with enable_thinking=True."""
+        messages = [ChatMessage.from_user("What is 2+2?")]
+
+        llm = TransformersChatGenerator(
+            model="Qwen/Qwen3-0.6B",
+            generation_kwargs={"max_new_tokens": 450},
+            enable_thinking=True,
+            device=ComponentDevice.from_str("cpu"),
+        )
+
+        result = llm.run(messages)
+
+        assert "replies" in result
+        assert isinstance(result["replies"][0], ChatMessage)
+        reply_text = result["replies"][0].text
+        assert reply_text is not None
+        assert "<think>" in reply_text
+        assert "</think>" in reply_text
+        assert len(reply_text) > 0
+        assert "4" in reply_text.lower()
+
+
+class TestAsyncIntegration:
     @pytest.mark.integration
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
     @pytest.mark.asyncio
@@ -904,25 +984,3 @@ class TestTransformersChatGeneratorAsync:
         total_streamed_content = "".join(chunk.content for chunk in streaming_chunks)
         assert len(total_streamed_content.strip()) > 0
         assert "Paris" in total_streamed_content
-
-    def test_init_image_text_to_text(self, model_info_mock):
-        llm = TransformersChatGenerator(model="Qwen/Qwen2-VL-2B-Instruct")
-
-        assert llm
-        assert isinstance(llm, TransformersChatGenerator)
-        assert "model" in llm.huggingface_pipeline_kwargs
-
-    def test_init_image_text_to_text_task(self, model_info_mock):
-        generator = TransformersChatGenerator(
-            model="Qwen/Qwen2-VL-2B-Instruct",
-            task="image-text-to-text",
-            device=ComponentDevice.from_str("cpu"),
-            token=None,
-        )
-
-        assert generator.huggingface_pipeline_kwargs == {
-            "model": "Qwen/Qwen2-VL-2B-Instruct",
-            "task": "image-text-to-text",
-            "token": None,
-            "device": "cpu",
-        }

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -646,7 +646,9 @@ def test_add_answer_page_number_with_form_feed(mock_reader: TransformersExtracti
     "AutoModelForQuestionAnswering.from_pretrained"
 )
 def test_warm_up_use_hf_token(mocked_automodel, mocked_autotokenizer, initialized_token: Secret):
-    reader = TransformersExtractiveReader("deepset/roberta-base-squad2", device=ComponentDevice.from_str("cpu"))
+    reader = TransformersExtractiveReader(
+        "deepset/roberta-base-squad2", device=ComponentDevice.from_str("cpu"), token=initialized_token
+    )
 
     class MockedModel:
         def __init__(self):
@@ -664,7 +666,7 @@ def test_warm_up_use_hf_token(mocked_automodel, mocked_autotokenizer, initialize
     "haystack_integrations.components.readers.transformers.extractive_reader."
     "AutoModelForQuestionAnswering.from_pretrained"
 )
-def test_device_map_auto(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars_if_empty):
+def test_device_map_auto(mocked_automodel, _mocked_autotokenizer):
     reader = TransformersExtractiveReader("deepset/roberta-base-squad2", model_kwargs={"device_map": "auto"})
     auto_device = ComponentDevice.resolve_device(None)
 
@@ -686,7 +688,7 @@ def test_device_map_auto(mocked_automodel, _mocked_autotokenizer, del_hf_env_var
     "haystack_integrations.components.readers.transformers.extractive_reader."
     "AutoModelForQuestionAnswering.from_pretrained"
 )
-def test_device_map_str(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars_if_empty):
+def test_device_map_str(mocked_automodel, _mocked_autotokenizer):
     reader = TransformersExtractiveReader("deepset/roberta-base-squad2", model_kwargs={"device_map": "cpu:0"})
 
     class MockedModel:
@@ -707,7 +709,7 @@ def test_device_map_str(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars
     "haystack_integrations.components.readers.transformers.extractive_reader."
     "AutoModelForQuestionAnswering.from_pretrained"
 )
-def test_device_map_dict(mocked_automodel, _mocked_autotokenizer, del_hf_env_vars_if_empty):
+def test_device_map_dict(mocked_automodel, _mocked_autotokenizer):
     reader = TransformersExtractiveReader(
         "deepset/roberta-base-squad2", model_kwargs={"device_map": {"layer_1": 1, "classifier": "cpu"}}
     )
@@ -867,7 +869,7 @@ class TestDeduplication:
         assert keep is True
 
     def test_should_keep_missing_document_candidate_answer(
-        self, mock_reader: TransformersExtractiveReader, doc1: Document, candidate_answer: ExtractedAnswer
+        self, mock_reader: TransformersExtractiveReader, doc1: Document
     ):
         answer2 = "river in Maine"
         keep = mock_reader._should_keep(

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -17,6 +17,30 @@ from haystack.utils.device import ComponentDevice, DeviceMap
 from haystack_integrations.components.readers.transformers import TransformersExtractiveReader
 
 
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        reader = TransformersExtractiveReader(model="model", token=Secret.from_env_var("MISSING_HF_TOKEN"))
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            reader.warm_up()
+
+    @patch("haystack_integrations.components.readers.transformers.extractive_reader.AutoTokenizer.from_pretrained")
+    @patch(
+        "haystack_integrations.components.readers.transformers.extractive_reader."
+        "AutoModelForQuestionAnswering.from_pretrained"
+    )
+    def test_warm_up_is_idempotent(self, model_mock, tokenizer_mock):
+        model_mock.return_value.hf_device_map = {"": "cpu"}
+        reader = TransformersExtractiveReader(model="model", token=None)
+
+        reader.warm_up()
+        reader.warm_up()
+
+        model_mock.assert_called_once()
+        tokenizer_mock.assert_called_once()
+
+
 @pytest.fixture()
 def initialized_token(monkeypatch: MonkeyPatch) -> Secret:
     monkeypatch.setenv("HF_API_TOKEN", "secret-token")

--- a/integrations/transformers/tests/test_named_entity_extractor.py
+++ b/integrations/transformers/tests/test_named_entity_extractor.py
@@ -31,21 +31,12 @@ class TestComponentLifecycle:
         assert "MISSING_HF_TOKEN" in str(exc_info.value.__cause__)
 
     @patch("haystack_integrations.components.extractors.transformers.named_entity_extractor.pipeline")
-    @patch(
-        "haystack_integrations.components.extractors.transformers.named_entity_extractor."
-        "AutoModelForTokenClassification.from_pretrained"
-    )
-    @patch(
-        "haystack_integrations.components.extractors.transformers.named_entity_extractor.AutoTokenizer.from_pretrained"
-    )
-    def test_warm_up_is_idempotent(self, tokenizer_mock, model_mock, pipeline_mock):
+    def test_warm_up_is_idempotent(self, pipeline_mock):
         extractor = TransformersNamedEntityExtractor(model="model", token=None)
 
         extractor.warm_up()
         extractor.warm_up()
 
-        tokenizer_mock.assert_called_once()
-        model_mock.assert_called_once()
         pipeline_mock.assert_called_once()
 
 

--- a/integrations/transformers/tests/test_named_entity_extractor.py
+++ b/integrations/transformers/tests/test_named_entity_extractor.py
@@ -121,7 +121,7 @@ def test_named_entity_extractor_serde():
         _ = TransformersNamedEntityExtractor.from_dict(serde_data)
 
 
-def test_to_dict_default(del_hf_env_vars_if_empty):
+def test_to_dict_default():
     component = TransformersNamedEntityExtractor(
         model="dslim/bert-base-NER",
         device=ComponentDevice.from_str("mps"),
@@ -164,7 +164,7 @@ def test_to_dict_with_parameters():
     }
 
 
-def test_named_entity_extractor_from_dict_no_default_parameters(del_hf_env_vars_if_empty):
+def test_named_entity_extractor_from_dict_no_default_parameters():
     data = {
         "type": COMPONENT_TYPE,
         "init_parameters": {"model": "dslim/bert-base-NER"},

--- a/integrations/transformers/tests/test_named_entity_extractor.py
+++ b/integrations/transformers/tests/test_named_entity_extractor.py
@@ -20,6 +20,35 @@ COMPONENT_TYPE = (
 )
 
 
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        extractor = TransformersNamedEntityExtractor(model="model", token=Secret.from_env_var("MISSING_HF_TOKEN"))
+
+        with pytest.raises(ComponentError) as exc_info:
+            extractor.warm_up()
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "MISSING_HF_TOKEN" in str(exc_info.value.__cause__)
+
+    @patch("haystack_integrations.components.extractors.transformers.named_entity_extractor.pipeline")
+    @patch(
+        "haystack_integrations.components.extractors.transformers.named_entity_extractor."
+        "AutoModelForTokenClassification.from_pretrained"
+    )
+    @patch(
+        "haystack_integrations.components.extractors.transformers.named_entity_extractor.AutoTokenizer.from_pretrained"
+    )
+    def test_warm_up_is_idempotent(self, tokenizer_mock, model_mock, pipeline_mock):
+        extractor = TransformersNamedEntityExtractor(model="model", token=None)
+
+        extractor.warm_up()
+        extractor.warm_up()
+
+        tokenizer_mock.assert_called_once()
+        model_mock.assert_called_once()
+        pipeline_mock.assert_called_once()
+
+
 @pytest.fixture
 def raw_texts() -> list:
     return [
@@ -197,8 +226,6 @@ def test_named_entity_extractor_run():
 
     with patch.object(extractor, "_annotate", return_value=expected_annotations) as mock_annotate:
         extractor.pipeline = "mocked_pipeline"
-        extractor._warmed_up = True
-
         result = extractor.run(documents=documents, batch_size=2)
 
         mock_annotate.assert_called_once_with(["My name is Clara and I live in Berkeley, California."], batch_size=2)
@@ -219,7 +246,7 @@ def test_named_entity_extractor_run_fails_with_wrong_number_of_annotations():
     extractor = TransformersNamedEntityExtractor(model="dslim/bert-base-NER")
 
     with patch.object(extractor, "_annotate", return_value=[[]]):
-        extractor._warmed_up = True
+        extractor.pipeline = "mocked_pipeline"
 
         with pytest.raises(ComponentError, match="did not return the correct number of annotations"):
             extractor.run(documents=documents)

--- a/integrations/transformers/tests/test_text_router.py
+++ b/integrations/transformers/tests/test_text_router.py
@@ -54,7 +54,7 @@ class TestSerialization:
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
-    def test_from_dict(self, mock_auto_config_from_pretrained, del_hf_env_vars_if_empty):
+    def test_from_dict(self, mock_auto_config_from_pretrained):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         data = {
             "type": COMPONENT_TYPE,
@@ -82,7 +82,7 @@ class TestSerialization:
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
-    def test_from_dict_no_default_parameters(self, mock_auto_config_from_pretrained, del_hf_env_vars_if_empty):
+    def test_from_dict_no_default_parameters(self, mock_auto_config_from_pretrained):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         data = {
             "type": COMPONENT_TYPE,
@@ -101,7 +101,7 @@ class TestSerialization:
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
-    def test_from_dict_with_cpu_device(self, mock_auto_config_from_pretrained, del_hf_env_vars_if_empty):
+    def test_from_dict_with_cpu_device(self, mock_auto_config_from_pretrained):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         data = {
             "type": COMPONENT_TYPE,
@@ -155,41 +155,33 @@ class TestComponentLifecycle:
 
 
 class TestRun:
-    @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
     @patch("haystack_integrations.components.routers.transformers.text_router.pipeline")
-    def test_warm_up(self, hf_pipeline_mock, mock_auto_config_from_pretrained):
+    def test_warm_up(self, hf_pipeline_mock):
         hf_pipeline_mock.return_value = MagicMock(model=MagicMock(config=MagicMock(label2id={"en": 0, "de": 1})))
-        mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
-        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection")
+        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection", labels=["en", "de"])
         router.warm_up()
         assert router.pipeline is not None
 
-    @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
     @patch("haystack_integrations.components.routers.transformers.text_router.pipeline")
     @patch.object(TransformersTextRouter, "warm_up")
-    def test_run_calls_warm_up(self, warm_up_mock, hf_pipeline_mock, mock_auto_config_from_pretrained):
-        mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
+    def test_run_calls_warm_up(self, warm_up_mock, hf_pipeline_mock):
         hf_pipeline_mock.return_value = [{"label": "en", "score": 0.9}]
-        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection")
+        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection", labels=["en", "de"])
         warm_up_mock.side_effect = lambda: setattr(router, "pipeline", hf_pipeline_mock)
         router.run(text="test")
         warm_up_mock.assert_called_once()
 
-    @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
     @patch("haystack_integrations.components.routers.transformers.text_router.pipeline")
-    def test_run_fails_with_non_string_input(self, hf_pipeline_mock, mock_auto_config_from_pretrained):
-        mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
+    def test_run_fails_with_non_string_input(self, hf_pipeline_mock):
         hf_pipeline_mock.return_value = MagicMock(model=MagicMock(config=MagicMock(label2id={"en": 0, "de": 1})))
-        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection")
+        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection", labels=["en", "de"])
         with pytest.raises(TypeError):
             router.run(text=["wrong_input"])
 
-    @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
     @patch("haystack_integrations.components.routers.transformers.text_router.pipeline")
-    def test_run_unit(self, hf_pipeline_mock, mock_auto_config_from_pretrained):
-        mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
+    def test_run_unit(self, hf_pipeline_mock):
         hf_pipeline_mock.return_value = [{"label": "en", "score": 0.9}]
-        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection")
+        router = TransformersTextRouter(model="papluca/xlm-roberta-base-language-detection", labels=["en", "de"])
         router.pipeline = hf_pipeline_mock
         out = router.run("What is the color of the sky?")
         assert router.pipeline is not None

--- a/integrations/transformers/tests/test_text_router.py
+++ b/integrations/transformers/tests/test_text_router.py
@@ -12,7 +12,7 @@ from haystack_integrations.components.routers.transformers import TransformersTe
 COMPONENT_TYPE = "haystack_integrations.components.routers.transformers.text_router.TransformersTextRouter"
 
 
-class TestTransformersTextRouter:
+class TestSerialization:
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
     def test_to_dict(self, mock_auto_config_from_pretrained):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
@@ -79,7 +79,6 @@ class TestTransformersTextRouter:
             "model": "papluca/xlm-roberta-base-language-detection",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "text-classification",
-            "token": component.token.resolve_value(),
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
@@ -99,7 +98,6 @@ class TestTransformersTextRouter:
             "model": "papluca/xlm-roberta-base-language-detection",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "text-classification",
-            "token": component.token.resolve_value(),
         }
 
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
@@ -128,9 +126,35 @@ class TestTransformersTextRouter:
             "model": "papluca/xlm-roberta-base-language-detection",
             "device": ComponentDevice.from_str("cpu").to_hf(),
             "task": "text-classification",
-            "token": component.token.resolve_value(),
         }
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_init_when_labels_are_inferred(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            TransformersTextRouter(model="model", token=Secret.from_env_var("MISSING_HF_TOKEN"))
+
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        router = TransformersTextRouter(model="model", labels=["label"], token=Secret.from_env_var("MISSING_HF_TOKEN"))
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            router.warm_up()
+
+    @patch("haystack_integrations.components.routers.transformers.text_router.pipeline")
+    def test_warm_up_is_idempotent(self, pipeline_mock):
+        pipeline_mock.return_value = MagicMock(model=MagicMock(config=MagicMock(label2id={"label": 0})))
+        router = TransformersTextRouter(model="model", labels=["label"], token=None)
+
+        router.warm_up()
+        router.warm_up()
+
+        pipeline_mock.assert_called_once()
+
+
+class TestRun:
     @patch("haystack_integrations.components.routers.transformers.text_router.AutoConfig.from_pretrained")
     @patch("haystack_integrations.components.routers.transformers.text_router.pipeline")
     def test_warm_up(self, hf_pipeline_mock, mock_auto_config_from_pretrained):
@@ -171,6 +195,8 @@ class TestTransformersTextRouter:
         assert router.pipeline is not None
         assert out == {"en": "What is the color of the sky?"}
 
+
+class TestIntegration:
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
         router = TransformersTextRouter(

--- a/integrations/transformers/tests/test_utils.py
+++ b/integrations/transformers/tests/test_utils.py
@@ -7,13 +7,39 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from haystack.utils.auth import Secret
 from haystack.utils.device import ComponentDevice
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 from haystack_integrations.common.transformers.utils import (
     _resolve_hf_device_map,
     _StopWordsCriteria,
+    _with_hf_token,
 )
+
+
+def test_with_hf_token_resolves_token_without_mutating_kwargs():
+    hf_kwargs = {"model": "model"}
+    token = Mock(spec=Secret)
+    token.resolve_value.return_value = "resolved-token"
+
+    resolved_kwargs = _with_hf_token(hf_kwargs, token)
+
+    assert resolved_kwargs == {"model": "model", "token": "resolved-token"}
+    assert hf_kwargs == {"model": "model"}
+
+
+def test_with_hf_token_preserves_explicit_token_without_resolving_secret():
+    token = Mock(spec=Secret)
+
+    resolved_kwargs = _with_hf_token({"token": "explicit-token"}, token)
+
+    assert resolved_kwargs == {"token": "explicit-token"}
+    token.resolve_value.assert_not_called()
+
+
+def test_with_hf_token_adds_none_when_token_is_not_provided():
+    assert _with_hf_token({}, None) == {"token": None}
 
 
 def test_resolve_hf_device_map_only_device():

--- a/integrations/transformers/tests/test_zero_shot_document_classifier.py
+++ b/integrations/transformers/tests/test_zero_shot_document_classifier.py
@@ -52,7 +52,7 @@ class TestInitializationAndSerialization:
             },
         }
 
-    def test_from_dict(self, del_hf_env_vars_if_empty):
+    def test_from_dict(self):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {
@@ -82,7 +82,7 @@ class TestInitializationAndSerialization:
             "task": "zero-shot-classification",
         }
 
-    def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
+    def test_from_dict_no_default_parameters(self):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {"model": "cross-encoder/nli-deberta-v3-xsmall", "labels": ["positive", "negative"]},

--- a/integrations/transformers/tests/test_zero_shot_document_classifier.py
+++ b/integrations/transformers/tests/test_zero_shot_document_classifier.py
@@ -17,7 +17,7 @@ COMPONENT_TYPE = (
 )
 
 
-class TestTransformersZeroShotDocumentClassifier:
+class TestInitializationAndSerialization:
     def test_init(self):
         component = TransformersZeroShotDocumentClassifier(
             model="cross-encoder/nli-deberta-v3-xsmall", labels=["positive", "negative"]
@@ -80,7 +80,6 @@ class TestTransformersZeroShotDocumentClassifier:
             "model": "cross-encoder/nli-deberta-v3-xsmall",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": component.token.resolve_value(),
         }
 
     def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
@@ -98,9 +97,46 @@ class TestTransformersZeroShotDocumentClassifier:
             "model": "cross-encoder/nli-deberta-v3-xsmall",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": component.token.resolve_value(),
         }
 
+    def test_serialization_and_deserialization_pipeline(self, in_memory_doc_store):
+        pipeline = Pipeline()
+        retriever = InMemoryBM25Retriever(document_store=in_memory_doc_store)
+        document_classifier = TransformersZeroShotDocumentClassifier(
+            model="cross-encoder/nli-deberta-v3-xsmall", labels=["positive", "negative"]
+        )
+
+        pipeline.add_component(instance=retriever, name="retriever")
+        pipeline.add_component(instance=document_classifier, name="document_classifier")
+        pipeline.connect("retriever", "document_classifier")
+        pipeline_dump = pipeline.dumps()
+
+        new_pipeline = Pipeline.loads(pipeline_dump)
+
+        assert new_pipeline == pipeline
+
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        component = TransformersZeroShotDocumentClassifier(
+            model="model", labels=["label"], token=Secret.from_env_var("MISSING_HF_TOKEN")
+        )
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.classifiers.transformers.zero_shot_document_classifier.pipeline")
+    def test_warm_up_is_idempotent(self, pipeline_mock):
+        component = TransformersZeroShotDocumentClassifier(model="model", labels=["label"], token=None)
+
+        component.warm_up()
+        component.warm_up()
+
+        pipeline_mock.assert_called_once()
+
+
+class TestRun:
     @patch("haystack_integrations.components.classifiers.transformers.zero_shot_document_classifier.pipeline")
     def test_warm_up(self, hf_pipeline_mock):
         component = TransformersZeroShotDocumentClassifier(
@@ -164,6 +200,8 @@ class TestTransformersZeroShotDocumentClassifier:
         with pytest.raises(ValueError, match="do not have the classification field 'title': 0"):
             component.run(documents=documents)
 
+
+class TestIntegration:
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
         component = TransformersZeroShotDocumentClassifier(
@@ -179,19 +217,3 @@ class TestTransformersZeroShotDocumentClassifier:
         assert result["documents"][1].to_dict()["classification"]["label"] == "negative"
         assert "classification" not in positive_document.to_dict()
         assert "classification" not in negative_document.to_dict()
-
-    def test_serialization_and_deserialization_pipeline(self, in_memory_doc_store):
-        pipeline = Pipeline()
-        retriever = InMemoryBM25Retriever(document_store=in_memory_doc_store)
-        document_classifier = TransformersZeroShotDocumentClassifier(
-            model="cross-encoder/nli-deberta-v3-xsmall", labels=["positive", "negative"]
-        )
-
-        pipeline.add_component(instance=retriever, name="retriever")
-        pipeline.add_component(instance=document_classifier, name="document_classifier")
-        pipeline.connect("retriever", "document_classifier")
-        pipeline_dump = pipeline.dumps()
-
-        new_pipeline = Pipeline.loads(pipeline_dump)
-
-        assert new_pipeline == pipeline

--- a/integrations/transformers/tests/test_zero_shot_text_router.py
+++ b/integrations/transformers/tests/test_zero_shot_text_router.py
@@ -14,7 +14,7 @@ COMPONENT_TYPE = (
 )
 
 
-class TestTransformersZeroShotTextRouter:
+class TestSerialization:
     def test_to_dict(self):
         router = TransformersZeroShotTextRouter(labels=["query", "passage"])
         router_dict = router.to_dict()
@@ -64,7 +64,6 @@ class TestTransformersZeroShotTextRouter:
             "model": "MoritzLaurer/deberta-v3-base-zeroshot-v1.1-all-33",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": component.token.resolve_value(),
         }
 
     def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
@@ -82,9 +81,28 @@ class TestTransformersZeroShotTextRouter:
             "model": "MoritzLaurer/deberta-v3-base-zeroshot-v1.1-all-33",
             "device": ComponentDevice.resolve_device(None).to_hf(),
             "task": "zero-shot-classification",
-            "token": component.token.resolve_value(),
         }
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_HF_TOKEN", raising=False)
+        router = TransformersZeroShotTextRouter(labels=["label"], token=Secret.from_env_var("MISSING_HF_TOKEN"))
+
+        with pytest.raises(ValueError, match="MISSING_HF_TOKEN"):
+            router.warm_up()
+
+    @patch("haystack_integrations.components.routers.transformers.zero_shot_text_router.pipeline")
+    def test_warm_up_is_idempotent(self, pipeline_mock):
+        router = TransformersZeroShotTextRouter(labels=["label"], token=None)
+
+        router.warm_up()
+        router.warm_up()
+
+        pipeline_mock.assert_called_once()
+
+
+class TestRun:
     @patch("haystack_integrations.components.routers.transformers.zero_shot_text_router.pipeline")
     def test_warm_up(self, hf_pipeline_mock):
         router = TransformersZeroShotTextRouter(labels=["query", "passage"])
@@ -118,6 +136,8 @@ class TestTransformersZeroShotTextRouter:
         assert router.pipeline is not None
         assert out == {"query": "What is the color of the sky?"}
 
+
+class TestIntegration:
     @pytest.mark.integration
     def test_run(self, del_hf_env_vars_if_empty):
         router = TransformersZeroShotTextRouter(labels=["query", "passage"], device=ComponentDevice.from_str("cpu"))

--- a/integrations/transformers/tests/test_zero_shot_text_router.py
+++ b/integrations/transformers/tests/test_zero_shot_text_router.py
@@ -32,7 +32,7 @@ class TestSerialization:
             },
         }
 
-    def test_multi_label_survives_a_serialization_round_trip(self, del_hf_env_vars_if_empty):
+    def test_multi_label_survives_a_serialization_round_trip(self):
         """`multi_label` changes how the pipeline normalizes scores, so losing it changes routing decisions."""
         router = TransformersZeroShotTextRouter(labels=["query", "passage"], multi_label=True)
 
@@ -40,7 +40,7 @@ class TestSerialization:
 
         assert restored.multi_label is True
 
-    def test_from_dict(self, del_hf_env_vars_if_empty):
+    def test_from_dict(self):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {
@@ -66,7 +66,7 @@ class TestSerialization:
             "task": "zero-shot-classification",
         }
 
-    def test_from_dict_no_default_parameters(self, del_hf_env_vars_if_empty):
+    def test_from_dict_no_default_parameters(self):
         data = {
             "type": COMPONENT_TYPE,
             "init_parameters": {"labels": ["query", "passage"]},


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- pin `haystack-ai>=3.0.0` and `transformers>=5.0.0`: allows removing some compatibility code
- make `__init__` do basic validation and store configuration; network access and secret resolution only happens in `warm_up`
  - `TransformersTextRouter` is an exception: if the user does not provide explicit `labels`, it still needs to contact Hugging Face Hub at `__init__`: labels become the output sockets of the component
- Chat Generator: add `close` method that only shuts down the executor (no way to release the model); removed `shutdown` and `__del__`

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
