### PR TITLE
refactor!: langfuse connector - move tracer creation at warm_up

### DIFF
--- a/integrations/langfuse/pyproject.toml
+++ b/integrations/langfuse/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["haystack-ai>=2.22.0", "langfuse>=4.0.0"]
+dependencies = ["haystack-ai>=3.0.0", "langfuse>=4.0.0"]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langfuse#readme"

--- a/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
+++ b/integrations/langfuse/src/haystack_integrations/components/connectors/langfuse/langfuse_connector.py
@@ -157,18 +157,28 @@ class LangfuseConnector:
         self.span_handler = span_handler
         self.host = host
         self.langfuse_client_kwargs = langfuse_client_kwargs
+        self._httpx_client = httpx_client
+        self.tracer: LangfuseTracer | None = None
+
+    def warm_up(self) -> None:
+        """
+        Initialize the Langfuse client and enable tracing once.
+        """
+        if self.tracer is not None:
+            return
+
         resolved_langfuse_client_kwargs = {
-            "secret_key": secret_key.resolve_value() if secret_key else None,
-            "public_key": public_key.resolve_value() if public_key else None,
-            "httpx_client": httpx_client,
-            "host": host,
-            **(langfuse_client_kwargs or {}),
+            "secret_key": self.secret_key.resolve_value() if self.secret_key else None,
+            "public_key": self.public_key.resolve_value() if self.public_key else None,
+            "httpx_client": self._httpx_client,
+            "host": self.host,
+            **(self.langfuse_client_kwargs or {}),
         }
         self.tracer = LangfuseTracer(
             tracer=Langfuse(**resolved_langfuse_client_kwargs),
-            name=name,
-            public=public,
-            span_handler=span_handler,
+            name=self.name,
+            public=self.public,
+            span_handler=self.span_handler,
         )
         tracing.enable_tracing(self.tracer)
 
@@ -186,6 +196,8 @@ class LangfuseConnector:
             - `trace_url`: The URL to the tracing data.
             - `trace_id`: The ID of the trace.
         """
+        self.warm_up()
+        assert self.tracer is not None
         logger.debug(
             "Langfuse tracer invoked with the following context: '{invocation_context}'",
             invocation_context=invocation_context,

--- a/integrations/langfuse/tests/test_langfuse_connector.py
+++ b/integrations/langfuse/tests/test_langfuse_connector.py
@@ -6,15 +6,27 @@ import os
 
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from haystack import Pipeline
+import httpx
+import pytest
+from haystack import Pipeline, tracing
 from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.tracing.tracer import NullTracer
 from haystack.utils import Secret
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 from haystack_integrations.tracing.langfuse import DefaultSpanHandler
+
+
+@pytest.fixture
+def mock_langfuse(monkeypatch):
+    monkeypatch.setattr(tracing.tracer, "actual_tracer", NullTracer())
+    with patch("haystack_integrations.components.connectors.langfuse.langfuse_connector.Langfuse") as constructor:
+        constructor.return_value.get_trace_url.return_value = "https://example.com/trace"
+        constructor.return_value.get_current_trace_id.return_value = "12345"
+        yield constructor
 
 
 class CustomSpanHandler(DefaultSpanHandler):
@@ -22,32 +34,25 @@ class CustomSpanHandler(DefaultSpanHandler):
         pass
 
 
-class TestLangfuseConnector:
-    def test_run(self, monkeypatch):
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
-
+class TestRun:
+    def test_run(self, mock_langfuse):
         langfuse_connector = LangfuseConnector(
             name="Chat example - OpenAI",
             public=True,
-            secret_key=Secret.from_env_var("LANGFUSE_SECRET_KEY"),
-            public_key=Secret.from_env_var("LANGFUSE_PUBLIC_KEY"),
+            secret_key=Secret.from_token("secret"),
+            public_key=Secret.from_token("public"),
         )
-
-        mock_tracer = Mock()
-        mock_tracer.get_trace_url.return_value = "https://example.com/trace"
-        mock_tracer.get_trace_id.return_value = "12345"
-        langfuse_connector.tracer = mock_tracer
 
         response = langfuse_connector.run(invocation_context={"some_key": "some_value"})
         assert response["name"] == "Chat example - OpenAI"
         assert response["trace_url"] == "https://example.com/trace"
         assert response["trace_id"] == "12345"
+        mock_langfuse.assert_called_once()
+        assert tracing.tracer.actual_tracer is langfuse_connector.tracer
 
-    def test_to_dict(self, monkeypatch):
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
 
+class TestSerialization:
+    def test_to_dict(self):
         langfuse_connector = LangfuseConnector(name="Chat example - OpenAI")
         serialized = langfuse_connector.to_dict()
 
@@ -72,10 +77,7 @@ class TestLangfuseConnector:
             },
         }
 
-    def test_to_dict_with_params(self, monkeypatch):
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
-
+    def test_to_dict_with_params(self):
         langfuse_connector = LangfuseConnector(
             name="Chat example - OpenAI",
             public=True,
@@ -111,10 +113,7 @@ class TestLangfuseConnector:
             },
         }
 
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
-
+    def test_from_dict(self):
         data = {
             "type": "haystack_integrations.components.connectors.langfuse.langfuse_connector.LangfuseConnector",
             "init_parameters": {
@@ -144,10 +143,7 @@ class TestLangfuseConnector:
         assert langfuse_connector.host is None
         assert langfuse_connector.langfuse_client_kwargs is None
 
-    def test_from_dict_without_span_handler(self, monkeypatch):
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
-
+    def test_from_dict_without_span_handler(self):
         # All keys that would point to None (span_handler, host, langfuse_client_kwargs) are intentionally absent
         data = {
             "type": "haystack_integrations.components.connectors.langfuse.langfuse_connector.LangfuseConnector",
@@ -175,10 +171,7 @@ class TestLangfuseConnector:
         assert langfuse_connector.host is None
         assert langfuse_connector.langfuse_client_kwargs is None
 
-    def test_from_dict_with_params(self, monkeypatch):
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
-
+    def test_from_dict_with_params(self):
         data = {
             "type": "haystack_integrations.components.connectors.langfuse.langfuse_connector.LangfuseConnector",
             "init_parameters": {
@@ -212,10 +205,8 @@ class TestLangfuseConnector:
         assert langfuse_connector.host == "https://example.com"
         assert langfuse_connector.langfuse_client_kwargs == {"timeout": 30.0}
 
-    def test_from_dict_with_legacy_span_handler_format(self, monkeypatch):
+    def test_from_dict_with_legacy_span_handler_format(self):
         # Pipelines serialized before this fix wrap span_handler as {"type": ..., "data": {...}}
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
 
         data = {
             "type": "haystack_integrations.components.connectors.langfuse.langfuse_connector.LangfuseConnector",
@@ -249,8 +240,6 @@ class TestLangfuseConnector:
 
     def test_pipeline_serialization(self, monkeypatch):
         # Set test env vars
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
         monkeypatch.setenv("OPENAI_API_KEY", "openai_api_key")
 
         # Create pipeline with OpenAI LLM
@@ -285,3 +274,54 @@ class TestLangfuseConnector:
 
         # Verify pipeline is the same
         assert new_pipe == pipe
+
+
+class TestComponentLifecycle:
+    @pytest.mark.parametrize("key", ["LANGFUSE_SECRET_KEY", "LANGFUSE_PUBLIC_KEY"])
+    def test_key_resolved_at_warm_up_not_init(self, key, monkeypatch, mock_langfuse):
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
+        monkeypatch.delenv(key)
+        connector = LangfuseConnector("test")
+        assert connector.tracer is None
+        mock_langfuse.assert_not_called()
+        assert not tracing.is_tracing_enabled()
+
+        with pytest.raises(ValueError, match=key):
+            connector.warm_up()
+        assert connector.tracer is None
+        mock_langfuse.assert_not_called()
+
+        monkeypatch.setenv(key, "available-now")
+        connector.warm_up()
+        assert connector.tracer is not None
+        mock_langfuse.assert_called_once()
+
+    def test_warm_up_passes_configuration_and_is_idempotent(self, mock_langfuse):
+        client = Mock(spec=httpx.Client)
+        handler = CustomSpanHandler()
+        connector = LangfuseConnector(
+            "configured",
+            public=True,
+            public_key=Secret.from_token("public"),
+            secret_key=Secret.from_token("secret"),
+            httpx_client=client,
+            span_handler=handler,
+            host="https://example.com",
+            langfuse_client_kwargs={"timeout": 30, "host": "https://override.example.com"},
+        )
+        connector.warm_up()
+        first_tracer = connector.tracer
+        connector.warm_up()
+        assert connector.tracer is first_tracer
+        mock_langfuse.assert_called_once_with(
+            public_key="public",
+            secret_key="secret",
+            httpx_client=client,
+            host="https://override.example.com",
+            timeout=30,
+        )
+        assert handler.tracer is mock_langfuse.return_value
+        assert connector.tracer is not None
+        assert connector.tracer._name == "configured"
+        assert connector.tracer._public is True


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/440

### Proposed Changes:
- in the `LangfuseConnector`, resolve secrets and creat the tracer at `warm_up` (not at `__init__`)
- pin `haystack-ai>=3.0.0`
- (no changes needed for the tracer, that is not a component)

### How did you test it?
CI, new tests
I also executed code snippets from Haystack docs to avoid breaking something


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
