### PR TITLE
refactor!: watsonx - move client creation to warm_up

### DIFF
--- a/.github/workflows/watsonx.yml
+++ b/.github/workflows/watsonx.yml
@@ -105,7 +105,7 @@ jobs:
           path: python-coverage-comment-action-watsonx.txt
 
       - name: Run integration tests
-        if: matrix.python-version == '3.10' && runner.os == 'Linux'
+        if: matrix.python-version == '3.11' && runner.os == 'Linux'
         env:
           WATSONX_API_KEY: ${{ secrets.WATSONX_API_KEY }}
           WATSONX_PROJECT_ID: ${{ secrets.WATSONX_PROJECT_ID }}

--- a/integrations/watsonx/pyproject.toml
+++ b/integrations/watsonx/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["haystack-ai>=2.30.0", "ibm-watsonx-ai>=1.5.13", "pandas>=2.2.3"]
+dependencies = ["haystack-ai>=3.0.0", "ibm-watsonx-ai>=1.5.13", "pandas>=2.2.3"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/watsonx#readme"

--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/document_embedder.py
@@ -105,21 +105,27 @@ class WatsonxDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
-        # Initialize the embeddings client
-        credentials = Credentials(api_key=api_key.resolve_value(), url=api_base_url)
+        self.embedder: Embeddings | None = None
+
+    def warm_up(self) -> None:
+        """Create the Watsonx embeddings client."""
+        if self.embedder is not None:
+            return
+
+        credentials = Credentials(api_key=self.api_key.resolve_value(), url=self.api_base_url)
 
         params = {}
-        if truncate_input_tokens is not None:
-            params["truncate_input_tokens"] = truncate_input_tokens
+        if self.truncate_input_tokens is not None:
+            params["truncate_input_tokens"] = self.truncate_input_tokens
 
         self.embedder = Embeddings(
-            model_id=model,
+            model_id=self.model,
             credentials=credentials,
-            project_id=project_id.resolve_value(),
+            project_id=self.project_id.resolve_value(),
             params=params if params else None,  # type: ignore[arg-type]
-            batch_size=batch_size,
-            concurrency_limit=concurrency_limit,
-            max_retries=max_retries,
+            batch_size=self.batch_size,
+            concurrency_limit=self.concurrency_limit,
+            max_retries=self.max_retries,
         )
 
     def _get_telemetry_data(self) -> dict[str, Any]:
@@ -203,6 +209,8 @@ class WatsonxDocumentEmbedder:
             raise TypeError(msg)
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
+        self.warm_up()
+        assert self.embedder is not None  # noqa: S101
         embeddings = self.embedder.embed_documents(texts_to_embed)
 
         new_documents = []

--- a/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/text_embedder.py
+++ b/integrations/watsonx/src/haystack_integrations/components/embedders/watsonx/text_embedder.py
@@ -89,19 +89,25 @@ class WatsonxTextEmbedder:
         self.timeout = timeout
         self.max_retries = max_retries
 
-        # Initialize the embeddings client
-        credentials = Credentials(api_key=api_key.resolve_value(), url=api_base_url)
+        self.embedder: Embeddings | None = None
+
+    def warm_up(self) -> None:
+        """Create the Watsonx embeddings client."""
+        if self.embedder is not None:
+            return
+
+        credentials = Credentials(api_key=self.api_key.resolve_value(), url=self.api_base_url)
 
         params = {}
-        if truncate_input_tokens is not None:
-            params["truncate_input_tokens"] = truncate_input_tokens
+        if self.truncate_input_tokens is not None:
+            params["truncate_input_tokens"] = self.truncate_input_tokens
 
         self.embedder = Embeddings(
-            model_id=model,
+            model_id=self.model,
             credentials=credentials,
-            project_id=project_id.resolve_value(),
+            project_id=self.project_id.resolve_value(),
             params=params if params else None,  # type: ignore[arg-type]
-            max_retries=max_retries,
+            max_retries=self.max_retries,
         )
 
     def _get_telemetry_data(self) -> dict[str, Any]:
@@ -163,6 +169,8 @@ class WatsonxTextEmbedder:
             - 'meta': Information about the model usage
         """
         text_to_embed = self._prepare_input(text=text)
+        self.warm_up()
+        assert self.embedder is not None  # noqa: S101
         embedding = self.embedder.embed_query(text_to_embed)
         return {
             "embedding": embedding,

--- a/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
+++ b/integrations/watsonx/src/haystack_integrations/components/generators/watsonx/chat/chat_generator.py
@@ -201,12 +201,14 @@ class WatsonxChatGenerator:
         self.streaming_callback = streaming_callback
         self.tools = tools
 
-        self._initialize_client()
+        self.client: ModelInference | None = None
 
-    def _initialize_client(self) -> None:
-        """Initialize the Watsonx client with configured credentials."""
+    def warm_up(self) -> None:
+        """Create the Watsonx client."""
+        if self.client is not None:
+            return
+
         credentials = Credentials(api_key=self.api_key.resolve_value(), url=self.api_base_url)
-
         self.client = ModelInference(
             model_id=self.model,
             credentials=credentials,
@@ -289,6 +291,9 @@ class WatsonxChatGenerator:
         if not messages:
             return {"replies": []}
 
+        self.warm_up()
+        assert self.client is not None  # noqa: S101
+
         resolved_streaming_callback = select_streaming_callback(
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=False
         )
@@ -332,6 +337,9 @@ class WatsonxChatGenerator:
         messages = _normalize_messages(messages)
         if not messages:
             return {"replies": []}
+
+        self.warm_up()
+        assert self.client is not None  # noqa: S101
 
         resolved_streaming_callback = select_streaming_callback(
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=True
@@ -471,6 +479,7 @@ class WatsonxChatGenerator:
         :returns:
             A dictionary with the generated responses as ChatMessage instances.
         """
+        assert self.client is not None  # noqa: S101
         chunks: list[StreamingChunk] = []
         stream = self.client.chat_stream(
             messages=api_args["messages"], params=api_args["params"], tools=api_args.get("tools")
@@ -503,6 +512,7 @@ class WatsonxChatGenerator:
 
     def _handle_standard(self, api_args: dict[str, Any]) -> dict[str, list[ChatMessage]]:
         """Handle synchronous standard response."""
+        assert self.client is not None  # noqa: S101
         response = self.client.chat(
             messages=api_args["messages"], params=api_args["params"], tools=api_args.get("tools")
         )
@@ -515,6 +525,7 @@ class WatsonxChatGenerator:
         callback: StreamingCallbackT,
     ) -> dict[str, list[ChatMessage]]:
         """Handle asynchronous streaming response."""
+        assert self.client is not None  # noqa: S101
         chunks: list[StreamingChunk] = []
         stream_generator = await self.client.achat_stream(
             messages=api_args["messages"], params=api_args["params"], tools=api_args.get("tools")
@@ -550,6 +561,7 @@ class WatsonxChatGenerator:
 
     async def _handle_async_standard(self, api_args: dict[str, Any]) -> dict[str, list[ChatMessage]]:
         """Handle asynchronous standard response."""
+        assert self.client is not None  # noqa: S101
         response = await self.client.achat(
             messages=api_args["messages"], params=api_args["params"], tools=api_args.get("tools")
         )

--- a/integrations/watsonx/tests/test_chat_generator.py
+++ b/integrations/watsonx/tests/test_chat_generator.py
@@ -527,7 +527,6 @@ class TestMessageConversionAndMultimodal:
 
         generator = WatsonxChatGenerator(
             model="meta-llama/llama-3-2-11b-vision-instruct",
-            api_key=Secret.from_token("test-api-key"),
             project_id=Secret.from_token("test-project"),
         )
 
@@ -723,6 +722,7 @@ class TestMessageConversionAndMultimodal:
 
         generator = WatsonxChatGenerator(
             model="meta-llama/llama-3-2-11b-vision-instruct",
+            api_key=Secret.from_token("test-api-key"),
             project_id=Secret.from_token("test-project"),
         )
 

--- a/integrations/watsonx/tests/test_chat_generator.py
+++ b/integrations/watsonx/tests/test_chat_generator.py
@@ -38,87 +38,81 @@ def tools():
     ]
 
 
-class TestWatsonxChatGenerator:
-    @pytest.fixture
-    def mock_watsonx(self, monkeypatch) -> Generator[dict[str, AsyncMock | MagicMock], None]:
-        """Fixture for setting up common mocks"""
-        monkeypatch.setenv("WATSONX_API_KEY", "fake-api-key")
-        monkeypatch.setenv("WATSONX_PROJECT_ID", "fake-project-id")
+@pytest.fixture
+def mock_watsonx() -> Generator[dict[str, MagicMock], None]:
+    """Fixture for setting up common mocks"""
+    with patch("haystack_integrations.components.generators.watsonx.chat.chat_generator.ModelInference") as mock_model:
+        mock_model_instance = MagicMock()
+        mock_model_instance.chat = MagicMock(
+            return_value={
+                "choices": [
+                    {
+                        "message": {"content": "This is a generated response", "role": "assistant"},
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            }
+        )
+        mock_model_instance.achat = AsyncMock(
+            return_value={
+                "choices": [
+                    {
+                        "message": {"content": "Async generated response", "role": "assistant"},
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            }
+        )
+        mock_model_instance.chat_stream = MagicMock(
+            return_value=[
+                {"choices": [{"delta": {"content": "Streaming"}, "index": 0, "finish_reason": None}]},
+                {"choices": [{"delta": {"content": " response"}, "index": 0, "finish_reason": "stop"}]},
+            ]
+        )
 
-        with (
-            patch(
-                "haystack_integrations.components.generators.watsonx.chat.chat_generator.ModelInference"
-            ) as mock_model,
-            patch(
-                "haystack_integrations.components.generators.watsonx.chat.chat_generator.select_streaming_callback"
-            ) as mock_select_callback,
-        ):
-            mock_select_callback.side_effect = lambda init_callback, runtime_callback, requires_async: (
-                runtime_callback if runtime_callback is not None else init_callback
-            )
+        async def mock_achat_stream(messages=None, params=None, tools=None):
+            class MockAsyncGenerator:
+                def __init__(self):
+                    self._count = 0
 
-            mock_model_instance = MagicMock()
-            mock_model_instance.chat = MagicMock(
-                return_value={
-                    "choices": [
-                        {
-                            "message": {"content": "This is a generated response", "role": "assistant"},
-                            "index": 0,
-                            "finish_reason": "stop",
+                def __aiter__(self):
+                    return self
+
+                async def __anext__(self):
+                    self._count += 1
+                    if self._count == 1:
+                        return {
+                            "choices": [{"delta": {"content": "Async streaming"}, "finish_reason": None, "index": 0}]
                         }
-                    ],
-                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
-                }
-            )
-            mock_model_instance.achat = AsyncMock(
-                return_value={
-                    "choices": [
-                        {
-                            "message": {"content": "Async generated response", "role": "assistant"},
-                            "index": 0,
-                            "finish_reason": "stop",
-                        }
-                    ],
-                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
-                }
-            )
-            mock_model_instance.chat_stream = MagicMock(
-                return_value=[
-                    {"choices": [{"delta": {"content": "Streaming"}, "index": 0, "finish_reason": None}]},
-                    {"choices": [{"delta": {"content": " response"}, "index": 0, "finish_reason": "stop"}]},
-                ]
-            )
+                    elif self._count == 2:
+                        return {"choices": [{"delta": {"content": " response"}, "finish_reason": "stop", "index": 0}]}
+                    else:
+                        raise StopAsyncIteration
 
-            async def mock_achat_stream(messages=None, params=None, tools=None):
-                class MockAsyncGenerator:
-                    def __init__(self):
-                        self._count = 0
+            return MockAsyncGenerator()
 
-                    def __aiter__(self):
-                        return self
+        mock_model_instance.achat_stream = mock_achat_stream
+        mock_model.return_value = mock_model_instance
 
-                    async def __anext__(self):
-                        self._count += 1
-                        if self._count == 1:
-                            return {
-                                "choices": [
-                                    {"delta": {"content": "Async streaming"}, "finish_reason": None, "index": 0}
-                                ]
-                            }
-                        elif self._count == 2:
-                            return {
-                                "choices": [{"delta": {"content": " response"}, "finish_reason": "stop", "index": 0}]
-                            }
-                        else:
-                            raise StopAsyncIteration
+        yield {"model_instance": mock_model_instance}
 
-                return MockAsyncGenerator()
 
-            mock_model_instance.achat_stream = mock_achat_stream
-            mock_model.return_value = mock_model_instance
+@pytest.fixture
+def mock_select_callback() -> Generator[MagicMock, None]:
+    with patch(
+        "haystack_integrations.components.generators.watsonx.chat.chat_generator.select_streaming_callback"
+    ) as select_callback:
+        select_callback.side_effect = lambda init_callback, runtime_callback, requires_async: (
+            runtime_callback if runtime_callback is not None else init_callback
+        )
+        yield select_callback
 
-            yield {"model": mock_model, "model_instance": mock_model_instance, "select_callback": mock_select_callback}
 
+class TestInitialization:
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = WatsonxChatGenerator.SUPPORTED_MODELS
@@ -126,21 +120,17 @@ class TestWatsonxChatGenerator:
         assert len(models) > 0
         assert all(isinstance(m, str) for m in models)
 
-    def test_init_default(self, mock_watsonx):
+    def test_init_default(self):
         generator = WatsonxChatGenerator(project_id=Secret.from_token("fake-project-id"))
 
-        _, kwargs = mock_watsonx["model"].call_args
-        assert kwargs["model_id"] == "ibm/granite-4-h-small"
-        assert kwargs["project_id"] == "fake-project-id"
-        assert kwargs["verify"] is None
-
+        assert generator.client is None
         assert generator.model == "ibm/granite-4-h-small"
         assert isinstance(generator.project_id, Secret)
         assert generator.project_id.resolve_value() == "fake-project-id"
         assert generator.api_base_url == "https://us-south.ml.cloud.ibm.com"
         assert generator.tools is None
 
-    def test_init_with_all_params(self, mock_watsonx: dict[str, AsyncMock | MagicMock]) -> None:
+    def test_init_with_all_params(self) -> None:
         tool = Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=weather)
 
         generator = WatsonxChatGenerator(
@@ -152,27 +142,29 @@ class TestWatsonxChatGenerator:
             tools=[tool],
         )
 
-        _, kwargs = mock_watsonx["model"].call_args
-        assert kwargs["model_id"] == "ibm/granite-4-h-small"
-        assert kwargs["project_id"] == "test-project"
-        assert kwargs["verify"] is False
-
+        assert generator.client is None
         assert isinstance(generator.project_id, Secret)
         assert generator.project_id.resolve_value() == "test-project"
         assert generator.tools == [tool]
 
-    def test_init_with_toolset(self, mock_watsonx: dict[str, AsyncMock | MagicMock], tools: list[Tool]) -> None:
+    def test_init_with_toolset(self, tools: list[Tool]) -> None:
         toolset = Toolset(tools)
         generator = WatsonxChatGenerator(project_id=Secret.from_token("fake-project-id"), tools=toolset)
         assert generator.tools == toolset
 
-    def test_init_fails_without_project(self, mock_watsonx):
-        os.environ.pop("WATSONX_PROJECT_ID", None)
+    def test_init_with_streaming_callback(self):
+        def custom_callback(chunk: StreamingChunk):
+            pass
 
-        with pytest.raises(ValueError, match="None of the following authentication environment variables are set"):
-            WatsonxChatGenerator(api_key=Secret.from_token("test-api-key"))
+        generator = WatsonxChatGenerator(
+            project_id=Secret.from_token("test-project"),
+            streaming_callback=custom_callback,
+        )
+        assert generator.streaming_callback is custom_callback
 
-    def test_to_dict(self, mock_watsonx: dict[str, AsyncMock | MagicMock]) -> None:
+
+class TestSerialization:
+    def test_to_dict(self) -> None:
         generator = WatsonxChatGenerator(
             project_id=Secret.from_env_var("WATSONX_PROJECT_ID"), generation_kwargs={"max_tokens": 100}
         )
@@ -196,7 +188,7 @@ class TestWatsonxChatGenerator:
         }
         assert data == expected
 
-    def test_to_dict_with_params(self, mock_watsonx: dict[str, AsyncMock | MagicMock], tools: list[Tool]) -> None:
+    def test_to_dict_with_params(self, tools: list[Tool]) -> None:
         generator = WatsonxChatGenerator(
             project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
             generation_kwargs={"max_tokens": 100},
@@ -231,8 +223,7 @@ class TestWatsonxChatGenerator:
         loaded = WatsonxChatGenerator.from_dict(generator.to_dict())
         assert loaded.tools == tools
 
-    def test_from_dict(self, mock_watsonx):
-        assert mock_watsonx is not None
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.generators.watsonx.chat.chat_generator.WatsonxChatGenerator",
             "init_parameters": {
@@ -246,10 +237,10 @@ class TestWatsonxChatGenerator:
         generator = WatsonxChatGenerator.from_dict(data)
         assert generator.model == "ibm/granite-4-h-small"
         assert isinstance(generator.project_id, Secret)
-        assert generator.project_id.resolve_value() == "fake-project-id"
+        assert generator.project_id == Secret.from_env_var("WATSONX_PROJECT_ID")
         assert generator.generation_kwargs == {"max_tokens": 100}
 
-    def test_from_dict_with_callback(self, mock_watsonx):
+    def test_from_dict_with_callback(self):
         callback_str = "haystack.components.generators.utils.print_streaming_chunk"
         data = {
             "type": "haystack_integrations.components.generators.watsonx.chat.chat_generator.WatsonxChatGenerator",
@@ -264,7 +255,7 @@ class TestWatsonxChatGenerator:
         generator = WatsonxChatGenerator.from_dict(data)
         assert generator.streaming_callback is print_streaming_chunk
 
-    def test_from_dict_with_tools(self, mock_watsonx: dict[str, AsyncMock | MagicMock], tools: list[Tool]) -> None:
+    def test_from_dict_with_tools(self, tools: list[Tool]) -> None:
         data = {
             "type": "haystack_integrations.components.generators.watsonx.chat.chat_generator.WatsonxChatGenerator",
             "init_parameters": {
@@ -297,6 +288,54 @@ class TestWatsonxChatGenerator:
         assert len(generator.tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in generator.tools)
 
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("WATSONX_API_KEY", raising=False)
+        generator = WatsonxChatGenerator(project_id=Secret.from_token("fake-project-id"))
+
+        assert generator.client is None
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            generator.warm_up()
+
+    def test_project_id_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
+        generator = WatsonxChatGenerator(api_key=Secret.from_token("fake-api-key"))
+
+        assert generator.client is None
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            generator.warm_up()
+
+    def test_warm_up_is_idempotent(self):
+        with (
+            patch("haystack_integrations.components.generators.watsonx.chat.chat_generator.Credentials") as credentials,
+            patch(
+                "haystack_integrations.components.generators.watsonx.chat.chat_generator.ModelInference"
+            ) as model_inference,
+        ):
+            generator = WatsonxChatGenerator(
+                api_key=Secret.from_token("fake-api-key"),
+                project_id=Secret.from_token("fake-project-id"),
+                api_base_url="https://custom-url.ibm.com",
+                verify=False,
+                max_retries=5,
+            )
+            generator.warm_up()
+            client = generator.client
+            generator.warm_up()
+
+        credentials.assert_called_once_with(api_key="fake-api-key", url="https://custom-url.ibm.com")
+        model_inference.assert_called_once_with(
+            model_id="ibm/granite-4-h-small",
+            credentials=credentials.return_value,
+            project_id="fake-project-id",
+            verify=False,
+            max_retries=5,
+        )
+        assert generator.client is client
+
+
+class TestRun:
     def test_run_single_message(self, mock_watsonx):
         generator = WatsonxChatGenerator(
             api_key=Secret.from_token("test-api-key"),
@@ -331,15 +370,17 @@ class TestWatsonxChatGenerator:
             tools=None,
         )
 
-    def test_run_with_streaming(self, mock_watsonx):
+    def test_run_with_streaming(self, mock_watsonx, mock_select_callback):
         """Test streaming with callback through parent class"""
-        generator = WatsonxChatGenerator(project_id=Secret.from_token("test-project"))
+        generator = WatsonxChatGenerator(
+            api_key=Secret.from_token("test-api-key"), project_id=Secret.from_token("test-project")
+        )
 
         mock_callback = MagicMock()
         messages = [ChatMessage.from_user("Test prompt")]
         result = generator.run(messages=messages, streaming_callback=mock_callback)
 
-        mock_watsonx["select_callback"].assert_called_once_with(
+        mock_select_callback.assert_called_once_with(
             init_callback=None, runtime_callback=mock_callback, requires_async=False
         )
 
@@ -390,7 +431,7 @@ class TestWatsonxChatGenerator:
             messages=[{"role": "user", "content": "What's the capital of France?"}], params={}, tools=None
         )
 
-    def test_run_with_empty_messages(self, mock_watsonx):
+    def test_run_with_empty_messages(self):
         generator = WatsonxChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             project_id=Secret.from_token("test-project"),
@@ -399,17 +440,7 @@ class TestWatsonxChatGenerator:
         result = generator.run(messages=[])
         assert result["replies"] == []
 
-    def test_init_with_streaming_callback(self, mock_watsonx):
-        def custom_callback(chunk: StreamingChunk):
-            pass
-
-        generator = WatsonxChatGenerator(
-            project_id=Secret.from_token("test-project"),
-            streaming_callback=custom_callback,
-        )
-        assert generator.streaming_callback is custom_callback
-
-    def test_streaming_callback_priority(self, mock_watsonx):
+    def test_streaming_callback_priority(self, mock_watsonx, mock_select_callback):
         def init_callback(chunk: StreamingChunk):
             pass
 
@@ -417,6 +448,7 @@ class TestWatsonxChatGenerator:
             pass
 
         generator = WatsonxChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
             project_id=Secret.from_token("test-project"),
             streaming_callback=init_callback,
         )
@@ -424,7 +456,7 @@ class TestWatsonxChatGenerator:
         # Run with different callback - should use the runtime callback
         generator.run(messages=[ChatMessage.from_user("test")], streaming_callback=run_callback)
 
-        mock_watsonx["select_callback"].assert_called_once_with(
+        mock_select_callback.assert_called_once_with(
             init_callback=init_callback, runtime_callback=run_callback, requires_async=False
         )
 
@@ -461,7 +493,7 @@ class TestWatsonxChatGenerator:
         )
 
     @pytest.mark.asyncio
-    async def test_run_async_streaming(self, mock_watsonx):
+    async def test_run_async_streaming(self, mock_watsonx, mock_select_callback):
         generator = WatsonxChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             project_id=Secret.from_token("test-project"),
@@ -474,9 +506,7 @@ class TestWatsonxChatGenerator:
         messages = [ChatMessage.from_user("Test prompt")]
 
         result = await generator.run_async(messages=messages, streaming_callback=mock_callback)
-        mock_watsonx["select_callback"].assert_called_with(
-            init_callback=None, runtime_callback=mock_callback, requires_async=True
-        )
+        mock_select_callback.assert_called_with(init_callback=None, runtime_callback=mock_callback, requires_async=True)
         assert len(received_chunks) == 2
 
         assert received_chunks[0].content == "Async streaming"
@@ -485,8 +515,9 @@ class TestWatsonxChatGenerator:
         assert len(result["replies"]) == 1
         assert result["replies"][0].text == "Async streaming response"
 
-    # Multimodal Tests
-    def test_prepare_api_call_with_image(self, mock_watsonx):
+
+class TestMessageConversionAndMultimodal:
+    def test_prepare_api_call_with_image(self):
         """Test that a ChatMessage with ImageContent is converted to WatsonX format correctly."""
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
@@ -496,6 +527,7 @@ class TestWatsonxChatGenerator:
 
         generator = WatsonxChatGenerator(
             model="meta-llama/llama-3-2-11b-vision-instruct",
+            api_key=Secret.from_token("test-api-key"),
             project_id=Secret.from_token("test-project"),
         )
 
@@ -519,7 +551,7 @@ class TestWatsonxChatGenerator:
         assert "url" in watsonx_message["content"][1]["image_url"]
         assert watsonx_message["content"][1]["image_url"]["url"] == f"data:image/png;base64,{base64_image}"
 
-    def test_prepare_api_call_with_unsupported_mime_type(self, mock_watsonx):
+    def test_prepare_api_call_with_unsupported_mime_type(self):
         """Test that a ChatMessage with unsupported mime type raises ValueError."""
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
@@ -535,7 +567,7 @@ class TestWatsonxChatGenerator:
         with pytest.raises(ValueError, match="Unsupported image format: image/bmp"):
             generator._prepare_api_call(messages=[message])
 
-    def test_prepare_api_call_with_none_mime_type(self, mock_watsonx):
+    def test_prepare_api_call_with_none_mime_type(self):
         """Test that a ChatMessage with None mime type raises ValueError."""
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
@@ -553,7 +585,7 @@ class TestWatsonxChatGenerator:
         with pytest.raises(ValueError, match="Unsupported image format: None"):
             generator._prepare_api_call(messages=[message])
 
-    def test_prepare_api_call_image_in_non_user_message(self, mock_watsonx):
+    def test_prepare_api_call_image_in_non_user_message(self):
         """Test that images in non-user messages raise ValueError."""
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
@@ -571,9 +603,7 @@ class TestWatsonxChatGenerator:
         with pytest.raises(ValueError, match="Image content is only supported for user messages"):
             generator._prepare_api_call(messages=[message])
 
-    def test_convert_chunk_to_streaming_chunk_real_example(
-        self, mock_watsonx: dict[str, AsyncMock | MagicMock]
-    ) -> None:
+    def test_convert_chunk_to_streaming_chunk_real_example(self) -> None:
         component = WatsonxChatGenerator(
             project_id=Secret.from_token("test-project"), model="meta-llama/llama-3-2-11b-vision-instruct"
         )
@@ -715,7 +745,7 @@ class TestWatsonxChatGenerator:
         assert messages_arg[0]["content"][0]["type"] == "text"
         assert messages_arg[0]["content"][1]["type"] == "image_url"
 
-    def test_supported_image_formats(self, mock_watsonx):
+    def test_supported_image_formats(self):
         """Test that all supported image formats work correctly."""
         supported_formats = ["image/jpeg", "image/png"]
         base64_image = (
@@ -735,7 +765,7 @@ class TestWatsonxChatGenerator:
             api_call = generator._prepare_api_call(messages=[message])
             assert api_call is not None
 
-    def test_multiple_images_in_single_message(self, mock_watsonx):
+    def test_multiple_images_in_single_message(self):
         """Test handling multiple images in a single message."""
         base64_image = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
@@ -761,11 +791,11 @@ class TestWatsonxChatGenerator:
 
 
 @pytest.mark.integration
-class TestWatsonxChatGeneratorIntegration:
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
+@pytest.mark.skipif(
+    not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
+    reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
+)
+class TestIntegration:
     def test_live_run(self):
         generator = WatsonxChatGenerator(
             project_id=Secret.from_env_var("WATSONX_PROJECT_ID"),
@@ -782,10 +812,6 @@ class TestWatsonxChatGeneratorIntegration:
         assert len(results["replies"][0].text) > 0
         assert isinstance(generator.project_id, Secret)
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_live_run_with_toolset(self, tools: list[Tool]) -> None:
         """Test that WatsonxChatGenerator can run with a Toolset."""
         toolset = Toolset(tools)
@@ -821,10 +847,6 @@ class TestWatsonxChatGeneratorIntegration:
             "Response does not contain Paris or weather"
         )
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_live_run_streaming(self):
         generator = WatsonxChatGenerator(project_id=Secret.from_env_var("WATSONX_PROJECT_ID"))
         collected_chunks = []
@@ -843,10 +865,6 @@ class TestWatsonxChatGeneratorIntegration:
         assert len(collected_chunks) > 0
         assert all(isinstance(chunk, StreamingChunk) for chunk in collected_chunks)
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_live_run_with_tools_streaming(self, tools: list[Tool]) -> None:
         """
         Integration test that the WatsonxChatGenerator component can run with tools and streaming.
@@ -879,10 +897,6 @@ class TestWatsonxChatGeneratorIntegration:
         assert tool_call.tool_name == "weather"
         assert tool_call.arguments == {"city": "Paris"}
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_live_run_with_mixed_tools(self) -> None:
         """
         Integration test that verifies WatsonxChatGenerator works with mixed Tool and Toolset.
@@ -964,10 +978,6 @@ class TestWatsonxChatGeneratorIntegration:
         assert "paris" in final_message.text.lower()
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     async def test_live_run_async(self):
         generator = WatsonxChatGenerator(project_id=Secret.from_env_var("WATSONX_PROJECT_ID"))
         messages = [ChatMessage.from_user("What's the capital of Germany? Answer concisely.")]
@@ -981,10 +991,6 @@ class TestWatsonxChatGeneratorIntegration:
         assert len(results["replies"][0].text) > 0
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     async def test_live_run_async_with_tools(self, tools: list[Tool]) -> None:
         """Test async version with tools."""
         component = WatsonxChatGenerator(project_id=Secret.from_env_var("WATSONX_PROJECT_ID"), tools=tools)
@@ -1006,10 +1012,6 @@ class TestWatsonxChatGeneratorIntegration:
         assert tool_message.tool_calls[0].arguments == {"city": "Paris"}
         assert tool_message.meta["finish_reason"] == "tool_calls"
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_live_run_multimodal(self):
         generator = WatsonxChatGenerator(
             model="meta-llama/llama-4-maverick-17b-128e-instruct-fp8",

--- a/integrations/watsonx/tests/test_document_embedder.py
+++ b/integrations/watsonx/tests/test_document_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from haystack import Document
@@ -11,48 +11,18 @@ from haystack.utils.auth import Secret
 from haystack_integrations.components.embedders.watsonx.document_embedder import WatsonxDocumentEmbedder
 
 
-class TestWatsonXDocumentEmbedder:
-    @pytest.fixture
-    def mock_watsonx(self, monkeypatch):
-        """Fixture for setting up common mocks"""
-        monkeypatch.setenv("WATSONX_API_KEY", "fake-api-key")
-        monkeypatch.setenv("WATSONX_PROJECT_ID", "fake-project-id")
+@pytest.fixture
+def mock_embeddings():
+    """Fixture for setting up common mocks"""
+    with patch("haystack_integrations.components.embedders.watsonx.document_embedder.Embeddings") as embeddings:
+        yield embeddings.return_value
 
-        with patch(
-            "haystack_integrations.components.embedders.watsonx.document_embedder.Embeddings"
-        ) as mock_embeddings:
-            with patch(
-                "haystack_integrations.components.embedders.watsonx.document_embedder.Credentials"
-            ) as mock_credentials:
-                mock_creds_instance = MagicMock()
-                mock_credentials.return_value = mock_creds_instance
 
-                mock_embeddings_instance = MagicMock()
-                mock_embeddings.return_value = mock_embeddings_instance
-
-                yield {
-                    "credentials": mock_credentials,
-                    "embeddings": mock_embeddings,
-                    "creds_instance": mock_creds_instance,
-                    "embeddings_instance": mock_embeddings_instance,
-                }
-
-    def test_init_default(self, mock_watsonx):
+class TestInitializationAndSerialization:
+    def test_init_default(self):
         embedder = WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
 
-        mock_watsonx["credentials"].assert_called_once_with(
-            api_key="fake-api-key", url="https://us-south.ml.cloud.ibm.com"
-        )
-        mock_watsonx["embeddings"].assert_called_once_with(
-            model_id="ibm/slate-30m-english-rtrvr-v2",
-            credentials=mock_watsonx["creds_instance"],
-            project_id="fake-project-id",
-            params=None,
-            batch_size=1000,
-            concurrency_limit=5,
-            max_retries=None,
-        )
-
+        assert embedder.embedder is None
         assert embedder.model == "ibm/slate-30m-english-rtrvr-v2"
         assert embedder.prefix == ""
         assert embedder.suffix == ""
@@ -61,7 +31,7 @@ class TestWatsonXDocumentEmbedder:
         assert isinstance(embedder.project_id, Secret)
         assert embedder.project_id.resolve_value() == "fake-project-id"
 
-    def test_init_with_parameters(self, mock_watsonx):
+    def test_init_with_parameters(self):
         embedder = WatsonxDocumentEmbedder(
             api_key=Secret.from_token("fake-api-key"),
             api_base_url="https://custom-url.ibm.com",
@@ -75,33 +45,11 @@ class TestWatsonXDocumentEmbedder:
             max_retries=5,
         )
 
-        mock_watsonx["credentials"].assert_called_once_with(api_key="fake-api-key", url="https://custom-url.ibm.com")
-        mock_watsonx["embeddings"].assert_called_once_with(
-            model_id="ibm/slate-30m-english-rtrvr-v2",
-            credentials=mock_watsonx["creds_instance"],
-            project_id="custom-project-id",
-            params={"truncate_input_tokens": 128},
-            batch_size=500,
-            concurrency_limit=3,
-            max_retries=5,
-        )
-
+        assert embedder.embedder is None
         assert isinstance(embedder.project_id, Secret)
         assert embedder.project_id.resolve_value() == "custom-project-id"
 
-    def test_init_fail_wo_api_key(self, monkeypatch):
-        monkeypatch.delenv("WATSONX_API_KEY", raising=False)
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
-
-    def test_init_fail_wo_project_id(self, monkeypatch):
-        monkeypatch.setenv("WATSONX_API_KEY", "fake-api-key")
-        monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
-
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            WatsonxDocumentEmbedder()
-
-    def test_to_dict(self, mock_watsonx):
+    def test_to_dict(self):
         component = WatsonxDocumentEmbedder(project_id=Secret.from_env_var("WATSONX_PROJECT_ID"))
         data = component.to_dict()
 
@@ -124,7 +72,7 @@ class TestWatsonXDocumentEmbedder:
             },
         }
 
-    def test_from_dict(self, mock_watsonx):
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.embedders.watsonx.document_embedder.WatsonxDocumentEmbedder",
             "init_parameters": {
@@ -144,13 +92,63 @@ class TestWatsonXDocumentEmbedder:
         assert component.model == "ibm/slate-125m-english-rtrvr"
         assert component.api_base_url == "https://custom-url.ibm.com"
         assert isinstance(component.project_id, Secret)
-        assert component.project_id.resolve_value() == "fake-project-id"
+        assert component.project_id == Secret.from_env_var("WATSONX_PROJECT_ID")
         assert component.prefix == "prefix "
         assert component.suffix == " suffix"
         assert component.batch_size == 500
         assert component.concurrency_limit == 3
 
-    def test_prepare_texts_to_embed(self, mock_watsonx):
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("WATSONX_API_KEY", raising=False)
+        embedder = WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
+
+        assert embedder.embedder is None
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            embedder.warm_up()
+
+    def test_project_id_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
+        embedder = WatsonxDocumentEmbedder(api_key=Secret.from_token("fake-api-key"))
+
+        assert embedder.embedder is None
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            embedder.warm_up()
+
+    def test_warm_up_is_idempotent(self):
+        with (
+            patch("haystack_integrations.components.embedders.watsonx.document_embedder.Credentials") as credentials,
+            patch("haystack_integrations.components.embedders.watsonx.document_embedder.Embeddings") as embeddings,
+        ):
+            embedder = WatsonxDocumentEmbedder(
+                api_key=Secret.from_token("fake-api-key"),
+                api_base_url="https://custom-url.ibm.com",
+                project_id=Secret.from_token("fake-project-id"),
+                truncate_input_tokens=128,
+                batch_size=500,
+                concurrency_limit=3,
+                max_retries=5,
+            )
+            embedder.warm_up()
+            client = embedder.embedder
+            embedder.warm_up()
+
+        credentials.assert_called_once_with(api_key="fake-api-key", url="https://custom-url.ibm.com")
+        embeddings.assert_called_once_with(
+            model_id="ibm/slate-30m-english-rtrvr-v2",
+            credentials=credentials.return_value,
+            project_id="fake-project-id",
+            params={"truncate_input_tokens": 128},
+            batch_size=500,
+            concurrency_limit=3,
+            max_retries=5,
+        )
+        assert embedder.embedder is client
+
+
+class TestRun:
+    def test_prepare_texts_to_embed(self):
         embedder = WatsonxDocumentEmbedder(
             project_id=Secret.from_token("fake-project-id"),
             prefix="prefix ",
@@ -162,29 +160,33 @@ class TestWatsonXDocumentEmbedder:
         )
         assert prepared_text == ["prefix test\nThe food was delicious suffix"]
 
-    def test_run_wrong_input_format(self, mock_watsonx):
+    def test_run_wrong_input_format(self):
         embedder = WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
         with pytest.raises(TypeError, match=r"WatsonxDocumentEmbedder expects a list of Documents as input\."):
             embedder.run(documents="not a list")  # type: ignore
 
-    def test_run_empty_documents(self, mock_watsonx):
-        embedder = WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
+    def test_run_empty_documents(self, mock_embeddings):
+        embedder = WatsonxDocumentEmbedder(
+            api_key=Secret.from_token("fake-api-key"), project_id=Secret.from_token("fake-project-id")
+        )
         result = embedder.run(documents=[])
         assert result == {
             "documents": [],
             "meta": {"model": "ibm/slate-30m-english-rtrvr-v2", "truncate_input_tokens": None, "batch_size": 1000},
         }
 
-    def test_run_does_not_modify_original_documents(self, mock_watsonx):
+    def test_run_does_not_modify_original_documents(self, mock_embeddings):
         """Test that original documents are not modified during embedding"""
-        embedder = WatsonxDocumentEmbedder(project_id=Secret.from_token("fake-project-id"))
+        embedder = WatsonxDocumentEmbedder(
+            api_key=Secret.from_token("fake-api-key"), project_id=Secret.from_token("fake-project-id")
+        )
         original_docs = [
             Document(content="I love cheese"),
             Document(content="A transformer is a deep learning architecture"),
         ]
 
         # Mock the embedder to return embeddings
-        mock_watsonx["embeddings_instance"].embed_documents.return_value = [
+        mock_embeddings.embed_documents.return_value = [
             [0.1, 0.2, 0.3],
             [0.4, 0.5, 0.6],
         ]
@@ -201,7 +203,11 @@ class TestWatsonXDocumentEmbedder:
 
 
 @pytest.mark.integration
-class TestWatsonxDocumentEmbedderIntegration:
+@pytest.mark.skipif(
+    not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
+    reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
+)
+class TestIntegration:
     """Integration tests for WatsonxDocumentEmbedder (requires real credentials)"""
 
     @pytest.fixture
@@ -212,10 +218,6 @@ class TestWatsonxDocumentEmbedderIntegration:
             Document(content="Haystack is an open-source framework for building search systems"),
         ]
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_run(self, test_documents):
         """Test real API call with documents"""
         embedder = WatsonxDocumentEmbedder(
@@ -233,10 +235,6 @@ class TestWatsonxDocumentEmbedderIntegration:
 
         assert result["meta"]["model"] == "ibm/slate-30m-english-rtrvr-v2"
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_batch_processing(self, test_documents):
         """Test that batch processing works"""
         embedder = WatsonxDocumentEmbedder(
@@ -250,10 +248,6 @@ class TestWatsonxDocumentEmbedderIntegration:
         assert len(result["documents"]) == 3
         assert all(doc.embedding is not None for doc in result["documents"])
 
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_text_truncation(self):
         """Test that truncation works with long documents"""
         long_content = "This is a very long document. " * 10

--- a/integrations/watsonx/tests/test_text_embedder.py
+++ b/integrations/watsonx/tests/test_text_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from haystack.utils.auth import Secret
@@ -11,50 +11,18 @@ from ibm_watsonx_ai.wml_client_error import ApiRequestFailure
 from haystack_integrations.components.embedders.watsonx.text_embedder import WatsonxTextEmbedder
 
 
-class TestWatsonxTextEmbedder:
-    @pytest.fixture
-    def mock_watsonx(self, monkeypatch):
-        """Fixture for setting up common mocks"""
-        monkeypatch.setenv("WATSONX_API_KEY", "fake-api-key")
-        monkeypatch.setenv("WATSONX_PROJECT_ID", "fake-project-id")
-
-        with patch("haystack_integrations.components.embedders.watsonx.text_embedder.Embeddings") as mock_embeddings:
-            with patch(
-                "haystack_integrations.components.embedders.watsonx.text_embedder.Credentials"
-            ) as mock_credentials:
-                mock_creds_instance = MagicMock()
-                mock_credentials.return_value = mock_creds_instance
-
-                mock_embeddings_instance = MagicMock()
-                mock_embeddings.return_value = mock_embeddings_instance
-
-                yield {
-                    "credentials": mock_credentials,
-                    "embeddings": mock_embeddings,
-                    "creds_instance": mock_creds_instance,
-                    "embeddings_instance": mock_embeddings_instance,
-                }
-
-    def test_init_default(self, mock_watsonx):
+class TestInitializationAndSerialization:
+    def test_init_default(self):
         embedder = WatsonxTextEmbedder(project_id=Secret.from_token("fake-project-id"))
 
-        mock_watsonx["credentials"].assert_called_once_with(
-            api_key="fake-api-key", url="https://us-south.ml.cloud.ibm.com"
-        )
-        mock_watsonx["embeddings"].assert_called_once_with(
-            model_id="ibm/slate-30m-english-rtrvr-v2",
-            credentials=mock_watsonx["creds_instance"],
-            project_id="fake-project-id",
-            params=None,
-            max_retries=None,
-        )
+        assert embedder.embedder is None
         assert isinstance(embedder.project_id, Secret)
         assert embedder.project_id.resolve_value() == "fake-project-id"
         assert embedder.model == "ibm/slate-30m-english-rtrvr-v2"
         assert embedder.prefix == ""
         assert embedder.suffix == ""
 
-    def test_init_with_parameters(self, mock_watsonx):
+    def test_init_with_parameters(self):
         embedder = WatsonxTextEmbedder(
             api_key=Secret.from_token("fake-api-key"),
             model="ibm/slate-125m-english-rtrvr",
@@ -69,27 +37,9 @@ class TestWatsonxTextEmbedder:
         assert isinstance(embedder.project_id, Secret)
         assert embedder.project_id.resolve_value() == "custom-project-id"
 
-        mock_watsonx["credentials"].assert_called_once_with(api_key="fake-api-key", url="https://custom-url.ibm.com")
-        mock_watsonx["embeddings"].assert_called_once_with(
-            model_id="ibm/slate-125m-english-rtrvr",
-            credentials=mock_watsonx["creds_instance"],
-            project_id="custom-project-id",
-            params={"truncate_input_tokens": 128},
-            max_retries=5,
-        )
+        assert embedder.embedder is None
 
-    def test_init_fail_wo_api_key(self, monkeypatch):
-        monkeypatch.delenv("WATSONX_API_KEY", raising=False)
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            WatsonxTextEmbedder(project_id=Secret.from_env_var("WATSONX_PROJECT_ID"))
-
-    def test_init_fail_wo_project_id(self, monkeypatch):
-        monkeypatch.setenv("WATSONX_API_KEY", "fake-api-key")
-        monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            WatsonxTextEmbedder()
-
-    def test_to_dict(self, mock_watsonx):
+    def test_to_dict(self):
         component = WatsonxTextEmbedder(project_id=Secret.from_env_var("WATSONX_PROJECT_ID"))
         data = component.to_dict()
 
@@ -108,7 +58,7 @@ class TestWatsonxTextEmbedder:
             },
         }
 
-    def test_from_dict(self, mock_watsonx):
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.embedders.watsonx.text_embedder.WatsonxTextEmbedder",
             "init_parameters": {
@@ -126,11 +76,58 @@ class TestWatsonxTextEmbedder:
         assert component.model == "ibm/slate-125m-english-rtrvr"
         assert component.api_base_url == "https://custom-url.ibm.com"
         assert isinstance(component.project_id, Secret)
-        assert component.project_id.resolve_value() == "fake-project-id"
+        assert component.project_id == Secret.from_env_var("WATSONX_PROJECT_ID")
         assert component.prefix == "prefix "
         assert component.suffix == " suffix"
 
-    def test_prepare_input(self, mock_watsonx):
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("WATSONX_API_KEY", raising=False)
+        embedder = WatsonxTextEmbedder(project_id=Secret.from_token("fake-project-id"))
+
+        assert embedder.embedder is None
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            embedder.warm_up()
+
+    def test_project_id_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
+        embedder = WatsonxTextEmbedder(api_key=Secret.from_token("fake-api-key"))
+
+        assert embedder.embedder is None
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            embedder.warm_up()
+
+    def test_warm_up_is_idempotent(self):
+        with (
+            patch("haystack_integrations.components.embedders.watsonx.text_embedder.Credentials") as credentials,
+            patch("haystack_integrations.components.embedders.watsonx.text_embedder.Embeddings") as embeddings,
+        ):
+            embedder = WatsonxTextEmbedder(
+                api_key=Secret.from_token("fake-api-key"),
+                model="ibm/slate-125m-english-rtrvr",
+                api_base_url="https://custom-url.ibm.com",
+                project_id=Secret.from_token("fake-project-id"),
+                truncate_input_tokens=128,
+                max_retries=5,
+            )
+            embedder.warm_up()
+            client = embedder.embedder
+            embedder.warm_up()
+
+        credentials.assert_called_once_with(api_key="fake-api-key", url="https://custom-url.ibm.com")
+        embeddings.assert_called_once_with(
+            model_id="ibm/slate-125m-english-rtrvr",
+            credentials=credentials.return_value,
+            project_id="fake-project-id",
+            params={"truncate_input_tokens": 128},
+            max_retries=5,
+        )
+        assert embedder.embedder is client
+
+
+class TestRun:
+    def test_prepare_input(self):
         embedder = WatsonxTextEmbedder(
             project_id=Secret.from_token("fake-project-id"), prefix="prefix ", suffix=" suffix"
         )
@@ -138,7 +135,7 @@ class TestWatsonxTextEmbedder:
         prepared_input = embedder._prepare_input(input_text)
         assert prepared_input == "prefix The food was delicious suffix"
 
-    def test_run_wrong_input_format(self, mock_watsonx):
+    def test_run_wrong_input_format(self):
         embedder = WatsonxTextEmbedder(project_id=Secret.from_token("fake-project-id"))
         with pytest.raises(
             TypeError,
@@ -148,14 +145,14 @@ class TestWatsonxTextEmbedder:
             embedder.run(text=[1, 2, 3])
 
 
-class TestWatsonxTextEmbedderIntegration:
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
+    reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
+)
+class TestIntegration:
     """Integration tests for WatsonxTextEmbedder (requires real credentials)"""
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_run(self):
         """Test real API call with simple text"""
         embedder = WatsonxTextEmbedder(
@@ -173,11 +170,6 @@ class TestWatsonxTextEmbedderIntegration:
         assert "slate" in result["meta"]["model"].lower()
         assert "30m" in result["meta"]["model"].lower()
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_text_too_long(self):
         """Test handling of text that exceeds token limit when truncation is disabled"""
         embedder = WatsonxTextEmbedder(
@@ -194,11 +186,6 @@ class TestWatsonxTextEmbedderIntegration:
         assert "Please reduce the length of the input." in str(exc_info.value)
         assert "512" in str(exc_info.value)
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("WATSONX_API_KEY") or not os.environ.get("WATSONX_PROJECT_ID"),
-        reason="WATSONX_API_KEY or WATSONX_PROJECT_ID not set",
-    )
     def test_text_truncation(self):
         """Test that truncation works with long text"""
         embedder = WatsonxTextEmbedder(


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- move client creation (and secret resolution) to `warm_up`
- WatsonX is special: it exposes a single client that internally wraps sync and async clients. For this reason, I'm not introducing separate sync/async warm-up methods.
- no closing method since the WatsonX client does not expose it
- pin `haystack-ai>=3.0.0`

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
