### PR TITLE
fix(alloydb,mariadb): NO_VALUE sentinel collides with 'no_value'

### DIFF
--- a/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/filters.py
+++ b/integrations/alloydb/src/haystack_integrations/document_stores/alloydb/filters.py
@@ -20,7 +20,7 @@ PYTHON_TYPES_TO_PG_TYPES = {
     bool: "boolean",
 }
 
-NO_VALUE = "no_value"
+NO_VALUE = object()  # unique sentinel; can never equal a user-supplied filter value
 
 
 def _validate_filters(filters: dict[str, Any] | None = None) -> None:
@@ -48,7 +48,7 @@ def _convert_filters_to_where_clause_and_params(
         query, values = _parse_logical_condition(filters)
 
     where_clause = SQL(f" {operator} ") + query
-    params = tuple(value for value in values if value != NO_VALUE)
+    params = tuple(value for value in values if value is not NO_VALUE)
 
     return where_clause, params
 

--- a/integrations/alloydb/tests/test_filters.py
+++ b/integrations/alloydb/tests/test_filters.py
@@ -188,6 +188,15 @@ def test_validate_filters_invalid_type():
         _validate_filters("not a dict")
 
 
+def test_convert_filters_to_where_clause_and_params_value_equal_to_no_value_sentinel():
+    # the literal "no_value" must not be mistaken for the internal NO_VALUE marker and dropped from params
+    filters = {"field": "meta.tag", "operator": "==", "value": "no_value"}
+    where_clause, params = _convert_filters_to_where_clause_and_params(filters)
+
+    assert _render(where_clause) == " WHERE meta->>'tag' = %s"
+    assert params == ("no_value",)
+
+
 def test_convert_simple_equality_filter():
     filters = {"field": "meta.type", "operator": "==", "value": "article"}
     where_clause, params = _convert_filters_to_where_clause_and_params(filters)

--- a/integrations/mariadb/src/haystack_integrations/document_stores/mariadb/filters.py
+++ b/integrations/mariadb/src/haystack_integrations/document_stores/mariadb/filters.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from haystack.errors import FilterError
 
-NO_VALUE = "no_value"
+NO_VALUE = object()  # unique sentinel; can never equal a user-supplied filter value
 
 
 def _validate_filters(filters: dict[str, Any] | None = None) -> None:
@@ -31,7 +31,7 @@ def _convert_filters_to_where_clause_and_params(
     else:
         clause, values = _parse_logical_condition(filters)
 
-    params = [v for v in values if v != NO_VALUE]
+    params = [v for v in values if v is not NO_VALUE]
     return f" {operator} {clause}", params
 
 

--- a/integrations/mariadb/tests/test_filters.py
+++ b/integrations/mariadb/tests/test_filters.py
@@ -92,6 +92,19 @@ class TestFilterConversion:
             {"field": "meta.tag", "operator": operator, "value": value}
         ) == (clause, params)
 
+    @pytest.mark.parametrize(
+        ("operator", "value", "clause", "params"),
+        [
+            ("==", "no_value", " WHERE JSON_UNQUOTE(JSON_EXTRACT(meta, '$.tag')) = ?", ["no_value"]),
+            ("in", ["no_value", "x"], " WHERE JSON_UNQUOTE(JSON_EXTRACT(meta, '$.tag')) IN (?, ?)", ["no_value", "x"]),
+        ],
+    )
+    def test_value_equal_to_no_value_sentinel_keeps_its_param(self, operator, value, clause, params):
+        # the literal "no_value" must not be mistaken for the internal NO_VALUE marker and dropped from params
+        assert _convert_filters_to_where_clause_and_params(
+            {"field": "meta.tag", "operator": operator, "value": value}
+        ) == (clause, params)
+
     def test_top_level_field(self):
         assert _convert_filters_to_where_clause_and_params({"field": "id", "operator": "==", "value": "doc-1"}) == (
             " WHERE `id` = ?",


### PR DESCRIPTION
### Related Issues

- None. Follow-up to #3593, which fixed the same bug in pgvector.

### Proposed Changes:

`alloydb` and `mariadb` use the string `"no_value"` as the internal `NO_VALUE` sentinel for conditions that render without a parameter (`IS NULL` / `IS NOT NULL`), and `_convert_filters_to_where_clause_and_params` drops every param equal to it. A legitimate filter value `"no_value"` is dropped too, so the query keeps a placeholder with no matching param and fails at `execute()`:

```python
_convert_filters_to_where_clause_and_params({"field": "meta.tag", "operator": "==", "value": "no_value"})
# alloydb: (" WHERE meta->>'tag' = %s", ())
# mariadb: (" WHERE JSON_UNQUOTE(JSON_EXTRACT(meta, '$.tag')) = ?", [])
```

In mariadb this also affects `in` / `not in`, because list values are flattened into individual params: `in ["no_value", "x"]` renders `IN (?, ?)` with params `["x"]`.

#3593 fixed this in pgvector by making the sentinel a unique `object()` compared by identity. alloydb was copied from pgvector before that fix and mariadb has the same pattern, so this applies the same two-line change to both.

### How did you test it?

- Regression tests: `test_convert_filters_to_where_clause_and_params_value_equal_to_no_value_sentinel` (alloydb, same as the pgvector test from #3593) and `TestFilterConversion::test_value_equal_to_no_value_sentinel_keeps_its_param` (mariadb, `==` and `in`). Both fail before the change and pass after.
- Unit tests: alloydb 44 passed, mariadb 83 passed.
- `ruff check`, `ruff format --check` and `mypy` (using each integration's config) are clean for both.

Hatch is blocked by Windows Application Control on my machine, so these ran from a venv with each integration installed in editable mode rather than through `hatch run`. Integration tests, which need a database, are left to CI.

### Notes for the reviewer

- The alloydb test sits before `test_convert_simple_equality_filter` instead of at the end of the file, to avoid a conflict with #3799.
- alloydb also has the empty-`conditions` `IndexError` that #3946 fixes in pgvector. I left it out here so it can follow whatever approach is agreed there.
- Prepared with Claude Code running locally: it identified the affected stores, wrote the change and tests, and ran the reproduction and the checks above on my machine. I reviewed the diff and the results before opening this PR.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct
- [ ] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the conventional commit types for my PR title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
