### PR TITLE
fix(pgvector): raise FilterError on empty logical conditions

### DIFF
--- a/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
+++ b/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py
@@ -71,6 +71,13 @@ def _parse_logical_condition(condition: dict[str, Any]) -> tuple[Composed, list[
         msg = f"Unknown logical operator '{operator}'. Valid operators are: 'AND', 'OR'"
         raise FilterError(msg)
 
+    # an empty list of conditions has no unambiguous meaning: an empty 'AND' matches every document
+    # while an empty 'OR' matches none, so the same filter would mean opposite things depending on the
+    # operator. Callers building conditions dynamically should omit the group instead.
+    if not condition["conditions"]:
+        msg = f"'conditions' must not be empty in {condition}"
+        raise FilterError(msg)
+
     # logical conditions can be nested, so we need to parse them recursively
     conditions = []
     for c in condition["conditions"]:

--- a/integrations/pgvector/tests/test_filters.py
+++ b/integrations/pgvector/tests/test_filters.py
@@ -483,3 +483,21 @@ def test_validate_filters():
     invalid_filters = {"field": "meta.number", "value": "100"}
     with pytest.raises(ValueError):
         _validate_filters(invalid_filters)
+
+
+@pytest.mark.parametrize("operator", ["AND", "OR"])
+def test_logical_condition_empty_conditions_raises(operator):
+    with pytest.raises(FilterError):
+        _parse_logical_condition({"operator": operator, "conditions": []})
+
+
+def test_logical_condition_nested_empty_conditions_raises():
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.type", "operator": "==", "value": "article"},
+            {"operator": "OR", "conditions": []},
+        ],
+    }
+    with pytest.raises(FilterError):
+        _convert_filters_to_where_clause_and_params(filters)


### PR DESCRIPTION
### Related Issues

None — found while reading the filter code, not reported in the tracker.

### Proposed Changes:

`_parse_logical_condition` raises `IndexError: list index out of range` instead of
`FilterError` when a logical condition has an empty `conditions` list:

    {"operator": "AND", "conditions": []}   -> IndexError
    {"operator": "OR", "conditions": []}   -> IndexError
    {"operator": "AND", "conditions": [{...}, {"operator": "OR", "conditions": []}]} -> IndexError

Cause: after collecting sub-conditions the function decides whether to flatten with
`if isinstance(values[0], list)`. With no sub-conditions `values` is empty and the
subscript raises. It is reachable from `filter_documents()`, since `_validate_filters`
accepts the dict — both required keys are present. It shows up with dynamically-built
filters, where a conditions list assembled from user-selected facets can come out empty.

This raises `FilterError` rather than ignoring the group, because an empty `AND` is
conventionally true and an empty `OR` conventionally false — accepting it silently would
make the same filter mean opposite things depending on the operator. Same reasoning as
the existing empty-list check in `_validate_array_operator_value`.

The guard is placed after the operator validation so that
`test_logical_condition_unknown_operator`, which passes an empty conditions list with an
invalid operator, still reports the unknown operator rather than the empty list.

### How did you test it?

Three unit tests added to `tests/test_filters.py` — two parametrised for AND/OR, one
nested. Confirmed failing with `IndexError` before the change and passing after.
Full unit suite: 98 passed. `ruff check` and `ruff format --check` clean.

I could not run mypy locally (Windows Application Control blocks a compiled module it
loads on import), so that check is left to CI. The change adds no annotations or new
signatures.

### Notes for the reviewer

An AI assistant helped identify the issue and draft the patch and tests. I reproduced the
`IndexError` and verified the fix locally.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct
- [ ] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the conventional commit types for my PR title