### PR TITLE
fix(transformers): serialize overlap_threshold in TransformersExtractiveReader.to_dict

### DIFF
--- a/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
+++ b/integrations/transformers/src/haystack_integrations/components/readers/transformers/extractive_reader.py
@@ -150,6 +150,7 @@ class TransformersExtractiveReader:
             answers_per_seq=self.answers_per_seq,
             no_answer=self.no_answer,
             calibration_factor=self.calibration_factor,
+            overlap_threshold=self.overlap_threshold,
             model_kwargs=self.model_kwargs,
         )
 

--- a/integrations/transformers/tests/test_extractive_reader.py
+++ b/integrations/transformers/tests/test_extractive_reader.py
@@ -126,6 +126,7 @@ def test_to_dict(initialized_token: Secret):
             "answers_per_seq": None,
             "no_answer": True,
             "calibration_factor": 0.1,
+            "overlap_threshold": 0.01,
             "model_kwargs": {
                 "torch_dtype": "torch.float16",
                 "device_map": ComponentDevice.resolve_device(None).to_hf(),
@@ -154,6 +155,7 @@ def test_to_dict_no_token():
             "answers_per_seq": None,
             "no_answer": True,
             "calibration_factor": 0.1,
+            "overlap_threshold": 0.01,
             "model_kwargs": {
                 "torch_dtype": "torch.float16",
                 "device_map": ComponentDevice.resolve_device(None).to_hf(),
@@ -182,6 +184,7 @@ def test_to_dict_empty_model_kwargs(initialized_token: Secret):
             "answers_per_seq": None,
             "no_answer": True,
             "calibration_factor": 0.1,
+            "overlap_threshold": 0.01,
             "model_kwargs": {"device_map": ComponentDevice.resolve_device(None).to_hf()},
         },
     }
@@ -215,6 +218,7 @@ def test_to_dict_device_map(device_map, expected):
             "answers_per_seq": None,
             "no_answer": True,
             "calibration_factor": 0.1,
+            "overlap_threshold": 0.01,
             "model_kwargs": {"device_map": expected},
         },
     }
@@ -237,6 +241,7 @@ def test_from_dict():
             "answers_per_seq": None,
             "no_answer": True,
             "calibration_factor": 0.1,
+            "overlap_threshold": 0.01,
             "model_kwargs": {"torch_dtype": "torch.float16"},
         },
     }
@@ -253,11 +258,22 @@ def test_from_dict():
     assert component.answers_per_seq is None
     assert component.no_answer
     assert component.calibration_factor == 0.1
+    assert component.overlap_threshold == 0.01
     # torch_dtype is correctly deserialized
     assert component.model_kwargs == {
         "torch_dtype": torch.float16,
         "device_map": ComponentDevice.resolve_device(None).to_hf(),
     }
+
+
+def test_to_dict_from_dict_roundtrip_preserves_non_default_overlap_threshold():
+    component = TransformersExtractiveReader("my-model", token=None, overlap_threshold=0.5)
+
+    data = component.to_dict()
+    assert data["init_parameters"]["overlap_threshold"] == 0.5
+
+    restored = TransformersExtractiveReader.from_dict(data)
+    assert restored.overlap_threshold == 0.5
 
 
 def test_from_dict_no_default_parameters():
@@ -301,6 +317,7 @@ def test_from_dict_no_token():
             "answers_per_seq": None,
             "no_answer": True,
             "calibration_factor": 0.1,
+            "overlap_threshold": 0.01,
             "model_kwargs": {"torch_dtype": "torch.float16"},
         },
     }


### PR DESCRIPTION
### Problem

`TransformersExtractiveReader.__init__` takes `overlap_threshold` (default `0.01`), stores it on the instance, and `run()` uses it as the fallback when the per-call `overlap_threshold` argument is omitted:

```python
overlap_threshold = overlap_threshold or self.overlap_threshold
```

But `to_dict()` doesn't serialize it. A reader configured with a custom `overlap_threshold` — or with `None` to disable answer de-duplication entirely — silently reverts to `0.01` after `to_dict()` → `from_dict()`, so the setting is lost whenever a pipeline is saved and reloaded.

### Fix

Add `overlap_threshold=self.overlap_threshold` to the `default_to_dict` call.

### Tests

- The existing `test_to_dict*` assertions now include the key.
- New `test_to_dict_from_dict_roundtrip_preserves_non_default_overlap_threshold` pins a non-default value through a full round-trip.
- Both fail with the `to_dict` line reverted (verified locally: `hatch run test:unit tests/test_extractive_reader.py` — 35 passed with the fix, 7 failed without; `hatch run fmt-check` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uqJtTJWawYLVA5EdpUmho