### PR TITLE
fix(amazon_bedrock): serialize boto3_config in S3Downloader.to_dict

### DIFF
--- a/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
+++ b/integrations/amazon_bedrock/src/haystack_integrations/components/downloaders/s3/s3_downloader.py
@@ -299,6 +299,7 @@ class S3Downloader:
             aws_session_token=self.aws_session_token,
             aws_region_name=self.aws_region_name,
             aws_profile_name=self.aws_profile_name,
+            boto3_config=self.boto3_config,
             file_root_path=str(self.file_root_path),
             max_workers=self.max_workers,
             max_cache_size=self.max_cache_size,

--- a/integrations/amazon_bedrock/tests/test_s3_downloader.py
+++ b/integrations/amazon_bedrock/tests/test_s3_downloader.py
@@ -83,6 +83,7 @@ class TestS3Downloader:
                     "env_vars": ["AWS_PROFILE"],
                     "strict": False,
                 },
+                "boto3_config": boto3_config,
                 "file_root_path": str(tmp_path),
                 "file_extensions": None,
                 "max_cache_size": 100,
@@ -124,6 +125,7 @@ class TestS3Downloader:
                     "env_vars": ["AWS_PROFILE"],
                     "strict": False,
                 },
+                "boto3_config": boto3_config,
                 "file_root_path": str(tmp_path),
                 "s3_key_generation_function": None,
                 "s3_bucket_name_env": "S3_DOWNLOADER_BUCKET",
@@ -131,6 +133,7 @@ class TestS3Downloader:
         }
         d = S3Downloader.from_dict(data)
         assert Path(d.file_root_path) == tmp_path
+        assert d.boto3_config == boto3_config
 
     def test_to_dict_with_parameters(self, tmp_path):
         d = S3Downloader(
@@ -170,6 +173,7 @@ class TestS3Downloader:
                     "env_vars": ["AWS_PROFILE"],
                     "strict": False,
                 },
+                "boto3_config": None,
                 "file_root_path": str(tmp_path),
                 "file_extensions": [".txt"],
                 "max_cache_size": 400,


### PR DESCRIPTION
### Problem

`S3Downloader.__init__` takes `boto3_config` (a dict of options for the underlying boto3 client — timeouts, retries, proxies, …), stores it on the instance, and applies it at warm-up:

```python
Config(user_agent_extra="x-client-framework:haystack", **(self.boto3_config if self.boto3_config else {}))
```

`to_dict()` doesn't serialize it, so a downloader configured with a custom `boto3_config` loses it on `to_dict()` → `from_dict()`.

`test_to_dict` and `test_from_dict` are already `@pytest.mark.parametrize`-d over `boto3_config = [None, {"read_timeout": 10}]`, but the expected dict omits the key, so both parameter sets passed whatever `to_dict` did — the parametrization wasn't testing anything.

### Fix

Add `boto3_config=self.boto3_config` to the `default_to_dict` call.

### Tests

- `boto3_config` added to the expected dict in `test_to_dict` / `test_to_dict_with_parameters` and to the input in `test_from_dict`, with an assertion that the value survives `from_dict`.
- The `test_to_dict*` cases fail with the fix reverted (verified locally: `hatch run test:unit tests/test_s3_downloader.py` — 29 passed with the fix, 3 failed without; ruff clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uqJtTJWawYLVA5EdpUmho