### PR TITLE
feat!: vLLM - add lifecycle handling

### DIFF
--- a/integrations/vllm/pyproject.toml
+++ b/integrations/vllm/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.30.0", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0"]
+dependencies = ["haystack-ai>=3.0.0", "openai", "more_itertools>=9.0.0", "tqdm>=4.48.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/vllm#readme"

--- a/integrations/vllm/src/haystack_integrations/common/vllm/utils.py
+++ b/integrations/vllm/src/haystack_integrations/common/vllm/utils.py
@@ -9,15 +9,14 @@ from haystack.utils.http_client import init_http_client
 from openai import AsyncOpenAI, OpenAI
 
 
-def _create_openai_clients(
+def _openai_client_kwargs(
     api_key: Secret | None,
     api_base_url: str,
     timeout: float | None,
     max_retries: int | None,
-    http_client_kwargs: dict[str, Any] | None,
-) -> tuple[OpenAI, AsyncOpenAI]:
+) -> dict[str, Any]:
     """
-    Build sync and async OpenAI clients pointing at a vLLM server.
+    Build the common keyword arguments for OpenAI clients pointing at a vLLM server.
 
     A placeholder api key is used when the user did not supply one and no `VLLM_API_KEY` env var is set, because the
     OpenAI client requires a non-empty value.
@@ -33,11 +32,34 @@ def _create_openai_clients(
     if max_retries is not None:
         client_kwargs["max_retries"] = max_retries
 
+    return client_kwargs
+
+
+def _create_openai_client(
+    api_key: Secret | None,
+    api_base_url: str,
+    timeout: float | None,
+    max_retries: int | None,
+    http_client_kwargs: dict[str, Any] | None,
+) -> OpenAI:
+    """Build a synchronous OpenAI client pointing at a vLLM server."""
+    client_kwargs = _openai_client_kwargs(api_key, api_base_url, timeout, max_retries)
+    sync_http_client = init_http_client(http_client_kwargs, async_client=False)
     # openai>=3 annotates http_client as httpx2, but legacy httpx clients are supported at runtime.
     # https://github.com/openai/openai-python/blob/main/httpx2.md
-    sync_http_client = init_http_client(http_client_kwargs, async_client=False)
-    async_http_client = init_http_client(http_client_kwargs, async_client=True)
+    return OpenAI(http_client=sync_http_client, **client_kwargs)  # type: ignore[arg-type]
 
-    sync_client = OpenAI(http_client=sync_http_client, **client_kwargs)  # type: ignore[arg-type]
-    async_client = AsyncOpenAI(http_client=async_http_client, **client_kwargs)  # type: ignore[arg-type]
-    return sync_client, async_client
+
+def _create_async_openai_client(
+    api_key: Secret | None,
+    api_base_url: str,
+    timeout: float | None,
+    max_retries: int | None,
+    http_client_kwargs: dict[str, Any] | None,
+) -> AsyncOpenAI:
+    """Build an asynchronous OpenAI client pointing at a vLLM server."""
+    client_kwargs = _openai_client_kwargs(api_key, api_base_url, timeout, max_retries)
+    async_http_client = init_http_client(http_client_kwargs, async_client=True)
+    # openai>=3 annotates http_client as httpx2, but legacy httpx clients are supported at runtime.
+    # https://github.com/openai/openai-python/blob/main/httpx2.md
+    return AsyncOpenAI(http_client=async_http_client, **client_kwargs)  # type: ignore[arg-type]

--- a/integrations/vllm/src/haystack_integrations/components/embedders/vllm/document_embedder.py
+++ b/integrations/vllm/src/haystack_integrations/components/embedders/vllm/document_embedder.py
@@ -12,7 +12,7 @@ from openai import APIError, AsyncOpenAI, OpenAI
 from tqdm import tqdm
 from tqdm.asyncio import tqdm as async_tqdm
 
-from haystack_integrations.common.vllm.utils import _create_openai_clients
+from haystack_integrations.common.vllm.utils import _create_async_openai_client, _create_openai_client
 
 logger = logging.getLogger(__name__)
 
@@ -131,20 +131,40 @@ class VLLMDocumentEmbedder:
 
         self._client: OpenAI | None = None
         self._async_client: AsyncOpenAI | None = None
-        self._is_warmed_up = False
 
     def warm_up(self) -> None:
-        """Create the OpenAI clients."""
-        if self._is_warmed_up:
-            return
-        self._client, self._async_client = _create_openai_clients(
-            api_key=self.api_key,
-            api_base_url=self.api_base_url,
-            timeout=self.timeout,
-            max_retries=self.max_retries,
-            http_client_kwargs=self.http_client_kwargs,
-        )
-        self._is_warmed_up = True
+        """Create the synchronous OpenAI client."""
+        if self._client is None:
+            self._client = _create_openai_client(
+                api_key=self.api_key,
+                api_base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client_kwargs=self.http_client_kwargs,
+            )
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous OpenAI client."""
+        if self._async_client is None:
+            self._async_client = _create_async_openai_client(
+                api_key=self.api_key,
+                api_base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client_kwargs=self.http_client_kwargs,
+            )
+
+    def close(self) -> None:
+        """Close the synchronous OpenAI client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous OpenAI client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def _prepare_texts_to_embed(self, documents: list[Document]) -> dict[str, str]:
         """Concatenate each Document's text with the selected meta fields."""
@@ -254,8 +274,8 @@ class VLLMDocumentEmbedder:
         if not documents:
             return {"documents": [], "meta": {}}
 
-        if not self._is_warmed_up:
-            self.warm_up()
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
 
         texts_to_embed = self._prepare_texts_to_embed(documents)
         doc_ids_to_embeddings, meta = self._embed_batch(texts_to_embed, self.batch_size)
@@ -280,8 +300,8 @@ class VLLMDocumentEmbedder:
         if not documents:
             return {"documents": [], "meta": {}}
 
-        if not self._is_warmed_up:
-            self.warm_up()
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
 
         texts_to_embed = self._prepare_texts_to_embed(documents)
         doc_ids_to_embeddings, meta = await self._embed_batch_async(texts_to_embed, self.batch_size)

--- a/integrations/vllm/src/haystack_integrations/components/embedders/vllm/text_embedder.py
+++ b/integrations/vllm/src/haystack_integrations/components/embedders/vllm/text_embedder.py
@@ -9,7 +9,7 @@ from haystack.utils import Secret
 from openai import AsyncOpenAI, OpenAI
 from openai.types import CreateEmbeddingResponse
 
-from haystack_integrations.common.vllm.utils import _create_openai_clients
+from haystack_integrations.common.vllm.utils import _create_async_openai_client, _create_openai_client
 
 
 @component
@@ -103,20 +103,40 @@ class VLLMTextEmbedder:
 
         self._client: OpenAI | None = None
         self._async_client: AsyncOpenAI | None = None
-        self._is_warmed_up = False
 
     def warm_up(self) -> None:
-        """Create the OpenAI clients."""
-        if self._is_warmed_up:
-            return
-        self._client, self._async_client = _create_openai_clients(
-            api_key=self.api_key,
-            api_base_url=self.api_base_url,
-            timeout=self.timeout,
-            max_retries=self.max_retries,
-            http_client_kwargs=self.http_client_kwargs,
-        )
-        self._is_warmed_up = True
+        """Create the synchronous OpenAI client."""
+        if self._client is None:
+            self._client = _create_openai_client(
+                api_key=self.api_key,
+                api_base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client_kwargs=self.http_client_kwargs,
+            )
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous OpenAI client."""
+        if self._async_client is None:
+            self._async_client = _create_async_openai_client(
+                api_key=self.api_key,
+                api_base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client_kwargs=self.http_client_kwargs,
+            )
+
+    def close(self) -> None:
+        """Close the synchronous OpenAI client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous OpenAI client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def _prepare_input(self, text: str) -> dict[str, Any]:
         if not isinstance(text, str):
@@ -155,8 +175,7 @@ class VLLMTextEmbedder:
             - `meta`: Information about the usage of the model.
         """
         kwargs = self._prepare_input(text)
-        if not self._is_warmed_up:
-            self.warm_up()
+        self.warm_up()
         assert self._client is not None  # noqa: S101
         response = self._client.embeddings.create(**kwargs)
         return self._prepare_output(response)
@@ -172,8 +191,7 @@ class VLLMTextEmbedder:
             - `meta`: Information about the usage of the model.
         """
         kwargs = self._prepare_input(text)
-        if not self._is_warmed_up:
-            self.warm_up()
+        await self.warm_up_async()
         assert self._async_client is not None  # noqa: S101
         response = await self._async_client.embeddings.create(**kwargs)
         return self._prepare_output(response)

--- a/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
+++ b/integrations/vllm/src/haystack_integrations/components/generators/vllm/chat/chat_generator.py
@@ -37,7 +37,7 @@ from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat.chat_completion import Choice
 
-from haystack_integrations.common.vllm.utils import _create_openai_clients
+from haystack_integrations.common.vllm.utils import _create_async_openai_client, _create_openai_client
 
 logger = logging.getLogger(__name__)
 
@@ -255,22 +255,48 @@ class VLLMChatGenerator:
 
         self._client: OpenAI | None = None
         self._async_client: AsyncOpenAI | None = None
-        self._is_warmed_up = False
+        self._tools_warmed_up = False
+
+    def _warm_up_tools(self) -> None:
+        if not self._tools_warmed_up:
+            warm_up_tools(self.tools)
+            self._tools_warmed_up = True
 
     def warm_up(self) -> None:
-        """Create the OpenAI clients and warm up tools."""
-        if self._is_warmed_up:
-            return
+        """Create the synchronous OpenAI client and warm up tools."""
+        self._warm_up_tools()
+        if self._client is None:
+            self._client = _create_openai_client(
+                api_key=self.api_key,
+                api_base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client_kwargs=self.http_client_kwargs,
+            )
 
-        self._client, self._async_client = _create_openai_clients(
-            api_key=self.api_key,
-            api_base_url=self.api_base_url,
-            timeout=self.timeout,
-            max_retries=self.max_retries,
-            http_client_kwargs=self.http_client_kwargs,
-        )
-        warm_up_tools(self.tools)
-        self._is_warmed_up = True
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous OpenAI client and warm up tools."""
+        self._warm_up_tools()
+        if self._async_client is None:
+            self._async_client = _create_async_openai_client(
+                api_key=self.api_key,
+                api_base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client_kwargs=self.http_client_kwargs,
+            )
+
+    def close(self) -> None:
+        """Close the synchronous OpenAI client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous OpenAI client."""
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -464,9 +490,9 @@ class VLLMChatGenerator:
             A dictionary with the following key:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
+        self.warm_up()
+        assert self._client is not None  # noqa: S101
         messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
-            self.warm_up()
 
         if len(messages) == 0:
             return {"replies": []}
@@ -476,7 +502,6 @@ class VLLMChatGenerator:
         )
 
         api_kwargs = self._prepare_api_call(messages, streaming_callback, generation_kwargs, tools)
-        assert self._client is not None  # noqa: S101
         chat_completion = self._client.chat.completions.create(**api_kwargs)
 
         if streaming_callback is not None:
@@ -523,9 +548,9 @@ class VLLMChatGenerator:
             A dictionary with the following key:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
+        await self.warm_up_async()
+        assert self._async_client is not None  # noqa: S101
         messages = _normalize_messages(messages)
-        if not self._is_warmed_up:
-            self.warm_up()
 
         if len(messages) == 0:
             return {"replies": []}
@@ -535,7 +560,6 @@ class VLLMChatGenerator:
         )
 
         api_kwargs = self._prepare_api_call(messages, streaming_callback, generation_kwargs, tools)
-        assert self._async_client is not None  # noqa: S101
         chat_completion = await self._async_client.chat.completions.create(**api_kwargs)
 
         if streaming_callback is not None:

--- a/integrations/vllm/src/haystack_integrations/components/rankers/vllm/ranker.py
+++ b/integrations/vllm/src/haystack_integrations/components/rankers/vllm/ranker.py
@@ -127,14 +127,14 @@ class VLLMRanker:
         """Create the synchronous HTTP client."""
         if self._client is None:
             client = init_http_client(http_client_kwargs=self._client_kwargs(), async_client=False)
-            assert isinstance(client, httpx.Client)  # noqa: S101
+            assert client is not None  # noqa: S101
             self._client = client
 
     async def warm_up_async(self) -> None:
         """Create the asynchronous HTTP client."""
         if self._async_client is None:
             client = init_http_client(http_client_kwargs=self._client_kwargs(), async_client=True)
-            assert isinstance(client, httpx.AsyncClient)  # noqa: S101
+            assert client is not None  # noqa: S101
             self._async_client = client
 
     def close(self) -> None:

--- a/integrations/vllm/src/haystack_integrations/components/rankers/vllm/ranker.py
+++ b/integrations/vllm/src/haystack_integrations/components/rankers/vllm/ranker.py
@@ -109,24 +109,45 @@ class VLLMRanker:
         self.http_client_kwargs = http_client_kwargs
         self.extra_parameters = extra_parameters
 
-        self._headers = {"Content-Type": "application/json"}
-        if self.api_key is not None and (resolved_key := self.api_key.resolve_value()):
-            self._headers["Authorization"] = f"Bearer {resolved_key}"
-
         self._client: httpx.Client | None = None
         self._async_client: httpx.AsyncClient | None = None
-        self._is_warmed_up = False
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments used to create HTTP clients."""
+        headers = httpx.Headers((self.http_client_kwargs or {}).get("headers"))
+        headers["Content-Type"] = "application/json"
+        if self.api_key is not None and (resolved_key := self.api_key.resolve_value()):
+            headers["Authorization"] = f"Bearer {resolved_key}"
+
+        client_kwargs = self.http_client_kwargs.copy() if self.http_client_kwargs else {}
+        client_kwargs["headers"] = headers
+        return client_kwargs
 
     def warm_up(self) -> None:
-        """Create the httpx clients."""
-        if self._is_warmed_up:
-            return
+        """Create the synchronous HTTP client."""
+        if self._client is None:
+            client = init_http_client(http_client_kwargs=self._client_kwargs(), async_client=False)
+            assert isinstance(client, httpx.Client)  # noqa: S101
+            self._client = client
 
-        client = init_http_client(self.http_client_kwargs, async_client=False)
-        async_client = init_http_client(self.http_client_kwargs, async_client=True)
-        self._client = client if client is not None else httpx.Client()
-        self._async_client = async_client if async_client is not None else httpx.AsyncClient()
-        self._is_warmed_up = True
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous HTTP client."""
+        if self._async_client is None:
+            client = init_http_client(http_client_kwargs=self._client_kwargs(), async_client=True)
+            assert isinstance(client, httpx.AsyncClient)  # noqa: S101
+            self._async_client = client
+
+    def close(self) -> None:
+        """Close the synchronous HTTP client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous HTTP client."""
+        if self._async_client is not None:
+            await self._async_client.aclose()
+            self._async_client = None
 
     def _prepare_texts(self, documents: list[Document]) -> list[str]:
         """Concatenate each Document's text with the selected meta fields."""
@@ -210,13 +231,12 @@ class VLLMRanker:
 
         top_k, score_threshold = self._resolve_run_params(top_k, score_threshold)
 
-        if not self._is_warmed_up:
-            self.warm_up()
+        self.warm_up()
         assert self._client is not None  # noqa: S101
 
         body = self._prepare_request(query, documents, top_k)
         url = f"{self.api_base_url.rstrip('/')}/rerank"
-        response = self._client.post(url, json=body, headers=self._headers)
+        response = self._client.post(url, json=body)
         return self._parse_response(response.json(), documents, score_threshold)
 
     @component.output_types(documents=list[Document], meta=dict[str, Any])
@@ -246,11 +266,10 @@ class VLLMRanker:
 
         top_k, score_threshold = self._resolve_run_params(top_k, score_threshold)
 
-        if not self._is_warmed_up:
-            self.warm_up()
+        await self.warm_up_async()
         assert self._async_client is not None  # noqa: S101
 
         body = self._prepare_request(query, documents, top_k)
         url = f"{self.api_base_url.rstrip('/')}/rerank"
-        response = await self._async_client.post(url, json=body, headers=self._headers)
+        response = await self._async_client.post(url, json=body)
         return self._parse_response(response.json(), documents, score_threshold)

--- a/integrations/vllm/tests/test_chat_generator.py
+++ b/integrations/vllm/tests/test_chat_generator.py
@@ -223,7 +223,7 @@ class TestConvertChatCompletionToChatMessage:
         assert len(message.tool_calls) == 0
 
 
-class TestVLLMChatGeneratorInit:
+class TestInitialization:
     def test_init_default(self):
         component = VLLMChatGenerator(model=MODEL)
 
@@ -251,7 +251,7 @@ class TestVLLMChatGeneratorInit:
 
         assert component._client is None
         assert component._async_client is None
-        assert not component._is_warmed_up
+        assert not component._tools_warmed_up
         assert component.tools is None
         assert component.http_client_kwargs is None
         assert component.streaming_callback is None
@@ -263,30 +263,8 @@ class TestVLLMChatGeneratorInit:
         assert component.max_retries == 3
 
 
-class TestVLLMChatGeneratorWarmUp:
-    def test_warm_up_creates_clients(self):
-        component = VLLMChatGenerator(model=MODEL)
-        assert component._client is None
-
-        component.warm_up()
-
-        assert component._client is not None
-        assert component._async_client is not None
-        assert component._is_warmed_up is True
-
-    def test_warm_up_is_idempotent(self):
-        component = VLLMChatGenerator(model=MODEL)
-        component.warm_up()
-        first_client = component._client
-
-        component.warm_up()
-
-        assert component._client is first_client
-
-
-class TestVLLMChatGeneratorSerde:
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("VLLM_API_KEY", "test-key")
+class TestSerialization:
+    def test_to_dict(self):
         component = VLLMChatGenerator(
             model=MODEL,
             generation_kwargs={"max_tokens": 512},
@@ -351,7 +329,85 @@ class TestVLLMChatGeneratorSerde:
         assert component.streaming_callback is not None
 
 
-class TestVLLMChatGeneratorRun:
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_VLLM_API_KEY", raising=False)
+        component = VLLMChatGenerator(model=MODEL, api_key=Secret.from_env_var("MISSING_VLLM_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_VLLM_API_KEY"):
+            component.warm_up()
+
+    @patch("haystack_integrations.components.generators.vllm.chat.chat_generator._create_openai_client")
+    def test_sync_lifecycle(self, mock_client_cls):
+        component = VLLMChatGenerator(model=MODEL)
+        client = mock_client_cls.return_value
+
+        component.warm_up()
+        assert component._client is client
+        assert component._async_client is None
+        component.close()
+        client.close.assert_called_once_with()
+        assert component._client is None
+        component.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.vllm.chat.chat_generator._create_async_openai_client")
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self, mock_client_cls):
+        component = VLLMChatGenerator(model=MODEL)
+        client = MagicMock(close=AsyncMock())
+        mock_client_cls.return_value = client
+
+        await component.warm_up_async()
+        assert component._async_client is client
+        assert component._client is None
+        await component.close_async()
+        client.close.assert_awaited_once_with()
+        assert component._async_client is None
+        await component.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.generators.vllm.chat.chat_generator._create_openai_client")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        component = VLLMChatGenerator(model=MODEL)
+        component.warm_up()
+        component.warm_up()
+        mock_client_cls.assert_called_once()
+
+    @patch("haystack_integrations.components.generators.vllm.chat.chat_generator._create_async_openai_client")
+    @pytest.mark.asyncio
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        component = VLLMChatGenerator(model=MODEL)
+        await component.warm_up_async()
+        await component.warm_up_async()
+        mock_client_cls.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        component = VLLMChatGenerator(model=MODEL)
+        component.close()
+        await component.close_async()
+        assert component._client is None
+        assert component._async_client is None
+
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self):
+        component = VLLMChatGenerator(model=MODEL)
+        sync_client = MagicMock()
+        async_client = MagicMock(close=AsyncMock())
+        component._client = sync_client
+        component._async_client = async_client
+
+        component.close()
+        assert component._client is None
+        assert component._async_client is async_client
+        async_client.close.assert_not_awaited()
+        await component.close_async()
+        assert component._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_run(self, mock_chat_completion):  # noqa: ARG002
         component = VLLMChatGenerator(model=MODEL)
         response = component.run([ChatMessage.from_user("What's the capital of France")])
@@ -451,7 +507,7 @@ class TestVLLMChatGeneratorRun:
 
 
 @pytest.mark.asyncio
-class TestVLLMChatGeneratorRunAsync:
+class TestRunAsync:
     async def test_run_async_empty_messages(self):
         component = VLLMChatGenerator(model=MODEL)
         assert await component.run_async([]) == {"replies": []}
@@ -504,7 +560,6 @@ class TestVLLMChatGeneratorRunAsync:
             chunks_received.append(chunk)
 
         component = VLLMChatGenerator(model=MODEL, streaming_callback=callback)
-        component.warm_up()
 
         with patch("openai.resources.chat.completions.AsyncCompletions.create", new_callable=AsyncMock) as mock:
             mock.return_value = AsyncMockStream(openai_chunks)
@@ -532,7 +587,6 @@ class TestVLLMChatGeneratorRunAsync:
             streaming_chunks.append(chunk)
 
         component = VLLMChatGenerator(model=MODEL, streaming_callback=callback)
-        component.warm_up()
 
         with patch("openai.resources.chat.completions.AsyncCompletions.create", new_callable=AsyncMock) as mock:
             mock.return_value = AsyncMockStream(openai_chunks)
@@ -558,7 +612,7 @@ THINKING_KWARGS = {"extra_body": {"chat_template_kwargs": {"enable_thinking": Tr
 
 
 @pytest.mark.integration
-class TestVLLMChatGeneratorLiveRun:
+class TestIntegration:
     @pytest.mark.parametrize("generation_kwargs", [NO_THINKING_KWARGS, THINKING_KWARGS])
     def test_live_run(self, generation_kwargs):
         component = VLLMChatGenerator(model=MODEL, generation_kwargs=generation_kwargs)

--- a/integrations/vllm/tests/test_document_embedder.py
+++ b/integrations/vllm/tests/test_document_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
@@ -31,10 +31,8 @@ def _api_error() -> APIError:
     return APIError(message="boom", request=MagicMock(), body=None)
 
 
-class TestVLLMDocumentEmbedder:
-    def test_init_default(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
+class TestInitializationAndSerialization:
+    def test_init_default(self):
         embedder = VLLMDocumentEmbedder(model=MODEL)
         assert embedder.api_key == Secret.from_env_var("VLLM_API_KEY", strict=False)
         assert embedder.model == MODEL
@@ -50,7 +48,6 @@ class TestVLLMDocumentEmbedder:
         assert embedder.extra_parameters is None
         assert embedder._client is None
         assert embedder._async_client is None
-        assert embedder._is_warmed_up is False
 
     def test_init_with_parameters(self):
         embedder = VLLMDocumentEmbedder(
@@ -79,24 +76,7 @@ class TestVLLMDocumentEmbedder:
         assert embedder.raise_on_failure is True
         assert embedder.extra_parameters == {"dimensions": 32, "truncate_prompt_tokens": 256}
 
-    def test_warm_up(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
-        embedder = VLLMDocumentEmbedder(model=MODEL)
-        embedder.warm_up()
-
-        assert embedder._is_warmed_up is True
-        assert embedder._client is not None
-        assert embedder._async_client is not None
-
-        # idempotent
-        client_before = embedder._client
-        embedder.warm_up()
-        assert embedder._client is client_before
-
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
+    def test_to_dict(self):
         component_dict = component_to_dict(VLLMDocumentEmbedder(model=MODEL), "embedder")
         assert component_dict == {
             "type": "haystack_integrations.components.embedders.vllm.document_embedder.VLLMDocumentEmbedder",
@@ -119,8 +99,7 @@ class TestVLLMDocumentEmbedder:
             },
         }
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.embedders.vllm.document_embedder.VLLMDocumentEmbedder",
             "init_parameters": {
@@ -158,6 +137,86 @@ class TestVLLMDocumentEmbedder:
         assert embedder.raise_on_failure is False
         assert embedder.extra_parameters is None
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_VLLM_API_KEY", raising=False)
+        embedder = VLLMDocumentEmbedder(model=MODEL, api_key=Secret.from_env_var("MISSING_VLLM_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_VLLM_API_KEY"):
+            embedder.warm_up()
+
+    @patch("haystack_integrations.components.embedders.vllm.document_embedder._create_openai_client")
+    def test_sync_lifecycle(self, mock_client_cls):
+        embedder = VLLMDocumentEmbedder(model=MODEL)
+        client = mock_client_cls.return_value
+
+        embedder.warm_up()
+        assert embedder._client is client
+        assert embedder._async_client is None
+        embedder.close()
+        client.close.assert_called_once_with()
+        assert embedder._client is None
+        embedder.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.vllm.document_embedder._create_async_openai_client")
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self, mock_client_cls):
+        embedder = VLLMDocumentEmbedder(model=MODEL)
+        client = MagicMock(close=AsyncMock())
+        mock_client_cls.return_value = client
+
+        await embedder.warm_up_async()
+        assert embedder._async_client is client
+        assert embedder._client is None
+        await embedder.close_async()
+        client.close.assert_awaited_once_with()
+        assert embedder._async_client is None
+        await embedder.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.vllm.document_embedder._create_openai_client")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        embedder = VLLMDocumentEmbedder(model=MODEL)
+        embedder.warm_up()
+        embedder.warm_up()
+        mock_client_cls.assert_called_once()
+
+    @patch("haystack_integrations.components.embedders.vllm.document_embedder._create_async_openai_client")
+    @pytest.mark.asyncio
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        embedder = VLLMDocumentEmbedder(model=MODEL)
+        await embedder.warm_up_async()
+        await embedder.warm_up_async()
+        mock_client_cls.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        embedder = VLLMDocumentEmbedder(model=MODEL)
+        embedder.close()
+        await embedder.close_async()
+        assert embedder._client is None
+        assert embedder._async_client is None
+
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self):
+        embedder = VLLMDocumentEmbedder(model=MODEL)
+        sync_client = MagicMock()
+        async_client = MagicMock(close=AsyncMock())
+        embedder._client = sync_client
+        embedder._async_client = async_client
+
+        embedder.close()
+        assert embedder._client is None
+        assert embedder._async_client is async_client
+        async_client.close.assert_not_awaited()
+        await embedder.close_async()
+        assert embedder._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_prepare_texts_to_embed(self):
         embedder = VLLMDocumentEmbedder(
             model=MODEL, prefix="[", suffix="]", meta_fields_to_embed=["topic"], embedding_separator=" | "
@@ -195,7 +254,6 @@ class TestVLLMDocumentEmbedder:
             _fake_response([[0.1], [0.2]], prompt_tokens=2, total_tokens=2),
             _fake_response([[0.3]], prompt_tokens=1, total_tokens=1),
         ]
-        embedder._is_warmed_up = True
 
         docs = [Document(content=f"doc-{i}") for i in range(3)]
         result = embedder.run(docs)
@@ -208,7 +266,6 @@ class TestVLLMDocumentEmbedder:
         embedder = VLLMDocumentEmbedder(model=MODEL, batch_size=1, progress_bar=False)
         embedder._client = MagicMock()
         embedder._client.embeddings.create.side_effect = [_fake_response([[0.1]]), _api_error()]
-        embedder._is_warmed_up = True
 
         result = embedder.run([Document(content="a"), Document(content="b")])
 
@@ -219,7 +276,6 @@ class TestVLLMDocumentEmbedder:
         embedder = VLLMDocumentEmbedder(model=MODEL, raise_on_failure=True, progress_bar=False)
         embedder._client = MagicMock()
         embedder._client.embeddings.create.side_effect = _api_error()
-        embedder._is_warmed_up = True
 
         with pytest.raises(APIError):
             embedder.run([Document(content="a")])
@@ -229,13 +285,14 @@ class TestVLLMDocumentEmbedder:
         embedder = VLLMDocumentEmbedder(model=MODEL, progress_bar=True)
         embedder._async_client = MagicMock()
         embedder._async_client.embeddings.create = AsyncMock(return_value=_fake_response([[0.5], [0.6]]))
-        embedder._is_warmed_up = True
 
         docs = [Document(content="a"), Document(content="b")]
         result = await embedder.run_async(docs)
 
         assert [d.embedding for d in result["documents"]] == [[0.5], [0.6]]
 
+
+class TestIntegration:
     @pytest.mark.integration
     def test_live_run(self):
         embedder = VLLMDocumentEmbedder(model=MODEL, api_base_url=API_BASE_URL)

--- a/integrations/vllm/tests/test_ranker.py
+++ b/integrations/vllm/tests/test_ranker.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from haystack import Document
 from haystack.core.serialization import component_from_dict, component_to_dict
@@ -25,10 +26,8 @@ def _fake_response(results: list[dict], model: str = "fake-model", total_tokens:
     return response
 
 
-class TestVLLMRanker:
-    def test_init_default(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
+class TestInitializationAndSerialization:
+    def test_init_default(self):
         ranker = VLLMRanker(model=MODEL)
         assert ranker.model == MODEL
         assert ranker.api_key == Secret.from_env_var("VLLM_API_KEY", strict=False)
@@ -41,8 +40,6 @@ class TestVLLMRanker:
         assert ranker.extra_parameters is None
         assert ranker._client is None
         assert ranker._async_client is None
-        assert ranker._is_warmed_up is False
-        assert "Authorization" not in ranker._headers
 
     def test_init_with_parameters(self):
         ranker = VLLMRanker(
@@ -64,29 +61,14 @@ class TestVLLMRanker:
         assert ranker.meta_data_separator == " | "
         assert ranker.http_client_kwargs == {"verify": False}
         assert ranker.extra_parameters == {"truncate_prompt_tokens": 256}
-        assert ranker._headers["Authorization"] == "Bearer test-api-key"
+        assert ranker._client is None
+        assert ranker._async_client is None
 
     def test_init_invalid_top_k(self):
         with pytest.raises(ValueError, match="top_k must be > 0"):
             VLLMRanker(model=MODEL, top_k=0)
 
-    def test_warm_up(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
-        ranker = VLLMRanker(model=MODEL)
-        ranker.warm_up()
-
-        assert ranker._is_warmed_up is True
-        assert ranker._client is not None
-        assert ranker._async_client is not None
-
-        client_before = ranker._client
-        ranker.warm_up()
-        assert ranker._client is client_before
-
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
+    def test_to_dict(self):
         component_dict = component_to_dict(VLLMRanker(model=MODEL), "ranker")
         assert component_dict == {
             "type": "haystack_integrations.components.rankers.vllm.ranker.VLLMRanker",
@@ -103,8 +85,7 @@ class TestVLLMRanker:
             },
         }
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.rankers.vllm.ranker.VLLMRanker",
             "init_parameters": {
@@ -128,6 +109,99 @@ class TestVLLMRanker:
         assert ranker.meta_data_separator == " | "
         assert ranker.extra_parameters == {"truncate_prompt_tokens": 256}
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_VLLM_API_KEY", raising=False)
+        ranker = VLLMRanker(model=MODEL, api_key=Secret.from_env_var("MISSING_VLLM_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_VLLM_API_KEY"):
+            ranker.warm_up()
+
+    def test_sync_lifecycle(self):
+        client = MagicMock(spec=httpx.Client)
+        ranker = VLLMRanker(model=MODEL, api_key=Secret.from_token("test-api-key"))
+
+        with patch(
+            "haystack_integrations.components.rankers.vllm.ranker.init_http_client", return_value=client
+        ) as mock_init:
+            ranker.warm_up()
+            assert ranker._client is client
+            assert ranker._async_client is None
+            assert mock_init.call_args.kwargs["http_client_kwargs"]["headers"]["Authorization"] == (
+                "Bearer test-api-key"
+            )
+            ranker.close()
+            client.close.assert_called_once_with()
+            assert ranker._client is None
+            ranker.warm_up()
+            assert mock_init.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self):
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.aclose = AsyncMock()
+        ranker = VLLMRanker(model=MODEL)
+
+        with patch(
+            "haystack_integrations.components.rankers.vllm.ranker.init_http_client", return_value=client
+        ) as mock_init:
+            await ranker.warm_up_async()
+            assert ranker._async_client is client
+            assert ranker._client is None
+            await ranker.close_async()
+            client.aclose.assert_awaited_once_with()
+            assert ranker._async_client is None
+            await ranker.warm_up_async()
+            assert mock_init.call_count == 2
+
+    def test_warm_up_is_idempotent(self):
+        client = MagicMock(spec=httpx.Client)
+        ranker = VLLMRanker(model=MODEL)
+        with patch(
+            "haystack_integrations.components.rankers.vllm.ranker.init_http_client", return_value=client
+        ) as mock_init:
+            ranker.warm_up()
+            ranker.warm_up()
+            mock_init.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_warm_up_async_is_idempotent(self):
+        client = MagicMock(spec=httpx.AsyncClient)
+        ranker = VLLMRanker(model=MODEL)
+        with patch(
+            "haystack_integrations.components.rankers.vllm.ranker.init_http_client", return_value=client
+        ) as mock_init:
+            await ranker.warm_up_async()
+            await ranker.warm_up_async()
+            mock_init.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        ranker = VLLMRanker(model=MODEL)
+        ranker.close()
+        await ranker.close_async()
+        assert ranker._client is None
+        assert ranker._async_client is None
+
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self):
+        ranker = VLLMRanker(model=MODEL)
+        sync_client = MagicMock()
+        async_client = MagicMock(aclose=AsyncMock())
+        ranker._client = sync_client
+        ranker._async_client = async_client
+
+        ranker.close()
+        assert ranker._client is None
+        assert ranker._async_client is async_client
+        async_client.aclose.assert_not_awaited()
+        await ranker.close_async()
+        assert ranker._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_prepare_texts_with_meta(self):
         ranker = VLLMRanker(model=MODEL, meta_fields_to_embed=["topic"], meta_data_separator=" | ")
         docs = [Document(content="hello", meta={"topic": "ML"}), Document(content="world", meta={})]
@@ -187,7 +261,6 @@ class TestVLLMRanker:
                 {"index": 0, "relevance_score": 0.01},
             ]
         )
-        ranker._is_warmed_up = True
 
         docs = [
             Document(content="The capital of Brazil is Brasilia."),
@@ -218,12 +291,13 @@ class TestVLLMRanker:
         ranker._async_client.post = AsyncMock(
             return_value=_fake_response(results=[{"index": 0, "relevance_score": 0.42}])
         )
-        ranker._is_warmed_up = True
 
         out = await ranker.run_async(query="q", documents=[Document(content="a")])
 
         assert out["documents"][0].score == 0.42
 
+
+class TestIntegration:
     @pytest.mark.integration
     def test_live_run(self):
         ranker = VLLMRanker(model=MODEL, api_base_url=API_BASE_URL)

--- a/integrations/vllm/tests/test_text_embedder.py
+++ b/integrations/vllm/tests/test_text_embedder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from haystack.core.serialization import component_from_dict, component_to_dict
@@ -24,10 +24,8 @@ def _fake_response(embeddings: list[list[float]], prompt_tokens: int = 5, total_
     )
 
 
-class TestVLLMTextEmbedder:
-    def test_init_default(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
+class TestInitializationAndSerialization:
+    def test_init_default(self):
         embedder = VLLMTextEmbedder(model=MODEL)
         assert embedder.api_key == Secret.from_env_var("VLLM_API_KEY", strict=False)
         assert embedder.api_base_url == "http://localhost:8000/v1"
@@ -41,7 +39,6 @@ class TestVLLMTextEmbedder:
         assert embedder.extra_parameters is None
         assert embedder._client is None
         assert embedder._async_client is None
-        assert embedder._is_warmed_up is False
 
     def test_init_with_parameters(self):
         embedder = VLLMTextEmbedder(
@@ -67,24 +64,7 @@ class TestVLLMTextEmbedder:
         assert embedder.http_client_kwargs == {"proxy": "https://proxy.example.com"}
         assert embedder.extra_parameters == {"dimensions": 32, "truncate_prompt_tokens": 256}
 
-    def test_warm_up(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
-        embedder = VLLMTextEmbedder(model=MODEL)
-        embedder.warm_up()
-
-        assert embedder._is_warmed_up is True
-        assert embedder._client is not None
-        assert embedder._async_client is not None
-
-        # idempotent: calling again does not recreate clients
-        client_before = embedder._client
-        embedder.warm_up()
-        assert embedder._client is client_before
-
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
+    def test_to_dict(self):
         component_dict = component_to_dict(VLLMTextEmbedder(model=MODEL), "embedder")
         assert component_dict == {
             "type": "haystack_integrations.components.embedders.vllm.text_embedder.VLLMTextEmbedder",
@@ -102,8 +82,7 @@ class TestVLLMTextEmbedder:
             },
         }
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.embedders.vllm.text_embedder.VLLMTextEmbedder",
             "init_parameters": {
@@ -131,6 +110,86 @@ class TestVLLMTextEmbedder:
         assert embedder.http_client_kwargs is None
         assert embedder.extra_parameters is None
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("MISSING_VLLM_API_KEY", raising=False)
+        embedder = VLLMTextEmbedder(model=MODEL, api_key=Secret.from_env_var("MISSING_VLLM_API_KEY"))
+
+        with pytest.raises(ValueError, match="MISSING_VLLM_API_KEY"):
+            embedder.warm_up()
+
+    @patch("haystack_integrations.components.embedders.vllm.text_embedder._create_openai_client")
+    def test_sync_lifecycle(self, mock_client_cls):
+        embedder = VLLMTextEmbedder(model=MODEL)
+        client = mock_client_cls.return_value
+
+        embedder.warm_up()
+        assert embedder._client is client
+        assert embedder._async_client is None
+        embedder.close()
+        client.close.assert_called_once_with()
+        assert embedder._client is None
+        embedder.warm_up()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.vllm.text_embedder._create_async_openai_client")
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self, mock_client_cls):
+        embedder = VLLMTextEmbedder(model=MODEL)
+        client = MagicMock(close=AsyncMock())
+        mock_client_cls.return_value = client
+
+        await embedder.warm_up_async()
+        assert embedder._async_client is client
+        assert embedder._client is None
+        await embedder.close_async()
+        client.close.assert_awaited_once_with()
+        assert embedder._async_client is None
+        await embedder.warm_up_async()
+        assert mock_client_cls.call_count == 2
+
+    @patch("haystack_integrations.components.embedders.vllm.text_embedder._create_openai_client")
+    def test_warm_up_is_idempotent(self, mock_client_cls):
+        embedder = VLLMTextEmbedder(model=MODEL)
+        embedder.warm_up()
+        embedder.warm_up()
+        mock_client_cls.assert_called_once()
+
+    @patch("haystack_integrations.components.embedders.vllm.text_embedder._create_async_openai_client")
+    @pytest.mark.asyncio
+    async def test_warm_up_async_is_idempotent(self, mock_client_cls):
+        embedder = VLLMTextEmbedder(model=MODEL)
+        await embedder.warm_up_async()
+        await embedder.warm_up_async()
+        mock_client_cls.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        embedder = VLLMTextEmbedder(model=MODEL)
+        embedder.close()
+        await embedder.close_async()
+        assert embedder._client is None
+        assert embedder._async_client is None
+
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self):
+        embedder = VLLMTextEmbedder(model=MODEL)
+        sync_client = MagicMock()
+        async_client = MagicMock(close=AsyncMock())
+        embedder._client = sync_client
+        embedder._async_client = async_client
+
+        embedder.close()
+        assert embedder._client is None
+        assert embedder._async_client is async_client
+        async_client.close.assert_not_awaited()
+        await embedder.close_async()
+        assert embedder._async_client is None
+        sync_client.close.assert_called_once_with()
+
+
+class TestRun:
     def test_prepare_input_adds_dimensions_and_extra_body(self):
         embedder = VLLMTextEmbedder(
             model=MODEL, prefix="[", suffix="]", dimensions=32, extra_parameters={"truncate_prompt_tokens": 256}
@@ -153,7 +212,6 @@ class TestVLLMTextEmbedder:
         embedder = VLLMTextEmbedder(model=MODEL, prefix="[", suffix="]", dimensions=2)
         embedder._client = MagicMock()
         embedder._client.embeddings.create.return_value = _fake_response([[0.1, 0.2]])
-        embedder._is_warmed_up = True
 
         result = embedder.run("hello")
 
@@ -170,11 +228,12 @@ class TestVLLMTextEmbedder:
         embedder = VLLMTextEmbedder(model=MODEL)
         embedder._async_client = MagicMock()
         embedder._async_client.embeddings.create = AsyncMock(return_value=_fake_response([[0.3, 0.4]]))
-        embedder._is_warmed_up = True
 
         result = await embedder.run_async("world")
         assert result["embedding"] == [0.3, 0.4]
 
+
+class TestIntegration:
     @pytest.mark.integration
     def test_live_run(self):
         embedder = VLLMTextEmbedder(model=MODEL, api_base_url=API_BASE_URL)

--- a/integrations/vllm/tests/test_utils.py
+++ b/integrations/vllm/tests/test_utils.py
@@ -2,28 +2,40 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from haystack.utils import Secret
 
-from haystack_integrations.common.vllm.utils import _create_openai_clients
+from haystack_integrations.common.vllm.utils import _create_async_openai_client, _create_openai_client
 
 
-def test_create_openai_clients_placeholder_when_no_key():
-    sync_client, async_client = _create_openai_clients(
+def test_create_openai_client_placeholder_when_no_key():
+    client = _create_openai_client(
         api_key=None, api_base_url="http://localhost:8000/v1", timeout=None, max_retries=None, http_client_kwargs=None
     )
-    assert sync_client.api_key == "placeholder-api-key"
-    assert async_client.api_key == "placeholder-api-key"
-    assert str(sync_client.base_url) == "http://localhost:8000/v1/"
+    assert client.api_key == "placeholder-api-key"
+    assert str(client.base_url) == "http://localhost:8000/v1/"
+    client.close()
 
 
-def test_create_openai_clients_uses_resolved_key_and_forwards_options():
-    sync_client, _ = _create_openai_clients(
+def test_create_openai_client_uses_resolved_key_and_forwards_options():
+    client = _create_openai_client(
         api_key=Secret.from_token("real-key"),
         api_base_url="http://vllm:8000/v1",
         timeout=12.5,
         max_retries=7,
         http_client_kwargs=None,
     )
-    assert sync_client.api_key == "real-key"
-    assert sync_client.timeout == 12.5
-    assert sync_client.max_retries == 7
+    assert client.api_key == "real-key"
+    assert client.timeout == 12.5
+    assert client.max_retries == 7
+    client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_async_openai_client_placeholder_when_no_key():
+    client = _create_async_openai_client(
+        api_key=None, api_base_url="http://localhost:8000/v1", timeout=None, max_retries=None, http_client_kwargs=None
+    )
+    assert client.api_key == "placeholder-api-key"
+    assert str(client.base_url) == "http://localhost:8000/v1/"
+    await client.close()


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- separate sync and async lifecycle
- add closing methods
- in ranker, move client creation to `warm_up`
- pin `haystack-ai>=3.0.0`

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
