### PR TITLE
feat: RemoteWhisperTranscriber - add lifecycle handling

### DIFF
--- a/integrations/whisper/pyproject.toml
+++ b/integrations/whisper/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 # `openai` ships with `haystack-ai` and is used by `RemoteWhisperTranscriber`. `openai-whisper` (used by
 # `LocalWhisperTranscriber`) is imported lazily, so it is an optional dependency that users install only if
 # they want local transcription: `pip install "openai-whisper>=20231106"`.
-dependencies = ["haystack-ai>=2.24.1"]
+dependencies = ["haystack-ai>=3.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/whisper#readme"

--- a/integrations/whisper/src/haystack_integrations/components/audio/whisper/whisper_local.py
+++ b/integrations/whisper/src/haystack_integrations/components/audio/whisper/whisper_local.py
@@ -80,7 +80,7 @@ class LocalWhisperTranscriber:
         """
         Loads the model in memory.
         """
-        if not self._model:
+        if self._model is None:
             self._model = whisper.load_model(self.model, device=self.device.to_torch())
 
     def to_dict(self) -> dict[str, Any]:
@@ -124,8 +124,8 @@ class LocalWhisperTranscriber:
                 the Whisper model, such as the alignment data and the path to the audio file used
                 for the transcription.
         """
-        if self._model is None:
-            self.warm_up()
+        self.warm_up()
+        assert self._model is not None  # noqa: S101
 
         if whisper_params is None:
             whisper_params = self.whisper_params
@@ -179,8 +179,8 @@ class LocalWhisperTranscriber:
         :returns:
             A dictionary mapping 'file_path' to 'transcription'.
         """
-        if self._model is None:
-            self.warm_up()
+        self.warm_up()
+        assert self._model is not None  # noqa: S101
 
         return_segments = kwargs.pop("return_segments", False)
         transcriptions = {}
@@ -188,8 +188,7 @@ class LocalWhisperTranscriber:
         for source in sources:
             path = self._get_path(source)
 
-            # mypy doesn't know this is set in warm_up
-            transcription = self._model.transcribe(str(path), **kwargs)  # type: ignore[attr-defined]
+            transcription = self._model.transcribe(str(path), **kwargs)
 
             if not return_segments:
                 transcription.pop("segments", None)

--- a/integrations/whisper/src/haystack_integrations/components/audio/whisper/whisper_remote.py
+++ b/integrations/whisper/src/haystack_integrations/components/audio/whisper/whisper_remote.py
@@ -97,23 +97,48 @@ class RemoteWhisperTranscriber:
             )
         whisper_params["response_format"] = "json"
         self.whisper_params = whisper_params
-        # openai>=3 annotates http_client as httpx2, but legacy httpx clients are supported at runtime.
-        # https://github.com/openai/openai-python/blob/main/httpx2.md
-        http_client = init_http_client(self.http_client_kwargs, async_client=False)
-        async_http_client = init_http_client(self.http_client_kwargs, async_client=True)
+        self.client: OpenAI | None = None
+        self.async_client: AsyncOpenAI | None = None
 
-        self.client = OpenAI(
-            api_key=api_key.resolve_value(),
-            organization=organization,
-            base_url=api_base_url,
-            http_client=http_client,  # type: ignore[arg-type]
-        )
-        self.async_client = AsyncOpenAI(
-            api_key=api_key.resolve_value(),
-            organization=organization,
-            base_url=api_base_url,
-            http_client=async_http_client,  # type: ignore[arg-type]
-        )
+    def warm_up(self) -> None:
+        """Create the synchronous OpenAI client."""
+        if self.client is None:
+            # openai>=3 annotates http_client as httpx2, but legacy httpx clients are supported at runtime.
+            # https://github.com/openai/openai-python/blob/main/httpx2.md
+            api_key = self.api_key.resolve_value()
+            http_client = init_http_client(self.http_client_kwargs, async_client=False)
+            self.client = OpenAI(
+                api_key=api_key,
+                organization=self.organization,
+                base_url=self.api_base_url,
+                http_client=http_client,  # type: ignore[arg-type]
+            )
+
+    async def warm_up_async(self) -> None:
+        """Create the asynchronous OpenAI client."""
+        if self.async_client is None:
+            # openai>=3 annotates http_client as httpx2, but legacy httpx clients are supported at runtime.
+            # https://github.com/openai/openai-python/blob/main/httpx2.md
+            api_key = self.api_key.resolve_value()
+            async_http_client = init_http_client(self.http_client_kwargs, async_client=True)
+            self.async_client = AsyncOpenAI(
+                api_key=api_key,
+                organization=self.organization,
+                base_url=self.api_base_url,
+                http_client=async_http_client,  # type: ignore[arg-type]
+            )
+
+    def close(self) -> None:
+        """Close the synchronous OpenAI client."""
+        if self.client is not None:
+            self.client.close()
+            self.client = None
+
+    async def close_async(self) -> None:
+        """Close the asynchronous OpenAI client."""
+        if self.async_client is not None:
+            await self.async_client.close()
+            self.async_client = None
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -156,6 +181,9 @@ class RemoteWhisperTranscriber:
             - `documents`: A list of documents, one document for each file.
                 The content of each document is the transcribed text.
         """
+        self.warm_up()
+        assert self.client is not None  # noqa: S101
+
         documents = []
 
         for source in sources:
@@ -189,6 +217,9 @@ class RemoteWhisperTranscriber:
             - `documents`: A list of documents, one document for each file.
                 The content of each document is the transcribed text.
         """
+        await self.warm_up_async()
+        assert self.async_client is not None  # noqa: S101
+
         documents = []
 
         for source in sources:

--- a/integrations/whisper/tests/test_whisper_local.py
+++ b/integrations/whisper/tests/test_whisper_local.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,7 +17,7 @@ from haystack_integrations.components.audio.whisper import LocalWhisperTranscrib
 SAMPLES_PATH = Path(__file__).parent / "test_files"
 
 
-class TestLocalWhisperTranscriber:
+class TestInitialization:
     def test_init(self):
         transcriber = LocalWhisperTranscriber(
             model="large-v2"
@@ -31,6 +30,8 @@ class TestLocalWhisperTranscriber:
         with pytest.raises(ValueError, match="Model name 'whisper-1' not recognized"):
             LocalWhisperTranscriber(model="whisper-1")
 
+
+class TestSerialization:
     def test_to_dict(self):
         transcriber = LocalWhisperTranscriber()
         data = transcriber.to_dict()
@@ -95,20 +96,24 @@ class TestLocalWhisperTranscriber:
         assert transcriber.whisper_params == {}
         assert transcriber._model is None
 
-    def test_warmup(self):
+
+class TestComponentLifecycle:
+    def test_warm_up(self):
         with patch("haystack_integrations.components.audio.whisper.whisper_local.whisper") as mocked_whisper:
             transcriber = LocalWhisperTranscriber(model="large-v2", device=ComponentDevice.from_str("cpu"))
             mocked_whisper.load_model.assert_not_called()
             transcriber.warm_up()
             mocked_whisper.load_model.assert_called_once_with("large-v2", device=torch.device(type="cpu"))
 
-    def test_warmup_doesnt_reload(self):
+    def test_warm_up_is_idempotent(self):
         with patch("haystack_integrations.components.audio.whisper.whisper_local.whisper") as mocked_whisper:
             transcriber = LocalWhisperTranscriber(model="large-v2")
             transcriber.warm_up()
             transcriber.warm_up()
             mocked_whisper.load_model.assert_called_once()
 
+
+class TestRun:
     def test_run_with_path(self):
         comp = LocalWhisperTranscriber(model="large-v2")
         comp._model = MagicMock()
@@ -210,8 +215,9 @@ class TestLocalWhisperTranscriber:
             mocked_whisper.load_model.assert_called_once()
             assert results[0].content == "test transcription"
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="ffmpeg not installed on Windows CI")
+
+@pytest.mark.integration
+class TestIntegration:
     def test_whisper_local_transcriber(self, test_files_path):
         # Force CPU. By default the component resolves to the best available device, which is MPS on Apple
         # Silicon. Whisper inference on MPS is unreliable on the GitHub-hosted macOS runners and produced
@@ -247,8 +253,6 @@ class TestLocalWhisperTranscriber:
         # meta.audio_file should contain the temp path where we dumped the audio bytes
         assert docs[2].meta["audio_file"]
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="ffmpeg not installed on Windows CI")
     def test_whisper_local_transcriber_pipeline_and_url_source(self):
         pipe = Pipeline()
         pipe.add_component("fetcher", LinkContentFetcher())

--- a/integrations/whisper/tests/test_whisper_remote.py
+++ b/integrations/whisper/tests/test_whisper_remote.py
@@ -3,35 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from haystack.dataclasses import ByteStream
 from haystack.utils import Secret
-from openai import AsyncOpenAI
 
 from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
 
 
-class TestRemoteWhisperTranscriber:
-    def test_init_no_key(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            RemoteWhisperTranscriber()
-
-    def test_init_key_env_var(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
-        t = RemoteWhisperTranscriber()
-        assert t.client.api_key == "test_api_key"
-
-    def test_init_key_module_env_and_global_var(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key_2")
-        t = RemoteWhisperTranscriber()
-        assert t.client.api_key == "test_api_key_2"
-
+class TestInitialization:
     def test_init_default(self):
         transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
-        assert transcriber.client.api_key == "test_api_key"
+        assert transcriber.client is None
+        assert transcriber.async_client is None
         assert transcriber.model == "whisper-1"
         assert transcriber.organization is None
         assert transcriber.whisper_params == {"response_format": "json"}
@@ -59,14 +44,14 @@ class TestRemoteWhisperTranscriber:
             "temperature": "0.5",
         }
 
-    def test_init_overwrites_non_json_response_format(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+    def test_init_overwrites_non_json_response_format(self):
         # Only `response_format="json"` is supported; any other value is overwritten.
         transcriber = RemoteWhisperTranscriber(response_format="text")
         assert transcriber.whisper_params["response_format"] == "json"
 
-    def test_to_dict_default_parameters(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+
+class TestSerialization:
+    def test_to_dict_default_parameters(self):
         transcriber = RemoteWhisperTranscriber()
         data = transcriber.to_dict()
         assert data == {
@@ -81,8 +66,7 @@ class TestRemoteWhisperTranscriber:
             },
         }
 
-    def test_to_dict_with_custom_init_parameters(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+    def test_to_dict_with_custom_init_parameters(self):
         transcriber = RemoteWhisperTranscriber(
             api_key=Secret.from_env_var("ENV_VAR", strict=False),
             model="whisper-1",
@@ -110,9 +94,7 @@ class TestRemoteWhisperTranscriber:
             },
         }
 
-    def test_from_dict_with_default_parameters(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
-
+    def test_from_dict_with_default_parameters(self):
         data = {
             "type": "haystack_integrations.components.audio.whisper.whisper_remote.RemoteWhisperTranscriber",
             "init_parameters": {
@@ -132,9 +114,7 @@ class TestRemoteWhisperTranscriber:
         assert transcriber.whisper_params == {"response_format": "json"}
         assert transcriber.http_client_kwargs is None
 
-    def test_from_dict_with_custom_init_parameters(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
-
+    def test_from_dict_with_custom_init_parameters(self):
         data = {
             "type": "haystack_integrations.components.audio.whisper.whisper_remote.RemoteWhisperTranscriber",
             "init_parameters": {
@@ -173,11 +153,116 @@ class TestRemoteWhisperTranscriber:
             },
         }
 
-        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
-            RemoteWhisperTranscriber.from_dict(data)
+        transcriber = RemoteWhisperTranscriber.from_dict(data)
+        assert transcriber.client is None
+        assert transcriber.async_client is None
 
-    def test_run_with_path(self, monkeypatch, test_files_path):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+
+class TestComponentLifecycle:
+    def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        transcriber = RemoteWhisperTranscriber()
+
+        with pytest.raises(ValueError, match=r"None of the .* environment variables are set"):
+            transcriber.warm_up()
+
+    def test_sync_lifecycle(self):
+        with (
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.OpenAI") as mock_client_cls,
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.init_http_client"),
+        ):
+            transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+            client = mock_client_cls.return_value
+
+            transcriber.warm_up()
+            assert transcriber.client is client
+            assert transcriber.async_client is None
+
+            transcriber.close()
+            client.close.assert_called_once_with()
+            assert transcriber.client is None
+
+            transcriber.warm_up()
+            assert mock_client_cls.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_async_lifecycle(self):
+        with (
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.AsyncOpenAI") as mock_client_cls,
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.init_http_client"),
+        ):
+            transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+            client = mock_client_cls.return_value
+            client.close = AsyncMock()
+
+            await transcriber.warm_up_async()
+            assert transcriber.client is None
+            assert transcriber.async_client is client
+
+            await transcriber.close_async()
+            client.close.assert_awaited_once_with()
+            assert transcriber.async_client is None
+
+            await transcriber.warm_up_async()
+            assert mock_client_cls.call_count == 2
+
+    def test_warm_up_is_idempotent(self):
+        with (
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.OpenAI") as mock_openai,
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.init_http_client"),
+        ):
+            transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+            transcriber.warm_up()
+            transcriber.warm_up()
+
+        mock_openai.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_warm_up_async_is_idempotent(self):
+        with (
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.AsyncOpenAI") as mock_async_openai,
+            patch("haystack_integrations.components.audio.whisper.whisper_remote.init_http_client"),
+        ):
+            transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+            await transcriber.warm_up_async()
+            await transcriber.warm_up_async()
+
+        mock_async_openai.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_without_warm_up(self):
+        transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+
+        transcriber.close()
+        await transcriber.close_async()
+
+        assert transcriber.client is None
+        assert transcriber.async_client is None
+
+    @pytest.mark.asyncio
+    async def test_close_and_close_async_are_independent(self):
+        sync_client = Mock()
+        async_client = Mock()
+        async_client.close = AsyncMock()
+        transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+        transcriber.client = sync_client
+        transcriber.async_client = async_client
+
+        transcriber.close()
+
+        sync_client.close.assert_called_once_with()
+        async_client.close.assert_not_awaited()
+        assert transcriber.client is None
+        assert transcriber.async_client is async_client
+
+        await transcriber.close_async()
+
+        async_client.close.assert_awaited_once_with()
+        assert transcriber.async_client is None
+
+
+class TestRun:
+    def test_run_with_path(self, test_files_path):
         transcriber = RemoteWhisperTranscriber()
 
         mock_client = Mock()
@@ -193,8 +278,7 @@ class TestRemoteWhisperTranscriber:
         assert docs[0].meta["file_path"] == audio_path
         mock_client.audio.transcriptions.create.assert_called_once()
 
-    def test_run_with_bytestream(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+    def test_run_with_bytestream(self):
         transcriber = RemoteWhisperTranscriber()
 
         mock_client = Mock()
@@ -211,11 +295,52 @@ class TestRemoteWhisperTranscriber:
         assert docs[0].meta["file_path"] == "answer.wav"
         mock_client.audio.transcriptions.create.assert_called_once()
 
+
+class TestRunAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_with_path(self, test_files_path):
+        transcriber = RemoteWhisperTranscriber()
+
+        mock_client = Mock()
+        mock_client.audio.transcriptions.create = AsyncMock(
+            return_value=Mock(text="this is the content of the document.")
+        )
+        transcriber.async_client = mock_client
+
+        audio_path = str(test_files_path / "audio" / "this is the content of the document.wav")
+        output = await transcriber.run_async(sources=[audio_path])
+
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "this is the content of the document."
+        assert docs[0].meta["file_path"] == audio_path
+        mock_client.audio.transcriptions.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_bytestream(self):
+        transcriber = RemoteWhisperTranscriber()
+
+        mock_client = Mock()
+        mock_client.audio.transcriptions.create = AsyncMock(return_value=Mock(text="answer."))
+        transcriber.async_client = mock_client
+
+        source = ByteStream(data=b"fake audio bytes")
+        source.meta["file_path"] = "answer.wav"
+        output = await transcriber.run_async(sources=[source])
+
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "answer."
+        assert docs[0].meta["file_path"] == "answer.wav"
+        mock_client.audio.transcriptions.create.assert_awaited_once()
+
+
+@pytest.mark.integration
+class TestIntegration:
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
         reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
     )
-    @pytest.mark.integration
     def test_whisper_remote_transcriber(self, test_files_path):
         transcriber = RemoteWhisperTranscriber()
 
@@ -238,58 +363,13 @@ class TestRemoteWhisperTranscriber:
         assert docs[2].content.strip().lower() == "answer."
 
 
-class TestRemoteWhisperTranscriberAsync:
-    def test_init_async_client(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
-        transcriber = RemoteWhisperTranscriber()
-        assert isinstance(transcriber.async_client, AsyncOpenAI)
-        assert transcriber.async_client.api_key == "test_api_key"
-
-    @pytest.mark.asyncio
-    async def test_run_async_with_path(self, monkeypatch, test_files_path):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
-        transcriber = RemoteWhisperTranscriber()
-
-        mock_client = Mock()
-        mock_client.audio.transcriptions.create = AsyncMock(
-            return_value=Mock(text="this is the content of the document.")
-        )
-        transcriber.async_client = mock_client
-
-        audio_path = str(test_files_path / "audio" / "this is the content of the document.wav")
-        output = await transcriber.run_async(sources=[audio_path])
-
-        docs = output["documents"]
-        assert len(docs) == 1
-        assert docs[0].content == "this is the content of the document."
-        assert docs[0].meta["file_path"] == audio_path
-        mock_client.audio.transcriptions.create.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_run_async_with_bytestream(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
-        transcriber = RemoteWhisperTranscriber()
-
-        mock_client = Mock()
-        mock_client.audio.transcriptions.create = AsyncMock(return_value=Mock(text="answer."))
-        transcriber.async_client = mock_client
-
-        source = ByteStream(data=b"fake audio bytes")
-        source.meta["file_path"] = "answer.wav"
-        output = await transcriber.run_async(sources=[source])
-
-        docs = output["documents"]
-        assert len(docs) == 1
-        assert docs[0].content == "answer."
-        assert docs[0].meta["file_path"] == "answer.wav"
-        mock_client.audio.transcriptions.create.assert_awaited_once()
-
+@pytest.mark.integration
+class TestAsyncIntegration:
     @pytest.mark.asyncio
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
         reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
     )
-    @pytest.mark.integration
     async def test_whisper_remote_transcriber_async(self, test_files_path):
         transcriber = RemoteWhisperTranscriber()
 


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- for RemoteWhisperTranscriber
  - separate sync/async lifecycle
  - add closing methods
- pin `haystack>=3.0.0`  

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
